### PR TITLE
chore(repo-hygiene): remove redundant .npmrc + gitignore tgz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ sdk/ts/src/*.d.ts
 # ─── SDK generator temp ──────────────────────────────────────────────────────
 .gen_tmp/
 helm.yaml
+
+# build artifacts
+*.tgz
+sdk/ts/*.tgz

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

Two tiny hygiene cleanups. Zero behavior change.

1. **Remove `.npmrc`** — only content was `registry=https://registry.npmjs.org/` which is npm's hardcoded default. File was a no-op config that added cognitive overhead.

2. **Add `*.tgz` + `sdk/ts/*.tgz` to `.gitignore`** — prevents accidental commits of `npm pack` outputs. Also dropped one such stranded tarball (`sdk/ts/mindburn-helm-0.4.0.tgz`) that was sitting untracked locally.

Pure hygiene, merge and move on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)