### PR TITLE
docs(phase-1): sweep stale 0.3.0 references to 0.4.0

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -41,7 +41,7 @@ The schema shape is:
 
 ```json
 {
-  "helm_version": "0.3.0",
+  "helm_version": "0.4.0",
   "go_version": "go1.24.0",
   "go_os": "<os>",
   "go_arch": "<arch>",

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -107,7 +107,7 @@ The claim is scoped: **75µs p99 on the governed allow hot path in the benchmark
 
 ```json
 {
-  "helm_version": "0.3.0",
+  "helm_version": "0.4.0",
   "go_version": "go1.24.0",
   "hot_path_p99_us": 75,
   "baseline_p99_us": 2,

--- a/docs/architecture/path-aware-policy.md
+++ b/docs/architecture/path-aware-policy.md
@@ -49,7 +49,7 @@ A `SessionAction` captures the minimum needed to reason about the path:
 
 ## How policies consume it
 
-### CEL policies (v0.3.0)
+### CEL policies (v0.4.0)
 
 CEL programs currently access session history through the `Context` map. Example — deny if the session has already exfiltrated a file and is now attempting a network call:
 

--- a/docs/guides/otel-integration.md
+++ b/docs/guides/otel-integration.md
@@ -147,7 +147,7 @@ All HELM OTel attributes use the `helm.*` namespace:
 ```
 helm.decision.verdict        — ALLOW | DENY
 helm.decision.reason_code    — e.g., "PDP_DENY", "BUDGET_EXCEEDED"
-helm.decision.policy_ref     — e.g., "helm:v0.3.0"
+helm.decision.policy_ref     — e.g., "helm:v0.4.0"
 helm.decision.latency_ms     — Decision latency
 helm.effect.type             — E0-E4
 helm.effect.risk_tier        — LOW, MEDIUM, HIGH, CRITICAL

--- a/docs/security/owasp-agentic-top10-coverage.md
+++ b/docs/security/owasp-agentic-top10-coverage.md
@@ -1,7 +1,7 @@
 # HELM vs OWASP Agentic Top 10 Coverage Matrix
 
 Generated: 2026-04-13
-HELM Version: 0.3.0
+HELM Version: 0.4.0
 Guardian Pipeline: 6-gate + output quarantine
 Formal Verification: TLA+ (`proofs/GuardianPipeline.tla`)
 


### PR DESCRIPTION
## Summary

Finishes the **Phase 1 OSS truth sweep** from the [reality-first convergence plan](../../../../.claude/plans/swift-napping-treehouse.md#phase-1--oss-truth-sweep) for the 5 docs surfaces where the published version label diverged from \`VERSION=0.4.0\`.

**Total diff: 5 files, +5 / -5. Strings-only; no semantic change.**

## Changes

| File | What | Before → After |
|---|---|---|
| \`docs/guides/otel-integration.md\` | \`policy_ref\` example | \`"helm:v0.3.0"\` → \`"helm:v0.4.0"\` |
| \`docs/security/owasp-agentic-top10-coverage.md\` | "HELM Version" header | \`0.3.0\` → \`0.4.0\` |
| \`docs/architecture/path-aware-policy.md\` | CEL policies section heading | \`(v0.3.0)\` → \`(v0.4.0)\` |
| \`docs/BENCHMARKS.md\` | benchmark-result JSON example | \`"helm_version": "0.3.0"\` → \`"0.4.0"\` |
| \`benchmarks/README.md\` | benchmark-schema JSON example | \`"helm_version": "0.3.0"\` → \`"0.4.0"\` |

## Grounding — what the code actually emits

Both live benchmark result files already report \`0.4.0\`, so the doc examples were strictly stale:

\`\`\`
$ jq .helm_version benchmarks/results/latest.json core/benchmarks/results/latest.json
"0.4.0"
"0.4.0"
\`\`\`

## NOT changed (deliberate)

| File | Why skipped |
|---|---|
| \`dashboard/README.md\` | Says \`"HELM OSS 0.3.0+"\` — forward-compatible claim; still accurate |
| \`docs/standards/submissions/lfai-conformance-profile-v1.md\` | Dated claim: \`"as of 2026-04-15 commit tag 0.3.0"\` — historical snapshot tied to a specific submission date |
| \`sdk/ts/*/package-lock.json\` (5 files) | Regenerate via \`npm install\` after publishing \`@mindburn/helm\` 0.4.0 to npm. Blocked on package publish. |
| \`sdk/go/types_gen.go\` | Autogenerated file; regenerate via \`make codegen\`. Should land in a separate codegen PR. |

## Verification

\`\`\`
$ rg -n "0\\.3\\.0" docs/guides docs/security docs/architecture docs/BENCHMARKS.md benchmarks/README.md
(no matches)
\`\`\`

## Test plan

- [x] \`rg -n "0\\.3\\.0" docs/guides docs/security docs/architecture docs/BENCHMARKS.md benchmarks/README.md\` → zero matches
- [x] Actual benchmark result JSONs confirm \`"helm_version": "0.4.0"\` (doc examples now match runtime)
- [ ] CI (link-check / spell-check if configured)

Refs: \`/Users/ivan/.claude/plans/swift-napping-treehouse.md\` Phase 1 — OSS Truth Sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)