### PR TITLE
docs: add public docs origin manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The HTTP client/types layer is generated from [`api/openapi/helm.openapi.yaml`](
 
 ## Documentation
 
+Public OSS docs are sourced from this repository and canonically published through `docs.mindburn.org`. The owned docs set for sync is declared in `docs/public-docs.manifest.json`.
+
 - [Quickstart](docs/QUICKSTART.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Conformance](docs/CONFORMANCE.md)

--- a/docs/EXECUTION_SECURITY_MODEL.md
+++ b/docs/EXECUTION_SECURITY_MODEL.md
@@ -254,11 +254,11 @@ Each layer protects against failures in the other two.
 | Document | Relevance |
 | :--- | :--- |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | System-level model, VPL, TCB |
-| [SECURITY_MODEL.md](SECURITY_MODEL.md) | Execution pipeline, crypto chain |
-| [THREAT_MODEL.md](THREAT_MODEL.md) | Adversary classes and defenses |
+| [core/pkg/receipts](../core/pkg/receipts/) | Execution pipeline and receipt chain implementation |
+| [OWASP_MCP_THREAT_MAPPING.md](OWASP_MCP_THREAT_MAPPING.md) | Adversary classes and defenses |
 | [OWASP_MCP_THREAT_MAPPING.md](OWASP_MCP_THREAT_MAPPING.md) | OWASP MCP alignment |
-| [CAPABILITY_MANIFESTS.md](CAPABILITY_MANIFESTS.md) | Layer A configuration primitives |
-| [TCB_POLICY.md](TCB_POLICY.md) | TCB boundary rules |
+| [core/pkg/manifest](../core/pkg/manifest/) | Layer A configuration primitives |
+| [core/pkg/trust/registry](../core/pkg/trust/registry/) | TCB boundary and trust-registry rules |
 | [CONFORMANCE.md](CONFORMANCE.md) | Gate definitions, levels |
 
 _Canonical revision: 2026-03-21 · HELM UCS v1.2_

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": 1,
+  "repo": "helm-oss",
+  "display_name": "HELM OSS",
+  "docs_origin": {
+    "canonical_host": "docs.mindburn.org",
+    "source_repo": "Mindburn-Labs/helm-oss",
+    "source_root": "docs/"
+  },
+  "documents": [
+    {
+      "slug": "helm-oss",
+      "title": "HELM Documentation",
+      "section": "overview",
+      "source_path": "docs/index.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/quickstart",
+      "title": "Quickstart",
+      "section": "start-here",
+      "source_path": "docs/QUICKSTART.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/architecture",
+      "title": "Architecture",
+      "section": "start-here",
+      "source_path": "docs/ARCHITECTURE.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/conformance",
+      "title": "Conformance",
+      "section": "start-here",
+      "source_path": "docs/CONFORMANCE.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/verification",
+      "title": "Verification",
+      "section": "start-here",
+      "source_path": "docs/VERIFICATION.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/compatibility",
+      "title": "Compatibility",
+      "section": "start-here",
+      "source_path": "docs/COMPATIBILITY.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/publishing",
+      "title": "Publishing",
+      "section": "start-here",
+      "source_path": "docs/PUBLISHING.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/execution-security-model",
+      "title": "Execution Security Model",
+      "section": "interfaces",
+      "source_path": "docs/EXECUTION_SECURITY_MODEL.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/owasp-mcp-threat-mapping",
+      "title": "OWASP MCP Threat Mapping",
+      "section": "interfaces",
+      "source_path": "docs/OWASP_MCP_THREAT_MAPPING.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/sdks",
+      "title": "SDK Index",
+      "section": "interfaces",
+      "source_path": "docs/sdks/00_INDEX.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/benchmarks",
+      "title": "Benchmarks",
+      "section": "supporting-material",
+      "source_path": "docs/BENCHMARKS.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/troubleshooting",
+      "title": "Troubleshooting",
+      "section": "supporting-material",
+      "source_path": "docs/TROUBLESHOOTING.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/integrations/openai-compatible-proxy",
+      "title": "OpenAI-Compatible Proxy Integration",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/openai_baseurl.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/integrations/mcp",
+      "title": "MCP Integration",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/mcp.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/security/owasp-agentic-top10-mapping",
+      "title": "OWASP Agentic Top 10 Mapping",
+      "section": "security",
+      "source_path": "docs/security/owasp-agentic-top10-coverage.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add public docs manifest for owned OSS docs sync
- note docs.mindburn.org as the canonical public publishing target
- correct execution security model links to existing repository paths

## Validation
- jq . docs/public-docs.manifest.json
- verified every manifest source_path exists
- git diff --cached --check