### PR TITLE
Stabilize HELM evaluate response contract

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # ── Stage 1: Build ─────────────────────────────────────
 # SC-004: Base images pinned by digest for supply chain integrity
-FROM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN apk add --no-cache git ca-certificates
 
@@ -10,7 +12,7 @@ COPY core/ ./core/
 # Build Kernel CLI
 WORKDIR /src/core
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /helm ./cmd/helm/
+RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -o /helm ./cmd/helm/
 
 # ── Stage 2: Runtime ───────────────────────────────────
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,11 +1,13 @@
 # Stage 1: Build
-FROM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
+ARG TARGETOS
+ARG TARGETARCH
 RUN apk add --no-cache git ca-certificates
 WORKDIR /src
 COPY core/go.mod core/go.sum ./core/
 RUN cd core && go mod download
 COPY core/ ./core/
-RUN cd core && CGO_ENABLED=0 go build -ldflags="-s -w" -o /helm ./cmd/helm/
+RUN cd core && CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -o /helm ./cmd/helm/
 
 # Stage 2: Minimal runtime
 FROM alpine:3.21

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,6 +1,8 @@
 # ── Stage 1: Build ─────────────────────────────────────
 # SC-004: Base images pinned by digest for supply chain integrity
-FROM golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN apk add --no-cache git ca-certificates
 
@@ -8,8 +10,8 @@ WORKDIR /src
 COPY . ./
 
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o /helm ./cmd/helm/
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o /helm-node ./cmd/helm-node/
+RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -trimpath -o /helm ./cmd/helm/
+RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -trimpath -o /helm-node ./cmd/helm-node/
 
 # ── Stage 2: Runtime ───────────────────────────────────
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1

--- a/core/Dockerfile.api
+++ b/core/Dockerfile.api
@@ -3,7 +3,9 @@
 
 # Stage 1: Builder
 # SC-004: Base images pinned by digest for supply chain integrity
-FROM golang:1.24-alpine@sha256:8bee1901f1e530bfb4a7850aa7a479d17ae3a18beb6e09064ed54cfd245b7191 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -19,8 +21,8 @@ COPY . .
 
 # Build the application
 ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GOARCH=amd64
+ENV GOOS=${TARGETOS:-linux}
+ENV GOARCH=${TARGETARCH:-amd64}
 RUN go build -ldflags="-s -w" -trimpath -o /app/bin/helm ./core/cmd/helm
 
 # Stage 2: Runtime

--- a/core/pkg/api/server.go
+++ b/core/pkg/api/server.go
@@ -66,7 +66,9 @@ type EvaluateRequest struct {
 // EvaluateResponse is the JSON response sent back to SDKs.
 type EvaluateResponse struct {
 	Allow        bool   `json:"allow"`
+	Verdict      string `json:"verdict"`
 	ReceiptID    string `json:"receipt_id"`
+	DecisionID   string `json:"decision_id"`
 	DecisionHash string `json:"decision_hash"`
 	ReasonCode   string `json:"reason_code"`
 	PolicyRef    string `json:"policy_ref"`
@@ -95,6 +97,7 @@ func NewServer(cfg ServerConfig) *Server {
 
 func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/api/v1/evaluate", s.handleEvaluate)
+	s.mux.HandleFunc("/api/v1/guardian/evaluate", s.handleEvaluate)
 	s.mux.HandleFunc("/api/v1/receipts/", s.handleReceipts)
 	s.mux.HandleFunc("/api/v1/verify/", s.handleVerify)
 	s.mux.HandleFunc("/api/v1/health", s.handleHealth)
@@ -188,12 +191,17 @@ func (s *Server) handleEvaluate(w http.ResponseWriter, r *http.Request) {
 	if decResp.Allow {
 		status = "ALLOW"
 	}
+	decisionID := fmt.Sprintf("dec-%d", lamport)
+	policyRef := decResp.PolicyRef
+	if policyRef == "" {
+		policyRef = "default"
+	}
 
 	sig := sha256.Sum256([]byte(fmt.Sprintf("%s:%s:%s:%d", receiptID, status, prevHash, lamport)))
 
 	receipt := &Receipt{
 		ReceiptID:    receiptID,
-		DecisionID:   fmt.Sprintf("dec-%d", lamport),
+		DecisionID:   decisionID,
 		EffectID:     req.Tool,
 		Status:       status,
 		Timestamp:    time.Now().UTC().Format(time.RFC3339),
@@ -209,12 +217,20 @@ func (s *Server) handleEvaluate(w http.ResponseWriter, r *http.Request) {
 	s.sessions[req.SessionID] = append(s.sessions[req.SessionID], receiptID)
 	s.mu.Unlock()
 
+	w.Header().Set("X-Helm-Decision-ID", decisionID)
+	w.Header().Set("X-Helm-Verdict", status)
+	w.Header().Set("X-Helm-Policy-Version", policyRef)
+	w.Header().Set("X-Helm-Decision-Hash", decResp.DecisionHash)
+	w.Header().Set("X-Helm-Receipt-ID", receiptID)
+
 	writeJSON(w, http.StatusOK, EvaluateResponse{
 		Allow:        decResp.Allow,
+		Verdict:      status,
 		ReceiptID:    receiptID,
+		DecisionID:   decisionID,
 		DecisionHash: decResp.DecisionHash,
 		ReasonCode:   decResp.ReasonCode,
-		PolicyRef:    decResp.PolicyRef,
+		PolicyRef:    policyRef,
 		LamportClock: lamport,
 	})
 }


### PR DESCRIPTION
## Summary
- expose `/api/v1/evaluate` as the canonical evaluate endpoint with guardian compatibility preserved
- include stable verdict/decision metadata fields needed by HELM Pilot's fail-closed sidecar client
- retain receipt headers for policy version, decision hash, and receipt id

## Verification
- `go test ./core/pkg/api`
- `git diff --check`
