### PR TITLE
feat: preserve MCP governance backlog

### DIFF
--- a/core/cmd/helm/mcp_runtime.go
+++ b/core/cmd/helm/mcp_runtime.go
@@ -452,6 +452,10 @@ func wrapMCPAuth(next http.Handler, authMode, baseURL string) (http.Handler, err
 	case "oauth":
 		jwksURL := os.Getenv("HELM_OAUTH_JWKS_URL")
 		metadataURL := strings.TrimRight(baseURL, "/") + "/.well-known/oauth-protected-resource/mcp"
+		resource := strings.TrimSpace(os.Getenv("HELM_OAUTH_RESOURCE"))
+		if resource == "" {
+			resource = strings.TrimRight(baseURL, "/") + "/mcp"
+		}
 
 		if jwksURL != "" {
 			// Production JWKS/OIDC validation.
@@ -460,19 +464,13 @@ func wrapMCPAuth(next http.Handler, authMode, baseURL string) (http.Handler, err
 			if issuer == "" || audience == "" {
 				return nil, fmt.Errorf("HELM_OAUTH_ISSUER and HELM_OAUTH_AUDIENCE must be set when HELM_OAUTH_JWKS_URL is configured")
 			}
-			var scopes []string
-			if configured := strings.TrimSpace(os.Getenv("HELM_OAUTH_SCOPES")); configured != "" {
-				for _, s := range strings.FieldsFunc(configured, func(r rune) bool { return r == ',' || r == ' ' }) {
-					if trimmed := strings.TrimSpace(s); trimmed != "" {
-						scopes = append(scopes, trimmed)
-					}
-				}
-			}
+			scopes := parseMCPEnvList(os.Getenv("HELM_OAUTH_SCOPES"))
 
 			validator := mcppkg.NewJWKSValidator(mcppkg.JWKSConfig{
 				JWKSURL:  jwksURL,
 				Issuer:   issuer,
 				Audience: audience,
+				Resource: resource,
 				Scopes:   scopes,
 			})
 
@@ -483,14 +481,14 @@ func wrapMCPAuth(next http.Handler, authMode, baseURL string) (http.Handler, err
 				}
 				authz := r.Header.Get("Authorization")
 				if !strings.HasPrefix(authz, "Bearer ") {
-					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="helm-mcp", resource_metadata="%s"`, metadataURL))
+					w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="helm-mcp", resource_metadata="%s", resource="%s"`, metadataURL, resource))
 					http.Error(w, "missing bearer token", http.StatusUnauthorized)
 					return
 				}
 				tokenStr := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
-				_, err := validator.Validate(tokenStr)
+				claims, err := validator.ValidateAuthorization(tokenStr)
 				if err != nil {
-					challenge := fmt.Sprintf(`Bearer realm="helm-mcp", resource_metadata="%s"`, metadataURL)
+					challenge := fmt.Sprintf(`Bearer realm="helm-mcp", resource_metadata="%s", resource="%s"`, metadataURL, resource)
 					if validErr, ok := err.(*mcppkg.JWKSValidationError); ok && validErr.Kind == mcppkg.JWKSErrMissingScope {
 						challenge += fmt.Sprintf(`, error="insufficient_scope", error_description="%s"`, validErr.Message)
 					}
@@ -498,7 +496,11 @@ func wrapMCPAuth(next http.Handler, authMode, baseURL string) (http.Handler, err
 					http.Error(w, err.Error(), http.StatusUnauthorized)
 					return
 				}
-				next.ServeHTTP(w, r)
+				ctx := mcppkg.WithOAuthAuthorization(r.Context(), mcppkg.OAuthAuthorization{
+					Scopes:    claims.Scopes,
+					Resources: claims.Resources,
+				})
+				next.ServeHTTP(w, r.WithContext(ctx))
 			}), nil
 		}
 
@@ -516,13 +518,27 @@ func wrapMCPAuth(next http.Handler, authMode, baseURL string) (http.Handler, err
 			authz := r.Header.Get("Authorization")
 			provided := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
 			if !strings.HasPrefix(authz, "Bearer ") || provided != expectedToken {
-				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="helm-mcp", resource_metadata="%s"`, metadataURL))
+				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="helm-mcp", resource_metadata="%s", resource="%s"`, metadataURL, resource))
 				http.Error(w, "missing or invalid OAuth bearer token", http.StatusUnauthorized)
 				return
 			}
-			next.ServeHTTP(w, r)
+			ctx := mcppkg.WithOAuthAuthorization(r.Context(), mcppkg.OAuthAuthorization{
+				Scopes:    parseMCPEnvList(os.Getenv("HELM_OAUTH_SCOPES")),
+				Resources: []string{resource},
+			})
+			next.ServeHTTP(w, r.WithContext(ctx))
 		}), nil
 	default:
 		return nil, fmt.Errorf("unknown auth mode %q", authMode)
 	}
+}
+
+func parseMCPEnvList(raw string) []string {
+	var values []string
+	for _, value := range strings.FieldsFunc(raw, func(r rune) bool { return r == ',' || r == ' ' }) {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			values = append(values, trimmed)
+		}
+	}
+	return values
 }

--- a/core/cmd/helm/mcp_runtime_auth_test.go
+++ b/core/cmd/helm/mcp_runtime_auth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	mcppkg "github.com/Mindburn-Labs/helm-oss/core/pkg/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,10 +46,15 @@ func TestWrapMCPAuth_OAuthChallengesWithoutBearer(t *testing.T) {
 
 func TestWrapMCPAuth_OAuthAllowsValidBearer(t *testing.T) {
 	t.Setenv("HELM_OAUTH_BEARER_TOKEN", "testtoken")
+	t.Setenv("HELM_OAUTH_SCOPES", "mcp:tool:read,mcp:tool:write")
 
 	called := false
 	handler, err := wrapMCPAuth(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		called = true
+		auth, ok := mcppkg.OAuthAuthorizationFromContext(r.Context())
+		require.True(t, ok)
+		assert.Equal(t, []string{"mcp:tool:read", "mcp:tool:write"}, auth.Scopes)
+		assert.Equal(t, []string{"http://localhost:9194/mcp"}, auth.Resources)
 		w.WriteHeader(http.StatusNoContent)
 	}), "oauth", "http://localhost:9194")
 	require.NoError(t, err)

--- a/core/pkg/mcp/catalog.go
+++ b/core/pkg/mcp/catalog.go
@@ -17,13 +17,14 @@ type Catalog interface {
 
 // ToolRef represents a tool reference for catalog search and definition.
 type ToolRef struct {
-	Name         string           `json:"name"`
-	Title        string           `json:"title,omitempty"`
-	Description  string           `json:"description"`
-	ServerID     string           `json:"server_id,omitempty"`
-	Schema       any              `json:"schema,omitempty"` // Legacy input schema alias for /mcp/v1/*
-	OutputSchema any              `json:"output_schema,omitempty"`
-	Annotations  *ToolAnnotations `json:"annotations,omitempty"`
+	Name           string           `json:"name"`
+	Title          string           `json:"title,omitempty"`
+	Description    string           `json:"description"`
+	ServerID       string           `json:"server_id,omitempty"`
+	Schema         any              `json:"schema,omitempty"` // Legacy input schema alias for /mcp/v1/*
+	OutputSchema   any              `json:"output_schema,omitempty"`
+	Annotations    *ToolAnnotations `json:"annotations,omitempty"`
+	RequiredScopes []string         `json:"required_scopes,omitempty"`
 }
 
 // Validate checks that a ToolRef has a non-empty Name.

--- a/core/pkg/mcp/delegation_scope_test.go
+++ b/core/pkg/mcp/delegation_scope_test.go
@@ -88,6 +88,30 @@ func TestDelegationScope_ContextForwarded(t *testing.T) {
 	assert.Equal(t, "/tmp/test.txt", capturedCtx["path"])
 }
 
+func TestOAuthScopeContext_ForwardedToGuardian(t *testing.T) {
+	var capturedCtx map[string]interface{}
+	eval := &capturingEvaluator{
+		verdict: guardian.VerdictAllow,
+		capture: func(req guardian.DecisionRequest) {
+			capturedCtx = req.Context
+		},
+	}
+	fw := NewGovernanceFirewall(eval, nil)
+
+	err := fw.InterceptToolExecution(context.Background(), ToolExecutionRequest{
+		ToolName:       "file_read",
+		SessionID:      "sess-oauth",
+		RequiredScopes: []string{"mcp:tool:file_read"},
+		OAuthScopes:    []string{"mcp:tools", "mcp:tool:file_read"},
+		OAuthResources: []string{"https://gateway.example/mcp"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, capturedCtx)
+	assert.Equal(t, []string{"mcp:tool:file_read"}, capturedCtx["mcp_required_scopes"])
+	assert.Equal(t, []string{"mcp:tools", "mcp:tool:file_read"}, capturedCtx["oauth_scopes"])
+	assert.Equal(t, []string{"https://gateway.example/mcp"}, capturedCtx["oauth_resources"])
+}
+
 // TestDelegationScope_CapabilitiesFiltered verifies that the /mcp/v1/capabilities
 // endpoint filters tools when delegation headers are present.
 func TestDelegationScope_CapabilitiesFiltered(t *testing.T) {

--- a/core/pkg/mcp/gateway.go
+++ b/core/pkg/mcp/gateway.go
@@ -300,6 +300,15 @@ func (g *Gateway) handleExecute(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	if !hasAllOAuthScopes(r.Context(), tool.RequiredScopes) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(MCPToolCallResponse{
+			Error:      fmt.Sprintf("tool %q requires OAuth scopes: %s", req.Method, strings.Join(tool.RequiredScopes, ", ")),
+			ReasonCode: "MCP.OAUTH.INSUFFICIENT_SCOPE",
+		})
+		return
+	}
 
 	// 1. Validate and canonicalize args via PEP boundary
 	var argsHash string
@@ -323,9 +332,14 @@ func (g *Gateway) handleExecute(w http.ResponseWriter, r *http.Request) {
 	if g.exec != nil {
 		// Build execution request with delegation context from headers.
 		execReq := ToolExecutionRequest{
-			ToolName:  req.Method,
-			Arguments: req.Params,
-			SessionID: fmt.Sprintf("mcp-http-%s-%p", r.RemoteAddr, r),
+			ToolName:       req.Method,
+			Arguments:      req.Params,
+			SessionID:      fmt.Sprintf("mcp-http-%s-%p", r.RemoteAddr, r),
+			RequiredScopes: append([]string(nil), tool.RequiredScopes...),
+		}
+		if auth, ok := OAuthAuthorizationFromContext(r.Context()); ok {
+			execReq.OAuthScopes = append([]string(nil), auth.Scopes...)
+			execReq.OAuthResources = append([]string(nil), auth.Resources...)
 		}
 		if delegationID := r.Header.Get("X-HELM-Delegation-Session-ID"); delegationID != "" {
 			execReq.DelegationSessionID = delegationID
@@ -501,18 +515,28 @@ func (g *Gateway) handleJSONRPCRequest(ctx context.Context, id any, method strin
 		if err := json.Unmarshal(params, &req); err != nil {
 			return writeError(-32602, "invalid tools/call params")
 		}
-		if _, ok := findToolRef(g.catalog, req.Name); !ok {
+		tool, ok := findToolRef(g.catalog, req.Name)
+		if !ok {
 			return writeError(-32602, fmt.Sprintf("tool %q not found", req.Name))
+		}
+		if !hasAllOAuthScopes(ctx, tool.RequiredScopes) {
+			return writeError(-32001, fmt.Sprintf("tool %q requires OAuth scopes: %s", req.Name, strings.Join(tool.RequiredScopes, ", ")))
 		}
 		if g.exec == nil {
 			return writeError(-32603, "tool executor is not configured")
 		}
 
-		execResp, err := g.exec(ctx, ToolExecutionRequest{
-			ToolName:  req.Name,
-			Arguments: req.Arguments,
-			SessionID: "mcp-http-jsonrpc",
-		})
+		execReq := ToolExecutionRequest{
+			ToolName:       req.Name,
+			Arguments:      req.Arguments,
+			SessionID:      "mcp-http-jsonrpc",
+			RequiredScopes: append([]string(nil), tool.RequiredScopes...),
+		}
+		if auth, ok := OAuthAuthorizationFromContext(ctx); ok {
+			execReq.OAuthScopes = append([]string(nil), auth.Scopes...)
+			execReq.OAuthResources = append([]string(nil), auth.Resources...)
+		}
+		execResp, err := g.exec(ctx, execReq)
 		if err != nil {
 			return writeError(-32603, err.Error())
 		}

--- a/core/pkg/mcp/gateway_protocol_test.go
+++ b/core/pkg/mcp/gateway_protocol_test.go
@@ -92,6 +92,30 @@ func TestGateway_ToolsListIncludesStructuredToolMetadata(t *testing.T) {
 	assert.Equal(t, true, annotations["idempotentHint"])
 }
 
+func TestGateway_ToolsListIncludesRequiredScopes(t *testing.T) {
+	mux := newScopedProtocolTestMux(t, nil)
+
+	rec := performJSONRPCRequest(t, mux, http.MethodPost, "/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      20,
+		"method":  "tools/list",
+	}, map[string]string{
+		"MCP-Protocol-Version": LatestProtocolVersion,
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	result := payload["result"].(map[string]any)
+	tools := result["tools"].([]any)
+	require.Len(t, tools, 1)
+
+	tool := tools[0].(map[string]any)
+	assert.Equal(t, "scoped_tool", tool["name"])
+	assert.Equal(t, []any{"mcp:tool:scoped"}, tool["requiredScopes"])
+}
+
 func TestGateway_ToolsCallReturnsStructuredContent(t *testing.T) {
 	exec := func(_ context.Context, _ ToolExecutionRequest) (ToolExecutionResponse, error) {
 		structured := map[string]any{
@@ -139,6 +163,64 @@ func TestGateway_ToolsCallReturnsStructuredContent(t *testing.T) {
 	assert.Contains(t, textItem["text"], "\"path\": \"/tmp/demo.txt\"")
 }
 
+func TestGateway_ToolsCallRejectsMissingRequiredOAuthScope(t *testing.T) {
+	exec := func(_ context.Context, _ ToolExecutionRequest) (ToolExecutionResponse, error) {
+		return ToolExecutionResponse{Content: "ok"}, nil
+	}
+	mux := newScopedProtocolTestMux(t, exec)
+
+	rec := performJSONRPCRequest(t, mux, http.MethodPost, "/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      21,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "scoped_tool",
+		},
+	}, map[string]string{
+		"MCP-Protocol-Version": LatestProtocolVersion,
+	})
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	errPayload := payload["error"].(map[string]any)
+	assert.Equal(t, float64(-32001), errPayload["code"])
+	assert.Contains(t, errPayload["message"], "mcp:tool:scoped")
+}
+
+func TestGateway_RESTExecuteEnforcesRequiredOAuthScope(t *testing.T) {
+	exec := func(_ context.Context, req ToolExecutionRequest) (ToolExecutionResponse, error) {
+		assert.Equal(t, "scoped_tool", req.ToolName)
+		assert.Equal(t, []string{"mcp:tool:scoped"}, req.RequiredScopes)
+		assert.Equal(t, []string{"mcp:tool:scoped"}, req.OAuthScopes)
+		assert.Equal(t, []string{"http://localhost/mcp"}, req.OAuthResources)
+		return ToolExecutionResponse{Content: "ok"}, nil
+	}
+	mux := newScopedProtocolTestMux(t, exec)
+
+	body, err := json.Marshal(MCPToolCallRequest{Method: "scoped_tool"})
+	require.NoError(t, err)
+
+	missingReq := httptest.NewRequest(http.MethodPost, "/mcp/v1/execute", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, missingReq)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "MCP.OAUTH.INSUFFICIENT_SCOPE")
+
+	allowedReq := httptest.NewRequest(http.MethodPost, "/mcp/v1/execute", bytes.NewReader(body))
+	allowedReq = allowedReq.WithContext(WithOAuthAuthorization(allowedReq.Context(), OAuthAuthorization{
+		Scopes:    []string{"mcp:tool:scoped"},
+		Resources: []string{"http://localhost/mcp"},
+	}))
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, allowedReq)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "ok")
+}
+
 func TestGateway_UnsupportedProtocolVersionRejected(t *testing.T) {
 	mux := newProtocolTestMux(t, GatewayConfig{}, nil)
 
@@ -182,6 +264,27 @@ func newProtocolTestMux(t *testing.T, cfg GatewayConfig, exec ToolExecutor) *htt
 	catalog.RegisterCommonTools()
 
 	gw := NewGateway(catalog, cfg)
+	if exec != nil {
+		WithExecutor(exec)(gw)
+	}
+
+	mux := http.NewServeMux()
+	gw.RegisterRoutes(mux)
+	return mux
+}
+
+func newScopedProtocolTestMux(t *testing.T, exec ToolExecutor) *http.ServeMux {
+	t.Helper()
+
+	catalog := NewInMemoryCatalog()
+	require.NoError(t, catalog.Register(context.Background(), ToolRef{
+		Name:           "scoped_tool",
+		Description:    "requires a delegated MCP OAuth scope",
+		Schema:         map[string]any{"type": "object"},
+		RequiredScopes: []string{"mcp:tool:scoped"},
+	}))
+
+	gw := NewGateway(catalog, GatewayConfig{})
 	if exec != nil {
 		WithExecutor(exec)(gw)
 	}

--- a/core/pkg/mcp/jwks.go
+++ b/core/pkg/mcp/jwks.go
@@ -25,6 +25,7 @@ const (
 	JWKSErrInvalidAudience  JWKSValidationErrorKind = "invalid_audience"
 	JWKSErrInvalidSignature JWKSValidationErrorKind = "invalid_signature"
 	JWKSErrMissingScope     JWKSValidationErrorKind = "insufficient_scope"
+	JWKSErrInvalidResource  JWKSValidationErrorKind = "invalid_resource"
 	JWKSErrKeyNotFound      JWKSValidationErrorKind = "key_not_found"
 	JWKSErrMalformedToken   JWKSValidationErrorKind = "malformed_token"
 	JWKSErrFetchFailed      JWKSValidationErrorKind = "jwks_fetch_failed"
@@ -45,7 +46,22 @@ type JWKSConfig struct {
 	JWKSURL  string   // HELM_OAUTH_JWKS_URL — JWKS endpoint
 	Issuer   string   // HELM_OAUTH_ISSUER — expected iss claim
 	Audience string   // HELM_OAUTH_AUDIENCE — expected aud claim
+	Resource string   // HELM_OAUTH_RESOURCE — expected RFC 8707 resource indicator
 	Scopes   []string // HELM_OAUTH_SCOPES — required scopes
+}
+
+// OAuthTokenClaims contains validated token claims needed by MCP authorization.
+type OAuthTokenClaims struct {
+	RegisteredClaims jwt.RegisteredClaims
+	Scopes           []string
+	Resources        []string
+}
+
+type jwksClaims struct {
+	Scope     string   `json:"scope"`
+	Resource  string   `json:"resource"`
+	Resources []string `json:"resources"`
+	jwt.RegisteredClaims
 }
 
 // JWKSValidator validates bearer tokens against a JWKS endpoint.
@@ -74,6 +90,16 @@ func NewJWKSValidator(config JWKSConfig) *JWKSValidator {
 // Validate parses and validates a bearer token string.
 // Returns the parsed claims on success, or a typed JWKSValidationError on failure.
 func (v *JWKSValidator) Validate(tokenString string) (*jwt.RegisteredClaims, error) {
+	claims, err := v.ValidateAuthorization(tokenString)
+	if err != nil {
+		return nil, err
+	}
+	return &claims.RegisteredClaims, nil
+}
+
+// ValidateAuthorization parses and validates a bearer token string and returns
+// normalized OAuth metadata used by MCP scope and resource policy.
+func (v *JWKSValidator) ValidateAuthorization(tokenString string) (*OAuthTokenClaims, error) {
 	if err := v.refreshKeysIfNeeded(); err != nil {
 		return nil, err
 	}
@@ -84,11 +110,6 @@ func (v *JWKSValidator) Validate(tokenString string) (*jwt.RegisteredClaims, err
 		jwt.WithExpirationRequired(),
 		jwt.WithIssuedAt(),
 	)
-
-	type jwksClaims struct {
-		Scope string `json:"scope"`
-		jwt.RegisteredClaims
-	}
 
 	claims := &jwksClaims{}
 	token, err := parser.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (any, error) {
@@ -146,7 +167,52 @@ func (v *JWKSValidator) Validate(tokenString string) (*jwt.RegisteredClaims, err
 		}
 	}
 
-	return &claims.RegisteredClaims, nil
+	resources := claims.resourceIndicators()
+	if v.config.Resource != "" && !containsString(resources, v.config.Resource) {
+		return nil, &JWKSValidationError{
+			Kind:    JWKSErrInvalidResource,
+			Message: fmt.Sprintf("missing required resource indicator: %s", v.config.Resource),
+		}
+	}
+
+	return &OAuthTokenClaims{
+		RegisteredClaims: claims.RegisteredClaims,
+		Scopes:           strings.Fields(claims.Scope),
+		Resources:        resources,
+	}, nil
+}
+
+func (c *jwksClaims) resourceIndicators() []string {
+	seen := make(map[string]struct{})
+	var resources []string
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		resources = append(resources, value)
+	}
+	for _, audience := range c.Audience {
+		add(audience)
+	}
+	add(c.Resource)
+	for _, resource := range c.Resources {
+		add(resource)
+	}
+	return resources
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func (v *JWKSValidator) validateScopeString(scope string) error {

--- a/core/pkg/mcp/mcp_behavior_coverage_test.go
+++ b/core/pkg/mcp/mcp_behavior_coverage_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Mindburn-Labs/helm-oss/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-oss/core/pkg/guardian"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // ---- Protocol version tests ----
@@ -605,6 +606,30 @@ func TestJWKSValidationError_ErrorString(t *testing.T) {
 	s := e.Error()
 	if s != "expired_token: token expired at X" {
 		t.Fatalf("unexpected error string: %s", s)
+	}
+}
+
+func TestJWKSClaimsResourceIndicatorsDeduplicateSources(t *testing.T) {
+	claims := &jwksClaims{
+		Resource:  "https://gateway.example/mcp",
+		Resources: []string{"https://gateway.example/mcp", "https://gateway.example/mcp/v2"},
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience: jwt.ClaimStrings{"https://gateway.example/mcp", "https://other.example/api"},
+		},
+	}
+
+	resources := claims.resourceIndicators()
+	if len(resources) != 3 {
+		t.Fatalf("expected three deduplicated resource indicators, got %v", resources)
+	}
+	for _, expected := range []string{
+		"https://gateway.example/mcp",
+		"https://other.example/api",
+		"https://gateway.example/mcp/v2",
+	} {
+		if !containsString(resources, expected) {
+			t.Fatalf("expected %s in resource indicators %v", expected, resources)
+		}
 	}
 }
 

--- a/core/pkg/mcp/oauth_context.go
+++ b/core/pkg/mcp/oauth_context.go
@@ -1,0 +1,42 @@
+package mcp
+
+import "context"
+
+type oauthAuthorizationKey struct{}
+
+// OAuthAuthorization captures validated OAuth token metadata relevant to MCP policy.
+type OAuthAuthorization struct {
+	Scopes    []string
+	Resources []string
+}
+
+// WithOAuthAuthorization attaches validated OAuth authorization metadata to ctx.
+func WithOAuthAuthorization(ctx context.Context, auth OAuthAuthorization) context.Context {
+	return context.WithValue(ctx, oauthAuthorizationKey{}, auth)
+}
+
+// OAuthAuthorizationFromContext returns OAuth metadata previously attached to ctx.
+func OAuthAuthorizationFromContext(ctx context.Context) (OAuthAuthorization, bool) {
+	auth, ok := ctx.Value(oauthAuthorizationKey{}).(OAuthAuthorization)
+	return auth, ok
+}
+
+func hasAllOAuthScopes(ctx context.Context, required []string) bool {
+	if len(required) == 0 {
+		return true
+	}
+	auth, ok := OAuthAuthorizationFromContext(ctx)
+	if !ok {
+		return false
+	}
+	present := make(map[string]struct{}, len(auth.Scopes))
+	for _, scope := range auth.Scopes {
+		present[scope] = struct{}{}
+	}
+	for _, scope := range required {
+		if _, ok := present[scope]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/core/pkg/mcp/protocol.go
+++ b/core/pkg/mcp/protocol.go
@@ -55,6 +55,9 @@ func ToolDescriptorPayload(tool ToolRef) map[string]any {
 	if annotations := toolAnnotationsPayload(tool.Annotations); len(annotations) > 0 {
 		payload["annotations"] = annotations
 	}
+	if len(tool.RequiredScopes) > 0 {
+		payload["requiredScopes"] = append([]string(nil), tool.RequiredScopes...)
+	}
 	return payload
 }
 

--- a/core/pkg/mcp/server.go
+++ b/core/pkg/mcp/server.go
@@ -21,6 +21,12 @@ type ToolExecutionRequest struct {
 	DelegationSessionID    string   `json:"delegation_session_id,omitempty"`
 	DelegationVerifier     string   `json:"delegation_verifier,omitempty"`
 	DelegationAllowedTools []string `json:"delegation_allowed_tools,omitempty"`
+
+	// OAuth-aware fields are populated by the MCP gateway after bearer-token
+	// validation so Guardian decisions can retain the scope/resource evidence.
+	RequiredScopes []string `json:"required_scopes,omitempty"`
+	OAuthScopes    []string `json:"oauth_scopes,omitempty"`
+	OAuthResources []string `json:"oauth_resources,omitempty"`
 }
 
 // ToolExecutionResponse represents the result of a tool execution.
@@ -81,6 +87,15 @@ func (f *GovernanceFirewall) InterceptToolExecution(ctx context.Context, req Too
 	if req.DelegationSessionID != "" {
 		decisionCtx["delegation_session_id"] = req.DelegationSessionID
 		decisionCtx["delegation_verifier"] = req.DelegationVerifier
+	}
+	if len(req.RequiredScopes) > 0 {
+		decisionCtx["mcp_required_scopes"] = append([]string(nil), req.RequiredScopes...)
+	}
+	if len(req.OAuthScopes) > 0 {
+		decisionCtx["oauth_scopes"] = append([]string(nil), req.OAuthScopes...)
+	}
+	if len(req.OAuthResources) > 0 {
+		decisionCtx["oauth_resources"] = append([]string(nil), req.OAuthResources...)
 	}
 
 	decision, err := f.evaluator.EvaluateDecision(ctx, guardian.DecisionRequest{

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -12,7 +12,7 @@ This page describes the retained OSS compatibility surface, not every historical
 | --- | --- |
 | Go kernel and CLI | Supported |
 | OpenAI-compatible proxy | Supported |
-| MCP server and bundle generation | Supported |
+| MCP server, OAuth resource/scope enforcement, and bundle generation | Supported |
 | Evidence export and offline verification | Supported |
 | Go SDK | Supported |
 | Python SDK | Supported |
@@ -46,3 +46,7 @@ The retained CI verifies:
 ## Deployment Surface
 
 The repository keeps a Helm chart under `deploy/helm-chart/` for Kubernetes-based deployment. Interactive clients, static viewers, Node CLI wrappers, and generated browser-rendered reports are outside the retained OSS compatibility surface.
+
+## MCP 2026 Radar Notes
+
+The original Linear radar item pointed at `https://modelcontextprotocol.io/roadmap`; as of April 30, 2026 that URL returns a 404 and the current source is [MCP Roadmap](https://modelcontextprotocol.io/development/roadmap). The current roadmap frames enterprise-managed auth, gateway/proxy authorization propagation, and finer-grained least-privilege scopes as active enterprise/security directions, while RFC 8707 remains the normative OAuth source for resource indicators. HELM OSS implements this as an additive auth and metadata layer; protocol versions and existing tool schemas remain backward compatible.

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -14,6 +14,24 @@ helm serve --policy ./release.high_risk.v3.toml
 ./bin/helm mcp serve
 ```
 
+## OAuth Resource and Scope Enforcement
+
+`./bin/helm mcp serve --auth oauth` supports production JWKS validation and the dev-only `HELM_OAUTH_BEARER_TOKEN` fallback. Production mode validates issuer, audience, expiration, issued-at, configured global scopes, and the MCP resource indicator before forwarding the request to the gateway.
+
+Configure production OAuth with:
+
+| Variable | Purpose |
+| --- | --- |
+| `HELM_OAUTH_JWKS_URL` | JWKS endpoint used to verify bearer-token signatures |
+| `HELM_OAUTH_ISSUER` | Required `iss` claim |
+| `HELM_OAUTH_AUDIENCE` | Required `aud` claim |
+| `HELM_OAUTH_RESOURCE` | Required RFC 8707 resource indicator; defaults to `<base-url>/mcp` |
+| `HELM_OAUTH_SCOPES` | Comma- or space-separated scopes required before gateway entry |
+
+Tool definitions may also declare `required_scopes`. These are surfaced to MCP clients as `requiredScopes` in `tools/list` and are enforced again at execution time for both `/mcp/v1/execute` and JSON-RPC `tools/call`. A missing per-tool scope returns `MCP.OAUTH.INSUFFICIENT_SCOPE` on the REST surface or a JSON-RPC application error on the streamable MCP surface.
+
+The resource check follows [RFC 8707](https://datatracker.ietf.org/doc/html/rfc8707): the MCP gateway treats the token audience plus `resource` / `resources` token members as accepted resource indicators and rejects tokens that are not minted for this MCP endpoint.
+
 ## Build a Bundle
 
 ```bash

--- a/docs/INTEGRATIONS/microsoft_agent_governance_toolkit.md
+++ b/docs/INTEGRATIONS/microsoft_agent_governance_toolkit.md
@@ -56,7 +56,8 @@ For OpenAI-compatible stacks, prefer routing through the HELM proxy base URL whe
 
 This is compatibility coverage, not Microsoft certification. The helpers do not import AGT packages, do not modify AGT policies, and do not validate AGT evidence files. They give HELM a typed bridge for the same framework families so AGT and HELM can coexist without duplicating framework-specific glue in every customer project.
 
-Primary sources verified on 2026-04-29:
+Primary sources verified on 2026-04-30:
 
 - Microsoft Open Source Blog: <https://opensource.microsoft.com/blog/2026/04/02/introducing-the-agent-governance-toolkit-open-source-runtime-security-for-ai-agents/>
 - Microsoft AGT repository: <https://github.com/microsoft/agent-governance-toolkit>
+- Microsoft AGT releases: <https://github.com/microsoft/agent-governance-toolkit/releases>

--- a/docs/compliance/eu-ai-act-high-risk-pack.md
+++ b/docs/compliance/eu-ai-act-high-risk-pack.md
@@ -1,0 +1,33 @@
+---
+title: EU AI Act High-Risk Pack
+---
+
+# EU AI Act High-Risk Pack
+
+The HELM OSS EU AI Act reference pack is `reference_packs/eu_ai_act_high_risk.v1.json`.
+
+## Source Status
+
+Primary source verified on April 30, 2026: the European Commission AI Act Service Desk timeline says the majority of AI Act rules start applying on August 2, 2026, including Annex III high-risk AI system rules, Article 50 transparency rules, innovation-support measures, and national/EU-level enforcement.
+
+The same source notes that high-risk AI embedded in regulated products applies on August 2, 2027. The reference pack therefore distinguishes:
+
+- `high_risk_full`: `2026-08-02`
+- `high_risk_annex_i`: `2027-08-02`
+
+## Pack Coverage
+
+The pack maps HELM evidence requirements and policy rules to:
+
+- Article 9 risk management;
+- Article 11 technical documentation;
+- Article 13 transparency;
+- Article 14 human oversight;
+- Annex III high-risk deployment areas.
+
+The April 2026 MCP update also records two evidence requirements relevant to high-risk agent deployments:
+
+- `oauth_resource_binding`: bearer tokens used at the MCP gateway are checked against the intended resource indicator;
+- `tool_scope_enforcement`: per-tool scopes can be exposed in MCP metadata and enforced before execution.
+
+These requirements complement, but do not replace, receipt signing, ProofGraph verification, AI-BOM availability, conformity-assessment evidence, and QTSP timestamp anchoring.

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ This documentation set covers only the retained OSS surface of the repository.
 
 ## Compliance
 
+- [EU AI Act High-Risk Pack](compliance/eu-ai-act-high-risk-pack.md)
 - [NIST AI Agent Critical Infrastructure Alignment](compliance/nist-ai-agent-critical-infrastructure.md)
 - [NIST AI RMF to ISO 42001 Crosswalk](compliance/nist-ai-rmf-iso-42001-crosswalk.md)
 
@@ -34,3 +35,5 @@ This documentation set covers only the retained OSS surface of the repository.
 - [OpenAI-Compatible Proxy](INTEGRATIONS/openai_baseurl.md)
 - [MCP Surface](INTEGRATIONS/mcp.md)
 - [Microsoft Agent Governance Toolkit Coexistence](INTEGRATIONS/microsoft_agent_governance_toolkit.md)
+- [MCP Governance Competitive Radar](strategy/mcp-governance-competitive-radar-2026-04.md)
+- [Policy Research Watchlist](strategy/policy-research-watchlist-2026-04.md)

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -114,6 +114,20 @@
       "docs_origin_hint": "docs.mindburn.org"
     },
     {
+      "slug": "helm-oss/strategy/mcp-governance-competitive-radar-2026-04",
+      "title": "MCP Governance Competitive Radar - April 2026",
+      "section": "strategy",
+      "source_path": "docs/strategy/mcp-governance-competitive-radar-2026-04.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/strategy/policy-research-watchlist-2026-04",
+      "title": "Policy Research Watchlist - April 2026",
+      "section": "strategy",
+      "source_path": "docs/strategy/policy-research-watchlist-2026-04.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
       "slug": "helm-oss/security/owasp-agentic-top10-mapping",
       "title": "OWASP Agentic Top 10 Mapping",
       "section": "security",
@@ -121,10 +135,24 @@
       "docs_origin_hint": "docs.mindburn.org"
     },
     {
+      "slug": "helm-oss/security/prompt-injection-watchlist-2026-04",
+      "title": "Prompt Injection Watchlist - April 2026",
+      "section": "security",
+      "source_path": "docs/security/prompt-injection-watchlist-2026-04.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
       "slug": "helm-oss/compliance/nist-ai-agent-critical-infrastructure",
       "title": "NIST AI Agent Critical Infrastructure Alignment",
       "section": "compliance",
       "source_path": "docs/compliance/nist-ai-agent-critical-infrastructure.md",
+      "docs_origin_hint": "docs.mindburn.org"
+    },
+    {
+      "slug": "helm-oss/compliance/eu-ai-act-high-risk-pack",
+      "title": "EU AI Act High-Risk Pack",
+      "section": "compliance",
+      "source_path": "docs/compliance/eu-ai-act-high-risk-pack.md",
       "docs_origin_hint": "docs.mindburn.org"
     },
     {

--- a/docs/security/prompt-injection-watchlist-2026-04.md
+++ b/docs/security/prompt-injection-watchlist-2026-04.md
@@ -1,0 +1,29 @@
+---
+title: Prompt Injection Watchlist - April 2026
+---
+
+# Prompt Injection Watchlist - April 2026
+
+This note records the source verification and implementation decision for the April 2026 HOSS radar items on upstream prompt-injection defenses. It is not a production commitment; HELM remains the deterministic downstream execution boundary.
+
+## Source Verification
+
+| Linear | Source | Verification | Decision |
+| --- | --- | --- | --- |
+| `MIN-237` | [AgentWatcher: A Rule-based Prompt Injection Monitor](https://arxiv.org/abs/2604.01194v1) | arXiv record exists, submitted April 1, 2026; title and authors match the radar text | Keep as watchlist/prototype material |
+| `MIN-238` | [ICON: Indirect Prompt Injection Defense for Agents based on Inference-Time Correction](https://arxiv.org/abs/2602.20708v1) | arXiv record exists, submitted February 24, 2026; title and authors match the radar text | Keep as watchlist/prototype material |
+
+## HELM Mapping
+
+AgentWatcher is useful to evaluate because its rule-oriented framing can provide an explainable pre-filter before requests reach Guardian. A production implementation should live behind a policy toggle and emit evidence about which rule, source segment, and confidence threshold caused a short-circuit.
+
+ICON is an inference-time defense. It is complementary to HELM, not a replacement for HELM: the model-layer probe may reduce compromised plans before they are proposed, while HELM still governs the downstream action boundary with policy, effect, delegation, and receipt evidence.
+
+## No-Go Criteria
+
+Do not merge either approach into the default path until:
+
+- the implementation can run deterministically or preserve a deterministic evidence envelope around model-assisted decisions;
+- benchmark fixtures show the false-positive impact on benign tool-use workflows;
+- policy authors can disable the pre-filter without weakening HELM's existing Guardian gate;
+- emitted evidence can be replayed or independently inspected during incident review.

--- a/docs/strategy/mcp-governance-competitive-radar-2026-04.md
+++ b/docs/strategy/mcp-governance-competitive-radar-2026-04.md
@@ -1,0 +1,34 @@
+---
+title: MCP Governance Competitive Radar - April 2026
+---
+
+# MCP Governance Competitive Radar - April 2026
+
+This page records the April 2026 competitive scan for HELM OSS MCP governance. It distinguishes verified product signals from HELM's retained OSS differentiation.
+
+## Source Matrix
+
+| Linear | Source | Verification | HELM response |
+| --- | --- | --- | --- |
+| `MIN-204` | [Microsoft Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) | Repository exists under `microsoft`; public docs position AGT around runtime policy, identity, sandboxing, and OWASP Agentic coverage | Keep AGT as coexistence surface; HELM remains the receipt-bearing boundary and evidence-pack exporter |
+| `MIN-211` | [SurePath AI MCP Policy Controls](https://www.prnewswire.com/news-releases/surepath-ai-advances-real-time-model-context-protocol-mcp-policy-controls-to-govern-ai-actions-302709875.html) | Company release dated March 12, 2026 describes real-time MCP server/tool controls before execution | Emphasize HELM's local-first kernel, ProofGraph, and offline evidence verification |
+| `MIN-251` | [Invariant Gateway Guardrails](https://explorer.invariantlabs.ai/docs/guardrails/gateway/) | Official docs describe an LLM and MCP proxy that evaluates guardrails before and after requests | Position HELM as deterministic execution governance rather than content guardrail proxying |
+| `MIN-228` | [PolicyLayer Intercept](https://policylayer.com/docs/reference/policy-controls) | Official docs describe an open-source MCP proxy with fail-closed policy evaluation and JSONL audit logs | Keep fail-closed MCP behavior, but differentiate with signed receipts, ProofGraph, reference packs, and artifact verification |
+| `MIN-270` | [asqav SDK](https://pypi.org/project/asqav/) and [NIST FIPS 204](https://csrc.nist.gov/pubs/fips/204/final) | PyPI package describes ML-DSA signed action records; NIST FIPS 204 is the ML-DSA standard | Do not add a dependency; describe HELM's current signatures as classical and leave ML-DSA/PQC as optional roadmap work |
+| `MIN-218` | [Anthropic code execution tool](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/code-execution-tool) | Public Anthropic docs verify sandboxed API code execution and workspace scoping; no primary Anthropic page for "Claude Managed Agents GA" was found in this pass | Treat as adjacent positioning only; do not claim Managed Agents parity without a primary source |
+| `MIN-215` | [Agentic AI Foundation events program](https://events.linuxfoundation.org/2026/04/17/agentic-ai-foundation-announces-global-2026-events-program-anchored-by-agntcon-mcpcon-north-america-and-europe/) and [MCP roadmap](https://modelcontextprotocol.io/development/roadmap) | Linux Foundation event source verifies AAIF/MCPCon activity; MCP roadmap records Working Groups, SEPs, contributor ladder, and enterprise authorization priorities | Track SEPs and WG output; publish compatibility notes only when a stable spec or extension lands |
+
+## HELM OSS Position
+
+HELM OSS should avoid a "proxy-only" story. The competitive field increasingly validates MCP interception, fail-closed policy, tool-level controls, and structured audit events. HELM's retained wedge is the combination of:
+
+- deterministic pre-action governance at the execution boundary;
+- signed receipts and ProofGraph evidence rather than log-only audit trails;
+- offline evidence-pack verification and reference-pack alignment for regulated deployments;
+- provider-neutral deployment that can sit below framework-local or vendor-managed controls;
+- additive MCP OAuth resource and per-tool scope enforcement.
+
+## No-Dependency Decisions
+
+No competitor SDK is imported into HELM OSS from this scan. The verified response is documentation plus the first-party MCP OAuth resource/scope implementation. PQC/ML-DSA remains a roadmap option because adopting it would change key-management, release-signing, and verification policy across the evidence stack.
+

--- a/docs/strategy/policy-research-watchlist-2026-04.md
+++ b/docs/strategy/policy-research-watchlist-2026-04.md
@@ -1,0 +1,32 @@
+---
+title: Policy Research Watchlist - April 2026
+---
+
+# Policy Research Watchlist - April 2026
+
+This page records source verification and implementation decisions for April 2026 HELM OSS research radar items. Research items close when the source is verified and a clear adopt, watch, or no-go decision is recorded.
+
+## Verified Sources
+
+| Linear | Source | Verification | Decision |
+| --- | --- | --- | --- |
+| `MIN-195` | [AgentSpec: Customizable Runtime Enforcement for Safe and Reliable LLM Agents](https://arxiv.org/abs/2503.18666) | arXiv record exists; paper was submitted March 24, 2025 and later revised; accepted by ICSE 2026 per arXiv metadata | Watch for policy-authoring UX patterns; do not introduce a second DSL into HELM OSS |
+| `MIN-196` | [Zero-Knowledge Audit for Internet of Agents](https://arxiv.org/abs/2512.14737) and [Engineering Trustworthy MLOps with ZK Proofs](https://arxiv.org/abs/2505.20136) | Both arXiv records exist and align with privacy-preserving verification / ZK ML operations | Keep `core/pkg/zkgov` as the exploration surface; no default ZK proof requirement for evidence packs yet |
+| `MIN-199` | [Runtime Governance for AI Agents: Policies on Paths](https://arxiv.org/html/2603.16586v1) | arXiv HTML exists; paper frames policies as deterministic functions over execution paths and organizational state | Map to HELM session history, ProofGraph, and policy composition; no new formal language in this cycle |
+| `MIN-264` | [Before the Tool Call: Deterministic Pre-Action Authorization for Autonomous AI Agents](https://arxiv.org/abs/2603.20953) | arXiv record exists; source describes Open Agent Passport and pre-action authorization | HELM already implements the reference-monitor pattern; document as compatibility/positioning, not a new runtime dependency |
+| `MIN-273` | [OpenPort Protocol](https://arxiv.org/abs/2602.20196) | arXiv record exists; source describes authorization-dependent discovery, reason codes, scoped permissions, and fail-closed behavior | Track MAPL/grammar ideas; prefer compatibility notes and negative tests before schema changes |
+| `MIN-274` | [An AI Agent Execution Environment to Safeguard User Data](https://arxiv.org/abs/2604.19657) | arXiv record exists; source describes GAAP and deterministic confidentiality enforcement for private user data | Explore confidentiality-preserving evidence envelopes; no default private-data runtime added |
+| `MIN-279` | [SafePred](https://arxiv.org/abs/2602.01725) | arXiv record exists; source describes predictive guardrails for computer-using agents via world models | Prototype only behind explicit policy flags; no model-dependent guardrail in the default path |
+| `MIN-237` | [AgentWatcher](https://arxiv.org/abs/2604.01194v1) | arXiv record exists; source describes rule-based prompt-injection monitoring | See `docs/security/prompt-injection-watchlist-2026-04.md` |
+| `MIN-238` | [ICON](https://arxiv.org/abs/2602.20708v1) | arXiv record exists; source describes inference-time indirect prompt-injection correction | See `docs/security/prompt-injection-watchlist-2026-04.md` |
+
+## Adoption Criteria
+
+Move a watchlist item into implementation only when it satisfies all of these:
+
+- it preserves HELM's deterministic evidence model or wraps model-assisted decisions in replayable evidence;
+- it can be gated by policy without weakening current Guardian decisions;
+- it has local fixtures or negative tests that fail before implementation and pass after;
+- it does not require paid external services for default verification;
+- it clarifies rather than dilutes the OSS kernel boundary.
+

--- a/reference_packs/eu_ai_act_high_risk.v1.json
+++ b/reference_packs/eu_ai_act_high_risk.v1.json
@@ -78,6 +78,8 @@
     "evidence_pack_retention_days": 3650,
     "audit_chain_verification": true,
     "aibom_required": true,
+    "oauth_resource_binding": true,
+    "tool_scope_enforcement": true,
     "conformity_assessment": true,
     "qtsp_required": true,
     "qtsp_anchor_type": "RFC3161_EIDAS",


### PR DESCRIPTION
## Summary
- preserve discovered linear-hoss worktree changes before directory cleanup
- add MCP OAuth/resource handling updates, MCP protocol coverage, EU AI Act docs, and strategy/security watchlists

## Validation
- git diff --check
- secret-pattern scan of the preserved diff (only documentation variable names matched)