### PR TITLE
fix: correct openssf scorecard badge repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HELM
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Mindburn-Labs/helm-oss/badge)](https://scorecard.dev/viewer/?uri=github.com/Mindburn-Labs/helm-oss)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mindburn-labs/helm-oss/badge)](https://scorecard.dev/viewer/?uri=github.com/mindburn-labs/helm-oss)
 [![OpenSSF Best Practices](https://img.shields.io/badge/OpenSSF-Best%20Practices-informational)](BEST_PRACTICES.md)
 [![Release checksums](https://img.shields.io/badge/release-checksums-success)](docs/VERIFICATION.md)
 [![SLSA Level 3](https://img.shields.io/badge/SLSA-Level%203-blue)](docs/PUBLISHING.md)


### PR DESCRIPTION
Uses lowercase mindburn-labs in the OpenSSF Scorecard badge URL to fix the invalid repo path error.