### PR TITLE
ci: fetch main for tag release proto checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           version: "34.1"
       - uses: bufbuild/buf-setup-action@v1
+      - name: Fetch main ref for proto compatibility checks
+        run: git fetch origin main:refs/heads/main
       - name: Install codegen tools
         run: |
           python -m pip install --require-hashes -r .github/codegen-requirements.txt


### PR DESCRIPTION
## Summary\n- Fetches a local main ref during tag-triggered Release validation.\n- Fixes buf breaking in detached tag checkouts where .git#branch=main was unavailable.\n\n## Validation\n- make proto-breaking\n- Release failure confirmed on v0.5.0 was due to missing local main ref in tag checkout.