### PR TITLE
ci: fix release image and benchmark pinning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: mindburn-labs/helm-oss
 
 jobs:
   validate:

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ artifacts/*
 !artifacts/golden/
 !artifacts/golden/**
 reports/
+benchmarks/results/latest.json
 
 # ─── Temporary and logs ──────────────────────────────────────────────────────
 tmp/

--- a/core/benchmarks/hotpath_bench_test.go
+++ b/core/benchmarks/hotpath_bench_test.go
@@ -630,8 +630,9 @@ func TestOverheadReport(t *testing.T) {
 
 	reportJSON, _ := json.MarshalIndent(report, "", "  ")
 
-	// Write to benchmarks/results/
-	outDir := filepath.Join("..", "benchmarks", "results")
+	// go test runs this package from core/benchmarks, so walk back to the
+	// repository root before writing the generated benchmark report.
+	outDir := filepath.Join("..", "..", "benchmarks", "results")
 	_ = os.MkdirAll(outDir, 0750)
 	outPath := filepath.Join(outDir, "latest.json")
 	if err := os.WriteFile(outPath, reportJSON, 0644); err != nil {


### PR DESCRIPTION
## Summary\n- use lowercase GHCR image path for release container publishing\n- write generated benchmark reports to the root benchmarks/results path expected by release pinning\n- ignore generated latest benchmark report while keeping per-release snapshots pinnable\n\n## Validation\n- make bench-report\n- bash scripts/release/pin_benchmarks.sh v0.5.0