### PR TITLE
ci: ignore generated benchmark reports in docs coverage

### DIFF
--- a/scripts/check_documentation_coverage.py
+++ b/scripts/check_documentation_coverage.py
@@ -18,7 +18,7 @@ REQUIRED_COLUMNS = [
     'diataxis_type', 'owner_status', 'verification_command', 'gap_status', 'reviewer_notes'
 ]
 NON_DOC_STATUSES = {'not_applicable', 'known_gap', 'generated', 'external', 'mirror'}
-GENERATED_PREFIXES = ('artifacts/conformance',)
+GENERATED_PREFIXES = ('artifacts/conformance', 'benchmarks/results')
 
 
 def is_excluded(path: Path) -> bool:


### PR DESCRIPTION
## Summary\n- exclude generated benchmarks/results from docs coverage discovery\n- fixes release validation order where benchmark-report runs before release-readiness\n\n## Validation\n- rm -rf benchmarks/results && make bench-report >/dev/null && make docs-coverage docs-truth\n- rm -rf benchmarks/results && make bench-report >/dev/null && make release-readiness