### PR TITLE
ci: build console assets before release image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,11 @@ jobs:
       slim-digest: ${{ steps.push-slim.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Build console assets for main image
+        run: make build-console
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
## Summary
- Build the OSS console dist in the release container job before Docker Buildx runs.
- Fixes the v0.5.0 release failure where Dockerfile copied apps/console/dist but the fresh job had not generated it.

## Validation
- make build-console
- docker build -f Dockerfile -t helm-oss:release-main-smoke .