### PR TITLE
ci: use multiarch alpine base for slim image

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -12,7 +12,7 @@ RUN --mount=type=cache,id=helm-oss-go-mod,target=/go/pkg/mod --mount=type=cache,
     cd core && CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -o /helm ./cmd/helm/
 
 # Stage 2: Minimal runtime
-FROM alpine:3.21@sha256:f27cad9117495d32d067133afff942cb2dc745dfe9163e949f6bfe8a6a245339
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 RUN apk add --no-cache ca-certificates tzdata && \
     adduser -D -h /home/helm helm
 COPY --from=builder /helm /usr/local/bin/helm


### PR DESCRIPTION
## Summary
- Replace the slim image Alpine platform-specific digest with the multi-arch manifest digest for alpine:3.21.
- Fixes the v0.5.0 release slim image failure where arm64 used an amd64-only base and failed under QEMU with Invalid ELF image.

## Validation
- docker buildx imagetools inspect alpine:3.21
- docker buildx build --platform linux/amd64,linux/arm64 -f Dockerfile.slim --output type=cacheonly .