### PR TITLE
ci: authenticate cosign container signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,11 @@ jobs:
       packages: write
       id-token: write
     steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: sigstore/cosign-installer@v3
       - name: Sign main image keyless
         env:


### PR DESCRIPTION
## Summary
- Log in to GHCR before keyless cosign signing of release container images.
- Fixes the v0.5.0 release failure where cosign could obtain OIDC credentials but could not pull the private/protected GHCR image reference for signing.

## Validation
- Previous release run confirmed main and slim images build/push successfully.
- Failure log showed GHCR token request returned UNAUTHORIZED during cosign sign.
- This patch supplies the workflow GITHUB_TOKEN to docker/login-action before cosign.