### PR TITLE
docs: publish v0.5.0 release state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This scheme maps the main sections of HELM OSS Changelog in reading order.
 flowchart LR
   Page["HELM OSS Changelog"]
   A["[Unreleased]"]
-  B["[0.5.0] - 2026-05-12"]
+  B["[0.5.0] - 2026-05-13"]
   C["[0.4.0] - 2026-04-25"]
   D["Validation"]
   Page --> A
@@ -52,7 +52,10 @@ All notable changes to the retained HELM OSS surface are documented here. Public
 
 ## [Unreleased]
 
-## [0.5.0] - 2026-05-12
+## [0.5.0] - 2026-05-13
+
+Published at <https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.5.0>
+on 2026-05-13T09:15:00Z.
 
 - Bumped source, CLI fallback, OpenAPI, SDK package manifests, generated SDK
   version comments, Helm chart metadata, and Console visible version to

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ Agent proposal -> HELM boundary -> ALLOW / DENY / ESCALATE -> signed receipt
 
 - Repository: `Mindburn-Labs/helm-oss`
 - Root package identity: `helm-oss-root`
-- Current public release: `v0.4.0`
+- Current public release: `v0.5.0`
 - License: Apache-2.0
-- Supported security line: `0.4.x`; `0.3.x` is best effort
+- Supported security line: `0.5.x`; `0.4.x` is best effort
 - Canonical docs: <https://helm.docs.mindburn.org/oss>
 
-The current `v0.4.0` GitHub release includes CLI binaries, checksums, SBOM
-JSON, release-attestation metadata, `evidence-pack.tar`, `helm.mcpb`, and
-sample policy material. Future release docs must only claim assets that the
-retained release workflow or the release page actually provides.
+The current `v0.5.0` GitHub release was published on 2026-05-13 at
+<https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.5.0>. It includes
+CLI binaries, checksums, SBOM JSON, OpenVEX, release-attestation metadata,
+Cosign bundles, `evidence-pack.tar`, `helm.mcpb`, `helm.rb`, and sample policy
+material.
 
 ## What HELM OSS Does
 
@@ -215,10 +216,9 @@ Public OSS docs are sourced from this repo and published through
 
 ## Release Verification
 
-For `v0.4.0`, verify downloads with `SHA256SUMS.txt`, `sbom.json`,
-`release-attestation.json` metadata, the platform binary assets, and offline
-`evidence-pack.tar` verification. Cosign bundle verification applies only when
-`*.cosign.bundle` files are attached to a release.
+For `v0.5.0`, verify downloads with `SHA256SUMS.txt`, `sbom.json`,
+`v0.5.0.openvex.json`, `release-attestation.json`, the platform binary assets,
+matching `*.cosign.bundle` files, and offline `evidence-pack.tar` verification.
 
 See [docs/VERIFICATION.md](docs/VERIFICATION.md) and
 [docs/PUBLISHING.md](docs/PUBLISHING.md) for the full release verification path.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Security fixes are expected on the current minor version and, when practical, th
 
 | Version | Supported |
 | --- | --- |
-| `0.5.x` | Yes after `v0.5.0` is published |
+| `0.5.x` | Yes |
 | `0.4.x` | Yes |
 | `0.3.x` | Best effort |
 | Older | No |
@@ -57,14 +57,11 @@ The signing identity is the GitHub Actions workflow itself
 Verification commands and the recovery path are documented in
 [docs/VERIFICATION.md](docs/VERIFICATION.md).
 
-The current public GitHub release, `v0.4.0` published on 2026-04-25, does not
-attach `*.cosign.bundle` or `*.openvex.json` files. For that release, use
-`SHA256SUMS.txt`, `sbom.json`, `release-attestation.json`, offline
-`evidence-pack.tar` verification, and reproducible-build validation.
-
-The `v0.5.0` target release attaches OpenVEX and Cosign bundle material for
-every primary asset. Do not treat that material as public until the non-draft
-GitHub Release exists.
+The current public GitHub release, `v0.5.0` published on 2026-05-13, attaches
+OpenVEX and Cosign bundle material for every primary asset. Verify
+`SHA256SUMS.txt`, `sbom.json`, `v0.5.0.openvex.json`,
+`release-attestation.json`, offline `evidence-pack.tar`, and matching
+`*.cosign.bundle` files.
 
 ## Continuous Fuzzing
 

--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -210,9 +210,9 @@ If the `helm` command on your machine resolves to this HELM OSS binary, use `KUB
 
 ## Release And Conformance Gates
 
-Current public release: `v0.4.0`, published on 2026-04-25 at <https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.4.0>.
+Current public release: `v0.5.0`, published on 2026-05-13 at <https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.5.0>.
 
-The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `release-attestation.json` metadata, `evidence-pack.tar`, `release.high_risk.v3.toml`, `helm.mcpb`, and `helm.rb`. Do not claim Cosign bundle or OpenVEX verification for that release because those files are not attached to `v0.4.0`.
+The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `v0.5.0.openvex.json`, `release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm.mcpb`, `helm.rb`, and matching `*.cosign.bundle` files for each primary asset.
 
 Run conformance and docs gates:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -82,11 +82,11 @@ The retained workflow set under `.github/workflows/` covers:
 - GHCR image publication for `latest`, version tag, and slim tag
 - manual publication workflows for npm, PyPI, crates.io, and Maven-compatible distribution
 
-Current public GitHub release: `v0.4.0`, published on 2026-04-25 at
-<https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.4.0>.
+Current public GitHub release: `v0.5.0`, published on 2026-05-13 at
+<https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.5.0>.
 
 There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
-actual release baseline when auditing deltas.
+actual release baseline when auditing the `v0.5.0` delta.
 
 Its attached assets are:
 
@@ -97,16 +97,18 @@ Its attached assets are:
 - `helm-windows-amd64.exe`
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `release-attestation.json` metadata
+- `v0.5.0.openvex.json`
+- `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`
+- `sample-policy-material.tar`
 - `helm.mcpb`
 - `helm.rb`
+- matching `*.cosign.bundle` files for every primary asset
 
-Target `v0.5.0` assets additionally include `v0.5.0.openvex.json`,
-`sample-policy-material.tar`, and `*.cosign.bundle` files for every primary
-asset, including `SHA256SUMS.txt`. `sample-policy-material.tar` must include
-the sample policy and its referenced EU AI Act high-risk reference pack.
+`sample-policy-material.tar` includes the sample policy and its referenced EU
+AI Act high-risk reference pack. The Homebrew tap is
+`mindburnlabs/homebrew-tap`, and `mindburnlabs/tap/helm` resolves to `0.5.0`.
 
 The retained SDK package manifests are versioned with `VERSION`, but npm,
 PyPI, crates.io, and Maven publication require the corresponding registry
@@ -122,12 +124,9 @@ If a package or channel is not represented in the retained workflow set, it shou
 ## Verification
 
 Every public release must include enough material to verify what was downloaded.
-For `v0.4.0`, use `SHA256SUMS.txt`, `sbom.json`,
-`release-attestation.json` metadata, the platform binary assets, and the offline
-`evidence-pack.tar`.
-
-Cosign bundle verification applies only when `*.cosign.bundle` files are
-attached to the release.
+For `v0.5.0`, use `SHA256SUMS.txt`, `sbom.json`, `v0.5.0.openvex.json`,
+`release-attestation.json`, the platform binary assets, attached
+`*.cosign.bundle` files, and the offline `evidence-pack.tar`.
 
 Verify a downloaded binary blob:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -149,7 +149,7 @@ curl 'http://127.0.0.1:7714/api/v1/receipts?limit=20'
 ./bin/helm verify evidence-pack.tar --json
 ```
 
-Use the `v0.4.0` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
+Use the `v0.5.0` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
 
 ## 7. Validate The Checkout
 

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -33,11 +33,13 @@ flowchart LR
   optional --> verify
 ```
 
-Current public release: `v0.4.0`, published on 2026-04-25 at
-<https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.4.0>. The release
+Current public release: `v0.5.0`, published on 2026-05-13 at
+<https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.5.0>. The release
 assets visible on GitHub are Darwin/Linux/Windows binaries, `SHA256SUMS.txt`,
-`sbom.json`, `release-attestation.json` metadata, `evidence-pack.tar`,
-`release.high_risk.v3.toml`, `helm.mcpb`, and `helm.rb`.
+`sbom.json`, `v0.5.0.openvex.json`, `release-attestation.json`,
+`evidence-pack.tar`, `release.high_risk.v3.toml`,
+`sample-policy-material.tar`, `helm.mcpb`, `helm.rb`, and matching
+`*.cosign.bundle` files for each primary asset.
 
 ## Public Release Material
 
@@ -67,14 +69,10 @@ downloaded from a release page. Verify checksums, release metadata,
 receipt/evidence material, reproducible-build behavior, and signatures when
 signature bundles are attached.
 
-For `v0.4.0`, the public release does not expose `*.cosign.bundle` or
-`*.openvex.json` assets on GitHub. Use checksum verification, SBOM inspection,
-release metadata inspection, offline EvidencePack verification, and
-reproducible-build validation for that release. Use Cosign/OpenVEX verification
-only for releases that attach those files.
-
-The `v0.5.0` target workflow attaches OpenVEX and Cosign bundle assets for each
-primary release file after `make release-assets` stages the complete asset set.
+For `v0.5.0`, use checksum verification, SBOM inspection, OpenVEX inspection,
+release metadata inspection, offline EvidencePack verification,
+reproducible-build validation, and Cosign verification against the attached
+bundles.
 
 ## Source Truth
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -50,19 +50,19 @@ The verification path is local-first. `helm verify <evidence-pack.tar|dir>`
 performs offline checks by default; `--online` is optional and only runs after
 offline checks pass.
 
-Current public release: `v0.4.0`, published on 2026-04-25 at
-<https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.4.0>. The release
+Current public release: `v0.5.0`, published on 2026-05-13 at
+<https://github.com/Mindburn-Labs/helm-oss/releases/tag/v0.5.0>. The release
 page attaches platform binaries, `SHA256SUMS.txt`, `sbom.json`,
-`release-attestation.json` metadata, `evidence-pack.tar`, `release.high_risk.v3.toml`,
-`helm.mcpb`, and `helm.rb`.
+`v0.5.0.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
+`release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm.mcpb`,
+`helm.rb`, and matching `*.cosign.bundle` files for each primary asset.
 
-There is no public GitHub Release object for `v0.4.1`; treat `v0.4.0` as the
-actual public baseline until `v0.5.0` is published.
+There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
+actual baseline when auditing the `v0.5.0` delta.
 
-## v0.5.0 Target Asset Contract
+## v0.5.0 Asset Contract
 
-The `v0.5.0` release workflow stages all primary assets under
-`dist/release-assets/` before upload:
+The `v0.5.0` release attaches these primary assets:
 
 - `helm-darwin-amd64`
 - `helm-darwin-arm64`
@@ -175,13 +175,12 @@ Verify the bundled offline evidence pack:
 helm verify evidence-pack.tar
 ```
 
-For `v0.5.0`, this command must pass without network access. The verifier
+For `v0.5.0`, this command passes without network access. The verifier
 accepts both the legacy `receipts/` layout and the canonical
 `02_PROOFGRAPH/receipts/` layout.
 
-For `v0.4.0`, the included EvidencePack verifies offline and reports
-`anchor offline`; online proof anchoring depends on release-specific public
-proof metadata and credentials.
+For `v0.4.0`, the included EvidencePack also verifies offline and reports
+`anchor offline`, but that release does not attach OpenVEX or Cosign bundles.
 
 ## Cosign Artifact Verification When Bundles Are Attached
 

--- a/docs/governance/cncf-application.md
+++ b/docs/governance/cncf-application.md
@@ -132,10 +132,9 @@ Conduct is the Contributor Covenant 2.1, with reports routed to
 Security policy is in `SECURITY.md`. Vulnerability reports go to
 `security@mindburn.org`. Releases are built reproducibly (verified by the
 `reproducibility-check` job in `.github/workflows/release.yml`) and shipped with
-checksums, SBOM material, and release attestation. Cosign bundle and OpenVEX
-verification apply when those files are attached to the GitHub release; the
-current public `v0.4.0` release published on 2026-04-25 does not attach
-`*.cosign.bundle` or `*.openvex.json` assets. Continuous fuzzing is configured
+checksums, SBOM material, and release attestation. The current public
+`v0.5.0` release published on 2026-05-13 attaches Cosign bundle and OpenVEX
+assets for release verification. Continuous fuzzing is configured
 for upstream OSS-Fuzz under `oss-fuzz/`. The OpenSSF Scorecard runs weekly via
 `.github/workflows/scorecard.yml`. The OpenSSF Best Practices gold-tier mapping
 is in `BEST_PRACTICES.md`.

--- a/release/README.md
+++ b/release/README.md
@@ -12,14 +12,12 @@ files. It is not a complete copy of any GitHub release.
 
 ## Current Public Release
 
-The current public GitHub release is `v0.4.0`, published on 2026-04-25. Its
+The current public GitHub release is `v0.5.0`, published on 2026-05-13. Its
 visible release assets are platform binaries for Darwin, Linux, and Windows,
 `helm.mcpb`, `helm.rb`, `SHA256SUMS.txt`, `sbom.json`,
-`release-attestation.json` metadata, `evidence-pack.tar`, and
-`release.high_risk.v3.toml`.
-
-Do not document Cosign bundle or OpenVEX files as attached to `v0.4.0`; they
-were not present in the release asset list.
+`v0.5.0.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
+`release.high_risk.v3.toml`, `sample-policy-material.tar`, and matching
+`*.cosign.bundle` files for every primary asset.
 
 There is no public GitHub Release object for `v0.4.1`; the actual public
 baseline for the `v0.5.0` delta is `v0.4.0`.
@@ -27,7 +25,8 @@ baseline for the `v0.5.0` delta is `v0.4.0`.
 ## v0.5.0 Asset Contract
 
 `make release-assets` stages the `v0.5.0` asset set under
-`dist/release-assets/`:
+`dist/release-assets/`, and the release workflow attached that set to the
+GitHub release:
 
 - five CLI binaries
 - `SHA256SUMS.txt`


### PR DESCRIPTION
## Summary
- updates README and release/security docs from the v0.4.0 public release state to the published v0.5.0 release
- records the actual v0.5.0 publish date, asset set, OpenVEX/Cosign bundle availability, and Homebrew tap resolution
- keeps the v0.4.0 baseline correction for the missing v0.4.1 release object

## Validation
- make docs-coverage docs-truth
- downloaded v0.5.0 release assets and verified SHA256SUMS.txt
- verified v0.5.0 evidence-pack.tar offline with the published darwin-arm64 binary
- verified representative cosign bundles for release assets
- confirmed helm serve, helm mcp wrap, and helm proxy with local fixtures using the published binary
- updated mindburnlabs/homebrew-tap Formula/helm.rb to v0.5.0 and confirmed Homebrew resolves stable 0.5.0