### PR TITLE
docs: remove stale OSS scope references

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,7 +7,7 @@ HELM adopts the Contributor Covenant Code of Conduct, version 2.1:
 
 Contributors are expected to be respectful, constructive, and precise. Healthy
 technical disagreement is welcome when it stays focused on evidence, tradeoffs,
-and the project scope in `README.md` and `docs/OSS_SCOPE.md`.
+and the project scope in `README.md` and `docs/KERNEL_SCOPE.md`.
 
 ## Unacceptable Behavior
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@ Sandbox eligibility and to scale to a multi-organization maintainer set.
 ## Project Scope
 
 helm-ai-kernel is the open-source kernel for governed AI tool calling. Its public
-surface is documented in `README.md` and bounded by `docs/OSS_SCOPE.md`.
+surface is documented in `README.md` and bounded by `docs/KERNEL_SCOPE.md`.
 Anything outside that scope (hosted control-plane features, commercial
 Studio surfaces, private operational tooling) is governed elsewhere and is
 not in scope for this project's governance.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 HELM's public work is constrained to the OSS kernel, CLI, contracts, SDKs,
 Console, examples, deployment material, and verification artifacts described in
-`README.md` and `docs/OSS_SCOPE.md`.
+`README.md` and `docs/KERNEL_SCOPE.md`.
 
 Near-term open-source readiness work is tracked in
 [`docs/OSS_READINESS_AUDIT.md`](docs/OSS_READINESS_AUDIT.md). The highest

--- a/scripts/check_documentation_truth.py
+++ b/scripts/check_documentation_truth.py
@@ -34,7 +34,7 @@ OSS_CONSOLE_CONTRADICTIONS = (
     'does not present a hosted SaaS control plane, a product UI surface',
 )
 
-OSS_SCOPE_SPEC_ONLY_PATHS = (
+KERNEL_SCOPE_SPEC_ONLY_PATHS = (
     'crypto/hybrid',
     'crypto/zkproof',
     'memory',
@@ -222,12 +222,12 @@ def main() -> int:
             if marker in text:
                 failures.append(f'docs/ARCHITECTURE.md contradicts shipped apps/console with marker {marker!r}')
 
-    oss_scope = ROOT / 'docs' / 'OSS_SCOPE.md'
-    if oss_scope.exists():
-        text = read_text(oss_scope)
-        for rel_path in OSS_SCOPE_SPEC_ONLY_PATHS:
+    kernel_scope = ROOT / 'docs' / 'KERNEL_SCOPE.md'
+    if kernel_scope.exists():
+        text = read_text(kernel_scope)
+        for rel_path in KERNEL_SCOPE_SPEC_ONLY_PATHS:
             if not (ROOT / rel_path).exists() and f'| `{rel_path}/`' in text and '✅ Active' in text:
-                failures.append(f'docs/OSS_SCOPE.md marks missing path {rel_path}/ as active')
+                failures.append(f'docs/KERNEL_SCOPE.md marks missing path {rel_path}/ as active')
 
     sdk_go_mod = ROOT / 'sdk' / 'go' / 'go.mod'
     if sdk_go_mod.exists() and (ROOT / 'sdk' / 'go' / 'gen').exists():


### PR DESCRIPTION
Removes remaining docs and docs-truth references to docs/OSS_SCOPE.md after the canonical kernel scope rename.\n\nLocal checks:\n- git diff --check\n- make docs-coverage docs-truth\n- make verify-boundary