### PR TITLE
docs: update PR scope checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ make quality-pr
 
 ## Checklist
 
-- [ ] The change stays within the OSS scope in `README.md` and `docs/OSS_SCOPE.md`.
+- [ ] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
 - [ ] Public docs, SDKs, schemas, or examples are updated when behavior changes.
 - [ ] Security-sensitive material is not included in the PR.
 - [ ] Breaking public interface changes are called out in `CHANGELOG.md`.


### PR DESCRIPTION
Updates the hidden PR template scope checklist from the removed OSS scope file to the canonical kernel scope file.\n\nLocal checks:\n- git diff --check\n- rg --hidden -n 'OSS_SCOPE|docs/OSS_SCOPE.md' . --glob '!node_modules' --glob '!dist' --glob '!bin' --glob '!coverage' --glob '!.git'