### PR TITLE
fix: honor custom installer directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -89,6 +89,13 @@ fi
 echo -e "  • Installing to ${BOLD}${INSTALL_DIR}${NC}..."
 chmod +x "$DOWNLOAD_PATH"
 
+if [ ! -d "$INSTALL_DIR" ]; then
+    if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+        echo -e "${BLUE}  ℹ️  Sudo required to create install directory.${NC}"
+        sudo mkdir -p "$INSTALL_DIR"
+    fi
+fi
+
 if [ -w "$INSTALL_DIR" ]; then
     mv "$DOWNLOAD_PATH" "$INSTALL_DIR/$BIN_NAME"
 else


### PR DESCRIPTION
## Summary
- create custom INSTALL_DIR values before moving the downloaded helm-ai-kernel binary
- keep sudo fallback for protected install paths

## Validation
- git diff --check
- make build
- cd core && go test ./cmd/helm-ai-kernel -count=1
- make docs-coverage docs-truth
- make helm-chart-smoke
- make launch-release-dry-run
- bash scripts/launch/smoke.sh
- make release-smoke
- INSTALL_DIR=/tmp/helm-ai-kernel-install-smoke-final bash install.sh