### PR TITLE
feat(chart): publish to ghcr.io as OCI artifact, fix tag format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -310,8 +310,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
           version: v3.15.4
       - name: Login to GHCR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,9 +303,32 @@ jobs:
           git commit -m "Update helm-ai-kernel formula to ${GITHUB_REF_NAME}" || exit 0
           git push origin HEAD:main
 
+  chart:
+    runs-on: ubuntu-latest
+    needs: [validate, deployment-smoke, kind-smoke, container, cosign-container]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.15.4
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Package chart
+        run: |
+          mkdir -p dist/chart
+          helm package deploy/helm-chart -d dist/chart
+      - name: Push chart to ghcr.io
+        run: |
+          helm push dist/chart/helm-ai-kernel-*.tgz oci://ghcr.io/mindburn-labs/charts
+
   github-release:
     runs-on: ubuntu-latest
-    needs: [binaries, container, cosign-binaries, cosign-container, reproducibility-check, benchmark-pin, homebrew, deployment-smoke, kind-smoke, release-smoke]
+    needs: [binaries, container, cosign-binaries, cosign-container, reproducibility-check, benchmark-pin, homebrew, chart, deployment-smoke, kind-smoke, release-smoke]
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/deploy/helm-chart/Chart.yaml
+++ b/deploy/helm-chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: helm-ai-kernel
 description: HELM — Fail-closed AI execution firewall with cryptographic governance proofs
 type: application
-version: 0.5.0
-appVersion: "0.5.0"
+version: 0.5.1
+appVersion: "v0.5.0"
 home: https://github.com/Mindburn-Labs/helm-ai-kernel
 sources:
   - https://github.com/Mindburn-Labs/helm-ai-kernel


### PR DESCRIPTION
Adds a chart job to release.yml that packages deploy/helm-chart and pushes
it to oci://ghcr.io/mindburn-labs/charts on every tag, using GITHUB_TOKEN
(write:packages is already granted). The chart job runs after container
and cosign-container, and github-release now depends on chart, so a failed
chart push blocks the release.

Bumps chart version to 0.5.1 and aligns appVersion to "v0.5.0" so the
rendered Deployment matches the actual image tag in ghcr.io. release.yml
publishes containers as github.ref_name, which always carries the leading
"v"; previously a default `helm install` would have failed with
ImagePullBackOff against a non-existent :0.5.0 image.

This enables the ArtifactHub repository at mindburn-labs to discover the
chart automatically once the next tag is pushed.
