### PR TITLE
ci: fix Maven and UI package publishing

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -37,6 +37,10 @@ jobs:
       - name: Build
         working-directory: sdk/java
         run: mvn -q test package
+      - name: Import GPG key
+        env:
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        run: printf '%s' "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
       - name: Publish
         working-directory: sdk/java
         env:
@@ -49,5 +53,4 @@ jobs:
         run: >
           mvn --batch-mode deploy
           --settings ../../scripts/release/maven-settings.xml
-          -DaltDeploymentRepository=central::https://central.sonatype.com/api/v1/publisher/deployments/upload
           -Dgpg.passphrase="$MAVEN_GPG_PASSPHRASE"

--- a/packages/design-system-core/package.json
+++ b/packages/design-system-core/package.json
@@ -4,6 +4,11 @@
   "type": "module",
   "description": "Shared Mindburn UI foundation tokens, primitives, layouts, data, forms, feedback, and inspection components.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mindburn-Labs/helm-ai-kernel.git",
+    "directory": "packages/design-system-core"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -104,6 +104,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.2.1</version>
@@ -136,6 +147,26 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.7</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary
- Add repository metadata required for npm provenance on @mindburn/ui-core
- Switch Java SDK publishing to Sonatype Central Publishing Maven Plugin
- Import the Maven GPG private key before deploy and remove the invalid direct Portal API deployment URL

## Validation
- package JSON parse
- workflow YAML parse
- git diff --check
- mvn -q -f sdk/java/pom.xml -DskipTests -Dgpg.skip=true verify