### PR TITLE
ci: accept encoded Maven GPG keys

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -40,7 +40,17 @@ jobs:
       - name: Import GPG key
         env:
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-        run: printf '%s' "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
+        run: |
+          key_file="$RUNNER_TEMP/maven-gpg-private-key"
+          printf '%s' "$MAVEN_GPG_PRIVATE_KEY" > "$key_file"
+          if gpg --batch --import "$key_file"; then
+            exit 0
+          fi
+          if base64 --decode "$key_file" > "${key_file}.decoded" 2>/dev/null && gpg --batch --import "${key_file}.decoded"; then
+            exit 0
+          fi
+          printf '%b' "$MAVEN_GPG_PRIVATE_KEY" > "${key_file}.escaped"
+          gpg --batch --import "${key_file}.escaped"
       - name: Publish
         working-directory: sdk/java
         env:


### PR DESCRIPTION
## Summary
- Make Maven publish GPG import accept raw armor, base64-encoded key material, or escaped-newline armor
- Keep the publish workflow compatible with the existing maven-central environment secret

## Validation
- workflow YAML parse
- git diff --check