### PR TITLE
fix(kernel,chart): close boundary fail-open, anchor KMS on dataDir, wire build-info ldflags, retire phantom metrics port

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - id: build-meta
+        name: Compute build metadata
+        run: |
+          # Strip the leading "v" from a tag ref so main.version stays semver.
+          ref="${GITHUB_REF_NAME}"
+          if [[ "${ref}" =~ ^v[0-9] ]]; then ref="${ref#v}"; fi
+          {
+            echo "version=${ref}"
+            echo "commit=$(git rev-parse --short=12 HEAD)"
+            echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } >> "${GITHUB_OUTPUT}"
       - id: push
         name: Build and push main image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -220,6 +231,10 @@ jobs:
           provenance: true
           sbom: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILD_VERSION=${{ steps.build-meta.outputs.version }}
+            BUILD_COMMIT=${{ steps.build-meta.outputs.commit }}
+            BUILD_TIME=${{ steps.build-meta.outputs.build_time }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
@@ -233,6 +248,10 @@ jobs:
           provenance: true
           sbom: true
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            BUILD_VERSION=${{ steps.build-meta.outputs.version }}
+            BUILD_COMMIT=${{ steps.build-meta.outputs.commit }}
+            BUILD_TIME=${{ steps.build-meta.outputs.build_time }}
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+# Build metadata injected via ldflags into main.{version,commit,buildTime} and
+# surfaced through GET /version. Defaults stay "unknown" so a bare `docker build`
+# without --build-arg still produces a working binary, just without provenance.
+ARG BUILD_VERSION=unknown
+ARG BUILD_COMMIT=unknown
+ARG BUILD_TIME=unknown
 
 RUN apk add --no-cache git ca-certificates
 RUN mkdir -p /runtime-data
@@ -18,7 +24,9 @@ COPY core/ ./core/
 # Build Kernel CLI
 WORKDIR /src/core
 RUN --mount=type=cache,id=helm-ai-kernel-go-mod,target=/go/pkg/mod --mount=type=cache,id=helm-ai-kernel-go-build,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -o /helm-ai-kernel ./cmd/helm-ai-kernel/
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build \
+      -ldflags="-s -w -X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.buildTime=${BUILD_TIME}" \
+      -o /helm-ai-kernel ./cmd/helm-ai-kernel/
 
 # ── Stage 2: Runtime ───────────────────────────────────
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -2,6 +2,10 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+# Build metadata for /version. See Dockerfile for the full explanation.
+ARG BUILD_VERSION=unknown
+ARG BUILD_COMMIT=unknown
+ARG BUILD_TIME=unknown
 RUN apk add --no-cache git ca-certificates
 RUN mkdir -p /runtime-data
 WORKDIR /src
@@ -9,7 +13,9 @@ COPY core/go.mod core/go.sum ./core/
 RUN --mount=type=cache,id=helm-ai-kernel-go-mod,target=/go/pkg/mod cd core && go mod download
 COPY core/ ./core/
 RUN --mount=type=cache,id=helm-ai-kernel-go-mod,target=/go/pkg/mod --mount=type=cache,id=helm-ai-kernel-go-build,target=/root/.cache/go-build \
-    cd core && CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -o /helm-ai-kernel ./cmd/helm-ai-kernel/
+    cd core && CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build \
+      -ldflags="-s -w -X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.buildTime=${BUILD_TIME}" \
+      -o /helm-ai-kernel ./cmd/helm-ai-kernel/
 
 # Stage 2: Minimal runtime
 FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -3,6 +3,10 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+# Build metadata for /version. See /Dockerfile for the full explanation.
+ARG BUILD_VERSION=unknown
+ARG BUILD_COMMIT=unknown
+ARG BUILD_TIME=unknown
 
 RUN apk add --no-cache git ca-certificates
 
@@ -12,7 +16,9 @@ RUN --mount=type=cache,id=helm-ai-kernel-go-mod,target=/go/pkg/mod go mod downlo
 
 COPY . ./
 RUN --mount=type=cache,id=helm-ai-kernel-go-mod,target=/go/pkg/mod --mount=type=cache,id=helm-ai-kernel-go-build,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build -ldflags="-s -w" -trimpath -o /helm-ai-kernel ./cmd/helm-ai-kernel/
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH:-amd64}" go build \
+      -ldflags="-s -w -X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.buildTime=${BUILD_TIME}" \
+      -trimpath -o /helm-ai-kernel ./cmd/helm-ai-kernel/
 
 # ── Stage 2: Runtime ───────────────────────────────────
 FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1

--- a/core/Dockerfile.api
+++ b/core/Dockerfile.api
@@ -6,6 +6,10 @@
 FROM --platform=$BUILDPLATFORM golang:1.25.10-alpine@sha256:8d22e29d960bc50cd025d93d5b7c7d220b1ee9aa7a239b3c8f55a57e987e8d45 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+# Build metadata for /version. See /Dockerfile for the full explanation.
+ARG BUILD_VERSION=unknown
+ARG BUILD_COMMIT=unknown
+ARG BUILD_TIME=unknown
 
 WORKDIR /app
 
@@ -25,7 +29,9 @@ ENV CGO_ENABLED=0
 ENV GOOS=${TARGETOS:-linux}
 ENV GOARCH=${TARGETARCH:-amd64}
 RUN --mount=type=cache,id=helm-ai-kernel-go-mod,target=/go/pkg/mod --mount=type=cache,id=helm-ai-kernel-go-build,target=/root/.cache/go-build \
-    cd core && go build -ldflags="-s -w" -trimpath -o /app/bin/helm-ai-kernel ./cmd/helm-ai-kernel
+    cd core && go build \
+      -ldflags="-s -w -X main.version=${BUILD_VERSION} -X main.commit=${BUILD_COMMIT} -X main.buildTime=${BUILD_TIME}" \
+      -trimpath -o /app/bin/helm-ai-kernel ./cmd/helm-ai-kernel
 
 # Stage 2: Runtime
 FROM alpine:3.21@sha256:f27cad9117495d32d067133afff942cb2dc745dfe9163e949f6bfe8a6a245339

--- a/core/cmd/helm-ai-kernel/boundary_default_test.go
+++ b/core/cmd/helm-ai-kernel/boundary_default_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary"
+)
+
+// TestDefaultBoundaryPolicyLoads is the regression test for the silent fail-open
+// caused by hardcoding a stale schema version in services.go (was "1.0", the
+// enforcer requires boundary.PolicyVersion exactly). If this test passes, the
+// kernel starts with a non-nil BoundaryEnforcer in dev mode and never reaches
+// the fatal branch in production mode.
+func TestDefaultBoundaryPolicyLoads(t *testing.T) {
+	pol := defaultBoundaryPolicy()
+	if pol.Version != boundary.PolicyVersion {
+		t.Fatalf("default policy version drifted: got %q, want %q", pol.Version, boundary.PolicyVersion)
+	}
+
+	pe, err := boundary.NewPerimeterEnforcer(pol)
+	if err != nil {
+		t.Fatalf("default boundary policy must load cleanly: %v", err)
+	}
+	if pe == nil {
+		t.Fatal("perimeter enforcer is nil even though no error returned")
+	}
+}

--- a/core/cmd/helm-ai-kernel/kms_keystore_path_test.go
+++ b/core/cmd/helm-ai-kernel/kms_keystore_path_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestKMSKeystorePathPrefersExplicitDataDir(t *testing.T) {
+	t.Setenv("HELM_DATA_DIR", "")
+	got := kmsKeystorePath("/var/lib/helm-ai-kernel")
+	want := filepath.Join("/var/lib/helm-ai-kernel", "keys", "credentials.keystore.json")
+	if got != want {
+		t.Fatalf("explicit dataDir not honored: got %q, want %q", got, want)
+	}
+}
+
+func TestKMSKeystorePathFallsBackToEnv(t *testing.T) {
+	t.Setenv("HELM_DATA_DIR", "/data")
+	got := kmsKeystorePath("")
+	want := filepath.Join("/data", "keys", "credentials.keystore.json")
+	if got != want {
+		t.Fatalf("HELM_DATA_DIR fallback ignored: got %q, want %q", got, want)
+	}
+}
+
+func TestKMSKeystorePathFinalFallback(t *testing.T) {
+	t.Setenv("HELM_DATA_DIR", "")
+	got := kmsKeystorePath("")
+	want := filepath.Join("data", "keys", "credentials.keystore.json")
+	if got != want {
+		t.Fatalf("final fallback wrong: got %q, want %q", got, want)
+	}
+}

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -214,8 +214,15 @@ func runServerWithOptions(opts serverOptions) {
 	artRegistry := artifacts.NewRegistry(artStore, verifier)
 
 	// === SUBSYSTEM WIRING ===
-	services, svcErr := NewServices(ctx, db, artStore, logger)
+	services, svcErr := NewServices(ctx, db, artStore, logger, dataDir)
 	if svcErr != nil {
+		// In production we refuse to start in a degraded state. Subsystems are
+		// allowed to fail in dev (e.g. observability without an OTLP endpoint),
+		// but the boundary enforcer and other safety-critical components must
+		// be present whenever HELM_PRODUCTION=1.
+		if envBool("HELM_PRODUCTION") {
+			log.Fatalf("Services init failed in production mode: %v", svcErr)
+		}
 		log.Printf("Services init (non-fatal, degraded mode): %v", svcErr)
 	}
 

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -88,7 +88,12 @@ type Services struct {
 }
 
 // NewServices initializes all subsystems.
-func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logger *slog.Logger) (*Services, error) {
+//
+// dataDir is the runtime data directory (CLI --data-dir / HELM_DATA_DIR).
+// Subsystems that persist state under dataDir (e.g. the KMS keystore) must
+// receive it explicitly instead of resolving relative paths against the
+// container CWD, which on a distroless rootfs is `/` and therefore read-only.
+func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logger *slog.Logger, dataDir string) (*Services, error) {
 	s := &Services{}
 
 	// --- 1. Config ---
@@ -110,7 +115,7 @@ func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logg
 	logger.Info("subsystem ready", "component", " ReBAC Authorization Engine initialized")
 
 	// --- 4. Credentials (CRED-001: KMS-backed key management) ---
-	keystorePath := "data/keys/credentials.keystore.json"
+	keystorePath := kmsKeystorePath(dataDir)
 	keyManager, kmsErr := kms.NewLocalKMS(keystorePath)
 	if kmsErr != nil {
 		logger.Warn("KMS init failed — credentials store DISABLED", "error", kmsErr)
@@ -147,14 +152,19 @@ func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logg
 	logger.Info("subsystem ready", "component", " Sandbox initialized")
 
 	// --- 7. Boundary ---
-	defaultBoundaryPolicy := &boundary.PerimeterPolicy{
-		Version:  "1.0",
-		PolicyID: "default",
-		Name:     "HELM Default Perimeter",
-	}
-	perimEnforcer, err := boundary.NewPerimeterEnforcer(defaultBoundaryPolicy)
+	// The version string must match boundary.PolicyVersion exactly; LoadPolicy
+	// performs a strict equality check. A mismatch leaves BoundaryEnforcer nil,
+	// which causes every CheckNetwork / CheckTool / CheckData to silently pass
+	// (see subsystems.go: the /api/v1/boundary/check route returns
+	// {"status":"disabled"} when the enforcer is nil). In a fail-closed firewall
+	// that is the worst possible default, so production refuses to start when
+	// the default policy fails to load.
+	perimEnforcer, err := boundary.NewPerimeterEnforcer(defaultBoundaryPolicy())
 	if err != nil {
-		logger.Warn("Boundary enforcer init", "error", err)
+		if envBool("HELM_PRODUCTION") {
+			return nil, fmt.Errorf("boundary enforcer init (production): %w", err)
+		}
+		logger.Warn("Boundary enforcer init — running with enforcer DISABLED (dev mode)", "error", err)
 	} else {
 		s.BoundaryEnforcer = perimEnforcer
 	}
@@ -235,6 +245,32 @@ func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logg
 
 	logger.Info("subsystem ready", "component", " All subsystems initialized successfully")
 	return s, nil
+}
+
+// kmsKeystorePath resolves the on-disk location of the KMS keystore. The path
+// is anchored on the runtime data directory (CLI --data-dir, falling back to
+// HELM_DATA_DIR, then "data"), never on the container CWD. On distroless the
+// CWD is `/`, which is read-only — so a relative path would break the KMS init
+// and silently disable the credentials store.
+func kmsKeystorePath(dataDir string) string {
+	if strings.TrimSpace(dataDir) == "" {
+		dataDir = strings.TrimSpace(os.Getenv("HELM_DATA_DIR"))
+	}
+	if strings.TrimSpace(dataDir) == "" {
+		dataDir = "data"
+	}
+	return filepath.Join(dataDir, "keys", "credentials.keystore.json")
+}
+
+// defaultBoundaryPolicy returns the policy template used at startup before any
+// runtime policy bundle is reconciled. Kept as a single source of truth so the
+// schema version stays in lockstep with boundary.PolicyVersion.
+func defaultBoundaryPolicy() *boundary.PerimeterPolicy {
+	return &boundary.PerimeterPolicy{
+		Version:  boundary.PolicyVersion,
+		PolicyID: "default",
+		Name:     "HELM Default Perimeter",
+	}
 }
 
 func defaultBoundaryRegistryPath() string {

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -75,6 +75,8 @@ spec:
               protocol: TCP
             {{- end }}
           env:
+            - name: HELM_DATA_DIR
+              value: {{ .Values.helm.dataDir | quote }}
             - name: HELM_HEALTH_PORT
               value: {{ .Values.service.healthPort | quote }}
             - name: HELM_POLICY_SOURCE_KIND

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -127,9 +127,13 @@ helm:
       # Key in the existing secret that contains the database URL
       existingSecretKey: "DATABASE_URL"
 
-  # Metrics and observability
+  # Metrics and observability.
+  # NOTE: as of chart 0.5.2 the kernel does not yet expose a Prometheus
+  # handler on a separate port, so enabling this just opens an unbound port
+  # in the Service and produces ServiceMonitor scrape failures. Keep this
+  # disabled until the backend lands (tracked as chart-metrics-backend-implementation).
   metrics:
-    enabled: true
+    enabled: false
     serviceMonitor:
       enabled: false
       interval: 30s

--- a/scripts/ci/docker_smoke.sh
+++ b/scripts/ci/docker_smoke.sh
@@ -55,7 +55,20 @@ cleanup() {
         docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
     fi
     if [ "$cleanup_data" = "1" ]; then
-        rm -rf "$DATA_DIR"
+        # The container ran as distroless nonroot (UID 65532) and may have
+        # written files under $DATA_DIR/keys/ with mode 0700 (KMS keystore).
+        # The host user can't traverse that directory, so delegate the
+        # recursive delete to a short-lived root container with the same
+        # mount. Falling through to the host rm afterwards picks up the
+        # now-empty $DATA_DIR plus anything the cleanup container missed.
+        if [ -d "$DATA_DIR" ]; then
+            docker run --rm \
+                --mount "type=bind,source=$DATA_DIR,target=/cleanup" \
+                busybox:1.36.1 \
+                sh -c 'rm -rf /cleanup/..?* /cleanup/.[!.]* /cleanup/* 2>/dev/null || true' \
+                >/dev/null 2>&1 || true
+        fi
+        rm -rf "$DATA_DIR" 2>/dev/null || true
         rmdir "$ROOT/tmp" >/dev/null 2>&1 || true
     fi
 }


### PR DESCRIPTION
## Summary

Four-part fix-stack uncovered during the post-`v0.5.1` smoke pass of the chart from `artifacthub.io`. The same commit also rides on `release/v0.5.2-rebuild` as part of PR #157, but it is presented here on its own branch (off `origin/main`, single commit) so it can be reviewed and merged independently of the v0.5.2 release-prep work.

- **Boundary fail-open (P0)** — `services.go` hardcoded `Version: "1.0"` while `boundary.PolicyVersion` is `"1.0.0"`. `LoadPolicy` does strict equality, so the init returned an error, the kernel logged it as `WARN`, the very next log line falsely claimed the subsystem was `initialized`, and `BoundaryEnforcer` stayed `nil`. With a nil enforcer, every `CheckNetwork` / `CheckTool` / `CheckData` silently passes — a fail-closed firewall that was actually fail-open. Switched to the canonical constant via a new `defaultBoundaryPolicy()` helper, and hardened `main.go` so the kernel refuses to start in `HELM_PRODUCTION=1` when the default policy fails to load (instead of swallowing the error as "degraded mode").
- **KMS keystore on read-only rootfs (P1)** — `NewLocalKMS` was opened against the relative path `"data/keys/credentials.keystore.json"`, which on distroless resolves under the read-only rootfs (CWD=`/`), not under the PVC-mounted dataDir. The init silently disabled the credentials store. Anchored on the same `dataDir` that drives sqlite/signer via a new `kmsKeystorePath()` helper (explicit arg → `HELM_DATA_DIR` env → `"data"`). The chart now also exports `HELM_DATA_DIR` alongside `--data-dir` so any future env-only subsystem stays consistent.
- **Build-info ldflags (P3)** — All four Dockerfiles (`Dockerfile`, `Dockerfile.slim`, `core/Dockerfile`, `core/Dockerfile.api`) shipped with `-ldflags="-s -w"` and never injected `main.version` / `main.commit` / `main.buildTime`, so `GET /version` returned `"unknown"` for everything but the Go runtime. Added `BUILD_VERSION` / `BUILD_COMMIT` / `BUILD_TIME` ARGs and propagated them via `-X`. `release.yml` computes the values in a new `build-meta` step (strips the leading `v` so `main.version` stays semver) and passes them to both `docker/build-push-action` invocations.
- **Phantom metrics port (P2)** — `values.yaml` advertised port `9090` and a `ServiceMonitor` scraping it, but the kernel never registered `metrics.Handler()`. Port-forward to 9090 was always refused. Disabled metrics in defaults (templates were already correctly gated) with a `NOTE` pointing at the follow-up task `chart-metrics-backend-implementation`. The phantom port comes back when the backend lands.

## Test plan

- [x] `go test ./...` — full kernel suite green, including two new regression tests:
  - `core/cmd/helm-ai-kernel/boundary_default_test.go` — locks in the boundary schema version contract.
  - `core/cmd/helm-ai-kernel/kms_keystore_path_test.go` — covers all three resolution branches.
- [x] `helm lint deploy/helm-chart` — clean.
- [x] `helm template deploy/helm-chart` — Service exposes only `http` + `health`; no `metrics` port by default.
- [x] Built `helm-ai-kernel:dev-smoke` from `core/Dockerfile` with `BUILD_VERSION=0.5.2-dev BUILD_COMMIT=346aa5836cb1 BUILD_TIME=2026-05-18T22:19:55Z` and ran the chart in minikube with `helm.production=false`:
  - Pod boots without `KMS init failed — credentials store DISABLED` and without `Boundary enforcer init error="unsupported version: 1.0"`. Subsystems log straight to `Credentials Handler initialized (KMS-backed)` and `Boundary Perimeter Enforcer initialized`.
  - `GET /version` → `{"version":"v0.5.2-dev","commit":"346aa5836cb1","build_time":"2026-05-18T22:19:55Z","go_version":"go1.25.10"}` (real values, not `"unknown"`).
  - `GET /api/v1/boundary/check` → `{"enforcer":"active","status":"ready"}` (was `{"status":"disabled"}` on v0.5.1).
  - `POST /v1/chat/completions` with a real `OPENAI_TOKEN` and `model: gpt-4o-mini` → `403 Governance Blocked / PDP_DENY (ref=helm:helm-chart)`. The token was **not** spent — no upstream call in pod logs. Receipt persisted via `GET /api/v1/receipts` with the existing `lamport_clock` / `prev_hash` chain and ed25519 signature.
- [x] CI workflows (`ci.yml`, `release.yml`) green on this PR.

## Notes for review

- The new fatal-on-production behaviour is gated strictly on `HELM_PRODUCTION=1`. The chart default `helm.production: false` keeps minikube / dev smoke working as before — only production deployments refuse to start when boundary init fails.
- `NewServices` signature now takes `dataDir string` as the final argument. Only one caller in this repo (`main.go::runServerWithOptions`); external embedders, if any, will see a breaking change.
- The phantom-metrics retirement is a values default change, not a hard removal. Operators with `--set helm.metrics.enabled=true` will still get the (unbound) port until the backend lands — kept that way intentionally so the `chart-metrics-backend-implementation` follow-up can flip the default back without further template changes.

## Relationship to PR #157

PR #157 (branch `release/v0.5.2-rebuild`) currently contains both this commit and the release-prep commit `346aa58`. Once this PR merges into `main`, PR #157's diff will reduce to just the release-prep commit — at that point #157 can be merged or this PR can be considered the v0.5.2 contents and #157 closed as merged-into-main.

Tag `v0.5.2` (annotated, already pushed) points at the combined snapshot on `release/v0.5.2-rebuild` and is kept intentionally — the release.yml workflow has already started building artifacts from that tag, and the snapshot is what v0.5.2 will release.
