### PR TITLE
docs: publish v0.5.2 release references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 title: HELM AI Kernel Changelog
-last_reviewed: 2026-05-18
+last_reviewed: 2026-05-19
 ---
 
 # Changelog
@@ -38,20 +38,38 @@ This scheme maps the main sections of HELM AI Kernel Changelog in reading order.
 flowchart LR
   Page["HELM AI Kernel Changelog"]
   A["[Unreleased]"]
-  B["[0.5.1] - 2026-05-18"]
-  C["[0.5.0] - 2026-05-13"]
-  D["[0.4.0] - 2026-04-25"]
-  E["Validation"]
+  B["[0.5.2] - 2026-05-19"]
+  C["[0.5.1] - 2026-05-18"]
+  D["[0.5.0] - 2026-05-13"]
+  E["[0.4.0] - 2026-04-25"]
+  F["Validation"]
   Page --> A
   A --> B
   B --> C
   C --> D
   D --> E
+  E --> F
 ```
 
 All notable changes to the retained HELM AI Kernel surface are documented here. Public entries focus on developer-visible interfaces, compatibility, verification, SDKs, and security-relevant documentation.
 
 ## [Unreleased]
+
+## [0.5.2] - 2026-05-19
+
+Published at <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.2>
+on 2026-05-19T16:13:38Z.
+
+- Fixed default boundary policy initialization so the retained production
+  surface starts fail-closed when default policy material is missing or invalid.
+- Anchored KMS keystore state under the configured runtime data directory and
+  added regression coverage for that path.
+- Wired release build metadata into container builds and disabled the phantom
+  chart metrics port by default.
+- Refreshed Artifact Hub repository metadata and bumped the Helm chart release
+  contract to `0.5.2` / `v0.5.2`.
+- Kept release asset export and verification output visible during staging so
+  failing commands are diagnosable from workflow logs.
 
 ## [0.5.1] - 2026-05-18
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Agent proposal -> HELM boundary -> ALLOW / DENY / ESCALATE -> signed receipt
 
 - Repository: `Mindburn-Labs/helm-ai-kernel`
 - Root package identity: `helm-ai-kernel-root`
-- Current public release: `v0.5.1`
+- Current public release: `v0.5.2`
 - License: Apache-2.0
 - Supported security line: `0.5.x`; `0.4.x` is best effort
 - Canonical docs: <https://helm.docs.mindburn.org/helm-ai-kernel>
 
-The current `v0.5.1` GitHub release was published on 2026-05-18 at
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.1>. It includes
+The current `v0.5.2` GitHub release was published on 2026-05-19 at
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.2>. It includes
 CLI binaries, checksums, SBOM JSON, OpenVEX, release-attestation metadata,
 Cosign bundles, `evidence-pack.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, and sample policy
 material.
@@ -219,8 +219,8 @@ Public OSS docs are sourced from this repo and published through
 
 ## Release Verification
 
-For `v0.5.1`, verify downloads with `SHA256SUMS.txt`, `sbom.json`,
-`v0.5.1.openvex.json`, `release-attestation.json`, the platform binary assets,
+For `v0.5.2`, verify downloads with `SHA256SUMS.txt`, `sbom.json`,
+`v0.5.2.openvex.json`, `release-attestation.json`, the platform binary assets,
 matching `*.cosign.bundle` files, and offline `evidence-pack.tar` verification.
 
 Current release tooling derives artifact versions from tag refs, requires an

--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -1,6 +1,6 @@
 ---
 title: Developer Journey
-last_reviewed: 2026-05-12
+last_reviewed: 2026-05-19
 ---
 
 # Developer Journey
@@ -218,9 +218,9 @@ If the `helm` command on your machine resolves to this HELM AI Kernel binary, us
 
 ## Release And Conformance Gates
 
-Current public release: `v0.5.1`, published on 2026-05-18 at <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.1>.
+Current public release: `v0.5.2`, published on 2026-05-19 at <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.2>.
 
-The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `v0.5.1.openvex.json`, `release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, and matching `*.cosign.bundle` files for each primary asset.
+The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `v0.5.2.openvex.json`, `release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `v0.5.2.json`, and matching `*.cosign.bundle` files for each primary asset.
 
 Run conformance and docs gates:
 

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Deployment
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-19
 ---
 
 # Kubernetes Deployment
@@ -101,7 +101,7 @@ helm upgrade --install helm-ai-kernel deploy/helm-chart \
 | Value | Default | Source-backed behavior |
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/mindburn-labs/helm-ai-kernel` | Container image used by the Deployment. |
-| `image.tag` | chart `appVersion` | Defaults to `0.5.1` from `Chart.yaml`. |
+| `image.tag` | chart `appVersion` | Defaults to `v0.5.2` from `Chart.yaml`. |
 | `helm.bindAddr` | `0.0.0.0` | Required because the pod must bind beyond loopback. |
 | `service.port` | `8080` | Runtime HTTP port passed to `helm-ai-kernel serve --port`. |
 | `service.healthPort` | `8081` | Health probe port via `HELM_HEALTH_PORT`. |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,6 +1,6 @@
 ---
 title: Publishing
-last_reviewed: 2026-05-18
+last_reviewed: 2026-05-19
 ---
 
 # Publishing
@@ -94,8 +94,8 @@ The retained workflow set under `.github/workflows/` covers:
 - GHCR image publication for `latest`, version tag, and slim tag
 - manual publication workflows for npm, PyPI, crates.io, and Maven-compatible distribution
 
-Current public GitHub release: `v0.5.1`, published on 2026-05-18 at
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.1>.
+Current public GitHub release: `v0.5.2`, published on 2026-05-19 at
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.2>.
 
 There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
 actual release baseline when auditing the `v0.5.0` delta.
@@ -109,18 +109,19 @@ Its attached assets are:
 - `helm-ai-kernel-windows-amd64.exe`
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `v0.5.1.openvex.json`
+- `v0.5.2.openvex.json`
 - `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`
 - `sample-policy-material.tar`
 - `helm-ai-kernel.mcpb`
 - `helm-ai-kernel.rb`
+- `v0.5.2.json`
 - matching `*.cosign.bundle` files for every primary asset
 
 `sample-policy-material.tar` includes the sample policy and its referenced EU
 AI Act high-risk reference pack. The Homebrew tap is
-`mindburnlabs/homebrew-tap`, and `mindburnlabs/tap/helm-ai-kernel` resolves to `0.5.1`.
+`mindburnlabs/homebrew-tap`, and `mindburnlabs/tap/helm-ai-kernel` resolves to `0.5.2`.
 
 The retained SDK package manifests are versioned with `VERSION`, but npm,
 PyPI, crates.io, and Maven publication require the corresponding registry
@@ -141,7 +142,7 @@ writes the final `SHA256SUMS.txt`.
 ## Verification
 
 Every public release must include enough material to verify what was downloaded.
-For `v0.5.1`, use `SHA256SUMS.txt`, `sbom.json`, `v0.5.1.openvex.json`,
+For `v0.5.2`, use `SHA256SUMS.txt`, `sbom.json`, `v0.5.2.openvex.json`,
 `release-attestation.json`, the platform binary assets, attached
 `*.cosign.bundle` files, and the offline `evidence-pack.tar`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-last_reviewed: 2026-05-12
+last_reviewed: 2026-05-19
 ---
 
 # Quickstart
@@ -164,7 +164,7 @@ curl 'http://127.0.0.1:7714/api/v1/receipts?limit=20'
 ./bin/helm-ai-kernel verify evidence-pack.tar --json
 ```
 
-Use the `v0.5.1` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
+Use the `v0.5.2` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
 
 ## 7. Validate The Checkout
 

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -1,6 +1,6 @@
 ---
 title: Release and Security Evidence
-last_reviewed: 2026-05-18
+last_reviewed: 2026-05-19
 ---
 
 # HELM AI Kernel Release and Security Evidence
@@ -33,12 +33,13 @@ flowchart LR
   optional --> verify
 ```
 
-Current public release: `v0.5.1`, published on 2026-05-18 at
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.1>. The release
+Current public release: `v0.5.2`, published on 2026-05-19 at
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.2>. The release
 assets visible on GitHub are Darwin/Linux/Windows binaries, `SHA256SUMS.txt`,
-`sbom.json`, `v0.5.1.openvex.json`, `release-attestation.json`,
+`sbom.json`, `v0.5.2.openvex.json`, `release-attestation.json`,
 `evidence-pack.tar`, `release.high_risk.v3.toml`,
-`sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, and matching
+`sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`,
+`v0.5.2.json`, and matching
 `*.cosign.bundle` files for each primary asset.
 
 ## Public Release Material
@@ -75,7 +76,7 @@ EvidencePack, verifies the staged `evidence-pack.tar`, and only then writes
 final checksums. A failed EvidencePack verification blocks release asset
 publication.
 
-For `v0.5.1`, use checksum verification, SBOM inspection, OpenVEX inspection,
+For `v0.5.2`, use checksum verification, SBOM inspection, OpenVEX inspection,
 release metadata inspection, offline EvidencePack verification,
 reproducible-build validation, and Cosign verification against the attached
 bundles.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,6 +1,6 @@
 ---
 title: Verification
-last_reviewed: 2026-05-18
+last_reviewed: 2026-05-19
 ---
 
 # Verification
@@ -57,19 +57,20 @@ The verification path is local-first. `helm-ai-kernel verify <evidence-pack.tar|
 performs offline checks by default; `--online` is optional and only runs after
 offline checks pass.
 
-Current public release: `v0.5.1`, published on 2026-05-18 at
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.1>. The release
+Current public release: `v0.5.2`, published on 2026-05-19 at
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.2>. The release
 page attaches platform binaries, `SHA256SUMS.txt`, `sbom.json`,
-`v0.5.1.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
+`v0.5.2.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
 `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`,
-`helm-ai-kernel.rb`, and matching `*.cosign.bundle` files for each primary asset.
+`helm-ai-kernel.rb`, `v0.5.2.json`, and matching `*.cosign.bundle` files for
+each primary asset.
 
 There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
 actual baseline when auditing the `v0.5.0` delta.
 
-## v0.5.1 Asset Contract
+## v0.5.2 Asset Contract
 
-The `v0.5.1` release attaches these primary assets:
+The `v0.5.2` release attaches these primary assets:
 
 - `helm-ai-kernel-darwin-amd64`
 - `helm-ai-kernel-darwin-arm64`
@@ -78,7 +79,7 @@ The `v0.5.1` release attaches these primary assets:
 - `helm-ai-kernel-windows-amd64.exe`
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `v0.5.1.openvex.json`
+- `v0.5.2.openvex.json`
 - `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`
@@ -191,7 +192,7 @@ The release staging path runs the same offline verification before publishing
 release checksums. If this step fails, the release must be treated as incomplete
 and the exported EvidencePack must be repaired before attaching assets.
 
-For `v0.5.1`, this command passes without network access. The verifier
+For `v0.5.2`, this command passes without network access. The verifier
 accepts both the legacy `receipts/` layout and the canonical
 `02_PROOFGRAPH/receipts/` layout.
 

--- a/docs/governance/cncf-application.md
+++ b/docs/governance/cncf-application.md
@@ -1,6 +1,6 @@
 ---
 title: CNCF Sandbox Application
-last_reviewed: 2026-05-05
+last_reviewed: 2026-05-19
 ---
 
 # helm-ai-kernel CNCF Sandbox Application
@@ -125,7 +125,7 @@ Security policy is in `SECURITY.md`. Vulnerability reports go to
 `security@mindburn.org`. Releases are built reproducibly (verified by the
 `reproducibility-check` job in `.github/workflows/release.yml`) and shipped with
 checksums, SBOM material, and release attestation. The current public
-`v0.5.1` release published on 2026-05-18 attaches Cosign bundle and OpenVEX
+`v0.5.2` release published on 2026-05-19 attaches Cosign bundle and OpenVEX
 assets for release verification. Continuous fuzzing is configured
 for upstream OSS-Fuzz under `oss-fuzz/`. The OpenSSF Scorecard runs weekly via
 `.github/workflows/scorecard.yml`. The OpenSSF Best Practices gold-tier mapping

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -1,6 +1,6 @@
 ---
 title: SDK Index
-last_reviewed: 2026-05-12
+last_reviewed: 2026-05-19
 ---
 
 # SDK Index


### PR DESCRIPTION
## Summary
- mark v0.5.2 as the current public release across README and public docs
- add the v0.5.2 changelog entry and release timestamp
- keep SDK package state documented separately from the GitHub release

## Verification
- make docs-coverage docs-truth
- git diff --check