### PR TITLE
ci: fix Maven Central namespace and signing key publication

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         run: |
+          set -euo pipefail
           key_file="$RUNNER_TEMP/maven-gpg-private-key"
           printf '%s' "$MAVEN_GPG_PRIVATE_KEY" > "$key_file"
           if gpg --batch --import "$key_file"; then
@@ -51,6 +52,34 @@ jobs:
           fi
           printf '%b' "$MAVEN_GPG_PRIVATE_KEY" > "${key_file}.escaped"
           gpg --batch --import "${key_file}.escaped"
+      - name: Publish GPG public key
+        run: |
+          set -euo pipefail
+          fingerprint="$(gpg --batch --list-secret-keys --with-colons | awk -F: '$1 == "fpr" { print $10; exit }')"
+          test -n "$fingerprint"
+          echo "MAVEN_GPG_KEY_FINGERPRINT=$fingerprint" >> "$GITHUB_ENV"
+          gpg --batch --armor --export "$fingerprint" > "$RUNNER_TEMP/maven-public-key.asc"
+
+          sent=0
+          for keyserver in hkps://keyserver.ubuntu.com hkps://keys.openpgp.org hkp://pgp.mit.edu; do
+            if timeout 60s gpg --batch --keyserver "$keyserver" --send-keys "$fingerprint"; then
+              sent=1
+            else
+              echo "::warning::Could not upload Maven public key to $keyserver"
+            fi
+          done
+          test "$sent" = "1"
+
+          verify_home="$RUNNER_TEMP/gpg-keyserver-verify"
+          mkdir -p "$verify_home"
+          chmod 700 "$verify_home"
+          for attempt in 1 2 3; do
+            if GNUPGHOME="$verify_home" timeout 60s gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$fingerprint"; then
+              exit 0
+            fi
+            sleep 10
+          done
+          exit 1
       - name: Publish
         working-directory: sdk/java
         env:
@@ -63,4 +92,5 @@ jobs:
         run: >
           mvn --batch-mode deploy
           --settings ../../scripts/release/maven-settings.xml
+          -Dgpg.keyname="$MAVEN_GPG_KEY_FINGERPRINT"
           -Dgpg.passphrase="$MAVEN_GPG_PASSPHRASE"

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -59,7 +59,7 @@ The repository retains packaging metadata for the kernel binaries, container ima
 | TypeScript SDK | `@mindburn/helm-ai-kernel` |
 | Python SDK | `helm-sdk` |
 | Rust SDK | `helm-sdk` |
-| Java SDK | Source-available local Maven build under `sdk/java`; public package coordinate not verified |
+| Java SDK | Source-available local Maven build under `sdk/java`; source coordinate `org.mindburn.helm:helm-sdk`; public package coordinate not verified |
 | Go SDK | `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@main`; pin `@main` or a commit until tagged module releases are aligned |
 
 ## Release Inputs

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -56,7 +56,7 @@ distribution promises.
 | JavaScript | Uses `@mindburn/helm-ai-kernel` or raw HTTP/fetch | `sdk/ts/src/client.ts`, `examples/js_openai_baseurl/` | `make test-sdk-ts` |
 | Go SDK | Source/module path only; pin `@main` or a commit until tagged SDK modules are aligned | `sdk/go/client/client.go` | `cd sdk/go && go test ./...` |
 | Rust SDK | Package name `helm-sdk`; source manifest currently declares `0.5.1`. Verify registry state before publishing pinned install claims. | `sdk/rust/src/client.rs` | `make test-sdk-rust` |
-| Java | Source-available local Maven build; public coordinate not verified | `sdk/java/pom.xml` | `make test-sdk-java` |
+| Java | Source-available local Maven build; source manifest declares `org.mindburn.helm:helm-sdk:0.5.2`. Verify Maven Central before publishing install claims. | `sdk/java/pom.xml` | `make test-sdk-java` |
 
 Use `http://127.0.0.1:7714` for the local `helm-ai-kernel serve --policy` quickstart, `http://localhost:8080` for `helm-ai-kernel server` or the current Docker Compose mapping, and `http://localhost:9090/v1` only for the OpenAI-compatible proxy.
 

--- a/scripts/release/distribute.sh
+++ b/scripts/release/distribute.sh
@@ -78,6 +78,7 @@ else
     if mvn deploy -P release -DskipTests \
         --settings ../../scripts/release/maven-settings.xml \
         -DaltDeploymentRepository=central::https://central.sonatype.com/api/v1/publisher/deployments/upload \
+        ${MAVEN_GPG_KEY_FINGERPRINT:+-Dgpg.keyname="$MAVEN_GPG_KEY_FINGERPRINT"} \
         -Dgpg.passphrase="$MAVEN_GPG_PASSPHRASE"; then
         echo "✅ Maven package published."
     else

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -8,8 +8,9 @@ The Java SDK is source-available in this repository. Do not publish a public
 Maven or JitPack coordinate in OSS docs until a release workflow has verified
 that coordinate.
 
-Package metadata declares version `0.5.1` in `pom.xml`; that is source metadata,
-not proof that a public package is available.
+Package metadata declares coordinate `org.mindburn.helm:helm-sdk:0.5.2` in
+`pom.xml`; that is source metadata, not proof that a public package is
+available.
 
 ## Local Development
 
@@ -55,4 +56,5 @@ authoritative.
 
 ## Release Notes
 
-`0.5.1` is the release-hardening patch with the retained OpenAPI client surface and protobuf message bindings.
+`0.5.2` is the release-hardening patch with the retained OpenAPI client surface
+and protobuf message bindings.

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -4,9 +4,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.Mindburn-Labs</groupId>
+    <groupId>org.mindburn.helm</groupId>
     <artifactId>helm-sdk</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <packaging>jar</packaging>
 
     <name>HELM SDK</name>


### PR DESCRIPTION
## Summary
- move Java SDK Maven coordinate from the unsupported GitHub org namespace to org.mindburn.helm:helm-sdk:0.5.2
- publish the CI GPG public key to Central-supported keyservers and verify it from Ubuntu before deploy
- pass the imported signing key fingerprint into the Maven GPG plugin
- update Java SDK publishing docs to avoid claiming public availability until Central publish is verified

## Verification
- mvn -q test package (sdk/java)
- make test-sdk-java
- make docs-coverage docs-truth
- bash -n scripts/release/distribute.sh
- git diff --check