### PR TITLE
fix: use verified GitHub user Maven namespace

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -59,7 +59,7 @@ The repository retains packaging metadata for the kernel binaries, container ima
 | TypeScript SDK | `@mindburn/helm-ai-kernel` |
 | Python SDK | `helm-sdk` |
 | Rust SDK | `helm-sdk` |
-| Java SDK | Source-available local Maven build under `sdk/java`; source coordinate `org.mindburn.helm:helm-sdk`; public package coordinate not verified |
+| Java SDK | Source-available local Maven build under `sdk/java`; source coordinate `io.github.mindburnlabs:helm-sdk`; public package coordinate not verified |
 | Go SDK | `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@main`; pin `@main` or a commit until tagged module releases are aligned |
 
 ## Release Inputs

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -56,7 +56,7 @@ distribution promises.
 | JavaScript | Uses `@mindburn/helm-ai-kernel` or raw HTTP/fetch | `sdk/ts/src/client.ts`, `examples/js_openai_baseurl/` | `make test-sdk-ts` |
 | Go SDK | Source/module path only; pin `@main` or a commit until tagged SDK modules are aligned | `sdk/go/client/client.go` | `cd sdk/go && go test ./...` |
 | Rust SDK | Package name `helm-sdk`; source manifest currently declares `0.5.1`. Verify registry state before publishing pinned install claims. | `sdk/rust/src/client.rs` | `make test-sdk-rust` |
-| Java | Source-available local Maven build; source manifest declares `org.mindburn.helm:helm-sdk:0.5.2`. Verify Maven Central before publishing install claims. | `sdk/java/pom.xml` | `make test-sdk-java` |
+| Java | Source-available local Maven build; source manifest declares `io.github.mindburnlabs:helm-sdk:0.5.2`. Verify Maven Central before publishing install claims. | `sdk/java/pom.xml` | `make test-sdk-java` |
 
 Use `http://127.0.0.1:7714` for the local `helm-ai-kernel serve --policy` quickstart, `http://localhost:8080` for `helm-ai-kernel server` or the current Docker Compose mapping, and `http://localhost:9090/v1` only for the OpenAI-compatible proxy.
 

--- a/scripts/sdk/gen.sh
+++ b/scripts/sdk/gen.sh
@@ -397,7 +397,7 @@ docker run --rm -v "$PROJECT_ROOT:/work" -w /work "$GENERATOR_IMAGE" generate \
     -i /work/api/openapi/helm.openapi.yaml \
     -g java \
     -o /work/.gen_tmp/java \
-    --additional-properties=artifactId=helm,groupId=ai.mindburn.helm,invokerPackage=labs.mindburn.helm,modelPackage=labs.mindburn.helm.models,library=native \
+    --additional-properties=artifactId=helm,groupId=io.github.mindburnlabs,invokerPackage=labs.mindburn.helm,modelPackage=labs.mindburn.helm.models,library=native \
     --global-property=models 2>/dev/null
 
 JAVA_OUT="$PROJECT_ROOT/sdk/java/src/main/java/labs/mindburn/helm"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -23,7 +23,7 @@ flowchart LR
 | Python | `sdk/python/helm_sdk/` | `helm-sdk` | First-class local example under `examples/python_sdk/` | `make test-sdk-py` |
 | TypeScript / JavaScript | `sdk/ts/src/` | `@mindburn/helm-ai-kernel` | First-class local example under `examples/ts_sdk/` | `make test-sdk-ts` |
 | Rust | `sdk/rust/src/` | `helm-sdk` | Source-backed SDK package | `make test-sdk-rust` |
-| Java | `sdk/java/src/main/java/` | `com.github.Mindburn-Labs:helm-sdk` | Source-backed SDK package | `make test-sdk-java` |
+| Java | `sdk/java/src/main/java/` | `io.github.mindburnlabs:helm-sdk` | Source-backed SDK package | `make test-sdk-java` |
 
 ## What Is Covered
 

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -8,7 +8,7 @@ The Java SDK is source-available in this repository. Do not publish a public
 Maven or JitPack coordinate in OSS docs until a release workflow has verified
 that coordinate.
 
-Package metadata declares coordinate `org.mindburn.helm:helm-sdk:0.5.2` in
+Package metadata declares coordinate `io.github.mindburnlabs:helm-sdk:0.5.2` in
 `pom.xml`; that is source metadata, not proof that a public package is
 available.
 

--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.mindburn.helm</groupId>
+    <groupId>io.github.mindburnlabs</groupId>
     <artifactId>helm-sdk</artifactId>
     <version>0.5.2</version>
     <packaging>jar</packaging>


### PR DESCRIPTION
## Summary
- switch the Java SDK Maven coordinate to io.github.mindburnlabs:helm-sdk:0.5.2, the Central Portal GitHub-user namespace
- keep generated Java SDK metadata aligned with the publish coordinate
- update SDK and publishing docs while public Maven availability remains unverified until the publish run succeeds

## Verification
- mvn -q test package in sdk/java
- mvn -q help:evaluate -Dexpression=project.groupId -DforceStdout in sdk/java
- make docs-coverage docs-truth
- bash -n scripts/sdk/gen.sh
- git diff --check

## Context
The Central deployment for org.mindburn.helm:helm-sdk:0.5.2 reached Sonatype but failed with Namespace not allowed. Sonatype documents automatic GitHub namespaces as io.github.<github username>, not GitHub organization names.