### PR TITLE
ci: extend Maven Central publish wait

### DIFF
--- a/sdk/java/pom.xml
+++ b/sdk/java/pom.xml
@@ -112,6 +112,8 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
+                    <waitMaxTime>7200</waitMaxTime>
+                    <waitPollingInterval>15</waitPollingInterval>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- extend Sonatype Central publish polling from 30 minutes to 2 hours
- reduce polling noise by checking every 15 seconds

## Verification
- mvn -q test package
- git diff --check

## Context
The corrected Maven deployment uploaded successfully under `io.github.mindburnlabs`, then the Central plugin failed because the default 30-minute `waitMaxTime` elapsed before Sonatype reported the deployment as published.