### PR TITLE
docs: mark Java Maven package verified

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ The complete diagram doctrine lives in
 | Python SDK | `pip install helm-sdk` |
 | TypeScript SDK | `npm install @mindburn/helm-ai-kernel` |
 | Rust SDK | `cargo add helm-sdk` |
-| Java SDK | Source-available local Maven build under `sdk/java`; public package coordinate is not verified in this repo |
+| Java SDK | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.2` |
 | Design system core | Workspace source; public npm registry publication is not verified in this repo |
 
 HTTP clients are generated from

--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -182,7 +182,7 @@ Run online verification only after offline verification passes:
 | TypeScript / JavaScript | `npm install @mindburn/helm-ai-kernel` | `make test-sdk-ts` |
 | Rust | `cargo add helm-sdk` | `make test-sdk-rust` |
 | Go | source/module path `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go`; pin `@main` or a commit until tagged module releases are aligned | `cd sdk/go && go test ./...` |
-| Java | source-available local Maven build under `sdk/java`; public package coordinate not verified | `make test-sdk-java` |
+| Java | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.2` | `make test-sdk-java` |
 
 Use [SDK Index](sdks/00_INDEX.md) before publishing SDK install instructions.
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -59,7 +59,7 @@ The repository retains packaging metadata for the kernel binaries, container ima
 | TypeScript SDK | `@mindburn/helm-ai-kernel` |
 | Python SDK | `helm-sdk` |
 | Rust SDK | `helm-sdk` |
-| Java SDK | Source-available local Maven build under `sdk/java`; source coordinate `io.github.mindburnlabs:helm-sdk`; public package coordinate not verified |
+| Java SDK | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.2` |
 | Go SDK | `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@main`; pin `@main` or a commit until tagged module releases are aligned |
 
 ## Release Inputs

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -56,7 +56,7 @@ distribution promises.
 | JavaScript | Uses `@mindburn/helm-ai-kernel` or raw HTTP/fetch | `sdk/ts/src/client.ts`, `examples/js_openai_baseurl/` | `make test-sdk-ts` |
 | Go SDK | Source/module path only; pin `@main` or a commit until tagged SDK modules are aligned | `sdk/go/client/client.go` | `cd sdk/go && go test ./...` |
 | Rust SDK | Package name `helm-sdk`; source manifest currently declares `0.5.1`. Verify registry state before publishing pinned install claims. | `sdk/rust/src/client.rs` | `make test-sdk-rust` |
-| Java | Source-available local Maven build; source manifest declares `io.github.mindburnlabs:helm-sdk:0.5.2`. Verify Maven Central before publishing install claims. | `sdk/java/pom.xml` | `make test-sdk-java` |
+| Java | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.2`; verified by remote Maven resolution and repo1 artifacts. | `sdk/java/pom.xml` | `make test-sdk-java` |
 
 Use `http://127.0.0.1:7714` for the local `helm-ai-kernel serve --policy` quickstart, `http://localhost:8080` for `helm-ai-kernel server` or the current Docker Compose mapping, and `http://localhost:9090/v1` only for the OpenAI-compatible proxy.
 
@@ -122,7 +122,17 @@ let client = HelmClient::new("http://127.0.0.1:7714");
 
 ## Java
 
-The Java SDK is source-available in this repository. Use a local Maven build until a public package coordinate is verified.
+Use the verified Maven Central coordinate:
+
+```xml
+<dependency>
+  <groupId>io.github.mindburnlabs</groupId>
+  <artifactId>helm-sdk</artifactId>
+  <version>0.5.2</version>
+</dependency>
+```
+
+Use a local Maven build when editing this repository:
 
 ```bash
 cd sdk/java

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -23,7 +23,7 @@ flowchart LR
 | Python | `sdk/python/helm_sdk/` | `helm-sdk` | First-class local example under `examples/python_sdk/` | `make test-sdk-py` |
 | TypeScript / JavaScript | `sdk/ts/src/` | `@mindburn/helm-ai-kernel` | First-class local example under `examples/ts_sdk/` | `make test-sdk-ts` |
 | Rust | `sdk/rust/src/` | `helm-sdk` | Source-backed SDK package | `make test-sdk-rust` |
-| Java | `sdk/java/src/main/java/` | `io.github.mindburnlabs:helm-sdk` | Source-backed SDK package | `make test-sdk-java` |
+| Java | `sdk/java/src/main/java/` | `io.github.mindburnlabs:helm-sdk` | Published Maven Central package; source-backed SDK | `make test-sdk-java` |
 
 ## What Is Covered
 

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -4,13 +4,17 @@ Typed Java client for the retained HELM kernel API.
 
 ## Package Status
 
-The Java SDK is source-available in this repository. Do not publish a public
-Maven or JitPack coordinate in OSS docs until a release workflow has verified
-that coordinate.
+The Java SDK is published on Maven Central as
+`io.github.mindburnlabs:helm-sdk:0.5.2`. Remote Maven resolution and repo1
+artifacts were verified for this coordinate.
 
-Package metadata declares coordinate `io.github.mindburnlabs:helm-sdk:0.5.2` in
-`pom.xml`; that is source metadata, not proof that a public package is
-available.
+```xml
+<dependency>
+  <groupId>io.github.mindburnlabs</groupId>
+  <artifactId>helm-sdk</artifactId>
+  <version>0.5.2</version>
+</dependency>
+```
 
 ## Local Development
 


### PR DESCRIPTION
## Summary
- replace Java public-package warning text with the verified Maven Central coordinate
- add Maven dependency snippets for `io.github.mindburnlabs:helm-sdk:0.5.2`

## Verification
- make docs-coverage docs-truth
- git diff --check
- remote Maven resolution: `mvn -q -Dmaven.repo.local=$(mktemp -d) dependency:get -Dartifact=io.github.mindburnlabs:helm-sdk:0.5.2 -Dtransitive=false`
- repo1 POM returned HTTP 200 for `io/github/mindburnlabs/helm-sdk/0.5.2/helm-sdk-0.5.2.pom`
- repo1 JAR signature verified against key fingerprint `44253CDFCDE49C7E164B2C8299853C5D2F577524`