### PR TITLE
docs: refresh v0.5.4 release truth

### DIFF
--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -218,9 +218,9 @@ If the `helm` command on your machine resolves to this HELM AI Kernel binary, us
 
 ## Release And Conformance Gates
 
-Current public release: `v0.5.3`, published on 2026-05-19 at 22:23 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.3>.
+Current public release: `v0.5.4`, published on 2026-05-19 at 23:50 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>.
 
-The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `v0.5.3.openvex.json`, `release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `v0.5.3.json`, and matching `*.cosign.bundle` files for each primary asset.
+The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `v0.5.4.openvex.json`, `release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `v0.5.4.json`, and matching `*.cosign.bundle` files for each primary asset.
 
 Run conformance and docs gates:
 

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -101,7 +101,7 @@ helm upgrade --install helm-ai-kernel deploy/helm-chart \
 | Value | Default | Source-backed behavior |
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/mindburn-labs/helm-ai-kernel` | Container image used by the Deployment. |
-| `image.tag` | chart `appVersion` | Defaults to `v0.5.2` from `Chart.yaml`. |
+| `image.tag` | chart `appVersion` | Defaults to `v0.5.4` from `Chart.yaml`. |
 | `helm.bindAddr` | `0.0.0.0` | Required because the pod must bind beyond loopback. |
 | `service.port` | `8080` | Runtime HTTP port passed to `helm-ai-kernel serve --port`. |
 | `service.healthPort` | `8081` | Health probe port via `HELM_HEALTH_PORT`. |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -94,8 +94,8 @@ The retained workflow set under `.github/workflows/` covers:
 - GHCR image publication for `latest`, version tag, and slim tag
 - manual publication workflows for npm, PyPI, crates.io, and Maven-compatible distribution
 
-Current public GitHub release: `v0.5.3`, published on 2026-05-19 at
-22:23 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.3>.
+Current public GitHub release: `v0.5.4`, published on 2026-05-19 at
+23:50 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>.
 
 There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
 actual release baseline when auditing the `v0.5.0` delta.
@@ -109,19 +109,19 @@ Its attached assets are:
 - `helm-ai-kernel-windows-amd64.exe`
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `v0.5.3.openvex.json`
+- `v0.5.4.openvex.json`
 - `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`
 - `sample-policy-material.tar`
 - `helm-ai-kernel.mcpb`
 - `helm-ai-kernel.rb`
-- `v0.5.3.json`
+- `v0.5.4.json`
 - matching `*.cosign.bundle` files for every primary asset
 
 `sample-policy-material.tar` includes the sample policy and its referenced EU
-AI Act high-risk reference pack. The `v0.5.3` release attaches a
-`helm-ai-kernel.rb` formula asset for version `0.5.3`; verify the public
+AI Act high-risk reference pack. The `v0.5.4` release attaches a
+`helm-ai-kernel.rb` formula asset for version `0.5.4`; verify the public
 `mindburnlabs/homebrew-tap` state before documenting
 `brew install mindburnlabs/tap/helm-ai-kernel` as current.
 
@@ -144,7 +144,7 @@ writes the final `SHA256SUMS.txt`.
 ## Verification
 
 Every public release must include enough material to verify what was downloaded.
-For `v0.5.3`, use `SHA256SUMS.txt`, `sbom.json`, `v0.5.3.openvex.json`,
+For `v0.5.4`, use `SHA256SUMS.txt`, `sbom.json`, `v0.5.4.openvex.json`,
 `release-attestation.json`, the platform binary assets, attached
 `*.cosign.bundle` files, and the offline `evidence-pack.tar`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -164,7 +164,7 @@ curl 'http://127.0.0.1:7714/api/v1/receipts?limit=20'
 ./bin/helm-ai-kernel verify evidence-pack.tar --json
 ```
 
-Use the `v0.5.3` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
+Use the `v0.5.4` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
 
 ## 7. Validate The Checkout
 

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -33,13 +33,13 @@ flowchart LR
   optional --> verify
 ```
 
-Current public release: `v0.5.3`, published on 2026-05-19 at 22:23 UTC:
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.3>. The release
+Current public release: `v0.5.4`, published on 2026-05-19 at 23:50 UTC:
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>. The release
 assets visible on GitHub are Darwin/Linux/Windows binaries, `SHA256SUMS.txt`,
-`sbom.json`, `v0.5.3.openvex.json`, `release-attestation.json`,
+`sbom.json`, `v0.5.4.openvex.json`, `release-attestation.json`,
 `evidence-pack.tar`, `release.high_risk.v3.toml`,
 `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`,
-`v0.5.3.json`, and matching
+`v0.5.4.json`, and matching
 `*.cosign.bundle` files for each primary asset.
 
 ## Public Release Material
@@ -76,7 +76,7 @@ EvidencePack, verifies the staged `evidence-pack.tar`, and only then writes
 final checksums. A failed EvidencePack verification blocks release asset
 publication.
 
-For `v0.5.3`, use checksum verification, SBOM inspection, OpenVEX inspection,
+For `v0.5.4`, use checksum verification, SBOM inspection, OpenVEX inspection,
 release metadata inspection, offline EvidencePack verification,
 reproducible-build validation, and Cosign verification against the attached
 bundles.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -57,20 +57,20 @@ The verification path is local-first. `helm-ai-kernel verify <evidence-pack.tar|
 performs offline checks by default; `--online` is optional and only runs after
 offline checks pass.
 
-Current public release: `v0.5.3`, published on 2026-05-19 at 22:23 UTC:
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.3>. The release
+Current public release: `v0.5.4`, published on 2026-05-19 at 23:50 UTC:
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>. The release
 page attaches platform binaries, `SHA256SUMS.txt`, `sbom.json`,
-`v0.5.3.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
+`v0.5.4.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
 `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`,
-`helm-ai-kernel.rb`, `v0.5.3.json`, and matching `*.cosign.bundle` files for
+`helm-ai-kernel.rb`, `v0.5.4.json`, and matching `*.cosign.bundle` files for
 each primary asset.
 
 There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
 actual baseline when auditing the `v0.5.0` delta.
 
-## v0.5.3 Asset Contract
+## v0.5.4 Asset Contract
 
-The `v0.5.3` release attaches these primary assets:
+The `v0.5.4` release attaches these primary assets:
 
 - `helm-ai-kernel-darwin-amd64`
 - `helm-ai-kernel-darwin-arm64`
@@ -79,7 +79,7 @@ The `v0.5.3` release attaches these primary assets:
 - `helm-ai-kernel-windows-amd64.exe`
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `v0.5.3.openvex.json`
+- `v0.5.4.openvex.json`
 - `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`
@@ -192,7 +192,7 @@ The release staging path runs the same offline verification before publishing
 release checksums. If this step fails, the release must be treated as incomplete
 and the exported EvidencePack must be repaired before attaching assets.
 
-For `v0.5.3`, this command passes without network access. The verifier
+For `v0.5.4`, this command passes without network access. The verifier
 accepts both the legacy `receipts/` layout and the canonical
 `02_PROOFGRAPH/receipts/` layout.
 

--- a/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
+++ b/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
@@ -1,8 +1,8 @@
 # Final Implementation Report
 
-Status: release-candidate ready for HELM OSS Skill Packs MVP, HELM Launchpad OpenClaw/Hermes local-container support, and HELM Commercial Launchpad/Skills governance surfaces.
+Status: production release published for HELM OSS Skill Packs MVP, HELM Launchpad OpenClaw/Hermes local-container support, and HELM Commercial Launchpad/Skills governance surfaces. Homebrew tap distribution remains blocked on maintainer merge.
 
-`mission_100_percent_complete` is true for this production deployment milestone. Distribution remains gated: Homebrew, public website claims, and release tags must wait until the kernel and Enterprise PRs merge and main-branch CI preserves the same evidence.
+`mission_100_percent_complete` is false until the public Homebrew tap update is merged. Kernel PR #161 and Enterprise PR #30 are merged. Kernel release `v0.5.4` is published from `main`, release workflow `26131090671` passed, and the release EvidencePack verifies offline. Homebrew PR https://github.com/mindburnlabs/homebrew-tap/pull/2 updates the tap to v0.5.4 but requires a tap maintainer to merge. Public website claims remain blocked until docs-truth and owner review approve a public claims update.
 
 ## What Was Implemented
 
@@ -14,7 +14,9 @@ Status: release-candidate ready for HELM OSS Skill Packs MVP, HELM Launchpad Ope
 - [KEEP] OpenCode and Kilo Code remain `oss_candidate`; Codex, Claude Code, Cursor, and Junie remain external/BYO adapters.
 - [KEEP] DigitalOcean and Hetzner remain dry-run by default; live mode requires explicit operator approval receipt and reconciliation.
 - [KEEP] OSS Skill Packs MVP, Codex plugin export, repo projection, scan/install/revoke receipts, and Skill Pack conformance tests remain in this release candidate.
-- [KEEP] Enterprise Launchpad and Skills APIs, route registry/OpenAPI parity, migrations, durable stores, Console Launchpad UI, Playwright coverage, and approved OSS boundary sync are included in the Enterprise release candidate.
+- [KEEP] Enterprise Launchpad and Skills APIs, route registry/OpenAPI parity, migrations, durable stores, Console Launchpad UI, Playwright coverage, and approved OSS boundary sync are merged through Enterprise PR #30.
+- [KEEP] Kernel release `v0.5.4` ships CLI binaries, checksums, SBOM JSON, OpenVEX, release attestation metadata, Cosign bundles, `evidence-pack.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, and sample policy material.
+- [KEEP] Release asset verification passed for `v0.5.4`: `SHA256SUMS.txt`, offline EvidencePack verification, and Cosign verification for all 14 signed assets.
 
 ## Exact Files Changed In This Final Pass
 
@@ -41,10 +43,14 @@ The full kernel branch diff also includes Launchpad runtime, promotion, receipts
 ## Evidence And Verification
 
 - Artifact workflow: `26110916296`, attempt `1`, head `2a04e2e0cbf45459a2f155bc51f79fb1d7dbbc1b`.
+- Kernel release: `v0.5.4`, workflow `26131090671`, source commit `0b60353c50eda54454fbb90e3e5ccd9db952ef8b`.
+- Enterprise merge: PR #30, merge commit `89f319bae0d2186acd76b7e5764ade881a8650e1`.
 - OpenClaw promotion refs: `github-actions://26110916296/1/artifact-verification/openclaw`, `github-actions://26110916296/1/live-e2e/openclaw`, `github-actions://26110916296/1/evidencepack/openclaw`, `github-actions://26110916296/1/teardown/openclaw`.
 - Hermes promotion refs: `github-actions://26110916296/1/artifact-verification/hermes`, `github-actions://26110916296/1/live-e2e/hermes`, `github-actions://26110916296/1/evidencepack/hermes`, `github-actions://26110916296/1/teardown/hermes`.
 - OpenClaw EvidencePack merkle root: `d309d1ab02b5238c5b7c6c6ee7ee5df8805fb42c994308919cdc94271199604c`.
 - Hermes EvidencePack merkle root: `2ca2efb22f3c936cac7b8a1a57e331fc2f3175a5a9eb704e02b97ed685af8dc3`.
+- Release EvidencePack verification: `helm-ai-kernel verify --bundle /tmp/helm-ai-kernel-v0.5.4-release/evidence-pack.tar` returned `VERIFIED`.
+- Release asset signature verification: `bash scripts/release/verify_cosign.sh /tmp/helm-ai-kernel-v0.5.4-release` returned `verified=14 failed=0`.
 
 ## Tests Passing
 
@@ -55,6 +61,10 @@ Kernel:
 - `bin/helm-ai-kernel verify --bundle` for Hermes downloaded EvidencePack directory and tar archive.
 - `go test ./core/pkg/skillpacks/... ./core/pkg/launchpad/... ./core/cmd/helm-ai-kernel/... ./core/pkg/mcp/... ./core/pkg/evidencepack/... ./core/pkg/verifier ./tests/skills/... ./tests/launchpad/...`
 - Prior gates on this branch: `make build`, `make test`, `make test-console`, `make test-platform`, `make launch-ready`, `make launch-security`.
+- Release workflow `26131090671`.
+- `shasum -a 256 -c SHA256SUMS.txt --ignore-missing` for downloaded v0.5.4 release assets.
+- `bin/helm-ai-kernel verify --bundle` for downloaded v0.5.4 `evidence-pack.tar`.
+- `bash scripts/release/verify_cosign.sh` for downloaded v0.5.4 release assets.
 
 Enterprise:
 
@@ -66,26 +76,25 @@ Enterprise:
 - `pnpm --dir apps/console test -- --run`
 - `pnpm --dir apps/console build`
 - `pnpm --dir e2e exec playwright test tests/launchpad.spec.ts --project=chromium`
+- Enterprise PR #30 remote CI checks, including `race-detector`, `Mutation Analysis`, `Boundary Verification`, `openapi-lint`, `evidence-pack`, `doccheck`, and JS typecheck/lint/test/build.
 
 ## Tests Failing
 
-None for this release-candidate evidence set.
+None for this production release evidence set.
 
 ## Security Review Result
 
-PASS for this release candidate. No app is promoted without signed OCI digest, cosign ref, SBOM ref, vulnerability scan ref, provenance ref, live e2e ref, teardown receipt ref, and offline EvidencePack verification. Proprietary apps remain external/BYO. Cloud live writes remain opt-in. Logs and reports do not include the OpenRouter key.
+PASS for this production release. No app is promoted without signed OCI digest, cosign ref, SBOM ref, vulnerability scan ref, provenance ref, live e2e ref, teardown receipt ref, and offline EvidencePack verification. Proprietary apps remain external/BYO. Cloud live writes remain opt-in. Logs and reports do not include the OpenRouter key.
 
-## Remaining Release Steps
+## Release Steps
 
-1. Commit and push the final kernel promotion/report updates.
-2. Sync Enterprise to the final kernel commit through `tools/sync-oss-kernel.sh`.
-3. Re-run Enterprise `make quality-pr` after final sync.
-4. Open the kernel release PR.
-5. Open the Enterprise release PR referencing the kernel PR/commit.
-6. Merge only after PR CI is green.
-7. Tag the kernel release and publish release notes with exact image digests, cosign refs, SBOM refs, vuln scan refs, EvidencePack refs, and verifier commands.
-8. Update Homebrew only after merged release artifacts exist.
-9. Update public website claims only after docs-truth passes on `main`.
+1. [KEEP] Kernel PR #161 merged.
+2. [KEEP] Kernel release `v0.5.4` published from `main`.
+3. [KEEP] Release assets, checksums, Cosign bundles, SBOM, OpenVEX, release attestation, Homebrew formula asset, and EvidencePack are available.
+4. [KEEP] Release EvidencePack verifies offline.
+5. [KEEP] Enterprise PR #30 merged.
+6. [DEFER] Homebrew tap PR https://github.com/mindburnlabs/homebrew-tap/pull/2 is open and awaiting maintainer merge.
+7. [DEFER] Public website claims remain blocked until docs-truth passes on `main` and owner review approves.
 
 ## Follow-Up PRs
 

--- a/docs/launchpad/final_report.json
+++ b/docs/launchpad/final_report.json
@@ -1,14 +1,19 @@
 {
-  "status": "release_candidate_ready",
-  "mission_scope": "HELM OSS Skill Packs MVP plus HELM Launchpad OpenClaw/Hermes local-container production release candidate, with HELM Commercial Launchpad/Skills governance surfaces",
+  "status": "production_release_published_homebrew_pr_open",
+  "mission_scope": "HELM OSS Skill Packs MVP plus HELM Launchpad OpenClaw/Hermes local-container production release, with HELM Commercial Launchpad/Skills governance surfaces merged",
   "production_ready": true,
-  "mission_100_percent_complete": true,
+  "mission_100_percent_complete": false,
   "release_distribution_complete": false,
-  "generated_at": "2026-05-19T17:10:00Z",
-  "kernel_branch": "skill-launch-remediation",
-  "kernel_head": "bd2d954e470a028640ea0e492efb79905d5f438a",
-  "enterprise_branch": "launchpad-final",
-  "enterprise_quality_gate": "make quality-pr passed after approved OSS sync",
+  "generated_at": "2026-05-20T01:06:39Z",
+  "kernel_branch": "main",
+  "kernel_head": "0b60353c50eda54454fbb90e3e5ccd9db952ef8b",
+  "kernel_release": "v0.5.4",
+  "kernel_release_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4",
+  "kernel_release_workflow": "26131090671",
+  "enterprise_branch": "main",
+  "enterprise_merge_commit": "89f319bae0d2186acd76b7e5764ade881a8650e1",
+  "enterprise_pr": "https://github.com/Mindburn-Labs/helm-ai-enterprise/pull/30",
+  "enterprise_quality_gate": "PR #30 checks passed and merged after approved OSS sync",
   "artifact_workflow": {
     "run_id": "26110916296",
     "run_attempt": "1",
@@ -95,9 +100,9 @@
     "Enterprise Launchpad and Skills APIs, OpenAPI/route parity, migrations, durable store, Console Launchpad feature, Playwright coverage, and approved OSS boundary sync"
   ],
   "not_implemented": [
-    "Homebrew formula release update is intentionally blocked until PR merge and release tagging",
-    "Mindburn public website claims are intentionally blocked until merged release evidence lands on main",
-    "Live DigitalOcean and Hetzner writes are opt-in only and are not required for this release candidate",
+    "Homebrew tap merge is blocked on repository permissions; PR https://github.com/mindburnlabs/homebrew-tap/pull/2 is open with the v0.5.4 formula",
+    "Mindburn public website claims are intentionally blocked until docs-truth and owner review approve a public claims update",
+    "Live DigitalOcean and Hetzner writes are opt-in only and are not required for this production release",
     "OpenCode and Kilo Code are not promoted because they have not passed the OpenClaw/Hermes evidence bar",
     "Codex, Claude Code, Cursor, and Junie are not redistributed and remain external/BYO adapters"
   ],
@@ -143,16 +148,21 @@
     "helm-ai-enterprise pnpm --dir apps/console typecheck",
     "helm-ai-enterprise pnpm --dir apps/console test -- --run",
     "helm-ai-enterprise pnpm --dir apps/console build",
-    "helm-ai-enterprise pnpm --dir e2e exec playwright test tests/launchpad.spec.ts --project=chromium"
+    "helm-ai-enterprise pnpm --dir e2e exec playwright test tests/launchpad.spec.ts --project=chromium",
+    "kernel release workflow 26131090671",
+    "v0.5.4 release SHA256SUMS verification",
+    "v0.5.4 release EvidencePack offline verification",
+    "v0.5.4 release Cosign bundle verification for 14 assets",
+    "Enterprise PR #30 remote CI checks"
   ],
   "tests_failing": [],
   "risks_remaining": [
-    "release distribution is not complete until kernel and Enterprise PRs merge",
-    "Homebrew and website claims must remain blocked until release artifacts are available from merged main",
+    "Homebrew tap remains on v0.5.0 until https://github.com/mindburnlabs/homebrew-tap/pull/2 is merged by a tap maintainer",
+    "public website claims remain blocked until docs-truth and owner review approve concrete evidence-backed claims",
     "Live cloud writes are intentionally excluded from normal gates",
     "Node.js 20 deprecation warnings are emitted by pinned upstream actions forced to Node 24; they are warnings, not failed gates"
   ],
-  "security_review_result": "PASS for this release candidate: no app is promoted without signed OCI digest, cosign ref, SBOM ref, vulnerability scan ref, provenance ref, live e2e ref, teardown receipt ref, and offline EvidencePack verification; proprietary apps remain external/BYO; cloud live writes remain opt-in; logs and reports do not include the OpenRouter key.",
+  "security_review_result": "PASS for this production release: no app is promoted without signed OCI digest, cosign ref, SBOM ref, vulnerability scan ref, provenance ref, live e2e ref, teardown receipt ref, and offline EvidencePack verification; proprietary apps remain external/BYO; cloud live writes remain opt-in; logs and reports do not include the OpenRouter key.",
   "docs_updated": [
     "docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md",
     "docs/launchpad/final_report.json",
@@ -168,15 +178,13 @@
     "docs/public-docs.manifest.json"
   ],
   "release_steps": [
-    "commit and push final kernel promotion/report updates",
-    "sync Enterprise lock to the final kernel commit through tools/sync-oss-kernel.sh",
-    "run Enterprise make quality-pr after final sync",
-    "open kernel release PR",
-    "open Enterprise release PR referencing the kernel PR/commit",
-    "merge only after PR CI is green",
-    "tag kernel release and publish release notes with exact image digests, cosign refs, SBOM refs, vuln scan refs, EvidencePack refs, and verifier commands",
-    "update Homebrew formula after merged release artifacts exist",
-    "update public website claims only after docs-truth passes on main"
+    "kernel PR #161 merged",
+    "kernel release v0.5.4 published from main",
+    "v0.5.4 release assets, checksums, Cosign bundles, SBOM, OpenVEX, release attestation, Homebrew formula asset, and EvidencePack are available",
+    "v0.5.4 release EvidencePack verifies offline",
+    "Enterprise PR #30 merged",
+    "Homebrew tap PR https://github.com/mindburnlabs/homebrew-tap/pull/2 is open and awaiting maintainer merge",
+    "public website claims remain blocked until docs-truth passes on main and owner review approves"
   ],
   "follow_up_prs": [
     "OpenCode signed OCI and live conformance promotion",

--- a/release/README.md
+++ b/release/README.md
@@ -12,26 +12,26 @@ files. It is not a complete copy of any GitHub release.
 
 ## Current Public Release
 
-The current public GitHub release is `v0.5.1`, published on 2026-05-18. Its
+The current public GitHub release is `v0.5.4`, published on 2026-05-19 at 23:50 UTC. Its
 visible release assets are platform binaries for Darwin, Linux, and Windows,
 `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `SHA256SUMS.txt`, `sbom.json`,
-`v0.5.1.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
+`v0.5.4.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
 `release.high_risk.v3.toml`, `sample-policy-material.tar`, and matching
 `*.cosign.bundle` files for every primary asset.
 
 There is no public GitHub Release object for `v0.4.1`; the actual public
 baseline for the `v0.5.0` delta is `v0.4.0`.
 
-## v0.5.1 Asset Contract
+## v0.5.4 Asset Contract
 
-`make release-assets` stages the `v0.5.1` asset set under
+`make release-assets` stages the `v0.5.4` asset set under
 `dist/release-assets/`, and the release workflow attached that set to the
 GitHub release:
 
 - five CLI binaries
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `v0.5.1.openvex.json`
+- `v0.5.4.openvex.json`
 - `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`


### PR DESCRIPTION
Refreshes release-truth docs after the v0.5.4 production release and Enterprise PR #30 merge.

Evidence verified locally:
- `shasum -a 256 -c SHA256SUMS.txt --ignore-missing` for downloaded v0.5.4 release assets.
- `bin/helm-ai-kernel verify --bundle /tmp/helm-ai-kernel-v0.5.4-release/evidence-pack.tar` returned `VERIFIED`.
- `bash scripts/release/verify_cosign.sh /tmp/helm-ai-kernel-v0.5.4-release` returned `verified=14 failed=0`.
- `make docs-truth` passed.
- `jq . docs/launchpad/final_report.json` passed.
- `git diff --check` passed.

Notes:
- The v0.5.4 release page has been updated with Launchpad artifact/evidence refs.
- Homebrew tap update is open separately at https://github.com/mindburnlabs/homebrew-tap/pull/2; this report keeps `mission_100_percent_complete` false until that distribution PR is merged.
- Public website claims remain blocked.
