### PR TITLE
docs: mark v0.5.4 distribution complete

### DIFF
--- a/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
+++ b/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
@@ -1,8 +1,8 @@
 # Final Implementation Report
 
-Status: production release published for HELM OSS Skill Packs MVP, HELM Launchpad OpenClaw/Hermes local-container support, and HELM Commercial Launchpad/Skills governance surfaces. Homebrew tap distribution remains blocked on maintainer merge.
+Status: production release published for HELM OSS Skill Packs MVP, HELM Launchpad OpenClaw/Hermes local-container support, and HELM Commercial Launchpad/Skills governance surfaces.
 
-`mission_100_percent_complete` is false until the public Homebrew tap update is merged. Kernel PR #161 and Enterprise PR #30 are merged. Kernel release `v0.5.4` is published from `main`, release workflow `26131090671` passed, and the release EvidencePack verifies offline. Homebrew PR https://github.com/mindburnlabs/homebrew-tap/pull/2 updates the tap to v0.5.4 but requires a tap maintainer to merge. Public website claims remain blocked until docs-truth and owner review approve a public claims update.
+`mission_100_percent_complete` is true for this production deployment milestone. Kernel PR #161 and Enterprise PR #30 are merged. Kernel release `v0.5.4` is published from `main`, release workflow `26131090671` passed, and the release EvidencePack verifies offline. Homebrew PR https://github.com/mindburnlabs/homebrew-tap/pull/2 merged the public tap update to v0.5.4. Public website claims remain blocked until docs-truth and owner review approve a public claims update.
 
 ## What Was Implemented
 
@@ -93,7 +93,7 @@ PASS for this production release. No app is promoted without signed OCI digest, 
 3. [KEEP] Release assets, checksums, Cosign bundles, SBOM, OpenVEX, release attestation, Homebrew formula asset, and EvidencePack are available.
 4. [KEEP] Release EvidencePack verifies offline.
 5. [KEEP] Enterprise PR #30 merged.
-6. [DEFER] Homebrew tap PR https://github.com/mindburnlabs/homebrew-tap/pull/2 is open and awaiting maintainer merge.
+6. [KEEP] Homebrew tap PR https://github.com/mindburnlabs/homebrew-tap/pull/2 merged.
 7. [DEFER] Public website claims remain blocked until docs-truth passes on `main` and owner review approves.
 
 ## Follow-Up PRs

--- a/docs/launchpad/final_report.json
+++ b/docs/launchpad/final_report.json
@@ -1,15 +1,17 @@
 {
-  "status": "production_release_published_homebrew_pr_open",
+  "status": "production_release_published",
   "mission_scope": "HELM OSS Skill Packs MVP plus HELM Launchpad OpenClaw/Hermes local-container production release, with HELM Commercial Launchpad/Skills governance surfaces merged",
   "production_ready": true,
-  "mission_100_percent_complete": false,
-  "release_distribution_complete": false,
-  "generated_at": "2026-05-20T01:06:39Z",
+  "mission_100_percent_complete": true,
+  "release_distribution_complete": true,
+  "generated_at": "2026-05-20T01:31:09Z",
   "kernel_branch": "main",
   "kernel_head": "0b60353c50eda54454fbb90e3e5ccd9db952ef8b",
   "kernel_release": "v0.5.4",
   "kernel_release_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4",
   "kernel_release_workflow": "26131090671",
+  "homebrew_tap_pr": "https://github.com/mindburnlabs/homebrew-tap/pull/2",
+  "homebrew_tap_merge_commit": "b0b6244170d867dececc7c5576c174914fc661d1",
   "enterprise_branch": "main",
   "enterprise_merge_commit": "89f319bae0d2186acd76b7e5764ade881a8650e1",
   "enterprise_pr": "https://github.com/Mindburn-Labs/helm-ai-enterprise/pull/30",
@@ -100,7 +102,6 @@
     "Enterprise Launchpad and Skills APIs, OpenAPI/route parity, migrations, durable store, Console Launchpad feature, Playwright coverage, and approved OSS boundary sync"
   ],
   "not_implemented": [
-    "Homebrew tap merge is blocked on repository permissions; PR https://github.com/mindburnlabs/homebrew-tap/pull/2 is open with the v0.5.4 formula",
     "Mindburn public website claims are intentionally blocked until docs-truth and owner review approve a public claims update",
     "Live DigitalOcean and Hetzner writes are opt-in only and are not required for this production release",
     "OpenCode and Kilo Code are not promoted because they have not passed the OpenClaw/Hermes evidence bar",
@@ -157,7 +158,6 @@
   ],
   "tests_failing": [],
   "risks_remaining": [
-    "Homebrew tap remains on v0.5.0 until https://github.com/mindburnlabs/homebrew-tap/pull/2 is merged by a tap maintainer",
     "public website claims remain blocked until docs-truth and owner review approve concrete evidence-backed claims",
     "Live cloud writes are intentionally excluded from normal gates",
     "Node.js 20 deprecation warnings are emitted by pinned upstream actions forced to Node 24; they are warnings, not failed gates"
@@ -183,7 +183,7 @@
     "v0.5.4 release assets, checksums, Cosign bundles, SBOM, OpenVEX, release attestation, Homebrew formula asset, and EvidencePack are available",
     "v0.5.4 release EvidencePack verifies offline",
     "Enterprise PR #30 merged",
-    "Homebrew tap PR https://github.com/mindburnlabs/homebrew-tap/pull/2 is open and awaiting maintainer merge",
+    "Homebrew tap PR https://github.com/mindburnlabs/homebrew-tap/pull/2 merged",
     "public website claims remain blocked until docs-truth passes on main and owner review approves"
   ],
   "follow_up_prs": [


### PR DESCRIPTION
Marks the Launchpad final report complete now that the Homebrew tap v0.5.4 PR has merged.

Evidence:
- Kernel release v0.5.4 is published: https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4
- Enterprise PR #30 is merged: https://github.com/Mindburn-Labs/helm-ai-enterprise/pull/30
- Homebrew tap PR #2 is merged: https://github.com/mindburnlabs/homebrew-tap/pull/2
- Public tap now points at formula version 0.5.4.

Validation:
- `jq . docs/launchpad/final_report.json`
- `make docs-truth`
- `git diff --check`

Public website claims remain blocked pending a separate docs-truth/owner-reviewed website update.
