### PR TITLE
fix: resolve Scorecard ws advisory

### DIFF
--- a/packages/design-system-core/package-lock.json
+++ b/packages/design-system-core/package-lock.json
@@ -5079,9 +5079,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/design-system-core/package.json
+++ b/packages/design-system-core/package.json
@@ -161,6 +161,9 @@
     "vite": "^7.2.6",
     "vitest": "^4.0.18"
   },
+  "overrides": {
+    "ws": "8.20.1"
+  },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/scripts/ci/vuln_audit.sh
+++ b/scripts/ci/vuln_audit.sh
@@ -42,7 +42,7 @@ if command -v npm >/dev/null 2>&1; then
         if [ -f "$dir/package-lock.json" ]; then
             rel="${dir#"$ROOT"/}"
             run_step "npm audit $rel" \
-                bash -lc "cd '$dir' && npm audit --omit=dev --audit-level=high"
+                bash -lc "cd '$dir' && npm audit --audit-level=moderate"
         fi
     done
 else


### PR DESCRIPTION
## Summary
- pin design-system transitive ws resolution to 8.20.1
- regenerate package-lock.json for @mindburn/ui-core
- make npm vulnerability audits include dev dependencies at moderate severity

## Validation
- npm ci (packages/design-system-core)
- npm audit --audit-level=moderate (sdk/ts, apps/console, packages/design-system-core)
- make test-design-system
- GOROOT=/Users/ivan/.local/share/mise/installs/go/1.25.10 PATH=/Users/ivan/.local/share/mise/installs/go/1.25.10/bin:$PATH make quality-pr

## Notes
- GitHub ruleset main protection was hardened separately through the repository rulesets API.
- OpenSSF Best Practices registration still requires authenticated bestpractices.dev project creation.