### PR TITLE
launchpad: pin final GA evidence run

### DIFF
--- a/.github/workflows/launchpad-clean-install.yml
+++ b/.github/workflows/launchpad-clean-install.yml
@@ -38,10 +38,11 @@ jobs:
       - name: Start Docker-compatible local-container runtime
         run: |
           set -euo pipefail
+          colima delete -f >/dev/null 2>&1 || true
           if [[ "$(uname -m)" == "arm64" ]]; then
             colima start --cpu 2 --memory 4 --disk 20 --arch x86_64 --vm-type=vz --vz-rosetta \
-              || colima start --cpu 2 --memory 4 --disk 20 --arch x86_64 \
-              || colima start --cpu 2 --memory 4 --disk 20
+              || { colima delete -f >/dev/null 2>&1 || true; colima start --cpu 2 --memory 4 --disk 20 --arch x86_64; } \
+              || { colima delete -f >/dev/null 2>&1 || true; colima start --cpu 2 --memory 4 --disk 20; }
           else
             colima start --cpu 2 --memory 4 --disk 20
           fi

--- a/docs/LAUNCHPAD.md
+++ b/docs/LAUNCHPAD.md
@@ -68,10 +68,10 @@ helm-ai-kernel verify --bundle <pack>
 
 | App | Availability | Evidence |
 | --- | --- | --- |
-| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
 | Codex / Claude Code / Cursor / Junie | `external_proprietary_adapter` | BYO/external adapters only; HELM governs execution and does not redistribute them |
 
 ## Safety Model

--- a/docs/launchpad/CLEAN_INSTALL_GA.md
+++ b/docs/launchpad/CLEAN_INSTALL_GA.md
@@ -95,10 +95,10 @@ accepted for backward compatibility.
 
 | App | Availability | Image |
 | --- | --- | --- |
-| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501` |
-| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f` |
-| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f` |
-| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba` |
+| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9` |
+| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e` |
+| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38` |
+| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65` |
 
 Codex, Claude Code, Cursor, and Junie remain external/BYO adapters.
 

--- a/docs/launchpad/CONFORMANCE.md
+++ b/docs/launchpad/CONFORMANCE.md
@@ -47,13 +47,13 @@ Implemented checks currently prove:
   from signed CI evidence, live e2e, teardown, receipts, and offline
   EvidencePack verification, not from assertion.
 - OpenClaw image:
-  `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501`.
+  `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9`.
 - Hermes image:
-  `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f`.
+  `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e`.
 - OpenCode image:
-  `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f`.
+  `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38`.
 - Kilo Code image:
-  `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba`.
+  `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65`.
 - Local-container OpenRouter egress requires a launch-scoped egress proxy
   receipt, can use the signed egress-proxy image from the artifact workflow, and
   rejects non-OpenRouter allowlists.

--- a/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
+++ b/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
@@ -6,7 +6,7 @@ Launchpad/Skills governance surfaces.
 
 This file is not the current Launchpad GA support truth. Current Launchpad v1
 truth is recorded in `docs/launchpad/v1_report.json`: OpenClaw, Hermes,
-OpenCode, and Kilo Code are `oss_supported` after workflow `26179980172`
+OpenCode, and Kilo Code are `oss_supported` after workflow `26186959337`
 passed signed artifact build, SBOM, vulnerability scan, live OpenRouter
 launch, teardown, and offline EvidencePack verification for all four.
 

--- a/docs/launchpad/final_report.json
+++ b/docs/launchpad/final_report.json
@@ -3,7 +3,7 @@
   "historical_report": true,
   "superseded_by": "docs/launchpad/v1_report.json",
   "current_launchpad_ga_truth": {
-    "artifact_workflow_run_id": "26179980172",
+    "artifact_workflow_run_id": "26186959337",
     "supported_apps": [
       "openclaw",
       "hermes",

--- a/docs/launchpad/v1_report.json
+++ b/docs/launchpad/v1_report.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "generated_at": "2026-05-20T22:17:30Z",
   "milestone": "Launchpad v1.0 Governed App Execution + Cloud Beta",
-  "status": "market_best_contracts_implemented_four_app_local_container_clean_install_and_digitalocean_live_passed_hetzner_blocked",
+  "status": "ga_hardening_contracts_implemented_four_app_local_container_clean_install_and_digitalocean_live_passed_hetzner_blocked",
   "release_truth_base": {
     "release_tag": "v0.5.5",
     "release_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.5",
@@ -10,6 +10,7 @@
     "release_workflow_run_id": "26188554059",
     "v1_artifact_workflow_run_id": "26186959337",
     "v1_artifact_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26186959337",
+    "v1_artifact_workflow_head_sha": "176e4528bbda4b464b1f9a9df9ac8ba196171d3c",
     "v1_artifact_workflow_conclusion": "success_four_app_signed_artifact_sbom_vuln_scan_live_conformance_teardown_offline_evidencepack_verify",
     "v1_artifact_workflow_fix": "local-container live conformance uses configurable runtime timeout and 30m Go test timeout for cold four-app pulls",
     "release_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26188554059",
@@ -78,7 +79,7 @@
     "openclaw": {
       "availability": "oss_supported",
       "local_container": "supported",
-      "ghcr_digest": "sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501",
+      "ghcr_digest": "sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9",
       "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/openclaw",
       "mcp_manifest": "openclaw.default",
       "model_gateway": "logical_binding_env_projection",
@@ -87,7 +88,7 @@
     "hermes": {
       "availability": "oss_supported",
       "local_container": "supported",
-      "ghcr_digest": "sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f",
+      "ghcr_digest": "sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e",
       "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/hermes",
       "mcp_manifest": "hermes.default",
       "model_gateway": "logical_binding_env_projection",
@@ -98,7 +99,7 @@
       "local_container": "supported",
       "upstream_release": "v1.15.5",
       "upstream_commit": "d7a6e1daaf2271bcd0b611fbb27d4956806e475a",
-      "ghcr_digest": "sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f",
+      "ghcr_digest": "sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38",
       "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/opencode",
       "mcp_manifest": "opencode.default",
       "model_gateway": "logical_binding_env_projection",
@@ -111,7 +112,7 @@
       "local_container": "supported",
       "upstream_release": "v7.3.1",
       "upstream_commit": "64c60812ae730a30db1fa2226d9e446f7f10c127",
-      "ghcr_digest": "sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba",
+      "ghcr_digest": "sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65",
       "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/kilocode",
       "mcp_manifest": "kilocode.default",
       "model_gateway": "logical_binding_env_projection",
@@ -248,7 +249,7 @@
       "openapi_route_parity": "passed"
     },
     "docs_platform": {
-      "helm_public_accuracy": "passed_with_market_best_worktree_overlay",
+      "helm_public_accuracy": "passed_with_ga_hardening_worktree_overlay",
       "full_validate": "passed"
     },
     "mindburn_public_site": {

--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f
-    digest: sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f
+    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
+    digest: sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
     source: https://github.com/NousResearch/hermes-agent
     ref: v2026.5.16
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f
+    artifact_digest: sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
     sbom_tool: syft
     sbom_ref: artifact://sbom-hermes.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-hermes.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26179980172/1/artifact-verification/hermes
-    live_e2e_run_id: github-actions://26179980172/1/live-e2e/hermes
-    evidence_pack_ref: github-actions://26179980172/1/evidencepack/hermes
-    teardown_receipt_ref: github-actions://26179980172/1/teardown/hermes
+    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/hermes
+    live_e2e_run_id: github-actions://26186959337/1/live-e2e/hermes
+    evidence_pack_ref: github-actions://26186959337/1/evidencepack/hermes
+    teardown_receipt_ref: github-actions://26186959337/1/teardown/hermes
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,10 +90,11 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
+    artifact_workflow_run: github-actions://26186959337/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/hermes:v2026.5.16
     latest_release: v2026.5.16
-    promotion_provenance_ref: github-actions://26179980172/1
+    promotion_provenance_ref: github-actions://26186959337/1
     release_published_at: "2026-05-16T09:59:15Z"
     upstream_commit: a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
     upstream_repo: https://github.com/NousResearch/hermes-agent

--- a/registry/launchpad/apps/kilocode.yaml
+++ b/registry/launchpad/apps/kilocode.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba
-    digest: sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba
+    image: ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
+    digest: sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
     source: https://github.com/Kilo-Org/kilocode
     ref: v7.3.1
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba
+    artifact_digest: sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
     sbom_tool: syft
     sbom_ref: artifact://sbom-kilocode.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-kilocode.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26179980172/1/artifact-verification/kilocode
-    live_e2e_run_id: github-actions://26179980172/1/live-e2e/kilocode
-    evidence_pack_ref: github-actions://26179980172/1/evidencepack/kilocode
-    teardown_receipt_ref: github-actions://26179980172/1/teardown/kilocode
+    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/kilocode
+    live_e2e_run_id: github-actions://26186959337/1/live-e2e/kilocode
+    evidence_pack_ref: github-actions://26186959337/1/evidencepack/kilocode
+    teardown_receipt_ref: github-actions://26186959337/1/teardown/kilocode
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,9 +90,9 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://26179980172/1
+    artifact_workflow_run: github-actions://26186959337/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
-    promotion_provenance_ref: github-actions://26179980172/1
+    promotion_provenance_ref: github-actions://26186959337/1
     upstream_commit: 64c60812ae730a30db1fa2226d9e446f7f10c127
     upstream_ref: v7.3.1
     upstream_repo: https://github.com/Kilo-Org/kilocode

--- a/registry/launchpad/apps/openclaw.yaml
+++ b/registry/launchpad/apps/openclaw.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501
-    digest: sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501
+    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
+    digest: sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
     source: https://github.com/openclaw/openclaw
     ref: v2026.5.12
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501
+    artifact_digest: sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
     sbom_tool: syft
     sbom_ref: artifact://sbom-openclaw.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-openclaw.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26179980172/1/artifact-verification/openclaw
-    live_e2e_run_id: github-actions://26179980172/1/live-e2e/openclaw
-    evidence_pack_ref: github-actions://26179980172/1/evidencepack/openclaw
-    teardown_receipt_ref: github-actions://26179980172/1/teardown/openclaw
+    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/openclaw
+    live_e2e_run_id: github-actions://26186959337/1/live-e2e/openclaw
+    evidence_pack_ref: github-actions://26186959337/1/evidencepack/openclaw
+    teardown_receipt_ref: github-actions://26186959337/1/teardown/openclaw
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,10 +90,11 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
+    artifact_workflow_run: github-actions://26186959337/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/openclaw:v2026.5.12
     latest_release: v2026.5.12
-    promotion_provenance_ref: github-actions://26179980172/1
+    promotion_provenance_ref: github-actions://26186959337/1
     release_published_at: "2026-05-14T18:28:04Z"
     upstream_commit: f066dd2f31c231f38fbcaacd6f6dfce0801143b3
     upstream_repo: https://github.com/openclaw/openclaw

--- a/registry/launchpad/apps/opencode.yaml
+++ b/registry/launchpad/apps/opencode.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f
-    digest: sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f
+    image: ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
+    digest: sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
     source: https://github.com/anomalyco/opencode
     ref: v1.15.5
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f
+    artifact_digest: sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
     sbom_tool: syft
     sbom_ref: artifact://sbom-opencode.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-opencode.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26179980172/1/artifact-verification/opencode
-    live_e2e_run_id: github-actions://26179980172/1/live-e2e/opencode
-    evidence_pack_ref: github-actions://26179980172/1/evidencepack/opencode
-    teardown_receipt_ref: github-actions://26179980172/1/teardown/opencode
+    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/opencode
+    live_e2e_run_id: github-actions://26186959337/1/live-e2e/opencode
+    evidence_pack_ref: github-actions://26186959337/1/evidencepack/opencode
+    teardown_receipt_ref: github-actions://26186959337/1/teardown/opencode
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,9 +90,9 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://26179980172/1
+    artifact_workflow_run: github-actions://26186959337/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
-    promotion_provenance_ref: github-actions://26179980172/1
+    promotion_provenance_ref: github-actions://26186959337/1
     upstream_commit: d7a6e1daaf2271bcd0b611fbb27d4956806e475a
     upstream_ref: v1.15.5
     upstream_repo: https://github.com/anomalyco/opencode

--- a/scripts/launch/clean_install_gate.sh
+++ b/scripts/launch/clean_install_gate.sh
@@ -121,8 +121,15 @@ collect_remote_audit_inputs() {
       > "$TRANSCRIPT_DIR/audit/release-download.stdout" 2> "$TRANSCRIPT_DIR/audit/release-download.stderr" || status="FAIL"
     gh run view "$ARTIFACT_RUN_ID" --repo "$REPO" --log \
       > "$TRANSCRIPT_DIR/audit/logs/launchpad-artifacts.log" 2> "$TRANSCRIPT_DIR/audit/logs/launchpad-artifacts.stderr" || status="FAIL"
-    gh run view 26131090671 --repo "$REPO" --log \
-      > "$TRANSCRIPT_DIR/audit/logs/release.log" 2> "$TRANSCRIPT_DIR/audit/logs/release.stderr" || status="FAIL"
+    local release_run_id
+    release_run_id="$(gh run list --repo "$REPO" --workflow release.yml --branch "$RELEASE_TAG" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+    if [[ -n "$release_run_id" ]]; then
+      gh run view "$release_run_id" --repo "$REPO" --log \
+        > "$TRANSCRIPT_DIR/audit/logs/release.log" 2> "$TRANSCRIPT_DIR/audit/logs/release.stderr" || status="FAIL"
+    else
+      status="FAIL"
+      printf 'release workflow run not found for %s\n' "$RELEASE_TAG" > "$TRANSCRIPT_DIR/audit/logs/release.stderr"
+    fi
     gh run download "$ARTIFACT_RUN_ID" --repo "$REPO" -n launchpad-artifact-manifest \
       -D "$TRANSCRIPT_DIR/audit/artifact-manifest" \
       > "$TRANSCRIPT_DIR/audit/artifact-manifest.stdout" 2> "$TRANSCRIPT_DIR/audit/artifact-manifest.stderr" || status="FAIL"

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -49,6 +49,8 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 	requireContains(t, cleanGate, `"supported_apps": ["openclaw", "hermes", "opencode", "kilocode"]`)
 	requireContains(t, cleanGate, `"candidate_promotion_apps": []`)
 	requireContains(t, cleanGate, `"deprecated_include_candidates_flag": "accepted_noop_all_four_apps_are_supported"`)
+	requireContains(t, cleanGate, "gh run list --repo \"$REPO\" --workflow release.yml --branch \"$RELEASE_TAG\"")
+	requireNotContains(t, cleanGate, "gh run view 26131090671", "scripts/launch/clean_install_gate.sh")
 
 	cleanWorkflow := readDoc(t, root, ".github/workflows/launchpad-clean-install.yml")
 	requireContains(t, cleanWorkflow, "default: v0.5.5")

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -114,7 +114,7 @@ func TestHistoricalLaunchpadReportsDeclareSupersededTruth(t *testing.T) {
 	jsonReport := readDoc(t, root, "docs/launchpad/final_report.json")
 	requireContains(t, jsonReport, `"historical_report": true`)
 	requireContains(t, jsonReport, `"superseded_by": "docs/launchpad/v1_report.json"`)
-	requireContains(t, jsonReport, `"artifact_workflow_run_id": "26179980172"`)
+	requireContains(t, jsonReport, `"artifact_workflow_run_id": "26186959337"`)
 	requireContains(t, jsonReport, `"opencode"`)
 	requireContains(t, jsonReport, `"kilocode"`)
 }
@@ -126,9 +126,12 @@ func TestLaunchpadClaimsDoNotOverstateIsolationEgressOrWebSocketMCP(t *testing.T
 		"SECURITY_REVIEW.md",
 		"FINAL_IMPLEMENTATION_REPORT.md",
 		"THREAT_MODEL_ADDENDUM.md",
+		"v1_report.json",
 	} {
 		body := strings.ToLower(readLaunchpadDoc(t, root, rel))
 		for _, forbidden := range []string{
+			"market_best",
+			"best on market",
 			"no sensitive prompt data left",
 			"hostile-agent-grade docker",
 			"websocket mcp is supported",

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -55,7 +55,8 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 	cleanWorkflow := readDoc(t, root, ".github/workflows/launchpad-clean-install.yml")
 	requireContains(t, cleanWorkflow, "default: v0.5.5")
 	requireContains(t, cleanWorkflow, `default: "26186959337"`)
-	requireContains(t, cleanWorkflow, "brew install colima docker jq qemu")
+	requireContains(t, cleanWorkflow, "brew install colima docker jq qemu lima-additional-guestagents")
+	requireContains(t, cleanWorkflow, "colima delete -f")
 
 	artifactWorkflow := readDoc(t, root, ".github/workflows/launchpad-artifacts.yml")
 	requireContains(t, artifactWorkflow, "run_candidate_live_conformance")

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -55,6 +55,7 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 	cleanWorkflow := readDoc(t, root, ".github/workflows/launchpad-clean-install.yml")
 	requireContains(t, cleanWorkflow, "default: v0.5.5")
 	requireContains(t, cleanWorkflow, `default: "26186959337"`)
+	requireContains(t, cleanWorkflow, "brew install colima docker jq qemu")
 
 	artifactWorkflow := readDoc(t, root, ".github/workflows/launchpad-artifacts.yml")
 	requireContains(t, artifactWorkflow, "run_candidate_live_conformance")

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-05-20T23:39:28Z
-# Commit: e035633112240c993f87788b0058db6a925dec29
+# Generated: 2026-05-21T00:34:18Z
+# Commit: 320276bc4c21c2d692dad38c073f35f697bf72be
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md


### PR DESCRIPTION
## Summary
- pin Launchpad GA docs, clean-install defaults, app registry specs, and claims tests to artifact/live conformance run 26186959337
- refresh four app signed OCI digests and promotion refs from the successful run
- add a docs-truth guard against reintroducing market-best claims and refresh the protected boundary manifest

## Verification
- make quality-pr
- go test ./tests/launchpad/... ./core/pkg/launchpad/... ./core/pkg/mcp/... ./core/cmd/helm-ai-kernel
- make docs-truth
- git diff --check
- tools/boundary/generate-manifest.sh && make verify-boundary
- offline verified four EvidencePack tarballs from run 26186959337 with helm-ai-kernel verify --bundle