### PR TITLE
ci: install qemu for launchpad clean install

### DIFF
--- a/.github/workflows/launchpad-clean-install.yml
+++ b/.github/workflows/launchpad-clean-install.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           set -euo pipefail
           brew update
-          brew install colima docker jq
+          brew install colima docker jq qemu
 
       - name: Start Docker-compatible local-container runtime
         run: |


### PR DESCRIPTION
## Summary
- install qemu in the Launchpad macOS clean-install workflow so Colima can start x86_64 emulation on arm64 macOS runners

## Validation
- previous clean-install run 26190638378 failed before Launchpad install at Colima startup with qemu-img missing
- change is limited to CI dependency setup