### PR TITLE
ci: install lima guest agents for clean install

### DIFF
--- a/.github/workflows/launchpad-clean-install.yml
+++ b/.github/workflows/launchpad-clean-install.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           set -euo pipefail
           brew update
-          brew install colima docker jq qemu
+          brew install colima docker jq qemu lima-additional-guestagents
 
       - name: Start Docker-compatible local-container runtime
         run: |


### PR DESCRIPTION
## Summary
- add lima-additional-guestagents to the Launchpad macOS clean-install runtime setup
- required for Colima x86_64 emulation on arm64 GitHub macOS runners after qemu is installed

## Validation
- prior rerun 26191133496 reached Colima startup and failed with missing Linux-x86_64 guest agent before HELM install