### PR TITLE
launchpad: report clean install status from shell result

### DIFF
--- a/scripts/launch/clean_install_gate.sh
+++ b/scripts/launch/clean_install_gate.sh
@@ -206,14 +206,13 @@ redact_transcripts() {
 
 write_final_report() {
   local status="$1"
-  python3 - "$OUTPUT" "$COMMANDS_JSONL" "$EVIDENCE_JSONL" "$LAUNCH_IDS_JSONL" "$GHCR_JSON" "$SECRET_AUDIT_JSON" "$REMOTE_AUDIT_JSON" "$RELEASE_TAG" "$HOST_KIND" "$ARTIFACT_RUN_ID" <<'PY'
+  python3 - "$OUTPUT" "$status" "$COMMANDS_JSONL" "$EVIDENCE_JSONL" "$LAUNCH_IDS_JSONL" "$GHCR_JSON" "$SECRET_AUDIT_JSON" "$REMOTE_AUDIT_JSON" "$RELEASE_TAG" "$HOST_KIND" "$ARTIFACT_RUN_ID" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-output, commands_path, evidence_path, launch_ids_path, ghcr_path, secret_path, remote_path, release_tag, host_kind, artifact_run_id = sys.argv[1:]
-status = sys.stdin.read().strip() or "FAIL"
+output, status, commands_path, evidence_path, launch_ids_path, ghcr_path, secret_path, remote_path, release_tag, host_kind, artifact_run_id = sys.argv[1:]
 
 def read_jsonl(path):
     p = Path(path)
@@ -331,7 +330,7 @@ main() {
 
   redact_transcripts
 
-  write_final_report "$final_status" <<<"$final_status"
+  write_final_report "$final_status"
   printf 'clean-install: wrote redacted report to %s\n' "$OUTPUT"
   [[ "$final_status" == "PASS" ]]
 }

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -44,6 +44,8 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 	requireContains(t, cleanGate, "--include-candidates")
 	requireContains(t, cleanGate, `RELEASE_TAG="v0.5.5"`)
 	requireContains(t, cleanGate, `ARTIFACT_RUN_ID="26179980172"`)
+	requireContains(t, cleanGate, "output, status, commands_path")
+	requireNotContains(t, cleanGate, "status = sys.stdin.read()", "scripts/launch/clean_install_gate.sh")
 	requireContains(t, cleanGate, `"supported_apps": ["openclaw", "hermes", "opencode", "kilocode"]`)
 	requireContains(t, cleanGate, `"candidate_promotion_apps": []`)
 	requireContains(t, cleanGate, `"deprecated_include_candidates_flag": "accepted_noop_all_four_apps_are_supported"`)


### PR DESCRIPTION
## Summary
- pass the clean-install shell status into the report writer as an argv value instead of trying to read it from stdin after the Python here-doc
- add a focused claims guard so the script does not regress to the stale stdin status pattern

## Validation
- bash -n scripts/launch/clean_install_gate.sh
- go test ./tests/launchpad -run TestLaunchpadClaimsMarketPromotedAppsAsSupported -count=1
- clean-install run 26191607504 passed every command and EvidencePack verification, but exposed the stale top-level JSON status default