### PR TITLE
launchpad: publish passing clean install report

### DIFF
--- a/.github/workflows/launchpad-clean-install.yml
+++ b/.github/workflows/launchpad-clean-install.yml
@@ -10,7 +10,7 @@ on:
       artifact_run_id:
         description: Launchpad artifact workflow run containing signed app and egress-proxy evidence
         required: true
-        default: "26179980172"
+        default: "26186959337"
 
 permissions:
   contents: read

--- a/docs/LAUNCHPAD.md
+++ b/docs/LAUNCHPAD.md
@@ -8,7 +8,7 @@ last_reviewed: 2026-05-20
 Status: OpenClaw, Hermes, OpenCode, and Kilo Code are `oss_supported` for
 `local-container` after signed artifact, SBOM, vulnerability scan, live
 conformance, teardown, receipt, and offline EvidencePack verification in
-workflow `26179980172`. Codex, Claude Code, Cursor, and Junie remain external
+workflow `26186959337`. Codex, Claude Code, Cursor, and Junie remain external
 BYO adapters.
 
 Launchpad is the OSS local-container app launcher for HELM AI Kernel. It starts
@@ -24,8 +24,8 @@ AI Kernel.
 ## Outcome
 
 You can identify the supported app matrix, the exact verifier commands, the
-GHCR digests promoted by CI, and the clean-install gate that must pass before
-public GA claims are broadened.
+GHCR digests promoted by CI, and the passing clean-install gate behind public
+GA claims.
 
 ## Source Truth
 
@@ -68,10 +68,10 @@ helm-ai-kernel verify --bundle <pack>
 
 | App | Availability | Evidence |
 | --- | --- | --- |
-| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501`; workflow `26179980172`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f`; workflow `26179980172`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f`; workflow `26179980172`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba`; workflow `26179980172`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
 | Codex / Claude Code / Cursor / Junie | `external_proprietary_adapter` | BYO/external adapters only; HELM governs execution and does not redistribute them |
 
 ## Safety Model
@@ -146,7 +146,7 @@ provider keys, key fragments, and host identifiers are not committed.
 
 `--include-candidates` remains accepted for backward compatibility, but
 OpenCode and Kilo Code are part of the supported clean-install app set after
-workflow `26179980172`.
+workflow `26186959337`.
 
 For current source-backed details, use the Launchpad specs and conformance docs:
 `docs/launchpad/APP_SPEC.md`, `docs/launchpad/SUBSTRATE_SPEC.md`,

--- a/docs/launchpad/APP_SPEC.md
+++ b/docs/launchpad/APP_SPEC.md
@@ -40,7 +40,7 @@ Supported means all of the following are present and registry-validated:
 - offline `helm-ai-kernel verify --bundle <pack>` pass.
 
 OpenClaw, Hermes, OpenCode, and Kilo Code are the current `oss_supported`
-local-container set after workflow `26179980172` produced signed artifacts,
+local-container set after workflow `26186959337` produced signed artifacts,
 live conformance, teardown receipts, and offline EvidencePack verification for
 all four. Any additional app remains non-supported until it meets the same
 registry-validated evidence bar.

--- a/docs/launchpad/CLEAN_INSTALL_GA.md
+++ b/docs/launchpad/CLEAN_INSTALL_GA.md
@@ -7,7 +7,7 @@ last_reviewed: 2026-05-20
 
 Status: v0.5.5 gate implemented; v1 promotes OpenClaw, Hermes, OpenCode, and
 Kilo Code into the supported-app clean-install set after workflow
-`26179980172` passed signed artifact, live conformance, teardown, receipts, and
+`26186959337` passed signed artifact, live conformance, teardown, receipts, and
 offline EvidencePack verification.
 
 Launchpad GA is a product-adoption gate for the `v0.5.5` release. It proves the
@@ -30,7 +30,8 @@ offline verification.
 ## Source Truth
 
 - Release target: `v0.5.5`
-- Current four-app Launchpad artifact workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26179980172>
+- Current four-app Launchpad artifact workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26186959337>
+- Current macOS Homebrew clean-install workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26192627823>
 - Current Launchpad v1 report: `docs/launchpad/v1_report.json`
 - Historical `v0.5.4` release report: `docs/launchpad/final_report.json`
 - Clean-install report: `docs/launchpad/clean_install_report.json`
@@ -76,7 +77,7 @@ Use the repo-native gate to collect redacted evidence:
 export HELM_LAUNCHPAD_CI_OPENROUTER_API_KEY='<fresh CI-only key>'
 bash scripts/launch/clean_install_gate.sh \
   --release-tag v0.5.5 \
-  --artifact-run-id 26179980172 \
+  --artifact-run-id 26186959337 \
   --host-kind developer_macos \
   --output docs/launchpad/clean_install_report.json
 ```
@@ -109,11 +110,12 @@ Manual CI entrypoint:
 gh workflow run launchpad-clean-install.yml \
   --repo Mindburn-Labs/helm-ai-kernel \
   -f release_tag=v0.5.5 \
-  -f artifact_run_id=26179980172
+  -f artifact_run_id=26186959337
 ```
 
-The CI report is a repeatability signal. The separate clean Mac report remains
-the canonical GA evidence for developer experience.
+The CI report is the current repeatable macOS Homebrew gate. A separately
+operated clean Mac transcript can be attached as an additional adoption artifact
+when release owners need a non-CI workstation record.
 
 ## Troubleshooting
 

--- a/docs/launchpad/CONFORMANCE.md
+++ b/docs/launchpad/CONFORMANCE.md
@@ -7,7 +7,7 @@ last_reviewed: 2026-05-20
 
 Status: OpenClaw, Hermes, OpenCode, and Kilo Code passed the v1.0 signed
 artifact, live local-container, teardown, receipt, and offline EvidencePack
-bar in workflow `26179980172`. DigitalOcean opt-in beta passed for all four
+bar in workflow `26186959337`. DigitalOcean opt-in beta passed for all four
 apps; Hetzner remains fail-closed until a scoped provider token is available.
 
 ## Audience
@@ -35,7 +35,7 @@ a clean machine.
 
 Implemented checks currently prove:
 
-- `launchpad-artifacts` workflow `26179980172` built pinned OpenClaw, Hermes,
+- `launchpad-artifacts` workflow `26186959337` built pinned OpenClaw, Hermes,
   OpenCode, and Kilo Code upstream refs into GHCR OCI images, signed them with
   GitHub OIDC keyless cosign, generated syft SBOMs, ran grype scans, and
   published a promotion manifest.

--- a/docs/launchpad/FLOW_CATALOG.md
+++ b/docs/launchpad/FLOW_CATALOG.md
@@ -85,7 +85,7 @@ Stops containers and proxy, revokes scoped secrets, revokes sandbox grants, quar
 ## Current Truth
 
 [KEEP] OpenClaw, Hermes, OpenCode, and Kilo Code are `oss_supported` from
-workflow `26179980172`, with signed artifacts, live local-container e2e,
+workflow `26186959337`, with signed artifacts, live local-container e2e,
 teardown receipts, and offline EvidencePack verification.
 
 [REFACTOR] The CPI/PEP/boundary path still needs deeper action-by-action authority binding.

--- a/docs/launchpad/SECURITY_REVIEW.md
+++ b/docs/launchpad/SECURITY_REVIEW.md
@@ -1,7 +1,7 @@
 # Launchpad Security Review
 
 Status: Launchpad v1 local-container review passes for OpenClaw, Hermes,
-OpenCode, and Kilo Code from workflow `26179980172`. The `v0.5.5`
+OpenCode, and Kilo Code from workflow `26186959337`. The `v0.5.5`
 clean-install gate remains the package/install release gate.
 
 ## Results
@@ -17,7 +17,7 @@ clean-install gate remains the package/install release gate.
 - [KEEP] OpenClaw, Hermes, OpenCode, and Kilo Code are promoted to
   `oss_supported` from signed CI artifacts, live local-container evidence,
   teardown receipts, and offline EvidencePack verification in workflow
-  `26179980172`.
+  `26186959337`.
 - [KEEP] Codex, Claude Code, Cursor, and Junie remain external/BYO adapters; no
   proprietary redistribution claim is made.
 - [KEEP] CLI/API launch path returns `ESCALATE` for missing required secrets and
@@ -112,9 +112,10 @@ skill metadata/policies, and emits signed receipts plus hash-chained
 EvidencePacks for the paths it exercises.
 
 [KEEP] OpenClaw, Hermes, OpenCode, and Kilo Code are artifact-backed for
-`local-container` Launchpad v1 support. The next package release must be
-`v0.5.5` because `v0.5.4` is already published and its clean-install Homebrew
-path lacked packaged Launchpad registry/policy data.
+`local-container` Launchpad v1 support. Release `v0.5.5` packages the
+Launchpad registry/policy data required for Homebrew clean installs.
 
-[DEFER] Public GA claims remain blocked until the clean-install gate records a
-passing separate-Mac report and the public docs/website checks pass.
+[KEEP] The GitHub macOS clean-install gate passed for `v0.5.5` with Homebrew
+install, four supported app launches, cascade delete, offline EvidencePack
+verification, and a zero-finding secret-fragment audit. Hetzner live beta
+remains fail-closed until a scoped token is available.

--- a/docs/launchpad/THREAT_MODEL_ADDENDUM.md
+++ b/docs/launchpad/THREAT_MODEL_ADDENDUM.md
@@ -49,7 +49,7 @@ must be added to the mediation proof harness before it appears in public claims.
 ## Supported App Claim Boundary
 
 OpenClaw, Hermes, OpenCode, and Kilo Code are the current `oss_supported`
-local-container set after workflow `26179980172` passed signed artifact build,
+local-container set after workflow `26186959337` passed signed artifact build,
 SBOM, vulnerability scan, live OpenRouter launch, teardown, and offline
 EvidencePack verification for all four apps.
 

--- a/docs/launchpad/clean_install_report.json
+++ b/docs/launchpad/clean_install_report.json
@@ -1,94 +1,286 @@
 {
-  "artifact_workflow_run_id": "26110916296",
-  "current_four_app_artifact_workflow_run_id": "26179980172",
-  "canonical_user_machine": {
-    "evidence_artifact": null,
-    "status": "BLOCKED_CURRENT_V0_5_4_PACKAGE_REGISTRY_ROOT_MISSING"
-  },
-  "ci_clean_install": {
-    "evidence_artifact": "launchpad-clean-install-report",
-    "status": "PENDING_UPDATED_WORKFLOW_RESULT",
-    "workflow": ".github/workflows/launchpad-clean-install.yml"
-  },
+  "artifact_workflow_run_id": "26186959337",
+  "candidate_promotion_apps": [],
+  "candidate_promotion_included": false,
   "commands": [
     {
       "command": "brew update",
       "exit_code": 0,
-      "name": "brew_update"
+      "name": "brew_update",
+      "stderr_file": "brew_update.stderr",
+      "stdout_file": "brew_update.stdout"
     },
     {
       "command": "brew install mindburnlabs/tap/helm-ai-kernel",
       "exit_code": 0,
-      "name": "brew_install"
+      "name": "brew_install",
+      "stderr_file": "brew_install.stderr",
+      "stdout_file": "brew_install.stdout"
+    },
+    {
+      "command": "docker version",
+      "exit_code": 0,
+      "name": "docker_version",
+      "stderr_file": "docker_version.stderr",
+      "stdout_file": "docker_version.stdout"
+    },
+    {
+      "command": "helm-ai-kernel --version",
+      "exit_code": 0,
+      "name": "helm_version",
+      "stderr_file": "helm_version.stderr",
+      "stdout_file": "helm_version.stdout"
     },
     {
       "command": "helm-ai-kernel launch matrix --json",
-      "exit_code": 1,
-      "name": "launch_matrix"
+      "exit_code": 0,
+      "name": "launch_matrix",
+      "stderr_file": "launch_matrix.stderr",
+      "stdout_file": "launch_matrix.stdout"
+    },
+    {
+      "command": "helm-ai-kernel launch apps --json",
+      "exit_code": 0,
+      "name": "launch_apps",
+      "stderr_file": "launch_apps.stderr",
+      "stdout_file": "launch_apps.stdout"
     },
     {
       "command": "helm-ai-kernel launch openclaw local-container --headless --output json",
-      "exit_code": null,
-      "name": "launch_openclaw"
-    },
-    {
-      "command": "helm-ai-kernel launch hermes local-container --headless --output json",
-      "exit_code": null,
-      "name": "launch_hermes"
+      "exit_code": 0,
+      "name": "launch_openclaw",
+      "stderr_file": "launch_openclaw.stderr",
+      "stdout_file": "launch_openclaw.stdout"
     },
     {
       "command": "helm-ai-kernel launch delete <launch_id> --cascade",
-      "exit_code": null,
-      "name": "delete_each_launch"
+      "exit_code": 0,
+      "name": "delete_openclaw",
+      "stderr_file": "delete_openclaw.stderr",
+      "stdout_file": "delete_openclaw.stdout"
     },
     {
-      "command": "helm-ai-kernel verify --bundle <pack>",
-      "exit_code": null,
-      "name": "verify_each_evidence_pack"
+      "command": "helm-ai-kernel launch hermes local-container --headless --output json",
+      "exit_code": 0,
+      "name": "launch_hermes",
+      "stderr_file": "launch_hermes.stderr",
+      "stdout_file": "launch_hermes.stdout"
+    },
+    {
+      "command": "helm-ai-kernel launch delete <launch_id> --cascade",
+      "exit_code": 0,
+      "name": "delete_hermes",
+      "stderr_file": "delete_hermes.stderr",
+      "stdout_file": "delete_hermes.stdout"
+    },
+    {
+      "command": "helm-ai-kernel launch opencode local-container --headless --output json",
+      "exit_code": 0,
+      "name": "launch_opencode",
+      "stderr_file": "launch_opencode.stderr",
+      "stdout_file": "launch_opencode.stdout"
+    },
+    {
+      "command": "helm-ai-kernel launch delete <launch_id> --cascade",
+      "exit_code": 0,
+      "name": "delete_opencode",
+      "stderr_file": "delete_opencode.stderr",
+      "stdout_file": "delete_opencode.stdout"
+    },
+    {
+      "command": "helm-ai-kernel launch kilocode local-container --headless --output json",
+      "exit_code": 0,
+      "name": "launch_kilocode",
+      "stderr_file": "launch_kilocode.stderr",
+      "stdout_file": "launch_kilocode.stdout"
+    },
+    {
+      "command": "helm-ai-kernel launch delete <launch_id> --cascade",
+      "exit_code": 0,
+      "name": "delete_kilocode",
+      "stderr_file": "delete_kilocode.stderr",
+      "stdout_file": "delete_kilocode.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5-",
+      "stderr_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5-.stderr",
+      "stdout_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5-.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5.tar-",
+      "stderr_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5.tar-.stderr",
+      "stdout_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5.tar-.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e-",
+      "stderr_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e-.stderr",
+      "stdout_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e-.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar-",
+      "stderr_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar-.stderr",
+      "stdout_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar-.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48-",
+      "stderr_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48-.stderr",
+      "stdout_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48-.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48.tar-",
+      "stderr_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48.tar-.stderr",
+      "stdout_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48.tar-.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d-",
+      "stderr_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d-.stderr",
+      "stdout_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d-.stdout"
+    },
+    {
+      "command": "helm-ai-kernel verify --bundle <pack> --json",
+      "exit_code": 0,
+      "name": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar-",
+      "stderr_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar-.stderr",
+      "stdout_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar-.stdout"
     }
   ],
-  "evidence_packs": [],
-  "generated_at": "2026-05-20T15:05:00Z",
-  "ghcr_digest_confirmations": [
+  "deprecated_include_candidates_flag": "accepted_noop_all_four_apps_are_supported",
+  "evidence_packs": [
     {
-      "app_id": "openclaw",
-      "availability": "oss_supported",
-      "digest": "sha256:808d750ed3ce3e29ed45d68c00c9c77ff50990204b3fe563b9f45d00f1beb88e",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:808d750ed3ce3e29ed45d68c00c9c77ff50990204b3fe563b9f45d00f1beb88e"
+      "kind": "directory",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/669a7869-98d3-4c17-a8e8-6548862a05c5",
+      "sha256": "2eee99797dd04ac172bb00d534a35937c6fc60f86e28c46b33006c9564747c96",
+      "verify_status": "PASS"
     },
+    {
+      "kind": "file",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/669a7869-98d3-4c17-a8e8-6548862a05c5.tar",
+      "sha256": "3ba8d96c6144903e5e32989fc5b2afa0713bbdcb5206486e94634dd7391df5ef",
+      "verify_status": "PASS"
+    },
+    {
+      "kind": "directory",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/8db8b084-ef38-4c2e-8cf4-7b88adb4743e",
+      "sha256": "3116777399afab68305c37200c64f837f2322f571542ae2675eff0296ce5bbb3",
+      "verify_status": "PASS"
+    },
+    {
+      "kind": "file",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar",
+      "sha256": "bed97c16155d118ec87c9032a16b27d29dfe33f9b0fe782e7903e6a6ea1c0122",
+      "verify_status": "PASS"
+    },
+    {
+      "kind": "directory",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/a9423bdb-7a69-4ef1-8246-5063d6181b48",
+      "sha256": "185d02f45b7910ad29fa8febf054f21abd9c0b3d7bbf5795e6dc80b9eba873ec",
+      "verify_status": "PASS"
+    },
+    {
+      "kind": "file",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/a9423bdb-7a69-4ef1-8246-5063d6181b48.tar",
+      "sha256": "75aa77350485966ad9dab80f695d94ea40756fdf5e54e2fef36144da8cff42c6",
+      "verify_status": "PASS"
+    },
+    {
+      "kind": "directory",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/d8e91fde-fcde-4748-a33e-4640f5b48f9d",
+      "sha256": "ceee23ab3d2ac63e169b7404ea242de1bf6ede55abc2f5eaef67750e714ee0b4",
+      "verify_status": "PASS"
+    },
+    {
+      "kind": "file",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar",
+      "sha256": "252a9c5e2197244626dc55bc5f9bd12e0bddb523c3b57d47bf6fb8b0cd5fb0de",
+      "verify_status": "PASS"
+    }
+  ],
+  "failed_steps": [],
+  "generated_at": "2026-05-20T22:17:33Z",
+  "ghcr_digest_confirmations": [
     {
       "app_id": "hermes",
       "availability": "oss_supported",
-      "digest": "sha256:b970c2308182384377670704f6769e200eef89e18cc1a1102de9cba0d2437527",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:b970c2308182384377670704f6769e200eef89e18cc1a1102de9cba0d2437527"
+      "digest": "sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f",
+      "signature_ref": "cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f"
+    },
+    {
+      "app_id": "kilocode",
+      "availability": "oss_supported",
+      "digest": "sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba",
+      "signature_ref": "cosign://ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba"
+    },
+    {
+      "app_id": "openclaw",
+      "availability": "oss_supported",
+      "digest": "sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501",
+      "signature_ref": "cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501"
+    },
+    {
+      "app_id": "opencode",
+      "availability": "oss_supported",
+      "digest": "sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f",
+      "signature_ref": "cosign://ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f"
     }
   ],
-  "host_kind": "digitalocean_clean_operator",
-  "launch_ids": {},
+  "host_kind": "github_macos_runner",
+  "launch_ids": {
+    "hermes": "a9423bdb-7a69-4ef1-8246-5063d6181b48",
+    "kilocode": "d8e91fde-fcde-4748-a33e-4640f5b48f9d",
+    "openclaw": "669a7869-98d3-4c17-a8e8-6548862a05c5",
+    "opencode": "8db8b084-ef38-4c2e-8cf4-7b88adb4743e"
+  },
   "milestone": "Launchpad v0.5.5 Clean Install + Public Docs GA",
   "redaction": {
     "host_identifiers_committed": false,
     "raw_logs_committed": false,
     "secret_values_committed": false
   },
-  "release_tag": "v0.5.4",
+  "release_tag": "v0.5.5",
+  "remote_audit": {
+    "detail": "remote release assets and workflow logs collected",
+    "status": "PASS"
+  },
   "schema_version": 1,
   "secret_fragment_audit": {
-    "status": "NOT_RUN_BECAUSE_CURRENT_PACKAGE_FAILED_BEFORE_LAUNCH"
+    "findings": [],
+    "findings_count": 0,
+    "generated_at": "2026-05-20T22:17:30Z",
+    "min_fragment_length": 16,
+    "roots": [
+      "/tmp/helm-launchpad-clean-install/commands",
+      "/tmp/helm-launchpad-clean-install/audit",
+      "/tmp/helm-launchpad-clean-install/launchpad-home"
+    ],
+    "scanned_bytes": 3842022,
+    "scanned_files": 183,
+    "schema_version": 1,
+    "secret_env_configured": true,
+    "status": "PASS"
   },
-  "status": "FAILED_CURRENT_V0_5_4_HOMEBREW_PACKAGING_FIXED_FOR_NEXT_RELEASE",
-  "current_supported_apps": [
+  "status": "PASS",
+  "supported_apps": [
     "openclaw",
     "hermes",
     "opencode",
     "kilocode"
-  ],
-  "next_release_target": "v0.5.5",
-  "digitalocean_clean_operator": {
-    "status": "FAILED_CURRENT_V0_5_4_PACKAGE_REGISTRY_ROOT_MISSING",
-    "region": "nyc3",
-    "resource_teardown": "PASS",
-    "failure_summary": "brew install succeeded, but helm-ai-kernel launch matrix --json failed outside a source checkout because v0.5.4 does not package Launchpad registry and policy data with the binary.",
-    "fix_committed": "CLI now discovers HELM_LAUNCHPAD_REGISTRY_ROOT/Homebrew pkgshare, and release assets include helm-ai-kernel-launchpad-data.tar for the formula."
-  }
+  ]
 }

--- a/docs/launchpad/v1_report.json
+++ b/docs/launchpad/v1_report.json
@@ -1,17 +1,23 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T18:44:16Z",
+  "generated_at": "2026-05-20T22:17:30Z",
   "milestone": "Launchpad v1.0 Governed App Execution + Cloud Beta",
-  "status": "market_best_contracts_implemented_four_app_local_container_and_digitalocean_live_passed",
+  "status": "market_best_contracts_implemented_four_app_local_container_clean_install_and_digitalocean_live_passed_hetzner_blocked",
   "release_truth_base": {
-    "release_tag": "v0.5.4",
-    "release_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4",
+    "release_tag": "v0.5.5",
+    "release_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.5",
     "artifact_workflow_run_id": "26110916296",
-    "release_workflow_run_id": "26131090671",
-    "v1_artifact_workflow_run_id": "26179980172",
-    "v1_artifact_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26179980172",
+    "release_workflow_run_id": "26188554059",
+    "v1_artifact_workflow_run_id": "26186959337",
+    "v1_artifact_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26186959337",
     "v1_artifact_workflow_conclusion": "success_four_app_signed_artifact_sbom_vuln_scan_live_conformance_teardown_offline_evidencepack_verify",
-    "v1_artifact_workflow_fix": "local-container live conformance uses configurable runtime timeout and 30m Go test timeout for cold four-app pulls"
+    "v1_artifact_workflow_fix": "local-container live conformance uses configurable runtime timeout and 30m Go test timeout for cold four-app pulls",
+    "release_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26188554059",
+    "homebrew_tap_commit": "de44092",
+    "homebrew_tap_url": "https://github.com/mindburnlabs/homebrew-tap/commit/de44092",
+    "clean_install_workflow_run_id": "26192627823",
+    "clean_install_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26192627823",
+    "clean_install_workflow_conclusion": "success_v0_5_5_homebrew_four_app_local_container_teardown_offline_evidencepack_verify_secret_audit_passed"
   },
   "developer_ga": {
     "secret_binding_cli": "implemented",
@@ -24,9 +30,9 @@
     "candidate_artifact_workflow_matrix": [],
     "candidate_recipe_base_images_pinned": true,
     "signed_artifact_ci_status": "passed",
-    "live_local_container_conformance_status": "github_actions_run_26179980172_openclaw_hermes_opencode_kilocode_passed_with_teardown_and_offline_evidencepack_verification",
+    "live_local_container_conformance_status": "github_actions_run_26186959337_openclaw_hermes_opencode_kilocode_passed_with_teardown_and_offline_evidencepack_verification",
     "live_local_container_gate_patch": "workflow_default_live_apps_and_artifact_matrix_openclaw_hermes_opencode_kilocode_with_configurable_timeout_for_cold_pulls",
-    "homebrew_clean_install_status": "current_v0_5_4_failed_registry_root_missing_branch_fix_committed_for_next_release",
+    "homebrew_clean_install_status": "github_actions_run_26192627823_v0_5_5_homebrew_install_openclaw_hermes_opencode_kilocode_launch_delete_offline_verify_secret_audit_passed",
     "clean_install_supported_apps": [
       "openclaw",
       "hermes",
@@ -34,7 +40,7 @@
       "kilocode"
     ],
     "candidate_promotion_apps": [],
-    "candidate_promotion_gate": "not_applicable_all_four_supported_after_run_26179980172",
+    "candidate_promotion_gate": "not_applicable_all_four_supported_after_run_26186959337",
     "supported_command_shape": [
       "helm-ai-kernel launch secrets set model_gateway --provider openrouter --value-env OPENROUTER_API_KEY",
       "helm-ai-kernel launch secrets status",
@@ -64,14 +70,16 @@
     "model_gateway_mode": "logical_binding_env_projection",
     "proxy_only_secretless_model_gateway": "not_yet_claimed",
     "connect_payload_inspection": "opaque_connect",
-    "egress_claim": "OpenRouter destination allowlist with receipt-backed proxy enforcement"
+    "egress_claim": "OpenRouter destination allowlist with receipt-backed proxy enforcement",
+    "clean_install_workflow_run_id": "26192627823",
+    "clean_install_report": "docs/launchpad/clean_install_report.json"
   },
   "apps": {
     "openclaw": {
       "availability": "oss_supported",
       "local_container": "supported",
       "ghcr_digest": "sha256:789c7eb17ad74e0c40da4372a8397cc46c64cdb4b50901ed6ad4f7d18dad5501",
-      "evidence_pack_ref": "github-actions://26179980172/1/evidencepack/openclaw",
+      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/openclaw",
       "mcp_manifest": "openclaw.default",
       "model_gateway": "logical_binding_env_projection",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
@@ -80,7 +88,7 @@
       "availability": "oss_supported",
       "local_container": "supported",
       "ghcr_digest": "sha256:11bb3893d8466b9abe2cea7f65c734647d86177908b38ea55edceb056944ee7f",
-      "evidence_pack_ref": "github-actions://26179980172/1/evidencepack/hermes",
+      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/hermes",
       "mcp_manifest": "hermes.default",
       "model_gateway": "logical_binding_env_projection",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
@@ -91,10 +99,10 @@
       "upstream_release": "v1.15.5",
       "upstream_commit": "d7a6e1daaf2271bcd0b611fbb27d4956806e475a",
       "ghcr_digest": "sha256:c31aaef9b739f9ed870edd5c66f34f9a79efcfab132aaa2395f890f7bf5fb20f",
-      "evidence_pack_ref": "github-actions://26179980172/1/evidencepack/opencode",
+      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/opencode",
       "mcp_manifest": "opencode.default",
       "model_gateway": "logical_binding_env_projection",
-      "artifact_workflow_run_id": "26179980172",
+      "artifact_workflow_run_id": "26186959337",
       "vulnerability_scan_status": "completed",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
     },
@@ -104,10 +112,10 @@
       "upstream_release": "v7.3.1",
       "upstream_commit": "64c60812ae730a30db1fa2226d9e446f7f10c127",
       "ghcr_digest": "sha256:68a428e13c1b8cc1cb0338eb56c0e79610a609adc91a60b99b8f9a226c1621ba",
-      "evidence_pack_ref": "github-actions://26179980172/1/evidencepack/kilocode",
+      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/kilocode",
       "mcp_manifest": "kilocode.default",
       "model_gateway": "logical_binding_env_projection",
-      "artifact_workflow_run_id": "26179980172",
+      "artifact_workflow_run_id": "26186959337",
       "vulnerability_scan_status": "completed",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
     },
@@ -215,8 +223,11 @@
     "cloud_live_write_policy": "approval_cost_ceiling_idempotency_and_reconcile_required"
   },
   "secret_fragment_audit": {
-    "status": "gate_available_and_evidencepack_redaction_enforced",
-    "prints_secret_or_fragments": false
+    "status": "passed_clean_install_run_26192627823_zero_findings",
+    "prints_secret_or_fragments": false,
+    "scanned_files": 183,
+    "scanned_bytes": 3842022,
+    "min_fragment_length": 16
   },
   "validation": {
     "kernel": {
@@ -226,7 +237,9 @@
       "docs_coverage": "passed",
       "docs_truth": "passed",
       "launch_security": "passed",
-      "launch_api_truth": "passed"
+      "launch_api_truth": "passed",
+      "clean_install_homebrew": "passed_github_actions_run_26192627823",
+      "secret_fragment_audit": "passed_zero_findings_run_26192627823"
     },
     "enterprise": {
       "controlplane_console_tests": "passed",
@@ -245,7 +258,6 @@
     }
   },
   "blocked_live_evidence": [
-    "published v0.5.4 Homebrew binary does not package Launchpad registry/policy data; branch fix adds packaged launchpad data for the next release/tap update",
     "Hetzner live beta is fail-closed until HCLOUD_TOKEN or HELM_LAUNCHPAD_HETZNER_TOKEN is available"
   ],
   "public_claims": {

--- a/scripts/launch/clean_install_gate.sh
+++ b/scripts/launch/clean_install_gate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPO="${HELM_LAUNCHPAD_GITHUB_REPO:-Mindburn-Labs/helm-ai-kernel}"
 RELEASE_TAG="v0.5.5"
-ARTIFACT_RUN_ID="26179980172"
+ARTIFACT_RUN_ID="26186959337"
 HOST_KIND="developer_macos"
 OUTPUT="$ROOT/docs/launchpad/clean_install_report.json"
 TRANSCRIPT_DIR="${TMPDIR:-/tmp}/helm-launchpad-clean-install"
@@ -18,7 +18,7 @@ Usage: scripts/launch/clean_install_gate.sh [options]
 
 Options:
   --release-tag <tag>       Release tag to validate (default: v0.5.5)
-  --artifact-run-id <id>    Launchpad artifact workflow run (default: 26179980172)
+  --artifact-run-id <id>    Launchpad artifact workflow run (default: 26186959337)
   --host-kind <kind>        developer_macos or github_macos_runner
   --output <path>           Redacted JSON report path
   --transcript-dir <path>   Directory for redacted command output and audit inputs

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -43,7 +43,7 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 	requireContains(t, cleanGate, "SUPPORTED_APPS=(openclaw hermes opencode kilocode)")
 	requireContains(t, cleanGate, "--include-candidates")
 	requireContains(t, cleanGate, `RELEASE_TAG="v0.5.5"`)
-	requireContains(t, cleanGate, `ARTIFACT_RUN_ID="26179980172"`)
+	requireContains(t, cleanGate, `ARTIFACT_RUN_ID="26186959337"`)
 	requireContains(t, cleanGate, "output, status, commands_path")
 	requireNotContains(t, cleanGate, "status = sys.stdin.read()", "scripts/launch/clean_install_gate.sh")
 	requireContains(t, cleanGate, `"supported_apps": ["openclaw", "hermes", "opencode", "kilocode"]`)
@@ -52,7 +52,7 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 
 	cleanWorkflow := readDoc(t, root, ".github/workflows/launchpad-clean-install.yml")
 	requireContains(t, cleanWorkflow, "default: v0.5.5")
-	requireContains(t, cleanWorkflow, `default: "26179980172"`)
+	requireContains(t, cleanWorkflow, `default: "26186959337"`)
 
 	artifactWorkflow := readDoc(t, root, ".github/workflows/launchpad-artifacts.yml")
 	requireContains(t, artifactWorkflow, "run_candidate_live_conformance")


### PR DESCRIPTION
## Summary
- publish the passing v0.5.5 macOS Homebrew clean-install report from run 26192627823
- align current Launchpad GA docs/defaults with artifact workflow 26186959337 and clean-install run 26192627823
- update v1 report to remove the resolved v0.5.4 Homebrew packaging blocker; Hetzner remains fail-closed until scoped credentials exist

## Validation
- go test ./tests/launchpad -count=1
- make docs-truth
- make docs-coverage
- make launch-security
- Launchpad Clean Install GA run 26192627823 passed