### PR TITLE
launchpad: reconcile final GA evidence pins

### DIFF
--- a/.github/workflows/launchpad-clean-install.yml
+++ b/.github/workflows/launchpad-clean-install.yml
@@ -10,7 +10,7 @@ on:
       artifact_run_id:
         description: Launchpad artifact workflow run containing signed app and egress-proxy evidence
         required: true
-        default: "26186959337"
+        default: "26198407296"
 
 permissions:
   contents: read

--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -218,9 +218,9 @@ If the `helm` command on your machine resolves to this HELM AI Kernel binary, us
 
 ## Release And Conformance Gates
 
-Current public release: `v0.5.4`, published on 2026-05-19 at 23:50 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>.
+Current public release: `v0.5.5`, published on 2026-05-20 at 21:13 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.5>.
 
-The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `v0.5.4.openvex.json`, `release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `v0.5.4.json`, and matching `*.cosign.bundle` files for each primary asset.
+The release page includes Darwin/Linux/Windows binaries, `SHA256SUMS.txt`, `sbom.json`, `v0.5.5.openvex.json`, `release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel-launchpad-data.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `v0.5.5.json`, and matching `*.cosign.bundle` files for each primary asset.
 
 Run conformance and docs gates:
 

--- a/docs/LAUNCHPAD.md
+++ b/docs/LAUNCHPAD.md
@@ -8,7 +8,7 @@ last_reviewed: 2026-05-20
 Status: OpenClaw, Hermes, OpenCode, and Kilo Code are `oss_supported` for
 `local-container` after signed artifact, SBOM, vulnerability scan, live
 conformance, teardown, receipt, and offline EvidencePack verification in
-workflow `26186959337`. Codex, Claude Code, Cursor, and Junie remain external
+workflow `26198407296`. Codex, Claude Code, Cursor, and Junie remain external
 BYO adapters.
 
 Launchpad is the OSS local-container app launcher for HELM AI Kernel. It starts
@@ -68,10 +68,10 @@ helm-ai-kernel verify --bundle <pack>
 
 | App | Availability | Evidence |
 | --- | --- | --- |
-| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
-| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65`; workflow `26186959337`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995`; workflow `26198407296`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652`; workflow `26198407296`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550`; workflow `26198407296`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
+| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6`; workflow `26198407296`; live conformance, teardown, receipts, and offline EvidencePack verification passed |
 | Codex / Claude Code / Cursor / Junie | `external_proprietary_adapter` | BYO/external adapters only; HELM governs execution and does not redistribute them |
 
 ## Safety Model
@@ -146,7 +146,7 @@ provider keys, key fragments, and host identifiers are not committed.
 
 `--include-candidates` remains accepted for backward compatibility, but
 OpenCode and Kilo Code are part of the supported clean-install app set after
-workflow `26186959337`.
+workflow `26198407296`.
 
 For current source-backed details, use the Launchpad specs and conformance docs:
 `docs/launchpad/APP_SPEC.md`, `docs/launchpad/SUBSTRATE_SPEC.md`,

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -94,8 +94,8 @@ The retained workflow set under `.github/workflows/` covers:
 - GHCR image publication for `latest`, version tag, and slim tag
 - manual publication workflows for npm, PyPI, crates.io, and Maven-compatible distribution
 
-Current public GitHub release: `v0.5.4`, published on 2026-05-19 at
-23:50 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>.
+Current public GitHub release: `v0.5.5`, published on 2026-05-20 at
+21:13 UTC: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.5>.
 
 There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
 actual release baseline when auditing the `v0.5.0` delta.
@@ -109,19 +109,20 @@ Its attached assets are:
 - `helm-ai-kernel-windows-amd64.exe`
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `v0.5.4.openvex.json`
+- `v0.5.5.openvex.json`
 - `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`
 - `sample-policy-material.tar`
+- `helm-ai-kernel-launchpad-data.tar`
 - `helm-ai-kernel.mcpb`
 - `helm-ai-kernel.rb`
-- `v0.5.4.json`
+- `v0.5.5.json`
 - matching `*.cosign.bundle` files for every primary asset
 
 `sample-policy-material.tar` includes the sample policy and its referenced EU
-AI Act high-risk reference pack. The `v0.5.4` release attaches a
-`helm-ai-kernel.rb` formula asset for version `0.5.4`; verify the public
+AI Act high-risk reference pack. The `v0.5.5` release attaches a
+`helm-ai-kernel.rb` formula asset for version `0.5.5`; verify the public
 `mindburnlabs/homebrew-tap` state before documenting
 `brew install mindburnlabs/tap/helm-ai-kernel` as current.
 
@@ -144,7 +145,7 @@ writes the final `SHA256SUMS.txt`.
 ## Verification
 
 Every public release must include enough material to verify what was downloaded.
-For `v0.5.4`, use `SHA256SUMS.txt`, `sbom.json`, `v0.5.4.openvex.json`,
+For `v0.5.5`, use `SHA256SUMS.txt`, `sbom.json`, `v0.5.5.openvex.json`,
 `release-attestation.json`, the platform binary assets, attached
 `*.cosign.bundle` files, and the offline `evidence-pack.tar`.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -164,7 +164,7 @@ curl 'http://127.0.0.1:7714/api/v1/receipts?limit=20'
 ./bin/helm-ai-kernel verify evidence-pack.tar --json
 ```
 
-Use the `v0.5.4` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
+Use the `v0.5.5` release `evidence-pack.tar` or an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
 
 ## 7. Validate The Checkout
 

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -33,13 +33,13 @@ flowchart LR
   optional --> verify
 ```
 
-Current public release: `v0.5.4`, published on 2026-05-19 at 23:50 UTC:
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>. The release
+Current public release: `v0.5.5`, published on 2026-05-20 at 21:13 UTC:
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.5>. The release
 assets visible on GitHub are Darwin/Linux/Windows binaries, `SHA256SUMS.txt`,
-`sbom.json`, `v0.5.4.openvex.json`, `release-attestation.json`,
+`sbom.json`, `v0.5.5.openvex.json`, `release-attestation.json`,
 `evidence-pack.tar`, `release.high_risk.v3.toml`,
-`sample-policy-material.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`,
-`v0.5.4.json`, and matching
+`sample-policy-material.tar`, `helm-ai-kernel-launchpad-data.tar`,
+`helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `v0.5.5.json`, and matching
 `*.cosign.bundle` files for each primary asset.
 
 ## Public Release Material
@@ -76,7 +76,7 @@ EvidencePack, verifies the staged `evidence-pack.tar`, and only then writes
 final checksums. A failed EvidencePack verification blocks release asset
 publication.
 
-For `v0.5.4`, use checksum verification, SBOM inspection, OpenVEX inspection,
+For `v0.5.5`, use checksum verification, SBOM inspection, OpenVEX inspection,
 release metadata inspection, offline EvidencePack verification,
 reproducible-build validation, and Cosign verification against the attached
 bundles.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -57,20 +57,20 @@ The verification path is local-first. `helm-ai-kernel verify <evidence-pack.tar|
 performs offline checks by default; `--online` is optional and only runs after
 offline checks pass.
 
-Current public release: `v0.5.4`, published on 2026-05-19 at 23:50 UTC:
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.4>. The release
+Current public release: `v0.5.5`, published on 2026-05-20 at 21:13 UTC:
+<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.5>. The release
 page attaches platform binaries, `SHA256SUMS.txt`, `sbom.json`,
-`v0.5.4.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
-`release.high_risk.v3.toml`, `sample-policy-material.tar`, `helm-ai-kernel.mcpb`,
-`helm-ai-kernel.rb`, `v0.5.4.json`, and matching `*.cosign.bundle` files for
-each primary asset.
+`v0.5.5.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
+`release.high_risk.v3.toml`, `sample-policy-material.tar`,
+`helm-ai-kernel-launchpad-data.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`,
+`v0.5.5.json`, and matching `*.cosign.bundle` files for each primary asset.
 
 There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
 actual baseline when auditing the `v0.5.0` delta.
 
-## v0.5.4 Asset Contract
+## v0.5.5 Asset Contract
 
-The `v0.5.4` release attaches these primary assets:
+The `v0.5.5` release attaches these primary assets:
 
 - `helm-ai-kernel-darwin-amd64`
 - `helm-ai-kernel-darwin-arm64`
@@ -79,11 +79,12 @@ The `v0.5.4` release attaches these primary assets:
 - `helm-ai-kernel-windows-amd64.exe`
 - `SHA256SUMS.txt`
 - `sbom.json`
-- `v0.5.4.openvex.json`
+- `v0.5.5.openvex.json`
 - `release-attestation.json`
 - `evidence-pack.tar`
 - `release.high_risk.v3.toml`
 - `sample-policy-material.tar`
+- `helm-ai-kernel-launchpad-data.tar`
 - `helm-ai-kernel.mcpb`
 - `helm-ai-kernel.rb`
 
@@ -192,7 +193,7 @@ The release staging path runs the same offline verification before publishing
 release checksums. If this step fails, the release must be treated as incomplete
 and the exported EvidencePack must be repaired before attaching assets.
 
-For `v0.5.4`, this command passes without network access. The verifier
+For `v0.5.5`, this command passes without network access. The verifier
 accepts both the legacy `receipts/` layout and the canonical
 `02_PROOFGRAPH/receipts/` layout.
 

--- a/docs/launchpad/APP_SPEC.md
+++ b/docs/launchpad/APP_SPEC.md
@@ -40,7 +40,7 @@ Supported means all of the following are present and registry-validated:
 - offline `helm-ai-kernel verify --bundle <pack>` pass.
 
 OpenClaw, Hermes, OpenCode, and Kilo Code are the current `oss_supported`
-local-container set after workflow `26186959337` produced signed artifacts,
+local-container set after workflow `26198407296` produced signed artifacts,
 live conformance, teardown receipts, and offline EvidencePack verification for
 all four. Any additional app remains non-supported until it meets the same
 registry-validated evidence bar.

--- a/docs/launchpad/CLEAN_INSTALL_GA.md
+++ b/docs/launchpad/CLEAN_INSTALL_GA.md
@@ -7,7 +7,7 @@ last_reviewed: 2026-05-20
 
 Status: v0.5.5 gate implemented; v1 promotes OpenClaw, Hermes, OpenCode, and
 Kilo Code into the supported-app clean-install set after workflow
-`26186959337` passed signed artifact, live conformance, teardown, receipts, and
+`26198407296` passed signed artifact, live conformance, teardown, receipts, and
 offline EvidencePack verification.
 
 Launchpad GA is a product-adoption gate for the `v0.5.5` release. It proves the
@@ -30,8 +30,8 @@ offline verification.
 ## Source Truth
 
 - Release target: `v0.5.5`
-- Current four-app Launchpad artifact workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26186959337>
-- Current macOS Homebrew clean-install workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26192627823>
+- Current four-app Launchpad artifact workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26198407296>
+- Current macOS Homebrew clean-install workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26199878246>
 - Current Launchpad v1 report: `docs/launchpad/v1_report.json`
 - Historical `v0.5.4` release report: `docs/launchpad/final_report.json`
 - Clean-install report: `docs/launchpad/clean_install_report.json`
@@ -77,7 +77,7 @@ Use the repo-native gate to collect redacted evidence:
 export HELM_LAUNCHPAD_CI_OPENROUTER_API_KEY='<fresh CI-only key>'
 bash scripts/launch/clean_install_gate.sh \
   --release-tag v0.5.5 \
-  --artifact-run-id 26186959337 \
+  --artifact-run-id 26198407296 \
   --host-kind developer_macos \
   --output docs/launchpad/clean_install_report.json
 ```
@@ -95,10 +95,10 @@ accepted for backward compatibility.
 
 | App | Availability | Image |
 | --- | --- | --- |
-| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9` |
-| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e` |
-| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38` |
-| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65` |
+| OpenClaw | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995` |
+| Hermes | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652` |
+| OpenCode | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550` |
+| Kilo Code | `oss_supported` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6` |
 
 Codex, Claude Code, Cursor, and Junie remain external/BYO adapters.
 
@@ -110,7 +110,7 @@ Manual CI entrypoint:
 gh workflow run launchpad-clean-install.yml \
   --repo Mindburn-Labs/helm-ai-kernel \
   -f release_tag=v0.5.5 \
-  -f artifact_run_id=26186959337
+  -f artifact_run_id=26198407296
 ```
 
 The CI report is the current repeatable macOS Homebrew gate. A separately

--- a/docs/launchpad/CONFORMANCE.md
+++ b/docs/launchpad/CONFORMANCE.md
@@ -7,7 +7,7 @@ last_reviewed: 2026-05-20
 
 Status: OpenClaw, Hermes, OpenCode, and Kilo Code passed the v1.0 signed
 artifact, live local-container, teardown, receipt, and offline EvidencePack
-bar in workflow `26186959337`. DigitalOcean opt-in beta passed for all four
+bar in workflow `26198407296`. DigitalOcean opt-in beta passed for all four
 apps; Hetzner remains fail-closed until a scoped provider token is available.
 
 ## Audience
@@ -35,7 +35,7 @@ a clean machine.
 
 Implemented checks currently prove:
 
-- `launchpad-artifacts` workflow `26186959337` built pinned OpenClaw, Hermes,
+- `launchpad-artifacts` workflow `26198407296` built pinned OpenClaw, Hermes,
   OpenCode, and Kilo Code upstream refs into GHCR OCI images, signed them with
   GitHub OIDC keyless cosign, generated syft SBOMs, ran grype scans, and
   published a promotion manifest.
@@ -47,13 +47,13 @@ Implemented checks currently prove:
   from signed CI evidence, live e2e, teardown, receipts, and offline
   EvidencePack verification, not from assertion.
 - OpenClaw image:
-  `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9`.
+  `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995`.
 - Hermes image:
-  `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e`.
+  `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652`.
 - OpenCode image:
-  `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38`.
+  `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550`.
 - Kilo Code image:
-  `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65`.
+  `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6`.
 - Local-container OpenRouter egress requires a launch-scoped egress proxy
   receipt, can use the signed egress-proxy image from the artifact workflow, and
   rejects non-OpenRouter allowlists.

--- a/docs/launchpad/FLOW_CATALOG.md
+++ b/docs/launchpad/FLOW_CATALOG.md
@@ -85,7 +85,7 @@ Stops containers and proxy, revokes scoped secrets, revokes sandbox grants, quar
 ## Current Truth
 
 [KEEP] OpenClaw, Hermes, OpenCode, and Kilo Code are `oss_supported` from
-workflow `26186959337`, with signed artifacts, live local-container e2e,
+workflow `26198407296`, with signed artifacts, live local-container e2e,
 teardown receipts, and offline EvidencePack verification.
 
 [REFACTOR] The CPI/PEP/boundary path still needs deeper action-by-action authority binding.

--- a/docs/launchpad/SECURITY_REVIEW.md
+++ b/docs/launchpad/SECURITY_REVIEW.md
@@ -1,7 +1,7 @@
 # Launchpad Security Review
 
 Status: Launchpad v1 local-container review passes for OpenClaw, Hermes,
-OpenCode, and Kilo Code from workflow `26186959337`. The `v0.5.5`
+OpenCode, and Kilo Code from workflow `26198407296`. The `v0.5.5`
 clean-install gate remains the package/install release gate.
 
 ## Results
@@ -17,7 +17,7 @@ clean-install gate remains the package/install release gate.
 - [KEEP] OpenClaw, Hermes, OpenCode, and Kilo Code are promoted to
   `oss_supported` from signed CI artifacts, live local-container evidence,
   teardown receipts, and offline EvidencePack verification in workflow
-  `26186959337`.
+  `26198407296`.
 - [KEEP] Codex, Claude Code, Cursor, and Junie remain external/BYO adapters; no
   proprietary redistribution claim is made.
 - [KEEP] CLI/API launch path returns `ESCALATE` for missing required secrets and

--- a/docs/launchpad/THREAT_MODEL_ADDENDUM.md
+++ b/docs/launchpad/THREAT_MODEL_ADDENDUM.md
@@ -49,7 +49,7 @@ must be added to the mediation proof harness before it appears in public claims.
 ## Supported App Claim Boundary
 
 OpenClaw, Hermes, OpenCode, and Kilo Code are the current `oss_supported`
-local-container set after workflow `26186959337` passed signed artifact build,
+local-container set after workflow `26198407296` passed signed artifact build,
 SBOM, vulnerability scan, live OpenRouter launch, teardown, and offline
 EvidencePack verification for all four apps.
 

--- a/docs/launchpad/clean_install_report.json
+++ b/docs/launchpad/clean_install_report.json
@@ -1,5 +1,5 @@
 {
-  "artifact_workflow_run_id": "26186959337",
+  "artifact_workflow_run_id": "26198407296",
   "candidate_promotion_apps": [],
   "candidate_promotion_included": false,
   "commands": [
@@ -104,113 +104,113 @@
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5-",
-      "stderr_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5-.stderr",
-      "stdout_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5-.stdout"
+      "name": "verify_71eaad24-e800-4b32-a8b6-157e4566b691-",
+      "stderr_file": "verify_71eaad24-e800-4b32-a8b6-157e4566b691-.stderr",
+      "stdout_file": "verify_71eaad24-e800-4b32-a8b6-157e4566b691-.stdout"
     },
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5.tar-",
-      "stderr_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5.tar-.stderr",
-      "stdout_file": "verify_669a7869-98d3-4c17-a8e8-6548862a05c5.tar-.stdout"
+      "name": "verify_71eaad24-e800-4b32-a8b6-157e4566b691.tar-",
+      "stderr_file": "verify_71eaad24-e800-4b32-a8b6-157e4566b691.tar-.stderr",
+      "stdout_file": "verify_71eaad24-e800-4b32-a8b6-157e4566b691.tar-.stdout"
     },
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e-",
-      "stderr_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e-.stderr",
-      "stdout_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e-.stdout"
+      "name": "verify_7fe3610a-3971-4906-90d0-7ddb1242bccf-",
+      "stderr_file": "verify_7fe3610a-3971-4906-90d0-7ddb1242bccf-.stderr",
+      "stdout_file": "verify_7fe3610a-3971-4906-90d0-7ddb1242bccf-.stdout"
     },
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar-",
-      "stderr_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar-.stderr",
-      "stdout_file": "verify_8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar-.stdout"
+      "name": "verify_7fe3610a-3971-4906-90d0-7ddb1242bccf.tar-",
+      "stderr_file": "verify_7fe3610a-3971-4906-90d0-7ddb1242bccf.tar-.stderr",
+      "stdout_file": "verify_7fe3610a-3971-4906-90d0-7ddb1242bccf.tar-.stdout"
     },
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48-",
-      "stderr_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48-.stderr",
-      "stdout_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48-.stdout"
+      "name": "verify_9eebb477-c858-4ae5-9c6b-4ba5840f9667-",
+      "stderr_file": "verify_9eebb477-c858-4ae5-9c6b-4ba5840f9667-.stderr",
+      "stdout_file": "verify_9eebb477-c858-4ae5-9c6b-4ba5840f9667-.stdout"
     },
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48.tar-",
-      "stderr_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48.tar-.stderr",
-      "stdout_file": "verify_a9423bdb-7a69-4ef1-8246-5063d6181b48.tar-.stdout"
+      "name": "verify_9eebb477-c858-4ae5-9c6b-4ba5840f9667.tar-",
+      "stderr_file": "verify_9eebb477-c858-4ae5-9c6b-4ba5840f9667.tar-.stderr",
+      "stdout_file": "verify_9eebb477-c858-4ae5-9c6b-4ba5840f9667.tar-.stdout"
     },
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d-",
-      "stderr_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d-.stderr",
-      "stdout_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d-.stdout"
+      "name": "verify_f842ae77-6bfb-459f-931c-fe655b724963-",
+      "stderr_file": "verify_f842ae77-6bfb-459f-931c-fe655b724963-.stderr",
+      "stdout_file": "verify_f842ae77-6bfb-459f-931c-fe655b724963-.stdout"
     },
     {
       "command": "helm-ai-kernel verify --bundle <pack> --json",
       "exit_code": 0,
-      "name": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar-",
-      "stderr_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar-.stderr",
-      "stdout_file": "verify_d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar-.stdout"
+      "name": "verify_f842ae77-6bfb-459f-931c-fe655b724963.tar-",
+      "stderr_file": "verify_f842ae77-6bfb-459f-931c-fe655b724963.tar-.stderr",
+      "stdout_file": "verify_f842ae77-6bfb-459f-931c-fe655b724963.tar-.stdout"
     }
   ],
   "deprecated_include_candidates_flag": "accepted_noop_all_four_apps_are_supported",
   "evidence_packs": [
     {
       "kind": "directory",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/669a7869-98d3-4c17-a8e8-6548862a05c5",
-      "sha256": "2eee99797dd04ac172bb00d534a35937c6fc60f86e28c46b33006c9564747c96",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/71eaad24-e800-4b32-a8b6-157e4566b691",
+      "sha256": "c8b0bf2a5ceffaa196a7275549e0f1c99394b3ada224b5a402bede0e2d26f739",
       "verify_status": "PASS"
     },
     {
       "kind": "file",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/669a7869-98d3-4c17-a8e8-6548862a05c5.tar",
-      "sha256": "3ba8d96c6144903e5e32989fc5b2afa0713bbdcb5206486e94634dd7391df5ef",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/71eaad24-e800-4b32-a8b6-157e4566b691.tar",
+      "sha256": "a7f86dc59957f64cd83dca21a408ab52eeb122d6400639dc4ce14b98ed5a4f59",
       "verify_status": "PASS"
     },
     {
       "kind": "directory",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/8db8b084-ef38-4c2e-8cf4-7b88adb4743e",
-      "sha256": "3116777399afab68305c37200c64f837f2322f571542ae2675eff0296ce5bbb3",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/7fe3610a-3971-4906-90d0-7ddb1242bccf",
+      "sha256": "03ff111d03d728b3291ad5d7a92154411de08dda36ac31bc6b70bedd3e9ba83d",
       "verify_status": "PASS"
     },
     {
       "kind": "file",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/8db8b084-ef38-4c2e-8cf4-7b88adb4743e.tar",
-      "sha256": "bed97c16155d118ec87c9032a16b27d29dfe33f9b0fe782e7903e6a6ea1c0122",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/7fe3610a-3971-4906-90d0-7ddb1242bccf.tar",
+      "sha256": "31985646b7b63bdb1b2f40a2adc830c2038292bd66e51014be32e427c7aa0d66",
       "verify_status": "PASS"
     },
     {
       "kind": "directory",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/a9423bdb-7a69-4ef1-8246-5063d6181b48",
-      "sha256": "185d02f45b7910ad29fa8febf054f21abd9c0b3d7bbf5795e6dc80b9eba873ec",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/9eebb477-c858-4ae5-9c6b-4ba5840f9667",
+      "sha256": "8d454da48eb0cac51c1e29c7e5576ab5308190bb158c1bf734a309cb9bb75f9d",
       "verify_status": "PASS"
     },
     {
       "kind": "file",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/a9423bdb-7a69-4ef1-8246-5063d6181b48.tar",
-      "sha256": "75aa77350485966ad9dab80f695d94ea40756fdf5e54e2fef36144da8cff42c6",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/9eebb477-c858-4ae5-9c6b-4ba5840f9667.tar",
+      "sha256": "a75c6db661ae95fb63982b88d4ab18bc9d123de5b0b5393984599d81ad321d8e",
       "verify_status": "PASS"
     },
     {
       "kind": "directory",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/d8e91fde-fcde-4748-a33e-4640f5b48f9d",
-      "sha256": "ceee23ab3d2ac63e169b7404ea242de1bf6ede55abc2f5eaef67750e714ee0b4",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/f842ae77-6bfb-459f-931c-fe655b724963",
+      "sha256": "fec40b87692d1319960c64658f7060ec7fb19401052676747825c4582125cc08",
       "verify_status": "PASS"
     },
     {
       "kind": "file",
-      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/d8e91fde-fcde-4748-a33e-4640f5b48f9d.tar",
-      "sha256": "252a9c5e2197244626dc55bc5f9bd12e0bddb523c3b57d47bf6fb8b0cd5fb0de",
+      "path": "$TRANSCRIPT_DIR/launchpad-home/evidencepacks/f842ae77-6bfb-459f-931c-fe655b724963.tar",
+      "sha256": "884fc8ce67b58880910d79c4a47150adee5f286a2dba251ae01ea697925876b2",
       "verify_status": "PASS"
     }
   ],
   "failed_steps": [],
-  "generated_at": "2026-05-20T22:17:33Z",
+  "generated_at": "2026-05-21T01:39:16Z",
   "ghcr_digest_confirmations": [
     {
       "app_id": "hermes",
@@ -243,10 +243,10 @@
   ],
   "host_kind": "github_macos_runner",
   "launch_ids": {
-    "hermes": "a9423bdb-7a69-4ef1-8246-5063d6181b48",
-    "kilocode": "d8e91fde-fcde-4748-a33e-4640f5b48f9d",
-    "openclaw": "669a7869-98d3-4c17-a8e8-6548862a05c5",
-    "opencode": "8db8b084-ef38-4c2e-8cf4-7b88adb4743e"
+    "hermes": "7fe3610a-3971-4906-90d0-7ddb1242bccf",
+    "kilocode": "71eaad24-e800-4b32-a8b6-157e4566b691",
+    "openclaw": "9eebb477-c858-4ae5-9c6b-4ba5840f9667",
+    "opencode": "f842ae77-6bfb-459f-931c-fe655b724963"
   },
   "milestone": "Launchpad v0.5.5 Clean Install + Public Docs GA",
   "redaction": {
@@ -263,14 +263,14 @@
   "secret_fragment_audit": {
     "findings": [],
     "findings_count": 0,
-    "generated_at": "2026-05-20T22:17:30Z",
+    "generated_at": "2026-05-21T01:39:13Z",
     "min_fragment_length": 16,
     "roots": [
       "/tmp/helm-launchpad-clean-install/commands",
       "/tmp/helm-launchpad-clean-install/audit",
       "/tmp/helm-launchpad-clean-install/launchpad-home"
     ],
-    "scanned_bytes": 3842022,
+    "scanned_bytes": 3980778,
     "scanned_files": 183,
     "schema_version": 1,
     "secret_env_configured": true,

--- a/docs/launchpad/v1_report.json
+++ b/docs/launchpad/v1_report.json
@@ -1,23 +1,23 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-05-20T22:17:30Z",
+  "generated_at": "2026-05-21T01:39:16Z",
   "milestone": "Launchpad v1.0 Governed App Execution + Cloud Beta",
   "status": "ga_hardening_contracts_implemented_four_app_local_container_clean_install_and_digitalocean_live_passed_hetzner_blocked",
   "release_truth_base": {
     "release_tag": "v0.5.5",
     "release_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.5",
-    "artifact_workflow_run_id": "26110916296",
+    "artifact_workflow_run_id": "26198407296",
     "release_workflow_run_id": "26188554059",
-    "v1_artifact_workflow_run_id": "26186959337",
-    "v1_artifact_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26186959337",
-    "v1_artifact_workflow_head_sha": "176e4528bbda4b464b1f9a9df9ac8ba196171d3c",
+    "v1_artifact_workflow_run_id": "26198407296",
+    "v1_artifact_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26198407296",
+    "v1_artifact_workflow_head_sha": "7d9f0a2b1bf6b33c17b9319cee1b80d73f72cd47",
     "v1_artifact_workflow_conclusion": "success_four_app_signed_artifact_sbom_vuln_scan_live_conformance_teardown_offline_evidencepack_verify",
     "v1_artifact_workflow_fix": "local-container live conformance uses configurable runtime timeout and 30m Go test timeout for cold four-app pulls",
     "release_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26188554059",
     "homebrew_tap_commit": "de44092",
     "homebrew_tap_url": "https://github.com/mindburnlabs/homebrew-tap/commit/de44092",
-    "clean_install_workflow_run_id": "26192627823",
-    "clean_install_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26192627823",
+    "clean_install_workflow_run_id": "26199878246",
+    "clean_install_workflow_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26199878246",
     "clean_install_workflow_conclusion": "success_v0_5_5_homebrew_four_app_local_container_teardown_offline_evidencepack_verify_secret_audit_passed"
   },
   "developer_ga": {
@@ -31,9 +31,9 @@
     "candidate_artifact_workflow_matrix": [],
     "candidate_recipe_base_images_pinned": true,
     "signed_artifact_ci_status": "passed",
-    "live_local_container_conformance_status": "github_actions_run_26186959337_openclaw_hermes_opencode_kilocode_passed_with_teardown_and_offline_evidencepack_verification",
+    "live_local_container_conformance_status": "github_actions_run_26198407296_openclaw_hermes_opencode_kilocode_passed_with_teardown_and_offline_evidencepack_verification",
     "live_local_container_gate_patch": "workflow_default_live_apps_and_artifact_matrix_openclaw_hermes_opencode_kilocode_with_configurable_timeout_for_cold_pulls",
-    "homebrew_clean_install_status": "github_actions_run_26192627823_v0_5_5_homebrew_install_openclaw_hermes_opencode_kilocode_launch_delete_offline_verify_secret_audit_passed",
+    "homebrew_clean_install_status": "github_actions_run_26199878246_v0_5_5_homebrew_install_openclaw_hermes_opencode_kilocode_launch_delete_offline_verify_secret_audit_passed",
     "clean_install_supported_apps": [
       "openclaw",
       "hermes",
@@ -41,7 +41,7 @@
       "kilocode"
     ],
     "candidate_promotion_apps": [],
-    "candidate_promotion_gate": "not_applicable_all_four_supported_after_run_26186959337",
+    "candidate_promotion_gate": "not_applicable_all_four_supported_after_run_26198407296",
     "supported_command_shape": [
       "helm-ai-kernel launch secrets set model_gateway --provider openrouter --value-env OPENROUTER_API_KEY",
       "helm-ai-kernel launch secrets status",
@@ -72,15 +72,15 @@
     "proxy_only_secretless_model_gateway": "not_yet_claimed",
     "connect_payload_inspection": "opaque_connect",
     "egress_claim": "OpenRouter destination allowlist with receipt-backed proxy enforcement",
-    "clean_install_workflow_run_id": "26192627823",
+    "clean_install_workflow_run_id": "26199878246",
     "clean_install_report": "docs/launchpad/clean_install_report.json"
   },
   "apps": {
     "openclaw": {
       "availability": "oss_supported",
       "local_container": "supported",
-      "ghcr_digest": "sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9",
-      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/openclaw",
+      "ghcr_digest": "sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995",
+      "evidence_pack_ref": "github-actions://26198407296/1/evidencepack/openclaw",
       "mcp_manifest": "openclaw.default",
       "model_gateway": "logical_binding_env_projection",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
@@ -88,8 +88,8 @@
     "hermes": {
       "availability": "oss_supported",
       "local_container": "supported",
-      "ghcr_digest": "sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e",
-      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/hermes",
+      "ghcr_digest": "sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652",
+      "evidence_pack_ref": "github-actions://26198407296/1/evidencepack/hermes",
       "mcp_manifest": "hermes.default",
       "model_gateway": "logical_binding_env_projection",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
@@ -99,11 +99,11 @@
       "local_container": "supported",
       "upstream_release": "v1.15.5",
       "upstream_commit": "d7a6e1daaf2271bcd0b611fbb27d4956806e475a",
-      "ghcr_digest": "sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38",
-      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/opencode",
+      "ghcr_digest": "sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550",
+      "evidence_pack_ref": "github-actions://26198407296/1/evidencepack/opencode",
       "mcp_manifest": "opencode.default",
       "model_gateway": "logical_binding_env_projection",
-      "artifact_workflow_run_id": "26186959337",
+      "artifact_workflow_run_id": "26198407296",
       "vulnerability_scan_status": "completed",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
     },
@@ -112,11 +112,11 @@
       "local_container": "supported",
       "upstream_release": "v7.3.1",
       "upstream_commit": "64c60812ae730a30db1fa2226d9e446f7f10c127",
-      "ghcr_digest": "sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65",
-      "evidence_pack_ref": "github-actions://26186959337/1/evidencepack/kilocode",
+      "ghcr_digest": "sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6",
+      "evidence_pack_ref": "github-actions://26198407296/1/evidencepack/kilocode",
       "mcp_manifest": "kilocode.default",
       "model_gateway": "logical_binding_env_projection",
-      "artifact_workflow_run_id": "26186959337",
+      "artifact_workflow_run_id": "26198407296",
       "vulnerability_scan_status": "completed",
       "cloud_beta": "digitalocean_live_launch_delete_reconcile_verify_passed_hetzner_fail_closed_until_token"
     },
@@ -224,7 +224,7 @@
     "cloud_live_write_policy": "approval_cost_ceiling_idempotency_and_reconcile_required"
   },
   "secret_fragment_audit": {
-    "status": "passed_clean_install_run_26192627823_zero_findings",
+    "status": "passed_clean_install_run_26199878246_zero_findings",
     "prints_secret_or_fragments": false,
     "scanned_files": 183,
     "scanned_bytes": 3842022,
@@ -239,8 +239,8 @@
       "docs_truth": "passed",
       "launch_security": "passed",
       "launch_api_truth": "passed",
-      "clean_install_homebrew": "passed_github_actions_run_26192627823",
-      "secret_fragment_audit": "passed_zero_findings_run_26192627823"
+      "clean_install_homebrew": "passed_github_actions_run_26199878246",
+      "secret_fragment_audit": "passed_zero_findings_run_26199878246"
     },
     "enterprise": {
       "controlplane_console_tests": "passed",

--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
-    digest: sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
+    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652
+    digest: sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652
     source: https://github.com/NousResearch/hermes-agent
     ref: v2026.5.16
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
+    artifact_digest: sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:807f96a9bcc831a810ac77a775dec8f8486ad7df68dd024feb3d75a0a148a03e
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652
     sbom_tool: syft
     sbom_ref: artifact://sbom-hermes.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-hermes.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/hermes
-    live_e2e_run_id: github-actions://26186959337/1/live-e2e/hermes
-    evidence_pack_ref: github-actions://26186959337/1/evidencepack/hermes
-    teardown_receipt_ref: github-actions://26186959337/1/teardown/hermes
+    artifact_verification_ref: github-actions://26198407296/1/artifact-verification/hermes
+    live_e2e_run_id: github-actions://26198407296/1/live-e2e/hermes
+    evidence_pack_ref: github-actions://26198407296/1/evidencepack/hermes
+    teardown_receipt_ref: github-actions://26198407296/1/teardown/hermes
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,11 +90,11 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://26186959337/1
+    artifact_workflow_run: github-actions://26198407296/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/hermes:v2026.5.16
     latest_release: v2026.5.16
-    promotion_provenance_ref: github-actions://26186959337/1
+    promotion_provenance_ref: github-actions://26198407296/1
     release_published_at: "2026-05-16T09:59:15Z"
     upstream_commit: a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
     upstream_repo: https://github.com/NousResearch/hermes-agent

--- a/registry/launchpad/apps/kilocode.yaml
+++ b/registry/launchpad/apps/kilocode.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
-    digest: sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
+    image: ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6
+    digest: sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6
     source: https://github.com/Kilo-Org/kilocode
     ref: v7.3.1
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
+    artifact_digest: sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:59d6eec39e1eb7f3ccdf218055b9590cffe55fd19ca58feb5944369c833c8f65
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6
     sbom_tool: syft
     sbom_ref: artifact://sbom-kilocode.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-kilocode.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/kilocode
-    live_e2e_run_id: github-actions://26186959337/1/live-e2e/kilocode
-    evidence_pack_ref: github-actions://26186959337/1/evidencepack/kilocode
-    teardown_receipt_ref: github-actions://26186959337/1/teardown/kilocode
+    artifact_verification_ref: github-actions://26198407296/1/artifact-verification/kilocode
+    live_e2e_run_id: github-actions://26198407296/1/live-e2e/kilocode
+    evidence_pack_ref: github-actions://26198407296/1/evidencepack/kilocode
+    teardown_receipt_ref: github-actions://26198407296/1/teardown/kilocode
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,9 +90,9 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://26186959337/1
+    artifact_workflow_run: github-actions://26198407296/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
-    promotion_provenance_ref: github-actions://26186959337/1
+    promotion_provenance_ref: github-actions://26198407296/1
     upstream_commit: 64c60812ae730a30db1fa2226d9e446f7f10c127
     upstream_ref: v7.3.1
     upstream_repo: https://github.com/Kilo-Org/kilocode

--- a/registry/launchpad/apps/openclaw.yaml
+++ b/registry/launchpad/apps/openclaw.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
-    digest: sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
+    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995
+    digest: sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995
     source: https://github.com/openclaw/openclaw
     ref: v2026.5.12
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
+    artifact_digest: sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:c5b6d872798514cab6e1a27f9f168aa4c38adb7166d711d49fd2a501aec8b1f9
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995
     sbom_tool: syft
     sbom_ref: artifact://sbom-openclaw.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-openclaw.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/openclaw
-    live_e2e_run_id: github-actions://26186959337/1/live-e2e/openclaw
-    evidence_pack_ref: github-actions://26186959337/1/evidencepack/openclaw
-    teardown_receipt_ref: github-actions://26186959337/1/teardown/openclaw
+    artifact_verification_ref: github-actions://26198407296/1/artifact-verification/openclaw
+    live_e2e_run_id: github-actions://26198407296/1/live-e2e/openclaw
+    evidence_pack_ref: github-actions://26198407296/1/evidencepack/openclaw
+    teardown_receipt_ref: github-actions://26198407296/1/teardown/openclaw
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,11 +90,11 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://26186959337/1
+    artifact_workflow_run: github-actions://26198407296/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/openclaw:v2026.5.12
     latest_release: v2026.5.12
-    promotion_provenance_ref: github-actions://26186959337/1
+    promotion_provenance_ref: github-actions://26198407296/1
     release_published_at: "2026-05-14T18:28:04Z"
     upstream_commit: f066dd2f31c231f38fbcaacd6f6dfce0801143b3
     upstream_repo: https://github.com/openclaw/openclaw

--- a/registry/launchpad/apps/opencode.yaml
+++ b/registry/launchpad/apps/opencode.yaml
@@ -9,8 +9,8 @@ redistribution: allowed_by_MIT_with_upstream_notice
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
-    digest: sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
+    image: ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550
+    digest: sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550
     source: https://github.com/anomalyco/opencode
     ref: v1.15.5
 runtime:
@@ -67,18 +67,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
+    artifact_digest: sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:3e258a0b5424b6a141e0e71516754cd7598a71b5727443c9620a90152dcc0f38
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550
     sbom_tool: syft
     sbom_ref: artifact://sbom-opencode.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-opencode.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://26186959337/1/artifact-verification/opencode
-    live_e2e_run_id: github-actions://26186959337/1/live-e2e/opencode
-    evidence_pack_ref: github-actions://26186959337/1/evidencepack/opencode
-    teardown_receipt_ref: github-actions://26186959337/1/teardown/opencode
+    artifact_verification_ref: github-actions://26198407296/1/artifact-verification/opencode
+    live_e2e_run_id: github-actions://26198407296/1/live-e2e/opencode
+    evidence_pack_ref: github-actions://26198407296/1/evidencepack/opencode
+    teardown_receipt_ref: github-actions://26198407296/1/teardown/opencode
 conformance:
     license_verified: true
     artifact_verified: true
@@ -90,9 +90,9 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://26186959337/1
+    artifact_workflow_run: github-actions://26198407296/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
-    promotion_provenance_ref: github-actions://26186959337/1
+    promotion_provenance_ref: github-actions://26198407296/1
     upstream_commit: d7a6e1daaf2271bcd0b611fbb27d4956806e475a
     upstream_ref: v1.15.5
     upstream_repo: https://github.com/anomalyco/opencode

--- a/scripts/launch/clean_install_gate.sh
+++ b/scripts/launch/clean_install_gate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPO="${HELM_LAUNCHPAD_GITHUB_REPO:-Mindburn-Labs/helm-ai-kernel}"
 RELEASE_TAG="v0.5.5"
-ARTIFACT_RUN_ID="26186959337"
+ARTIFACT_RUN_ID="26198407296"
 HOST_KIND="developer_macos"
 OUTPUT="$ROOT/docs/launchpad/clean_install_report.json"
 TRANSCRIPT_DIR="${TMPDIR:-/tmp}/helm-launchpad-clean-install"
@@ -18,7 +18,7 @@ Usage: scripts/launch/clean_install_gate.sh [options]
 
 Options:
   --release-tag <tag>       Release tag to validate (default: v0.5.5)
-  --artifact-run-id <id>    Launchpad artifact workflow run (default: 26186959337)
+  --artifact-run-id <id>    Launchpad artifact workflow run (default: 26198407296)
   --host-kind <kind>        developer_macos or github_macos_runner
   --output <path>           Redacted JSON report path
   --transcript-dir <path>   Directory for redacted command output and audit inputs

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -43,7 +43,7 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 	requireContains(t, cleanGate, "SUPPORTED_APPS=(openclaw hermes opencode kilocode)")
 	requireContains(t, cleanGate, "--include-candidates")
 	requireContains(t, cleanGate, `RELEASE_TAG="v0.5.5"`)
-	requireContains(t, cleanGate, `ARTIFACT_RUN_ID="26186959337"`)
+	requireContains(t, cleanGate, `ARTIFACT_RUN_ID="26198407296"`)
 	requireContains(t, cleanGate, "output, status, commands_path")
 	requireNotContains(t, cleanGate, "status = sys.stdin.read()", "scripts/launch/clean_install_gate.sh")
 	requireContains(t, cleanGate, `"supported_apps": ["openclaw", "hermes", "opencode", "kilocode"]`)
@@ -54,7 +54,7 @@ func TestLaunchpadClaimsMarketPromotedAppsAsSupported(t *testing.T) {
 
 	cleanWorkflow := readDoc(t, root, ".github/workflows/launchpad-clean-install.yml")
 	requireContains(t, cleanWorkflow, "default: v0.5.5")
-	requireContains(t, cleanWorkflow, `default: "26186959337"`)
+	requireContains(t, cleanWorkflow, `default: "26198407296"`)
 	requireContains(t, cleanWorkflow, "brew install colima docker jq qemu lima-additional-guestagents")
 	requireContains(t, cleanWorkflow, "colima delete -f")
 


### PR DESCRIPTION
## Summary
- update current Launchpad docs, clean-install gate defaults, and app registry specs from the older artifact run to final successful run 26198407296
- record clean-install evidence from run 26199878246 and current v0.5.5 public release metadata
- keep historical v0.5.4 reports marked as historical

## Validation
- go test ./core/pkg/launchpad/... ./core/pkg/mcp/... ./core/cmd/helm-ai-kernel ./tests/launchpad/...
- make docs-truth
- make verify-boundary
- git diff --check