### PR TITLE
ci(release): sync chart version with release tag before helm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,6 +346,21 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Sync chart version with release tag
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "Bumping deploy/helm-chart/Chart.yaml to version ${VERSION}"
+          yq -i ".version = \"${VERSION}\"" deploy/helm-chart/Chart.yaml
+          yq -i ".appVersion = \"v${VERSION}\"" deploy/helm-chart/Chart.yaml
+          # The artifacthub.io/images annotation is a YAML block scalar with
+          # image refs (incl. the -slim variant); patch tags in place with sed.
+          sed -i.bak -E \
+            "s|(ghcr\\.io/mindburn-labs/helm-ai-kernel:)v[0-9]+\\.[0-9]+\\.[0-9]+(-slim)?|\\1v${VERSION}\\2|g" \
+            deploy/helm-chart/Chart.yaml
+          rm -f deploy/helm-chart/Chart.yaml.bak
+          echo "--- updated Chart.yaml (head) ---"
+          head -16 deploy/helm-chart/Chart.yaml
       - name: Package chart
         run: |
           mkdir -p dist/chart


### PR DESCRIPTION
## Summary
- Chart.yaml version drifted from the release tag, so every recent release republished OCI tag 0.5.4 and ArtifactHub stayed on 0.5.4 even after v0.5.5 shipped.
- Patch Chart.yaml in the runner workspace from `${GITHUB_REF_NAME}` right before `helm package`, so packaging always reflects the tag.
- Edit is ephemeral; no bot commit, no extra permissions.

## Test plan
- [ ] Re-tag a patch release (e.g. v0.5.6) after merge and confirm the `chart` job logs the synced version.
- [ ] Verify `helm pull oci://ghcr.io/mindburn-labs/charts/helm-ai-kernel --version <new>` returns the new tag.
- [ ] Confirm ArtifactHub picks up the new version within ~30 min.