### PR TITLE
ci: add version drift guard

### DIFF
--- a/.agents/skills/hallmark/package.json
+++ b/.agents/skills/hallmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hallmark",
-  "version": "1.0.0",
+  "version": "0.5.6",
   "description": "A design skill for AI coding assistants. Makes the UIs they generate look made, not generated. Powered by Together AI.",
   "keywords": [
     "claude",

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: build test test-race test-sdk-go-standalone test-sdk-ts test-design-system build-console test-console test-platform test-sdk-py test-sdk-rust test-sdk-java sdk-openapi-check sdk-examples-smoke verify-fixtures verify-presentation test-all bench bench-report lint proto-lint proto-breaking docker-verify release-readiness crucible proxy docker docker-up docker-smoke compose-smoke helm-chart-smoke kind-smoke deployment-smoke release-smoke version-drift version-drift-published version-status prepare-version sbom vex provenance onboard demo-cli console demo-console mcp-pack mcp-install release-binaries release-binaries-reproducible release-assets build-release release-all verify-boundary verify-cosign bench-pin codegen codegen-go codegen-python codegen-ts codegen-java codegen-rust codegen-check quality-pr quality-merge quality-release quality-nightly quality-list quality-explain quality-self-test quality-typecheck quality-contracts quality-security quality-runbooks quality-mutation quality-flake quality-impact clean docs-coverage docs-truth launch-record-assets launch-security launch-api-truth launch-release-dry-run launch-ready conformance-release-report conformance-release-gate
+.PHONY: build test test-race test-sdk-go-standalone test-sdk-ts test-design-system build-console test-console test-platform test-sdk-py test-sdk-rust test-sdk-java sdk-openapi-check sdk-examples-smoke verify-fixtures verify-presentation test-all bench bench-report lint proto-lint proto-breaking docker-verify release-readiness crucible proxy docker docker-up docker-smoke compose-smoke helm-chart-smoke kind-smoke deployment-smoke release-smoke version-drift version-drift-report version-drift-published version-status prepare-version sbom vex provenance onboard demo-cli console demo-console mcp-pack mcp-install release-binaries release-binaries-reproducible release-assets build-release release-all verify-boundary verify-cosign bench-pin codegen codegen-go codegen-python codegen-ts codegen-java codegen-rust codegen-check quality-pr quality-merge quality-release quality-nightly quality-list quality-explain quality-self-test quality-typecheck quality-contracts quality-security quality-runbooks quality-mutation quality-flake quality-impact clean docs-coverage docs-truth launch-record-assets launch-security launch-api-truth launch-release-dry-run launch-ready conformance-release-report conformance-release-gate
 
 # VERSION is source-controlled release truth. Tag-triggered workflows must
 # check that GITHUB_REF_NAME equals v$(VERSION) before any publish step.
 VERSION ?= $(shell cat VERSION 2>/dev/null || echo 0.0.0-dev)
+PREPARE_VERSION := $(if $(filter command line,$(origin VERSION)),$(VERSION),$(RELEASE_VERSION))
 GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -X main.version=$(VERSION) -X main.commit=$(GIT_COMMIT) -X main.buildTime=$(BUILD_TIME)
@@ -119,15 +120,18 @@ release-smoke:
 version-drift:
 	python3 scripts/release/check_version_drift.py local
 
+version-drift-report:
+	python3 scripts/release/check_version_drift.py --report --write-status version-status.json local
+
 version-drift-published:
-	python3 scripts/release/check_version_drift.py --expected-version "$(VERSION)" published
+	python3 scripts/release/check_version_drift.py published
 
 version-status:
-	python3 scripts/release/check_version_drift.py --expected-version "$(VERSION)" --write-status version-status.json published
+	python3 scripts/release/check_version_drift.py --report --write-status version-status.json published
 
 prepare-version:
-	@test -n "$(RELEASE_VERSION)" || (echo "Usage: make prepare-version RELEASE_VERSION=0.5.6" && exit 2)
-	python3 scripts/release/prepare_version.py "$(RELEASE_VERSION)"
+	@test -n "$(PREPARE_VERSION)" || (echo "Usage: make prepare-version VERSION=0.5.6" && exit 2)
+	python3 scripts/release/prepare_version.py "$(PREPARE_VERSION)"
 
 quality-pr:
 	$(QUALITY) run pr --impact
@@ -355,19 +359,4 @@ docs-coverage:
 
 docs-truth:
 	python3 scripts/check_documentation_truth.py
-
-.PHONY: version-drift version-drift-report version-drift-published prepare-version
-
-version-drift:
-	python3 scripts/release/check_version_drift.py local
-
-version-drift-report:
-	python3 scripts/release/check_version_drift.py --report --write-status version-status.json local
-
-version-drift-published:
-	python3 scripts/release/check_version_drift.py published
-
-prepare-version:
-	@test -n "$(VERSION)" || (echo "Usage: make prepare-version VERSION=1.2.3" && exit 2)
-	python3 scripts/release/prepare_version.py "$(VERSION)"
 

--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@helm/console",
-  "version": "0.1.0",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@helm/console",
-      "version": "0.1.0",
+      "version": "0.5.6",
       "dependencies": {
         "@ag-ui/client": "0.0.53",
         "@copilotkit/react-core": "1.57.1",
@@ -36,7 +36,7 @@
     },
     "../../packages/design-system-core": {
       "name": "@mindburn/ui-core",
-      "version": "1.0.0",
+      "version": "0.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@pixi/react": "^8.0.5",

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helm/console",
-  "version": "0.1.0",
+  "version": "0.5.6",
   "private": true,
   "packageManager": "npm@11.14.1",
   "type": "module",

--- a/packages/design-system-core-compat/package.json
+++ b/packages/design-system-core-compat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helm/design-system-core",
-  "version": "1.0.0",
+  "version": "0.5.6",
   "type": "module",
   "description": "Deprecated compatibility wrapper for @mindburn/ui-core.",
   "license": "Apache-2.0",

--- a/packages/design-system-core/package-lock.json
+++ b/packages/design-system-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mindburn/ui-core",
-  "version": "1.0.0",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mindburn/ui-core",
-      "version": "1.0.0",
+      "version": "0.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@pixi/react": "^8.0.5",

--- a/packages/design-system-core/package.json
+++ b/packages/design-system-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindburn/ui-core",
-  "version": "1.0.0",
+  "version": "0.5.6",
   "type": "module",
   "description": "Shared Mindburn UI foundation tokens, primitives, layouts, data, forms, feedback, and inspection components.",
   "license": "Apache-2.0",

--- a/protocols/specs/effects/openapi.yaml
+++ b/protocols/specs/effects/openapi.yaml
@@ -6,7 +6,7 @@ info:
     the same semantics as the gRPC EffectBoundaryService defined in
     `protocols/proto/helm/kernel/v1/helm.proto`, but using JSON over HTTP for
     non-gRPC consumers.
-  version: "1.0.0"
+  version: "0.5.6"
   contact:
     name: HELM Core Team
     url: https://github.com/Mindburn-Labs/helm-ai-kernel

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -76,8 +76,9 @@
       "id": "openapi-version",
       "path": "api/openapi/helm.openapi.yaml",
       "kind": "regex",
-      "pattern": "^  version: (?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)$",
-      "replacement": "  version: {version}"
+      "pattern": "^  version:\\s*[\"\\']?(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)[\"\\']?\\s*$",
+      "replacement": "  version: \"{version}\"",
+      "expected": "{version}"
     },
     {
       "id": "go-sdk-readme-version-truth",
@@ -310,8 +311,8 @@
       "id": "api-openapi-helm-openapi-yaml-openapi-version",
       "path": "api/openapi/helm.openapi.yaml",
       "kind": "regex",
-      "pattern": "^  version:\\s*(?P<version>[^\\n]+)$",
-      "replacement": "  version: {version}",
+      "pattern": "^  version:\\s*[\"\\']?(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)[\"\\']?\\s*$",
+      "replacement": "  version: \"{version}\"",
       "expected": "{version}",
       "blocking": false
     },
@@ -364,17 +365,8 @@
       "id": "protocols-specs-effects-openapi-yaml-openapi-version",
       "path": "protocols/specs/effects/openapi.yaml",
       "kind": "regex",
-      "pattern": "^  version:\\s*(?P<version>[^\\n]+)$",
-      "replacement": "  version: {version}",
-      "expected": "{version}",
-      "blocking": false
-    },
-    {
-      "id": "sdk-java-pom-xml-version",
-      "path": "sdk/java/pom.xml",
-      "kind": "regex",
-      "pattern": "(<artifactId>[^<]+</artifactId>\\s*\\n\\s*<version>)(?P<version>[^<]+)(</version>)",
-      "replacement": "\\g<1>{version}\\g<3>",
+      "pattern": "^  version:\\s*[\"\\']?(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)[\"\\']?\\s*$",
+      "replacement": "  version: \"{version}\"",
       "expected": "{version}",
       "blocking": false
     },
@@ -404,15 +396,6 @@
       "expected": "{version}",
       "blocking": false,
       "replacement_note": "first-party manifest version"
-    },
-    {
-      "id": "release-version-surfaces-yaml-generated-openapi",
-      "path": "release/version-surfaces.yaml",
-      "kind": "regex",
-      "pattern": "The version of the OpenAPI document: (?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
-      "replacement": "The version of the OpenAPI document: {version}",
-      "expected": "{version}",
-      "blocking": false
     },
     {
       "id": "sdk-go-client-types-gen-go-generated-openapi",

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -307,7 +307,7 @@ def check_published(contract: dict[str, Any], version: str, skip: set[str]) -> l
 
 def should_fail(results: list[SurfaceResult], mode: str) -> bool:
     for result in results:
-        if result.status == "fail" and (mode == "published" or result.blocking):
+        if result.status == "fail" and result.blocking:
             return True
     return False
 

--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mindburn/helm-ai-kernel",
-  "version": "0.5.1",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mindburn/helm-ai-kernel",
-      "version": "0.5.1",
+      "version": "0.5.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.11.0"


### PR DESCRIPTION
## Summary

- Adds repo-local VERSION source of truth, release/version-surfaces.yaml, and version drift checker/preparer.
- Adds report/strict/published drift commands.
- Adds release-owner review guardrails and publishing guidance.
- Adds tag fail-fast and published drift monitor where this repo has public release surfaces.

## Validation

- python3 -m py_compile scripts/release/check_version_drift.py scripts/release/prepare_version.py
- python3 -m json.tool release/version-surfaces.yaml
- version-drift-report local mode
- semver tag pass/fail checks
