### PR TITLE
fix(ci,launchpad): unblock main CI and fail-fast egress proxy on local-container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,12 @@ jobs:
       - name: Command tests
         run: go test ./core/cmd/helm-ai-kernel -count=1
       - name: Fetch main ref for proto compatibility checks
-        run: git fetch origin main:refs/heads/main --force
+        run: |
+          if [ "$(git symbolic-ref --short -q HEAD || true)" = "main" ]; then
+            echo "On main; local refs/heads/main is already HEAD — nothing to fetch."
+          else
+            git fetch origin main:refs/heads/main --force
+          fi
       - name: Proto lint
         run: make proto-lint
       - name: Proto breaking

--- a/core/pkg/launchpad/session/healthcheck_runner.go
+++ b/core/pkg/launchpad/session/healthcheck_runner.go
@@ -68,6 +68,10 @@ func (DefaultHealthcheckRunner) Run(compiled plan.LaunchPlan, runtime RuntimeSta
 		}
 		workspace = wd
 	}
+	egressProxy, err := egressProxyFromEnv(compiled.SubstrateID, compiled.NetworkAllowlist)
+	if err != nil {
+		return HealthcheckResult{}, err
+	}
 	handle, err := lpruntime.NewLocalContainerRuntime().Start(lpruntime.ContainerRequest{
 		Plan:             compiled,
 		ImageDigest:      imageRef,
@@ -77,7 +81,7 @@ func (DefaultHealthcheckRunner) Run(compiled plan.LaunchPlan, runtime RuntimeSta
 		Command:          []string{"/bin/sh"},
 		Args:             []string{"-lc", check.Command},
 		NetworkAllowlist: compiled.NetworkAllowlist,
-		EgressProxy:      egressProxyFromEnv(compiled.NetworkAllowlist),
+		EgressProxy:      egressProxy,
 		AutoCleanup:      true,
 	})
 	if err != nil {

--- a/core/pkg/launchpad/session/runtime_starter.go
+++ b/core/pkg/launchpad/session/runtime_starter.go
@@ -284,7 +284,10 @@ func (DefaultRuntimeStarter) Start(compiled plan.LaunchPlan, opts ExecuteOptions
 		workspace = wd
 	}
 	secrets := runtimeSecrets(compiled, opts)
-	egressProxy := egressProxyFromEnv(compiled.NetworkAllowlist)
+	egressProxy, err := egressProxyFromEnv(compiled.SubstrateID, compiled.NetworkAllowlist)
+	if err != nil && !opts.RuntimeDryRun {
+		return RuntimeStartResult{}, err
+	}
 	runtime := lpruntime.NewLocalContainerRuntime()
 	runtime.IsolationMode = isolationModeFromEnv()
 	readiness, _ := time.ParseDuration(compiled.RuntimeReadinessTimeout)
@@ -345,26 +348,46 @@ func runtimeStartResultFromIsolation(isolation lpruntime.IsolationEvidence) Runt
 	}
 }
 
-func egressProxyFromEnv(allowlist []string) lpruntime.EgressProxy {
-	var egressProxy lpruntime.EgressProxy
+// substratesWithNetworkNamespace lists substrates whose workloads run in an
+// isolated network namespace where host-loopback proxies are unreachable.
+// For these, the LaunchOwnedEgressProxy default (listening on 127.0.0.1)
+// cannot serve the workload and silently produces curl exit 7 / HTTP 000
+// from inside the container — which then masquerades as an OpenRouter key
+// failure. Refuse the combination at start time with a clear remediation.
+var substratesWithNetworkNamespace = map[string]bool{
+	"local-container": true,
+}
+
+func egressProxyFromEnv(substrateID string, allowlist []string) (lpruntime.EgressProxy, error) {
 	if proxyURL := os.Getenv("HELM_LAUNCHPAD_EGRESS_PROXY_URL"); proxyURL != "" {
-		egressProxy = lpruntime.StaticEgressProxy{
+		return lpruntime.StaticEgressProxy{
 			ProxyURL:   proxyURL,
 			ReceiptRef: os.Getenv("HELM_LAUNCHPAD_EGRESS_PROXY_RECEIPT_REF"),
-		}
-	} else if proxyImage := os.Getenv("HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE"); proxyImage != "" {
-		egressProxy = lpruntime.DockerSidecarEgressProxy{
+		}, nil
+	}
+	if proxyImage := os.Getenv("HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE"); proxyImage != "" {
+		return lpruntime.DockerSidecarEgressProxy{
 			Image:      proxyImage,
 			ReceiptDir: os.Getenv("HELM_LAUNCHPAD_EGRESS_RECEIPT_DIR"),
-		}
-	} else if len(allowlist) > 0 {
-		proxy := lpruntime.NewLaunchOwnedEgressProxy()
-		if receiptDir := os.Getenv("HELM_LAUNCHPAD_EGRESS_RECEIPT_DIR"); receiptDir != "" {
-			proxy.ReceiptDir = receiptDir
-		}
-		egressProxy = proxy
+		}, nil
 	}
-	return egressProxy
+	if len(allowlist) == 0 {
+		return nil, nil
+	}
+	if substratesWithNetworkNamespace[substrateID] {
+		return nil, fmt.Errorf(
+			"egress proxy required for %q substrate with non-empty network allowlist: "+
+				"set HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE=<sha256-pinned image> to run a docker sidecar proxy, "+
+				"or HELM_LAUNCHPAD_EGRESS_PROXY_URL=<http://host:port> for an external proxy. "+
+				"The default loopback-listening proxy is unreachable from the container network namespace",
+			substrateID,
+		)
+	}
+	proxy := lpruntime.NewLaunchOwnedEgressProxy()
+	if receiptDir := os.Getenv("HELM_LAUNCHPAD_EGRESS_RECEIPT_DIR"); receiptDir != "" {
+		proxy.ReceiptDir = receiptDir
+	}
+	return proxy, nil
 }
 
 func runtimeSecrets(compiled plan.LaunchPlan, opts ExecuteOptions) map[string]string {

--- a/core/pkg/launchpad/session/runtime_starter_test.go
+++ b/core/pkg/launchpad/session/runtime_starter_test.go
@@ -1,9 +1,11 @@
 package session
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/plan"
+	lpruntime "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/runtime"
 )
 
 func TestRuntimeSecretsTokenBrokerDoesNotProjectRawProviderKey(t *testing.T) {
@@ -28,5 +30,76 @@ func TestRuntimeSecretsTokenBrokerDoesNotProjectRawProviderKey(t *testing.T) {
 	}
 	if secrets["HELM_MODEL_GATEWAY_URL"] != "https://gateway.example" {
 		t.Fatalf("broker URL missing: %#v", secrets)
+	}
+}
+
+func TestEgressProxyFromEnvStaticURL(t *testing.T) {
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_URL", "http://proxy.example:8080")
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_RECEIPT_REF", "receipt:test")
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE", "")
+
+	proxy, err := egressProxyFromEnv("local-container", []string{"openrouter.ai"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	static, ok := proxy.(lpruntime.StaticEgressProxy)
+	if !ok {
+		t.Fatalf("expected StaticEgressProxy, got %T", proxy)
+	}
+	if static.ProxyURL != "http://proxy.example:8080" {
+		t.Fatalf("proxy URL mismatch: %q", static.ProxyURL)
+	}
+	if static.ReceiptRef != "receipt:test" {
+		t.Fatalf("receipt ref mismatch: %q", static.ReceiptRef)
+	}
+}
+
+func TestEgressProxyFromEnvSidecarImage(t *testing.T) {
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_URL", "")
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE", "ghcr.io/example/proxy@sha256:abc")
+
+	proxy, err := egressProxyFromEnv("local-container", []string{"openrouter.ai"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sidecar, ok := proxy.(lpruntime.DockerSidecarEgressProxy)
+	if !ok {
+		t.Fatalf("expected DockerSidecarEgressProxy, got %T", proxy)
+	}
+	if sidecar.Image != "ghcr.io/example/proxy@sha256:abc" {
+		t.Fatalf("image mismatch: %q", sidecar.Image)
+	}
+}
+
+func TestEgressProxyFromEnvLocalContainerRefusesLoopbackDefault(t *testing.T) {
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_URL", "")
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE", "")
+
+	proxy, err := egressProxyFromEnv("local-container", []string{"openrouter.ai"})
+	if err == nil {
+		t.Fatalf("expected fail-fast error, got proxy %T", proxy)
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"local-container",
+		"HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE",
+		"HELM_LAUNCHPAD_EGRESS_PROXY_URL",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestEgressProxyFromEnvNoAllowlistReturnsNil(t *testing.T) {
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_URL", "")
+	t.Setenv("HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE", "")
+
+	proxy, err := egressProxyFromEnv("local-container", nil)
+	if err != nil {
+		t.Fatalf("unexpected error with empty allowlist: %v", err)
+	}
+	if proxy != nil {
+		t.Fatalf("expected nil proxy with empty allowlist, got %T", proxy)
 	}
 }


### PR DESCRIPTION
## Summary

Two independent bugs that surfaced after #204 merged to main:

- **`CI` workflow fails on push-to-main** — the `kernel` job's "Fetch main ref for proto compatibility checks" step runs `git fetch origin main:refs/heads/main --force`, which git refuses when `main` is the currently checked-out branch. PR runs are unaffected (detached HEAD), so the breakage only appears post-merge. Guarded with a `symbolic-ref` check.
- **`egressProxyFromEnv` silently falls back to `LaunchOwnedEgressProxy` for the `local-container` substrate** when neither `HELM_LAUNCHPAD_EGRESS_PROXY_URL` nor `HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE` is set. That proxy listens on host loopback (127.0.0.1) and is unreachable from the container netns; the healthcheck script reports `OpenRouter key check failed with HTTP status 000` and the launch lands in `REPAIR_REQUIRED` — masquerading as a bad-key problem. The fix refuses the combination at start time with a remediation message pointing to both env vars. `RuntimeDryRun` (`ModeDemo`) path keeps working.

## Test plan

- [x] `make test` — full kernel suite green locally
- [x] `make lint` — green locally
- [x] 4 new unit tests for `egressProxyFromEnv` (static URL, sidecar image, fail-fast refusal, no-allowlist returns nil)
- [x] CI guard locally simulated in a main worktree on `eae446a`: old command reproduces `fatal: refusing to fetch into branch 'refs/heads/main'`; new guard prints skip message and exits 0; `make proto-lint` and `make proto-breaking` both pass
- [x] Live-verified on Intel Mac (Intel-amd64 colima): without env vars kernel now fails fast at runtime start with the new error and no docker container is started; with env vars (sha-pinned egress-proxy image + real OpenRouter key) `state=RUNNING`, healthcheck PASS, sidecar proxy spawned, clean teardown via `launch delete --cascade`
- [x] CI on this PR goes green
- [ ] CI on `main` goes green after merge — the actual gate this PR fixes