### PR TITLE
fix: avoid real runtime in launchpad failure test

### DIFF
--- a/core/pkg/launchpad/session/executor_test.go
+++ b/core/pkg/launchpad/session/executor_test.go
@@ -12,7 +12,10 @@ import (
 
 func TestExecutorRequiresRuntimeBeforeRunning(t *testing.T) {
 	store := NewStore(t.TempDir())
-	run, err := NewExecutor(store).ExecuteLaunch(allowPlan(), ExecuteOptions{Reason: "test"})
+	run, err := NewExecutor(store).ExecuteLaunch(allowPlan(), ExecuteOptions{
+		Reason:         "test",
+		RuntimeStarter: failingRuntimeStarter{},
+	})
 	if err != nil {
 		t.Fatalf("ExecuteLaunch: %v", err)
 	}
@@ -169,6 +172,12 @@ func TestExecutorRunsNetworkedLaunchWithEgressReceipt(t *testing.T) {
 
 type fakeStarter struct {
 	called bool
+}
+
+type failingRuntimeStarter struct{}
+
+func (failingRuntimeStarter) Start(plan.LaunchPlan, ExecuteOptions) (RuntimeStartResult, error) {
+	return RuntimeStartResult{Runtime: "local-container"}, testError("runtime unavailable")
 }
 
 func (f *fakeStarter) Start(plan.LaunchPlan, ExecuteOptions) (RuntimeStartResult, error) {


### PR DESCRIPTION
## Summary
- inject a deterministic failing runtime starter in the launchpad runtime-failure test
- keep the test focused on repair-state behavior without requiring local Docker/runtime availability

## Verification
- go test ./core/pkg/launchpad/session -run TestExecutorRequiresRuntimeBeforeRunning -count=1 -timeout 30s
- go test ./core/pkg/launchpad/session -count=1 -timeout 60s
- git diff --check