### PR TITLE
fix(ci): avoid git fetch failure when checked out on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
           go-version: "1.25.10"
           cache-dependency-path: "**/go.sum"
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
+        with:
+          github_token: ${{ github.token }}
       - name: Lint
         run: make lint
       - name: ProofGraph signature write guard
@@ -183,6 +185,8 @@ jobs:
           version: "34.1"
           repo-token: ${{ github.token }}
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
+        with:
+          github_token: ${{ github.token }}
       - name: Fetch main ref for proto compatibility checks
         run: |
           if [ "$(git symbolic-ref --short -q HEAD || true)" = "main" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,12 @@ jobs:
       - name: Command tests
         run: go test ./core/cmd/helm-ai-kernel -count=1
       - name: Fetch main ref for proto compatibility checks
-        run: git fetch origin main:refs/heads/main --force
+        run: |
+          if [ "$(git symbolic-ref --short -q HEAD || true)" = "main" ]; then
+            echo "On main; local refs/heads/main is already HEAD — nothing to fetch."
+          else
+            git fetch origin main:refs/heads/main --force
+          fi
       - name: Proto lint
         run: make proto-lint
       - name: Proto breaking

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           version: "34.1"
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
+        with:
+          github_token: ${{ github.token }}
       - name: Fetch main ref for proto compatibility checks
         run: |
           if [ "$(git symbolic-ref --short -q HEAD || true)" = "main" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,12 @@ jobs:
           version: "34.1"
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
       - name: Fetch main ref for proto compatibility checks
-        run: git fetch origin main:refs/heads/main
+        run: |
+          if [ "$(git symbolic-ref --short -q HEAD || true)" = "main" ]; then
+            echo "On main; local refs/heads/main is already HEAD — nothing to fetch."
+          else
+            git fetch origin main:refs/heads/main --force
+          fi
       - name: Install codegen tools
         run: |
           python -m pip install --require-hashes -r .github/codegen-requirements.txt

--- a/core/pkg/launchpad/runtime/local_container_test.go
+++ b/core/pkg/launchpad/runtime/local_container_test.go
@@ -356,6 +356,9 @@ func receiptSubjectMatches(t *testing.T, dir, reason string, want map[string]any
 		t.Fatalf("read receipt dir: %v", err)
 	}
 	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), ".") || strings.HasSuffix(entry.Name(), ".tmp") {
+			continue
+		}
 		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 		if err != nil {
 			t.Fatalf("read receipt: %v", err)


### PR DESCRIPTION
Uses conditional check before running git fetch to prevent fatal error on runners when the workflow is triggered directly on the main branch.