### PR TITLE
Cover identity and regwatch helpers

### DIFF
--- a/core/pkg/compliance/regwatch/adapters_core_coverage_test.go
+++ b/core/pkg/compliance/regwatch/adapters_core_coverage_test.go
@@ -1,0 +1,161 @@
+package regwatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/compliance/jkg"
+)
+
+func TestAllDefaultAdaptersFetchHealthAndToggle(t *testing.T) {
+	ctx := context.Background()
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, adapter := range CreateDefaultAdaptersAll() {
+		t.Run(string(adapter.Type()), func(t *testing.T) {
+			changes, err := adapter.FetchChanges(ctx, since)
+			if err != nil {
+				t.Fatalf("FetchChanges: %v", err)
+			}
+			if changes == nil {
+				t.Fatal("FetchChanges returned nil slice")
+			}
+			if !adapter.IsHealthy(ctx) {
+				t.Fatal("adapter should start healthy")
+			}
+
+			setter, ok := adapter.(interface{ SetHealthy(bool) })
+			if !ok {
+				return
+			}
+			setter.SetHealthy(false)
+			if adapter.IsHealthy(ctx) {
+				t.Fatal("adapter stayed healthy after SetHealthy(false)")
+			}
+			setter.SetHealthy(true)
+			if !adapter.IsHealthy(ctx) {
+				t.Fatal("adapter stayed unhealthy after SetHealthy(true)")
+			}
+		})
+	}
+}
+
+func TestCFTCAdapterSeedDataAndTrackingAreas(t *testing.T) {
+	customAreas := []string{"prediction_markets", "ai_agents"}
+	adapter := NewCFTCAdapter(customAreas)
+	if got := adapter.TrackingAreas(); len(got) != len(customAreas) {
+		t.Fatalf("TrackingAreas len = %d, want %d", len(got), len(customAreas))
+	}
+	for i, area := range customAreas {
+		if adapter.TrackingAreas()[i] != area {
+			t.Fatalf("TrackingAreas[%d] = %q, want %q", i, adapter.TrackingAreas()[i], area)
+		}
+	}
+
+	changes, err := adapter.FetchChanges(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("FetchChanges: %v", err)
+	}
+	if len(changes) != 6 {
+		t.Fatalf("CFTC seed changes = %d, want 6", len(changes))
+	}
+	for _, change := range changes {
+		if change.SourceType != SourceCFTC {
+			t.Fatalf("SourceType = %s, want %s", change.SourceType, SourceCFTC)
+		}
+		if change.RegulatorID == "" || change.Framework == "" || change.Metadata == nil {
+			t.Fatalf("incomplete CFTC change: %#v", change)
+		}
+	}
+
+	defaulted := NewCFTCAdapter(nil)
+	if len(defaulted.TrackingAreas()) != 4 {
+		t.Fatalf("default TrackingAreas len = %d, want 4", len(defaulted.TrackingAreas()))
+	}
+}
+
+func TestEURLexUnknownFrameworkProducesNoChange(t *testing.T) {
+	adapter := NewEURLexAdapter([]string{"unknown-framework"})
+	changes, err := adapter.FetchChanges(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("FetchChanges: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Fatalf("unknown framework changes = %d, want 0", len(changes))
+	}
+}
+
+func TestEURLexAMLDAndDORAFrameworks(t *testing.T) {
+	adapter := NewEURLexAdapter([]string{"AMLD", "DORA"})
+	changes, err := adapter.FetchChanges(context.Background(), time.Time{})
+	if err != nil {
+		t.Fatalf("FetchChanges: %v", err)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("framework changes = %d, want 2", len(changes))
+	}
+	want := map[string]bool{"AMLD": false, "DORA": false}
+	for _, change := range changes {
+		if _, ok := want[change.Framework]; ok {
+			want[change.Framework] = true
+		}
+	}
+	for framework, seen := range want {
+		if !seen {
+			t.Fatalf("missing framework %s in %#v", framework, changes)
+		}
+	}
+}
+
+func TestSwarmIdleStopPollLoopAndFullChangeChannel(t *testing.T) {
+	idle := NewSwarm(&SwarmConfig{
+		PollInterval:     time.Hour,
+		MaxConcurrency:   1,
+		ChangeBufferSize: 1,
+	}, jkg.NewGraph())
+	idle.Stop()
+
+	tickerSwarm := NewSwarm(&SwarmConfig{
+		PollInterval:     time.Millisecond,
+		MaxConcurrency:   1,
+		ChangeBufferSize: 1,
+	}, jkg.NewGraph())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		tickerSwarm.pollLoop(ctx)
+		close(done)
+	}()
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("pollLoop did not exit after context cancellation")
+	}
+
+	full := NewSwarm(&SwarmConfig{
+		PollInterval:     time.Hour,
+		MaxConcurrency:   1,
+		ChangeBufferSize: 1,
+		RetryAttempts:    0,
+	}, jkg.NewGraph())
+	adapter := NewTestAdapter(SourceFinCEN, "US")
+	adapter.SetChanges([]*RegChange{
+		{Title: "first", SourceType: SourceFinCEN, ChangeType: ChangeNew, PublishedAt: time.Now()},
+		{Title: "second", SourceType: SourceFinCEN, ChangeType: ChangeGuidance, PublishedAt: time.Now()},
+	})
+	if err := full.RegisterAdapter(adapter); err != nil {
+		t.Fatalf("RegisterAdapter: %v", err)
+	}
+	full.PollNow(context.Background())
+	if full.GetMetrics().TotalChanges != 2 {
+		t.Fatalf("TotalChanges = %d, want 2", full.GetMetrics().TotalChanges)
+	}
+	select {
+	case <-full.Changes():
+	default:
+		t.Fatal("expected one buffered change")
+	}
+}

--- a/core/pkg/identity/identity_core_coverage_test.go
+++ b/core/pkg/identity/identity_core_coverage_test.go
@@ -1,0 +1,192 @@
+package identity
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestCertificateAuthorityCoreFlows(t *testing.T) {
+	if _, err := NewCertificateAuthority(CAConfig{}); err == nil {
+		t.Fatal("NewCertificateAuthority nil key error = nil")
+	}
+
+	_, caPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	ca, err := NewCertificateAuthority(CAConfig{CAID: "ca-1", PrivateKey: caPrivate})
+	if err != nil {
+		t.Fatalf("NewCertificateAuthority: %v", err)
+	}
+	if len(ca.CAPublicKey()) != ed25519.PublicKeySize*2 {
+		t.Fatalf("CAPublicKey length = %d, want %d", len(ca.CAPublicKey()), ed25519.PublicKeySize*2)
+	}
+
+	agentPublic, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate agent key: %v", err)
+	}
+	publicHex := hex.EncodeToString(agentPublic)
+	req := CertificateRequest{
+		AgentID:       "agent-1",
+		AgentName:     "Agent One",
+		PublicKey:     publicHex,
+		Capabilities:  []string{"E0", "E1"},
+		MaxDelegation: 2,
+		ValidityDays:  1,
+	}
+	cert, err := ca.IssueCertificate(context.Background(), req)
+	if err != nil {
+		t.Fatalf("IssueCertificate: %v", err)
+	}
+	if cert.CertID == "" || !strings.HasPrefix(cert.CertID, "cert-") {
+		t.Fatalf("CertID = %q, want generated cert id", cert.CertID)
+	}
+	if cert.IssuerID != "ca-1" || cert.Signature == "" {
+		t.Fatalf("issued cert missing issuer/signature: %#v", cert)
+	}
+	if err := ca.VerifyCertificate(context.Background(), cert); err != nil {
+		t.Fatalf("VerifyCertificate valid cert: %v", err)
+	}
+
+	byAgent, err := ca.GetCertificateByAgent(context.Background(), "agent-1")
+	if err != nil {
+		t.Fatalf("GetCertificateByAgent: %v", err)
+	}
+	if byAgent.CertID != cert.CertID {
+		t.Fatalf("GetCertificateByAgent CertID = %s, want %s", byAgent.CertID, cert.CertID)
+	}
+	if _, err := ca.GetCertificateByAgent(context.Background(), "missing-agent"); err == nil {
+		t.Fatal("GetCertificateByAgent missing error = nil")
+	}
+
+	if _, err := ca.IssueCertificate(context.Background(), CertificateRequest{PublicKey: publicHex}); err == nil {
+		t.Fatal("IssueCertificate missing agent id error = nil")
+	}
+	if _, err := ca.IssueCertificate(context.Background(), CertificateRequest{AgentID: "agent-2"}); err == nil {
+		t.Fatal("IssueCertificate missing public key error = nil")
+	}
+	if _, err := ca.IssueCertificate(context.Background(), CertificateRequest{AgentID: "agent-2", PublicKey: "bad"}); err == nil {
+		t.Fatal("IssueCertificate invalid public key error = nil")
+	}
+	defaultValidity, err := ca.IssueCertificate(context.Background(), CertificateRequest{
+		AgentID:   "agent-default-validity",
+		PublicKey: publicHex,
+	})
+	if err != nil {
+		t.Fatalf("IssueCertificate default validity: %v", err)
+	}
+	if defaultValidity.ExpiresAt.Sub(defaultValidity.IssuedAt) < 364*24*time.Hour {
+		t.Fatalf("default validity too short: %s", defaultValidity.ExpiresAt.Sub(defaultValidity.IssuedAt))
+	}
+
+	expired := *cert
+	expired.ExpiresAt = time.Now().Add(-time.Hour)
+	if err := ca.VerifyCertificate(context.Background(), &expired); err == nil {
+		t.Fatal("VerifyCertificate expired error = nil")
+	}
+	badEncoding := *cert
+	badEncoding.Signature = "not-hex"
+	if err := ca.VerifyCertificate(context.Background(), &badEncoding); err == nil {
+		t.Fatal("VerifyCertificate bad signature encoding error = nil")
+	}
+	badSignature := *cert
+	badSignature.Signature = hex.EncodeToString(make([]byte, ed25519.SignatureSize))
+	if err := ca.VerifyCertificate(context.Background(), &badSignature); err == nil {
+		t.Fatal("VerifyCertificate bad signature error = nil")
+	}
+
+	if err := ca.RevokeCertificate(context.Background(), "missing-cert"); err == nil {
+		t.Fatal("RevokeCertificate missing error = nil")
+	}
+	if err := ca.RevokeCertificate(context.Background(), cert.CertID); err != nil {
+		t.Fatalf("RevokeCertificate: %v", err)
+	}
+	if !cert.Revoked || cert.RevokedAt == nil {
+		t.Fatalf("revoked cert not marked revoked: %#v", cert)
+	}
+	if err := ca.VerifyCertificate(context.Background(), cert); err == nil {
+		t.Fatal("VerifyCertificate revoked error = nil")
+	}
+}
+
+func TestKeySetAndTokenManagerCoreFlows(t *testing.T) {
+	ks, err := NewInMemoryKeySet()
+	if err != nil {
+		t.Fatalf("NewInMemoryKeySet: %v", err)
+	}
+
+	tokenString, err := ks.Sign(context.Background(), jwt.RegisteredClaims{
+		Subject:   "agent-1",
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	})
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	parsed, err := jwt.ParseWithClaims(tokenString, &jwt.RegisteredClaims{}, ks.KeyFunc())
+	if err != nil {
+		t.Fatalf("ParseWithClaims signed token: %v", err)
+	}
+	if !parsed.Valid {
+		t.Fatal("signed token parsed invalid")
+	}
+
+	keyFunc := ks.KeyFunc()
+	if _, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodHS256, Header: map[string]interface{}{"alg": "HS256"}}); err == nil {
+		t.Fatal("KeyFunc wrong signing method error = nil")
+	}
+	if _, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodEdDSA, Header: map[string]interface{}{"alg": "EdDSA"}}); err == nil {
+		t.Fatal("KeyFunc missing kid error = nil")
+	}
+	if _, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodEdDSA, Header: map[string]interface{}{"alg": "EdDSA", "kid": "missing"}}); err == nil {
+		t.Fatal("KeyFunc unknown kid error = nil")
+	}
+
+	ks.mu.Lock()
+	savedKID := ks.currentKID
+	ks.currentKID = "missing"
+	ks.mu.Unlock()
+	if _, err := ks.Sign(context.Background(), jwt.RegisteredClaims{}); err == nil {
+		t.Fatal("Sign missing active key error = nil")
+	}
+	ks.mu.Lock()
+	ks.currentKID = savedKID
+	ks.mu.Unlock()
+
+	for i := 0; i < 11; i++ {
+		if err := ks.Rotate(); err != nil {
+			t.Fatalf("Rotate %d: %v", i, err)
+		}
+		time.Sleep(time.Nanosecond)
+	}
+	if len(ks.keys) > 10 {
+		t.Fatalf("key count = %d, want <= 10", len(ks.keys))
+	}
+
+	tm := NewTokenManager(ks)
+	identityToken, err := tm.GenerateToken(&AgentIdentity{
+		AgentID:     "agent-token",
+		DelegatorID: "user-1",
+		Scopes:      []string{"read", "execute"},
+	}, time.Hour)
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	claims, err := tm.ValidateToken(identityToken)
+	if err != nil {
+		t.Fatalf("ValidateToken: %v", err)
+	}
+	if claims.Subject != "agent-token" || claims.Type != PrincipalAgent || claims.DelegatorID != "user-1" {
+		t.Fatalf("unexpected token claims: %#v", claims)
+	}
+	if _, err := tm.ValidateToken("not-a-token"); err == nil {
+		t.Fatal("ValidateToken malformed token error = nil")
+	}
+}

--- a/core/pkg/identity/sso_jwk_core_coverage_test.go
+++ b/core/pkg/identity/sso_jwk_core_coverage_test.go
@@ -1,0 +1,235 @@
+package identity
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestJWKPublicKeyParsersAndSigningMethodMatching(t *testing.T) {
+	rsaPrivate, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	rsaJWK := jwkKey{
+		Kty: "RSA",
+		Kid: "rsa",
+		Alg: "RS256",
+		N:   jwkBytes(rsaPrivate.PublicKey.N.Bytes()),
+		E:   jwkBytes(big.NewInt(int64(rsaPrivate.PublicKey.E)).Bytes()),
+	}
+	rsaKey, err := jwkPublicKey(rsaJWK)
+	if err != nil {
+		t.Fatalf("jwkPublicKey RSA: %v", err)
+	}
+	if !signingMethodMatchesKey(jwt.SigningMethodRS256, rsaKey) {
+		t.Fatal("RSA key did not match RS256")
+	}
+	if !signingMethodMatchesKey(jwt.SigningMethodPS256, rsaKey) {
+		t.Fatal("RSA key did not match PS256")
+	}
+	if signingMethodMatchesKey(jwt.SigningMethodEdDSA, rsaKey) {
+		t.Fatal("RSA key matched EdDSA")
+	}
+	if _, err := rsaPublicKeyFromJWK(jwkKey{Kty: "RSA", E: rsaJWK.E}); err == nil {
+		t.Fatal("RSA missing modulus error = nil")
+	}
+	if _, err := rsaPublicKeyFromJWK(jwkKey{Kty: "RSA", N: rsaJWK.N, E: jwkBytes([]byte{2})}); err == nil {
+		t.Fatal("RSA invalid exponent error = nil")
+	}
+	if _, err := rsaPublicKeyFromJWK(jwkKey{Kty: "RSA", N: rsaJWK.N, E: jwkBytes([]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff})}); err == nil {
+		t.Fatal("RSA huge exponent error = nil")
+	}
+
+	ecdsaPrivate, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ECDSA key: %v", err)
+	}
+	ecJWK := jwkKey{
+		Kty: "EC",
+		Kid: "ec",
+		Alg: "ES256",
+		Crv: "P-256",
+		X:   jwkBytes(ecdsaPrivate.PublicKey.X.Bytes()),
+		Y:   jwkBytes(ecdsaPrivate.PublicKey.Y.Bytes()),
+	}
+	ecKey, err := jwkPublicKey(ecJWK)
+	if err != nil {
+		t.Fatalf("jwkPublicKey EC: %v", err)
+	}
+	if !signingMethodMatchesKey(jwt.SigningMethodES256, ecKey) {
+		t.Fatal("EC key did not match ES256")
+	}
+	if _, err := ecdsaPublicKeyFromJWK(jwkKey{Kty: "EC", Crv: "P-999", X: ecJWK.X, Y: ecJWK.Y}); err == nil {
+		t.Fatal("EC unsupported curve error = nil")
+	}
+	if _, err := ecdsaPublicKeyFromJWK(jwkKey{Kty: "EC", Crv: "P-256", X: ecJWK.X, Y: jwkBytes([]byte{1})}); err == nil {
+		t.Fatal("EC off-curve point error = nil")
+	}
+
+	edPublic, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate Ed25519 key: %v", err)
+	}
+	edJWK := jwkKey{Kty: "OKP", Kid: "ed", Alg: "EdDSA", Crv: "Ed25519", X: jwkBytes(edPublic)}
+	edKey, err := jwkPublicKey(edJWK)
+	if err != nil {
+		t.Fatalf("jwkPublicKey OKP: %v", err)
+	}
+	if !signingMethodMatchesKey(jwt.SigningMethodEdDSA, edKey) {
+		t.Fatal("Ed25519 key did not match EdDSA")
+	}
+	if _, err := ed25519PublicKeyFromJWK(jwkKey{Kty: "OKP", Crv: "P-256", X: edJWK.X}); err == nil {
+		t.Fatal("OKP wrong curve error = nil")
+	}
+	if _, err := ed25519PublicKeyFromJWK(jwkKey{Kty: "OKP", Crv: "Ed25519", X: jwkBytes([]byte{1})}); err == nil {
+		t.Fatal("OKP invalid length error = nil")
+	}
+
+	if _, err := jwkPublicKey(jwkKey{Kty: "oct"}); err == nil {
+		t.Fatal("unsupported key type error = nil")
+	}
+	if _, err := ellipticCurve("P-384"); err != nil {
+		t.Fatalf("P-384 curve: %v", err)
+	}
+	if _, err := ellipticCurve("P-521"); err != nil {
+		t.Fatalf("P-521 curve: %v", err)
+	}
+	if _, err := decodeJWKField("", "x"); err == nil {
+		t.Fatal("missing JWK field error = nil")
+	}
+	padded := base64.URLEncoding.EncodeToString([]byte("padded"))
+	if got, err := decodeJWKField(padded, "x"); err != nil || string(got) != "padded" {
+		t.Fatalf("decode padded field = %q, %v", string(got), err)
+	}
+	if _, err := decodeJWKField("%%%", "x"); err == nil {
+		t.Fatal("invalid JWK field error = nil")
+	}
+	if signingMethodMatchesKey(jwt.SigningMethodEdDSA, "not-a-key") {
+		t.Fatal("unknown key type matched signing method")
+	}
+}
+
+func TestJWKSKeyFuncBranches(t *testing.T) {
+	_, rsaJWK, edJWK := testJWKs(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(jwksDocument{Keys: []jwkKey{
+			{Kty: "oct", Use: "enc", Kid: "ignored"},
+			rsaJWK,
+			edJWK,
+		}})
+	}))
+	defer server.Close()
+
+	provider := &OIDCProvider{discoveryDoc: &oidcDiscoveryDoc{JWKSURI: server.URL}}
+	keyFunc, err := provider.jwksKeyFunc(context.Background())
+	if err != nil {
+		t.Fatalf("jwksKeyFunc: %v", err)
+	}
+	if key, err := keyFunc(&jwt.Token{
+		Method: jwt.SigningMethodRS256,
+		Header: map[string]interface{}{
+			"alg": "RS256",
+			"kid": "rsa",
+		},
+	}); err != nil || key == nil {
+		t.Fatalf("keyFunc RSA = %v, %v", key, err)
+	}
+	if key, err := keyFunc(&jwt.Token{
+		Method: jwt.SigningMethodEdDSA,
+		Header: map[string]interface{}{
+			"alg": "EdDSA",
+			"kid": "ed",
+		},
+	}); err != nil || key == nil {
+		t.Fatalf("keyFunc Ed25519 = %v, %v", key, err)
+	}
+	if _, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS256, Header: map[string]interface{}{"alg": "RS256"}}); err == nil {
+		t.Fatal("keyFunc missing kid error = nil")
+	}
+	if _, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS256, Header: map[string]interface{}{"alg": "RS256", "kid": "missing"}}); err == nil {
+		t.Fatal("keyFunc unknown kid error = nil")
+	}
+	if _, err := keyFunc(&jwt.Token{Method: jwt.SigningMethodRS512, Header: map[string]interface{}{"alg": "RS512", "kid": "rsa"}}); err == nil {
+		t.Fatal("keyFunc alg mismatch error = nil")
+	}
+
+	if _, err := (&OIDCProvider{}).jwksKeyFunc(context.Background()); err == nil {
+		t.Fatal("missing jwks_uri error = nil")
+	}
+	if _, err := (&OIDCProvider{discoveryDoc: &oidcDiscoveryDoc{JWKSURI: "://bad"}}).jwksKeyFunc(context.Background()); err == nil {
+		t.Fatal("bad JWKS URI error = nil")
+	}
+	statusServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer statusServer.Close()
+	if _, err := (&OIDCProvider{discoveryDoc: &oidcDiscoveryDoc{JWKSURI: statusServer.URL}}).jwksKeyFunc(context.Background()); err == nil {
+		t.Fatal("JWKS status error = nil")
+	}
+	jsonServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("{"))
+	}))
+	defer jsonServer.Close()
+	if _, err := (&OIDCProvider{discoveryDoc: &oidcDiscoveryDoc{JWKSURI: jsonServer.URL}}).jwksKeyFunc(context.Background()); err == nil {
+		t.Fatal("JWKS JSON error = nil")
+	}
+	noKeysServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(jwksDocument{Keys: []jwkKey{{Kty: "oct", Use: "enc", Kid: "ignored"}}})
+	}))
+	defer noKeysServer.Close()
+	if _, err := (&OIDCProvider{discoveryDoc: &oidcDiscoveryDoc{JWKSURI: noKeysServer.URL}}).jwksKeyFunc(context.Background()); err == nil {
+		t.Fatal("JWKS no signing keys error = nil")
+	}
+	invalidKeyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(jwksDocument{Keys: []jwkKey{{Kty: "RSA", Use: "sig", Kid: "bad"}}})
+	}))
+	defer invalidKeyServer.Close()
+	if _, err := (&OIDCProvider{discoveryDoc: &oidcDiscoveryDoc{JWKSURI: invalidKeyServer.URL}}).jwksKeyFunc(context.Background()); err == nil {
+		t.Fatal("JWKS invalid JWK error = nil")
+	}
+}
+
+func jwkBytes(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func testJWKs(t *testing.T) (*rsa.PrivateKey, jwkKey, jwkKey) {
+	t.Helper()
+	rsaPrivate, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	edPublic, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate Ed25519 key: %v", err)
+	}
+	return rsaPrivate,
+		jwkKey{
+			Kty: "RSA",
+			Use: "sig",
+			Kid: "rsa",
+			Alg: "RS256",
+			N:   jwkBytes(rsaPrivate.PublicKey.N.Bytes()),
+			E:   jwkBytes(big.NewInt(int64(rsaPrivate.PublicKey.E)).Bytes()),
+		},
+		jwkKey{
+			Kty: "OKP",
+			Use: "sig",
+			Kid: "ed",
+			Alg: "EdDSA",
+			Crv: "Ed25519",
+			X:   jwkBytes(edPublic),
+		}
+}


### PR DESCRIPTION
## Summary
- Add focused coverage for regwatch adapter health/seed/poll branches.
- Add focused identity CA/token/JWKS parser coverage.
- Use 2048-bit RSA fixtures for CodeQL-compliant test keys.

## Local verification
- go test ./pkg/compliance/regwatch ./pkg/identity -count=1
- git diff --check