### PR TITLE
Cover evidence pack and replay helpers

### DIFF
--- a/core/pkg/launchpad/receipts/evidence_pack_core_coverage_test.go
+++ b/core/pkg/launchpad/receipts/evidence_pack_core_coverage_test.go
@@ -1,0 +1,377 @@
+package receipts
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewReceiptPopulatesHashesAndIDs(t *testing.T) {
+	subject := map[string]any{"app_id": "demo", "digest": "sha256:abc"}
+
+	receipt := NewReceipt("launchpad.install", "launch-123", "ALLOW", subject)
+
+	if receipt.Type != "launchpad.install" || receipt.LaunchID != "launch-123" {
+		t.Fatalf("unexpected receipt identity: %+v", receipt)
+	}
+	if receipt.DecisionID != "launchpad.install:launch-123" {
+		t.Fatalf("unexpected decision id: %s", receipt.DecisionID)
+	}
+	if receipt.Verdict != "ALLOW" || receipt.Status != "ALLOW" || receipt.LamportClock != 1 {
+		t.Fatalf("unexpected receipt status fields: %+v", receipt)
+	}
+	if !strings.HasPrefix(receipt.DecisionHash, "sha256:") || !strings.HasPrefix(receipt.Hash, "sha256:") {
+		t.Fatalf("receipt hashes were not populated: %+v", receipt)
+	}
+	if receipt.ReceiptID != "launchpad.install:"+receipt.Hash {
+		t.Fatalf("unexpected receipt id: %s", receipt.ReceiptID)
+	}
+	if receipt.CreatedAt.IsZero() || receipt.CreatedAt.Location() != time.UTC {
+		t.Fatalf("receipt timestamp was not normalized to UTC: %v", receipt.CreatedAt)
+	}
+	if got := Hash(map[string]string{"stable": "value"}); !strings.HasPrefix(got, "sha256:") {
+		t.Fatalf("Hash returned unexpected digest: %s", got)
+	}
+}
+
+func TestWriteEvidencePackAddsDefaultReceiptAndCanonicalizesHostEvidence(t *testing.T) {
+	packDir, err := WriteEvidencePack(t.TempDir(), "launch-defaults", map[string][]byte{
+		"host_evidence/runtime.json": []byte(`{"host":"ci"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, rel := range []string{
+		"02_PROOFGRAPH/proofgraph.json",
+		"02_PROOFGRAPH/receipts/launchpad-kernel-verdict.json",
+		"11_HOST_EVIDENCE/runtime.json",
+	} {
+		if _, err := os.Stat(filepath.Join(packDir, rel)); err != nil {
+			t.Fatalf("expected default/canonical artifact %s: %v", rel, err)
+		}
+	}
+
+	data, err := os.ReadFile(filepath.Join(packDir, "04_EXPORTS", "launchpad_evidence_graph.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var graph EvidenceGraph
+	if err := json.Unmarshal(data, &graph); err != nil {
+		t.Fatal(err)
+	}
+	if len(graph.Nodes) != 1 || graph.Nodes[0].Verdict != "ESCALATE" {
+		t.Fatalf("default receipt was not represented in evidence graph: %+v", graph)
+	}
+}
+
+func TestWriteEvidencePackRejectsInvalidArtifactPath(t *testing.T) {
+	if _, err := WriteEvidencePack(t.TempDir(), "launch-invalid", map[string][]byte{
+		"../escape.json": []byte(`{}`),
+	}); err == nil {
+		t.Fatal("expected invalid artifact path to fail")
+	}
+}
+
+func TestWriteEvidencePackReportsFilesystemFailures(t *testing.T) {
+	receiptArtifact := map[string][]byte{
+		"receipts/kernel.json": []byte(`{"receipt_id":"r1","type":"launchpad.kernel","decision_id":"d1","decision_hash":"sha256:test","status":"ALLOW","verdict":"ALLOW","lamport_clock":1}`),
+	}
+
+	rootFile := filepath.Join(t.TempDir(), "root-file")
+	writeFile(t, rootFile, []byte("blocks mkdir"))
+	if _, err := WriteEvidencePack(rootFile, "launch-root-file", copyArtifacts(receiptArtifact)); err == nil {
+		t.Fatal("expected root file to block evidence pack directory creation")
+	}
+
+	for _, tc := range []struct {
+		name    string
+		setup   func(t *testing.T, packDir string)
+		payload map[string][]byte
+	}{
+		{
+			name: "required subdirectory path is file",
+			setup: func(t *testing.T, packDir string) {
+				writeFile(t, filepath.Join(packDir, "02_PROOFGRAPH"), []byte("not a directory"))
+			},
+			payload: receiptArtifact,
+		},
+		{
+			name: "score path is directory",
+			setup: func(t *testing.T, packDir string) {
+				if err := os.Mkdir(filepath.Join(packDir, "01_SCORE.json"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+			payload: receiptArtifact,
+		},
+		{
+			name: "artifact parent path is file",
+			setup: func(t *testing.T, packDir string) {
+				writeFile(t, filepath.Join(packDir, "04_EXPORTS", "nested"), []byte("not a directory"))
+			},
+			payload: map[string][]byte{
+				"nested/runtime.json": []byte(`{"ok":true}`),
+			},
+		},
+		{
+			name: "artifact target path is directory",
+			setup: func(t *testing.T, packDir string) {
+				if err := os.MkdirAll(filepath.Join(packDir, "04_EXPORTS", "runtime.json"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+			payload: map[string][]byte{
+				"runtime.json": []byte(`{"ok":true}`),
+			},
+		},
+		{
+			name: "manifest path is directory",
+			setup: func(t *testing.T, packDir string) {
+				if err := os.MkdirAll(filepath.Join(packDir, "04_EXPORTS", "launchpad_manifest.json"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+			payload: receiptArtifact,
+		},
+		{
+			name: "index path is directory",
+			setup: func(t *testing.T, packDir string) {
+				if err := os.Mkdir(filepath.Join(packDir, "00_INDEX.json"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+			payload: receiptArtifact,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			launchID := strings.ReplaceAll(tc.name, " ", "-")
+			packDir := filepath.Join(root, "evidencepacks", launchID)
+			if err := os.MkdirAll(packDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			tc.setup(t, packDir)
+
+			if _, err := WriteEvidencePack(root, launchID, copyArtifacts(tc.payload)); err == nil {
+				t.Fatal("expected filesystem collision to fail")
+			}
+		})
+	}
+}
+
+func TestEvidencePathHelpers(t *testing.T) {
+	tests := map[string]string{
+		"proofgraph.json":                 "02_PROOFGRAPH/proofgraph.json",
+		"receipts/kernel.json":            "02_PROOFGRAPH/receipts/kernel.json",
+		"03_TELEMETRY/runtime.json":       "03_TELEMETRY/runtime.json",
+		"host_evidence/externalhost.json": "11_HOST_EVIDENCE/externalhost.json",
+		"summary.json":                    "04_EXPORTS/summary.json",
+	}
+	for input, want := range tests {
+		if got := canonicalEvidencePath(input); got != want {
+			t.Fatalf("canonicalEvidencePath(%q) = %q, want %q", input, got, want)
+		}
+	}
+
+	for _, invalid := range []string{".", "../escape.json"} {
+		if _, err := cleanArtifactName(invalid); err == nil {
+			t.Fatalf("expected %q to be rejected", invalid)
+		}
+	}
+	if clean, err := cleanArtifactName("/nested/../artifact.json"); err != nil || clean != "artifact.json" {
+		t.Fatalf("unexpected cleaned artifact path %q: %v", clean, err)
+	}
+}
+
+func TestMergeExistingArtifactsNormalizesLegacyPaths(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "00_INDEX.json"), []byte("skip-index"))
+	writeFile(t, filepath.Join(dir, "01_SCORE.json"), []byte("skip-score"))
+	writeFile(t, filepath.Join(dir, "04_EXPORTS", "launchpad_manifest.json"), []byte("skip-manifest"))
+	writeFile(t, filepath.Join(dir, "04_EXPORTS", "launchpad_evidence_graph.json"), []byte("skip-graph"))
+	writeFile(t, filepath.Join(dir, "02_PROOFGRAPH", "proofgraph.json"), []byte("proofgraph"))
+	writeFile(t, filepath.Join(dir, "02_PROOFGRAPH", "receipts", "kernel.json"), []byte("receipt"))
+	writeFile(t, filepath.Join(dir, "04_EXPORTS", "report.json"), []byte("report"))
+
+	artifacts := map[string][]byte{
+		"04_EXPORTS/report.json": []byte("new-report"),
+	}
+	if err := mergeExistingArtifacts(dir, artifacts); err != nil {
+		t.Fatal(err)
+	}
+	if err := mergeExistingArtifacts(dir, map[string][]byte{}); err != nil {
+		t.Fatal(err)
+	}
+
+	assertBytes(t, artifacts, "proofgraph.json", []byte("proofgraph"))
+	assertBytes(t, artifacts, "receipts/kernel.json", []byte("receipt"))
+	assertBytes(t, artifacts, "04_EXPORTS/report.json", []byte("new-report"))
+	for _, skipped := range []string{"00_INDEX.json", "01_SCORE.json", "04_EXPORTS/launchpad_manifest.json", "04_EXPORTS/launchpad_evidence_graph.json"} {
+		if _, ok := artifacts[skipped]; ok {
+			t.Fatalf("expected %s to be skipped during merge", skipped)
+		}
+	}
+}
+
+func TestWriteEvidencePackArchiveWritesDeterministicTar(t *testing.T) {
+	packDir, err := WriteEvidencePack(t.TempDir(), "launch-archive", map[string][]byte{
+		"receipts/kernel-verdict.json": []byte(`{"receipt_id":"r1","type":"launchpad.kernel_verdict","decision_id":"d1","decision_hash":"sha256:test","status":"ALLOW","verdict":"ALLOW","lamport_clock":1}`),
+		"03_TELEMETRY/runtime.json":    []byte(`{"ok":true}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	archivePath, err := WriteEvidencePackArchive(packDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archivePath != packDir+".tar" {
+		t.Fatalf("unexpected archive path: %s", archivePath)
+	}
+
+	names, payloads := readTar(t, archivePath)
+	if !sortsBefore(names, "02_PROOFGRAPH/", "00_INDEX.json") {
+		t.Fatalf("archive should emit sorted directory entries before files: %v", names)
+	}
+	for _, rel := range []string{
+		"00_INDEX.json",
+		"01_SCORE.json",
+		"02_PROOFGRAPH/receipts/kernel-verdict.json",
+		"03_TELEMETRY/runtime.json",
+		"04_EXPORTS/launchpad_manifest.json",
+	} {
+		if _, ok := payloads[rel]; !ok {
+			t.Fatalf("archive missing %s; names=%v", rel, names)
+		}
+	}
+	if string(payloads["03_TELEMETRY/runtime.json"]) != `{"ok":true}` {
+		t.Fatalf("unexpected telemetry payload: %s", payloads["03_TELEMETRY/runtime.json"])
+	}
+}
+
+func TestWriteEvidencePackArchiveRejectsInvalidSources(t *testing.T) {
+	root := t.TempDir()
+	if _, err := WriteEvidencePackArchive(filepath.Join(root, "missing")); err == nil {
+		t.Fatal("expected missing source to fail")
+	}
+
+	filePath := filepath.Join(root, "source-file")
+	writeFile(t, filePath, []byte("not a directory"))
+	if _, err := WriteEvidencePackArchive(filePath); err == nil {
+		t.Fatal("expected file source to fail")
+	}
+
+	packDir := filepath.Join(root, "pack")
+	if err := os.Mkdir(packDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(packDir+".tar", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEvidencePackArchive(packDir); err == nil {
+		t.Fatal("expected archive path directory to fail")
+	}
+
+	brokenLinkPackDir := filepath.Join(root, "broken-link-pack")
+	if err := os.Mkdir(brokenLinkPackDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(brokenLinkPackDir, "missing-target"), filepath.Join(brokenLinkPackDir, "broken-link")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WriteEvidencePackArchive(brokenLinkPackDir); err == nil {
+		t.Fatal("expected broken symlink to fail archive file stat")
+	}
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertBytes(t *testing.T, artifacts map[string][]byte, key string, want []byte) {
+	t.Helper()
+	got, ok := artifacts[key]
+	if !ok {
+		t.Fatalf("missing merged artifact %s", key)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("artifact %s = %q, want %q", key, got, want)
+	}
+}
+
+func copyArtifacts(artifacts map[string][]byte) map[string][]byte {
+	copied := make(map[string][]byte, len(artifacts))
+	for key, value := range artifacts {
+		copied[key] = append([]byte(nil), value...)
+	}
+	return copied
+}
+
+func readTar(t *testing.T, path string) ([]string, map[string][]byte) {
+	t.Helper()
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+
+	reader := tar.NewReader(file)
+	var names []string
+	payloads := map[string][]byte{}
+	for {
+		header, err := reader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		names = append(names, header.Name)
+		if !header.ModTime.Equal(time.Unix(0, 0).UTC()) {
+			t.Fatalf("non-deterministic modtime for %s: %v", header.Name, header.ModTime)
+		}
+		if header.Typeflag == tar.TypeDir {
+			if header.Mode != 0o700 {
+				t.Fatalf("directory %s mode = %o", header.Name, header.Mode)
+			}
+			continue
+		}
+		if header.Mode != 0o600 {
+			t.Fatalf("file %s mode = %o", header.Name, header.Mode)
+		}
+		buf, err := io.ReadAll(reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payloads[header.Name] = buf
+	}
+	return names, payloads
+}
+
+func sortsBefore(values []string, before, after string) bool {
+	beforeIndex := -1
+	afterIndex := -1
+	for i, value := range values {
+		switch value {
+		case before:
+			beforeIndex = i
+		case after:
+			afterIndex = i
+		}
+	}
+	return beforeIndex >= 0 && afterIndex >= 0 && beforeIndex < afterIndex
+}

--- a/core/pkg/replay/tape_bridge_core_coverage_test.go
+++ b/core/pkg/replay/tape_bridge_core_coverage_test.go
@@ -1,0 +1,310 @@
+package replay
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/tape"
+)
+
+func TestReplayFromFileReadsJSONLAndReportsOpenError(t *testing.T) {
+	r1 := Receipt{ID: "file-r1", ToolName: "calc", Timestamp: parseTime("2026-01-01T00:00:00Z"), LamportClock: 1}
+	data1, _ := json.Marshal(r1)
+	h1 := sha256.Sum256(data1)
+	r2 := Receipt{ID: "file-r2", ToolName: "calc", PrevHash: hex.EncodeToString(h1[:]), Timestamp: parseTime("2026-01-01T00:00:01Z"), LamportClock: 2}
+
+	line1, _ := json.Marshal(r1)
+	line2, _ := json.Marshal(r2)
+	path := filepath.Join(t.TempDir(), "receipts.jsonl")
+	if err := os.WriteFile(path, append(append(line1, '\n'), line2...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := ReplayFromFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TotalReceipts != 2 || !result.ValidChain {
+		t.Fatalf("unexpected replay result: %+v", result)
+	}
+
+	if _, err := ReplayFromFile(filepath.Join(t.TempDir(), "missing.jsonl")); err == nil {
+		t.Fatal("expected missing replay file to fail")
+	}
+}
+
+func TestReplayFromReaderReportsDecodeError(t *testing.T) {
+	if _, err := ReplayFromReader(strings.NewReader("{not-json")); err == nil {
+		t.Fatal("expected malformed replay JSONL to fail")
+	}
+}
+
+func TestVisualizerLineageAndSummaryBranches(t *testing.T) {
+	events := []TimelineEvent{
+		{
+			EventID:    "root",
+			Type:       EventTypeDelegation,
+			Actor:      "alice",
+			Action:     "delegate",
+			Verdict:    "ALLOW",
+			ReasonCode: "delegated",
+			Depth:      1,
+		},
+		{
+			EventID:    "child",
+			ParentID:   "root",
+			Type:       EventTypeEffect,
+			Actor:      "bob",
+			Action:     "execute",
+			Verdict:    "ALLOW",
+			ReasonCode: "effect",
+			Depth:      2,
+		},
+		{
+			EventID:    "leaf",
+			ParentID:   "child",
+			Type:       EventTypeError,
+			Actor:      "bob",
+			Action:     "fail",
+			Verdict:    "ERROR",
+			ReasonCode: "runtime_error",
+			Depth:      3,
+		},
+	}
+
+	lineage, err := TraceLineage("lineage-1", events, "leaf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lineage.RootEvent != "root" || lineage.LeafEvent != "leaf" || lineage.TotalDepth != 3 {
+		t.Fatalf("unexpected lineage: %+v", lineage)
+	}
+
+	summary := computeSummary(events)
+	if summary.Delegations != 1 || summary.Effects != 1 || summary.Errors != 1 {
+		t.Fatalf("unexpected event counts: %+v", summary)
+	}
+	if summary.UniqueActors != 2 || summary.MaxDepth != 3 {
+		t.Fatalf("unexpected actor/depth summary: %+v", summary)
+	}
+	if summary.ReasonCodes["runtime_error"] != 1 {
+		t.Fatalf("reason codes were not counted: %+v", summary.ReasonCodes)
+	}
+}
+
+func TestClassifyEventAdditionalStatuses(t *testing.T) {
+	for _, tc := range []struct {
+		status string
+		want   TimelineEventType
+	}{
+		{status: "ESCALATED", want: EventTypeEscalation},
+		{status: "ERROR", want: EventTypeError},
+		{status: "SUCCESS", want: EventTypeEffect},
+	} {
+		if got := classifyEvent(Receipt{Status: tc.status}); got != tc.want {
+			t.Fatalf("classifyEvent(%q) = %s, want %s", tc.status, got, tc.want)
+		}
+	}
+}
+
+func TestTapeBridgeLoadsManifestEntriesAndConvertsEvents(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	entries := []tape.Entry{
+		replayTapeEntry(1, tape.EntryTypeRNGSeed, "rng", "seed-key", []byte("seed-value"), now),
+		replayTapeEntry(2, tape.EntryTypeNetwork, "network", "https://example.test", []byte("response-body"), now.Add(time.Second)),
+	}
+	writeReplayTapeFixture(t, dir, entries, nil)
+
+	source := NewTapeEventSource(dir)
+	events, err := source.GetRunEvents(context.Background(), "ignored-run-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].SequenceNumber != 1 || events[0].EventID != "rng" || events[0].PRNGSeed != "seed-key" {
+		t.Fatalf("unexpected RNG event conversion: %+v", events[0])
+	}
+	if events[0].PayloadHash != entries[0].ValueHash || events[0].OutputHash != entries[0].ValueHash {
+		t.Fatalf("hashes were not mapped from tape entry: %+v", events[0])
+	}
+	if got := events[0].Payload["tape_value"]; got != "seed-value" {
+		t.Fatalf("unexpected tape payload value: %#v", got)
+	}
+	if got := events[0].Payload["data_class"]; got != "PUBLIC" {
+		t.Fatalf("unexpected data class payload: %#v", got)
+	}
+
+	loaded, err := LoadTapeEntries(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != len(entries) {
+		t.Fatalf("expected %d loaded entries, got %d", len(entries), len(loaded))
+	}
+
+	hash, err := ComputeTapeRunHash(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(hash, "sha256:") {
+		t.Fatalf("unexpected tape run hash: %s", hash)
+	}
+}
+
+func TestTapeBridgeConvertsRunEventToTapeEntry(t *testing.T) {
+	event := RunEvent{
+		SequenceNumber: 7,
+		EventID:        "component",
+		EventType:      string(tape.EntryTypeRNGSeed),
+		PayloadHash:    "hash-7",
+		PRNGSeed:       "seed-7",
+		Timestamp:      time.Date(2026, 2, 3, 4, 5, 6, 0, time.UTC),
+		Payload: map[string]interface{}{
+			"data_class":       "CONFIDENTIAL",
+			"residency_region": "DE",
+			"encryption":       "AES-256-GCM",
+			"retention_basis":  "contract",
+		},
+	}
+
+	entry := RunEventToTapeEntry(event)
+	if entry.Seq != event.SequenceNumber || entry.Type != tape.EntryTypeRNGSeed || entry.ComponentID != event.EventID {
+		t.Fatalf("unexpected tape entry identity: %+v", entry)
+	}
+	if entry.Key != "seed-7" || entry.ValueHash != "hash-7" {
+		t.Fatalf("unexpected tape key/hash: %+v", entry)
+	}
+	if entry.DataClass != "CONFIDENTIAL" || entry.ResidencyRegion != "DE" ||
+		entry.Encryption != "AES-256-GCM" || entry.RetentionBasis != "contract" {
+		t.Fatalf("payload metadata was not copied: %+v", entry)
+	}
+}
+
+func TestTapeEventSourceReportsManifestLoadAndIntegrityErrors(t *testing.T) {
+	if _, err := NewTapeEventSource(t.TempDir()).GetRunEvents(context.Background(), "run"); err == nil {
+		t.Fatal("expected missing manifest to fail")
+	}
+
+	t.Run("entry read error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeReplayTapeManifest(t, dir, nil)
+		if err := os.Mkdir(filepath.Join(dir, "entry_0001.json"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewTapeEventSource(dir).GetRunEvents(context.Background(), "run"); err == nil {
+			t.Fatal("expected directory entry to fail ReadFile")
+		}
+	})
+
+	t.Run("entry parse error", func(t *testing.T) {
+		dir := t.TempDir()
+		writeReplayTapeManifest(t, dir, nil)
+		if err := os.WriteFile(filepath.Join(dir, "entry_0001.json"), []byte("{not-json"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewTapeEventSource(dir).GetRunEvents(context.Background(), "run"); err == nil {
+			t.Fatal("expected invalid tape entry JSON to fail")
+		}
+	})
+
+	t.Run("integrity error", func(t *testing.T) {
+		dir := t.TempDir()
+		entry := replayTapeEntry(1, tape.EntryTypeToolOutput, "tool", "tool-id", []byte("payload"), time.Now().UTC())
+		badManifest := &tape.Manifest{
+			RunID: "run",
+			Entries: []tape.ManifestItem{{
+				Seq:       entry.Seq,
+				Type:      entry.Type,
+				Key:       entry.Key,
+				SHA256:    "wrong-hash",
+				SizeBytes: int64(len(entry.Value)),
+			}},
+		}
+		writeReplayTapeFixture(t, dir, []tape.Entry{entry}, badManifest)
+		if _, err := NewTapeEventSource(dir).GetRunEvents(context.Background(), "run"); err == nil {
+			t.Fatal("expected manifest integrity mismatch to fail")
+		}
+	})
+}
+
+func replayTapeEntry(seq uint64, entryType tape.EntryType, componentID, key string, value []byte, timestamp time.Time) tape.Entry {
+	sum := sha256.Sum256(value)
+	return tape.Entry{
+		Seq:             seq,
+		Type:            entryType,
+		ComponentID:     componentID,
+		Key:             key,
+		ValueHash:       hex.EncodeToString(sum[:]),
+		Value:           value,
+		Timestamp:       timestamp,
+		DataClass:       "PUBLIC",
+		ResidencyRegion: "US",
+		Encryption:      "AES-256-GCM",
+		RetentionBasis:  "test",
+	}
+}
+
+func writeReplayTapeFixture(t *testing.T, dir string, entries []tape.Entry, manifest *tape.Manifest) {
+	t.Helper()
+	for _, entry := range entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "entry_"+zeroPadReplaySeq(entry.Seq)+".json")
+		if err := os.WriteFile(path, data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if manifest == nil {
+		manifest = &tape.Manifest{RunID: "run", Entries: make([]tape.ManifestItem, 0, len(entries))}
+		for _, entry := range entries {
+			manifest.Entries = append(manifest.Entries, tape.ManifestItem{
+				Seq:       entry.Seq,
+				Type:      entry.Type,
+				Key:       entry.Key,
+				SHA256:    entry.ValueHash,
+				SizeBytes: int64(len(entry.Value)),
+			})
+		}
+	}
+	writeReplayTapeManifest(t, dir, manifest)
+}
+
+func writeReplayTapeManifest(t *testing.T, dir string, manifest *tape.Manifest) {
+	t.Helper()
+	if manifest == nil {
+		manifest = &tape.Manifest{RunID: "run"}
+	}
+	if err := tape.WriteManifest(dir, manifest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func zeroPadReplaySeq(seq uint64) string {
+	switch {
+	case seq < 10:
+		return "000" + strconvFormatReplaySeq(seq)
+	case seq < 100:
+		return "00" + strconvFormatReplaySeq(seq)
+	case seq < 1000:
+		return "0" + strconvFormatReplaySeq(seq)
+	default:
+		return strconvFormatReplaySeq(seq)
+	}
+}
+
+func strconvFormatReplaySeq(seq uint64) string {
+	return strconv.FormatUint(seq, 10)
+}


### PR DESCRIPTION
## Summary\n- add evidence pack receipt/archive coverage\n- add replay JSONL, lineage, and tape bridge coverage\n\n## Verification\n- go test ./pkg/launchpad/receipts ./pkg/replay -count=1