### PR TITLE
Sharpen kernel traction docs and coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@
 [![GHCR chart](https://img.shields.io/badge/ghcr.io-helm--ai--kernel%20chart-0F1689?logo=helm&logoColor=white)](https://github.com/Mindburn-Labs/helm-ai-kernel/pkgs/container/charts%2Fhelm-ai-kernel)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/mindburn-labs)](https://artifacthub.io/packages/search?repo=mindburn-labs)
 
-HELM AI Kernel is the open-source execution firewall for MCP and AI agents.
-It sits between agent tool calls and side effects, evaluates authority before
-dispatch, and emits signed receipts that can be verified offline.
+HELM AI Kernel is the fail-closed execution firewall for AI agents.
 
-**Star HELM to follow open-source AI agent security, MCP quarantine, and proof
-receipts:** <https://github.com/Mindburn-Labs/helm-ai-kernel/stargazers>
+Mindburn Labs' HELM execution kernel for AI agents, not the Kubernetes package
+manager.
 
-## Try HELM Locally
+Models propose. HELM governs execution. Every ALLOW / DENY / ESCALATE decision
+leaves proof.
+
+## Try HELM AI Kernel Locally
 
 No account, hosted service, or production credential is required for the local
 proof path:
@@ -49,6 +50,10 @@ The local proof path shows the public value proposition in one frame:
 - a signed DENY receipt verifies offline
 - a flipped-verdict receipt fails verification
 
+Star HELM AI Kernel if you want to follow fail-closed AI agent execution, MCP
+quarantine, signed receipts, and offline-verifiable EvidencePacks:
+<https://github.com/Mindburn-Labs/helm-ai-kernel/stargazers>
+
 ![HELM MCP quarantine and receipt proof board](docs/assets/helm-mcp-quarantine-demo.svg)
 
 Sanitized transcripts are checked in under
@@ -64,11 +69,11 @@ Sanitized transcripts are checked in under
 
 ## Community And Product Links
 
-- Try OSS locally: [Quickstart](https://helm.docs.mindburn.org/helm-ai-kernel/quickstart?utm_source=github&utm_medium=readme&utm_campaign=oss-traction)
+- Try HELM AI Kernel locally: [Quickstart](https://helm.docs.mindburn.org/helm-ai-kernel/quickstart?utm_source=github&utm_medium=readme&utm_campaign=oss-traction)
 - Star on GitHub: [Mindburn-Labs/helm-ai-kernel](https://github.com/Mindburn-Labs/helm-ai-kernel?utm_source=github&utm_medium=readme&utm_campaign=oss-traction)
 - Join Discussions: [GitHub Discussions](https://github.com/Mindburn-Labs/helm-ai-kernel/discussions?utm_source=github&utm_medium=readme&utm_campaign=oss-traction)
 - Find first issues: [good first issue](https://github.com/Mindburn-Labs/helm-ai-kernel/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22)
-- Talk to Mindburn Labs about production agent governance: [Console](https://console.helm.mindburn.org?utm_source=github&utm_medium=readme&utm_campaign=oss-traction)
+- Talk to Mindburn Labs about production execution authority: [Console](https://console.helm.mindburn.org?utm_source=github&utm_medium=readme&utm_campaign=oss-traction)
 
 ## Launchpad And Console
 
@@ -295,7 +300,7 @@ Public OSS docs are sourced from this repo and published through
 - [Quickstart](docs/QUICKSTART.md)
 - [Community](COMMUNITY.md)
 - [Ecosystem](docs/ECOSYSTEM.md)
-- [OSS Traction Playbook](docs/TRACTION.md)
+- [HELM AI Kernel OSS Traction Plan](docs/TRACTION.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Conformance](docs/CONFORMANCE.md)
 - [Verification](docs/VERIFICATION.md)
@@ -306,7 +311,7 @@ Public OSS docs are sourced from this repo and published through
 - [OWASP Mapping](docs/OWASP_MCP_THREAT_MAPPING.md)
 - [NIST AI Agent Critical Infrastructure Alignment](docs/compliance/nist-ai-agent-critical-infrastructure.md)
 - [NIST AI RMF to ISO 42001 Crosswalk](docs/compliance/nist-ai-rmf-iso-42001-crosswalk.md)
-- Search-intent pages: [MCP execution firewall](docs/use-cases/mcp-execution-firewall.md), [AI agent security](docs/use-cases/ai-agent-security.md), [OpenAI-compatible AI gateway policy](docs/use-cases/openai-compatible-ai-gateway-policy.md), [LLM audit receipts](docs/use-cases/llm-audit-receipts.md), and [agent tool-call governance](docs/use-cases/agent-tool-call-governance.md)
+- Search-intent pages: [MCP tool quarantine](docs/use-cases/mcp-execution-firewall.md), [AI agent execution firewall](docs/use-cases/ai-agent-security.md), [OpenAI-compatible execution boundary](docs/use-cases/openai-compatible-ai-gateway-policy.md), [signed receipts for AI agent actions](docs/use-cases/llm-audit-receipts.md), and [AI agent side-effect governance](docs/use-cases/agent-tool-call-governance.md)
 
 ## Release Verification
 

--- a/core/pkg/conformance/sandbox/conformance_failure_core_coverage_test.go
+++ b/core/pkg/conformance/sandbox/conformance_failure_core_coverage_test.go
@@ -1,0 +1,268 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conformance"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/actuators"
+)
+
+func TestRegisteredSandboxConformanceFailureBranches(t *testing.T) {
+	errCreate := errors.New("create failed")
+	errExec := errors.New("exec failed")
+	errWrite := errors.New("write failed")
+	errRead := errors.New("read failed")
+	errPreflight := errors.New("preflight failed")
+	errPause := errors.New("pause failed")
+	errResume := errors.New("resume failed")
+	errEgress := errors.New("egress failed")
+
+	expectCaseError(t, "SBX-L1-LIFECYCLE-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseFailure(t, "SBX-L1-LIFECYCLE-001", &sandboxCaseActuator{
+		MockActuator: NewMockActuator(),
+		createPatch: func(handle *actuators.SandboxHandle) {
+			handle.ID = ""
+			handle.Status = actuators.StatusPaused
+			handle.Provider = "other"
+		},
+	})
+
+	expectCaseError(t, "SBX-L1-EXEC-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseError(t, "SBX-L1-EXEC-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), execErrs: []error{errExec}})
+	expectCaseFailure(t, "SBX-L1-EXEC-001", &sandboxCaseActuator{
+		MockActuator: NewMockActuator(),
+		execResults:  []*actuators.ExecResult{{ExitCode: 42}},
+	})
+
+	expectCaseError(t, "SBX-L1-FS-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseError(t, "SBX-L1-FS-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), writeErr: errWrite})
+	expectCaseError(t, "SBX-L1-FS-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), readErr: errRead})
+	expectCaseFailure(t, "SBX-L1-FS-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), readData: []byte("different")})
+
+	expectCaseError(t, "SBX-L1-RECEIPT-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseError(t, "SBX-L1-RECEIPT-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), execErrs: []error{errExec}})
+	expectCaseFailure(t, "SBX-L1-RECEIPT-001", &sandboxCaseActuator{
+		MockActuator: NewMockActuator(),
+		execResults:  []*actuators.ExecResult{{Receipt: actuators.ReceiptFragment{}}},
+	})
+
+	expectCaseError(t, "SBX-L2-PREFLIGHT-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), preflightErr: errPreflight})
+	expectCaseFailure(t, "SBX-L2-PREFLIGHT-001", &sandboxCaseActuator{
+		MockActuator:    NewMockActuator(),
+		preflightReport: &actuators.PreflightReport{Provider: "other", StrictPassed: true},
+	})
+
+	expectCaseError(t, "SBX-L2-TIMEOUT-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseFailure(t, "SBX-L2-TIMEOUT-001", &sandboxCaseActuator{
+		MockActuator: NewMockActuator(),
+		execResults:  []*actuators.ExecResult{{ExitCode: 0, TimedOut: false}},
+	})
+
+	expectCaseError(t, "SBX-L2-PERSISTENCE-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseClean(t, "SBX-L2-PERSISTENCE-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), pauseErr: actuators.ErrNotSupported})
+	expectCaseError(t, "SBX-L2-PERSISTENCE-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), pauseErr: errPause})
+	expectCaseError(t, "SBX-L2-PERSISTENCE-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), resumeErr: errResume})
+	expectCaseFailure(t, "SBX-L2-PERSISTENCE-001", &sandboxCaseActuator{
+		MockActuator: NewMockActuator(),
+		resumeHandle: &actuators.SandboxHandle{ID: "resumed", Status: actuators.StatusPaused, Provider: "mock"},
+	})
+
+	expectCaseError(t, "SBX-L3-EGRESS-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseClean(t, "SBX-L3-EGRESS-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), allowEgressErr: actuators.ErrNotSupported})
+	expectCaseError(t, "SBX-L3-EGRESS-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), allowEgressErr: errEgress})
+
+	expectCaseError(t, "SBX-L3-TAMPER-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseError(t, "SBX-L3-TAMPER-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), execErrs: []error{errExec}})
+	expectCaseError(t, "SBX-L3-TAMPER-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), execErrs: []error{nil, errExec}})
+	expectCaseFailure(t, "SBX-L3-TAMPER-001", &sandboxCaseActuator{
+		MockActuator: NewMockActuator(),
+		execResults: []*actuators.ExecResult{
+			{Receipt: actuators.ReceiptFragment{RequestHash: "sha256:a", StdoutHash: "sha256:a"}},
+			{Receipt: actuators.ReceiptFragment{RequestHash: "sha256:b", StdoutHash: "sha256:b"}},
+		},
+	})
+
+	for _, id := range []string{
+		"SBX-L3-AUTH-001",
+		"SBX-L3-EGRESS-002",
+		"SBX-L3-TIMEOUT-001",
+		"SBX-L3-NETERR-001",
+		"SBX-L3-MALFORMED-001",
+		"SBX-L3-RESUME-001",
+	} {
+		expectCaseClean(t, id, &sandboxCaseActuator{MockActuator: NewMockActuator()})
+	}
+
+	expectCaseError(t, "SBX-L3-RECEIPT-SPEC-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), createErr: errCreate})
+	expectCaseError(t, "SBX-L3-RECEIPT-SPEC-001", &sandboxCaseActuator{MockActuator: NewMockActuator(), execErrs: []error{errExec}})
+	expectCaseFailure(t, "SBX-L3-RECEIPT-SPEC-001", &sandboxCaseActuator{
+		MockActuator: NewMockActuator(),
+		execResults:  []*actuators.ExecResult{{Receipt: actuators.ReceiptFragment{}}},
+	})
+}
+
+func expectCaseError(t *testing.T, id string, actuator actuators.SandboxActuator) {
+	t.Helper()
+	failed, err := runSandboxConformanceCase(t, id, actuator)
+	if err == nil {
+		t.Fatalf("%s: expected error, failed=%v", id, failed)
+	}
+}
+
+func expectCaseFailure(t *testing.T, id string, actuator actuators.SandboxActuator) {
+	t.Helper()
+	failed, err := runSandboxConformanceCase(t, id, actuator)
+	if err != nil || !failed {
+		t.Fatalf("%s: expected assertion failure, failed=%v err=%v", id, failed, err)
+	}
+}
+
+func expectCaseClean(t *testing.T, id string, actuator actuators.SandboxActuator) {
+	t.Helper()
+	failed, err := runSandboxConformanceCase(t, id, actuator)
+	if err != nil || failed {
+		t.Fatalf("%s: expected clean result, failed=%v err=%v", id, failed, err)
+	}
+}
+
+func runSandboxConformanceCase(t *testing.T, id string, actuator actuators.SandboxActuator) (bool, error) {
+	t.Helper()
+	suite := conformance.NewSuite()
+	RegisterSandboxTests(suite, actuator)
+	for _, tc := range suite.TestsForLevel(conformance.LevelL3) {
+		if tc.ID != id {
+			continue
+		}
+		ctx := &conformance.TestContext{Level: tc.Level, Category: tc.Category}
+		err := tc.Run(ctx)
+		return ctx.Failed(), err
+	}
+	t.Fatalf("sandbox conformance case %s not registered", id)
+	return false, nil
+}
+
+type sandboxCaseActuator struct {
+	*MockActuator
+	provider        string
+	createErr       error
+	createPatch     func(*actuators.SandboxHandle)
+	terminateErr    error
+	execErrs        []error
+	execResults     []*actuators.ExecResult
+	execCalls       int
+	writeErr        error
+	readErr         error
+	readData        []byte
+	preflightErr    error
+	preflightReport *actuators.PreflightReport
+	pauseErr        error
+	resumeErr       error
+	resumeHandle    *actuators.SandboxHandle
+	allowEgressErr  error
+}
+
+func (a *sandboxCaseActuator) Provider() string {
+	if a.provider != "" {
+		return a.provider
+	}
+	return a.MockActuator.Provider()
+}
+
+func (a *sandboxCaseActuator) Create(ctx context.Context, spec *actuators.SandboxSpec) (*actuators.SandboxHandle, error) {
+	if a.createErr != nil {
+		return nil, a.createErr
+	}
+	handle, err := a.MockActuator.Create(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	if a.createPatch != nil {
+		a.createPatch(handle)
+	}
+	return handle, nil
+}
+
+func (a *sandboxCaseActuator) Terminate(ctx context.Context, id string) error {
+	if a.terminateErr != nil {
+		return a.terminateErr
+	}
+	return a.MockActuator.Terminate(ctx, id)
+}
+
+func (a *sandboxCaseActuator) Exec(ctx context.Context, id string, req *actuators.ExecRequest) (*actuators.ExecResult, error) {
+	call := a.execCalls
+	a.execCalls++
+	if call < len(a.execErrs) && a.execErrs[call] != nil {
+		return nil, a.execErrs[call]
+	}
+	if call < len(a.execResults) && a.execResults[call] != nil {
+		return a.execResults[call], nil
+	}
+	return a.MockActuator.Exec(ctx, id, req)
+}
+
+func (a *sandboxCaseActuator) WriteFile(ctx context.Context, id string, path string, data []byte) error {
+	if a.writeErr != nil {
+		return a.writeErr
+	}
+	return a.MockActuator.WriteFile(ctx, id, path, data)
+}
+
+func (a *sandboxCaseActuator) ReadFile(ctx context.Context, id string, path string) ([]byte, error) {
+	if a.readErr != nil {
+		return nil, a.readErr
+	}
+	if a.readData != nil {
+		return a.readData, nil
+	}
+	return a.MockActuator.ReadFile(ctx, id, path)
+}
+
+func (a *sandboxCaseActuator) Preflight(ctx context.Context) (*actuators.PreflightReport, error) {
+	if a.preflightErr != nil {
+		return nil, a.preflightErr
+	}
+	if a.preflightReport != nil {
+		return a.preflightReport, nil
+	}
+	return a.MockActuator.Preflight(ctx)
+}
+
+func (a *sandboxCaseActuator) Pause(ctx context.Context, id string) error {
+	if a.pauseErr != nil {
+		return a.pauseErr
+	}
+	return a.MockActuator.Pause(ctx, id)
+}
+
+func (a *sandboxCaseActuator) Resume(ctx context.Context, id string) (*actuators.SandboxHandle, error) {
+	if a.resumeErr != nil {
+		return nil, a.resumeErr
+	}
+	if a.resumeHandle != nil {
+		return a.resumeHandle, nil
+	}
+	return a.MockActuator.Resume(ctx, id)
+}
+
+func (a *sandboxCaseActuator) AllowEgress(ctx context.Context, id string, rules []actuators.EgressRule) error {
+	if a.allowEgressErr != nil {
+		return a.allowEgressErr
+	}
+	return a.MockActuator.AllowEgress(ctx, id, rules)
+}
+
+func TestMockActuatorAllowEgressMissingSandbox(t *testing.T) {
+	if err := NewMockActuator().AllowEgress(context.Background(), "missing", nil); !errors.Is(err, actuators.ErrSandboxNotFound) {
+		t.Fatalf("expected missing egress sandbox error, got %v", err)
+	}
+}
+
+func TestSandboxCaseActuatorProviderOverride(t *testing.T) {
+	actuator := &sandboxCaseActuator{MockActuator: NewMockActuator(), provider: "custom"}
+	if actuator.Provider() != "custom" {
+		t.Fatalf("provider override failed")
+	}
+}

--- a/core/pkg/conformance/sandbox/mock_core_coverage_test.go
+++ b/core/pkg/conformance/sandbox/mock_core_coverage_test.go
@@ -1,0 +1,178 @@
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/actuators"
+)
+
+func TestMockActuatorCoreBranches(t *testing.T) {
+	ctx := context.Background()
+	fixed := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	mock := NewMockActuator().WithClock(func() time.Time { return fixed })
+
+	handle, err := mock.Create(ctx, defaultSpec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !handle.CreatedAt.Equal(fixed) {
+		t.Fatalf("expected fixed clock timestamp, got %v", handle.CreatedAt)
+	}
+
+	result, err := mock.Exec(ctx, handle.ID, &actuators.ExecRequest{Command: []string{"echo", "hello", "world"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(result.Stdout) != "hello world\n" {
+		t.Fatalf("unexpected echo stdout: %q", result.Stdout)
+	}
+	if got := computeRequestHash(&actuators.ExecRequest{Command: []string{"echo", "hello", "world"}}); got != result.Receipt.RequestHash {
+		t.Fatalf("computeRequestHash mismatch: got %s want %s", got, result.Receipt.RequestHash)
+	}
+
+	if _, err := mock.Exec(ctx, "missing", &actuators.ExecRequest{}); !errors.Is(err, actuators.ErrSandboxNotFound) {
+		t.Fatalf("expected missing exec sandbox error, got %v", err)
+	}
+	if err := mock.Pause(ctx, handle.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mock.Exec(ctx, handle.ID, &actuators.ExecRequest{Command: []string{"echo", "paused"}}); err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("expected paused exec to fail, got %v", err)
+	}
+	if err := mock.Terminate(ctx, handle.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mock.Resume(ctx, handle.ID); !errors.Is(err, actuators.ErrSandboxTerminated) {
+		t.Fatalf("expected terminated resume error, got %v", err)
+	}
+}
+
+func TestMockActuatorFileListingLogsAndMissingPaths(t *testing.T) {
+	ctx := context.Background()
+	fixed := time.Date(2026, 4, 5, 6, 7, 8, 0, time.UTC)
+	mock := NewMockActuator().WithClock(func() time.Time { return fixed })
+	handle, err := mock.Create(ctx, defaultSpec())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mock.WriteFile(ctx, "missing", "/tmp/a.txt", []byte("a")); !errors.Is(err, actuators.ErrSandboxNotFound) {
+		t.Fatalf("expected missing write sandbox error, got %v", err)
+	}
+	if _, err := mock.ReadFile(ctx, "missing", "/tmp/a.txt"); !errors.Is(err, actuators.ErrSandboxNotFound) {
+		t.Fatalf("expected missing read sandbox error, got %v", err)
+	}
+	if _, err := mock.ReadFile(ctx, handle.ID, "/tmp/missing.txt"); err == nil || !strings.Contains(err.Error(), "file not found") {
+		t.Fatalf("expected missing file error, got %v", err)
+	}
+
+	if err := mock.WriteFile(ctx, handle.ID, "/tmp/a.txt", []byte("alpha")); err != nil {
+		t.Fatal(err)
+	}
+	if err := mock.WriteFile(ctx, handle.ID, "/tmp/b.txt", []byte("bravo")); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := mock.ListFiles(ctx, handle.ID, "/tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %+v", entries)
+	}
+	for _, entry := range entries {
+		if entry.IsDir || !entry.ModTime.Equal(fixed) {
+			t.Fatalf("unexpected file entry: %+v", entry)
+		}
+	}
+	if _, err := mock.ListFiles(ctx, "missing", "/tmp"); !errors.Is(err, actuators.ErrSandboxNotFound) {
+		t.Fatalf("expected missing list sandbox error, got %v", err)
+	}
+
+	if _, err := mock.Exec(ctx, handle.ID, &actuators.ExecRequest{Command: []string{"echo", "first"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mock.Exec(ctx, handle.ID, &actuators.ExecRequest{Command: []string{"echo", "second"}}); err != nil {
+		t.Fatal(err)
+	}
+	logs, err := mock.Logs(ctx, handle.ID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected all logs, got %+v", logs)
+	}
+	tail, err := mock.Logs(ctx, handle.ID, &actuators.LogOptions{Tail: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tail) != 1 || !strings.Contains(tail[0].Line, "second") {
+		t.Fatalf("unexpected tail logs: %+v", tail)
+	}
+	if _, err := mock.Logs(ctx, "missing", nil); !errors.Is(err, actuators.ErrSandboxNotFound) {
+		t.Fatalf("expected missing logs sandbox error, got %v", err)
+	}
+}
+
+func TestMockFaultAndDeterminismErrorBranches(t *testing.T) {
+	ctx := context.Background()
+	mock := NewMockActuator()
+	mock.InjectFault(FaultConfig{})
+	report, err := mock.Preflight(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.StrictPassed {
+		t.Fatalf("empty fault config should not fail preflight: %+v", report)
+	}
+	handle, err := mock.Create(ctx, defaultSpec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mock.Exec(ctx, handle.ID, &actuators.ExecRequest{Command: []string{"echo", "ok"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mock.Resume(ctx, handle.ID); err != nil {
+		t.Fatal(err)
+	}
+	mock.ClearFaults()
+
+	createErr := errors.New("create failed")
+	if ok, err := VerifyReceiptDeterminism(&determinismFaultActuator{MockActuator: NewMockActuator(), createErr: createErr}, &actuators.ExecRequest{}); err != createErr || ok {
+		t.Fatalf("expected create determinism error, ok=%v err=%v", ok, err)
+	}
+
+	execErr := errors.New("exec failed")
+	if ok, err := VerifyReceiptDeterminism(&determinismFaultActuator{MockActuator: NewMockActuator(), execErrs: []error{execErr}}, &actuators.ExecRequest{}); err != execErr || ok {
+		t.Fatalf("expected first exec determinism error, ok=%v err=%v", ok, err)
+	}
+	if ok, err := VerifyReceiptDeterminism(&determinismFaultActuator{MockActuator: NewMockActuator(), execErrs: []error{nil, execErr}}, &actuators.ExecRequest{}); err != execErr || ok {
+		t.Fatalf("expected second exec determinism error, ok=%v err=%v", ok, err)
+	}
+}
+
+type determinismFaultActuator struct {
+	*MockActuator
+	createErr error
+	execErrs  []error
+	execCalls int
+}
+
+func (a *determinismFaultActuator) Create(ctx context.Context, spec *actuators.SandboxSpec) (*actuators.SandboxHandle, error) {
+	if a.createErr != nil {
+		return nil, a.createErr
+	}
+	return a.MockActuator.Create(ctx, spec)
+}
+
+func (a *determinismFaultActuator) Exec(ctx context.Context, id string, req *actuators.ExecRequest) (*actuators.ExecResult, error) {
+	call := a.execCalls
+	a.execCalls++
+	if call < len(a.execErrs) && a.execErrs[call] != nil {
+		return nil, a.execErrs[call]
+	}
+	return a.MockActuator.Exec(ctx, id, req)
+}

--- a/core/pkg/llm/gateway/router_core_coverage_test.go
+++ b/core/pkg/llm/gateway/router_core_coverage_test.go
@@ -1,0 +1,268 @@
+package gateway
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func TestBlessedProfileRoutingAndDefaults(t *testing.T) {
+	profiles := GetBlessedProfiles()
+	if len(profiles) != 4 {
+		t.Fatalf("expected 4 blessed profiles, got %d", len(profiles))
+	}
+
+	router := NewGatewayRouter()
+	if err := router.Route(context.Background(), "local/ollama"); err != nil {
+		t.Fatal(err)
+	}
+	if router.ActiveProfile().Provider != ProviderOllama {
+		t.Fatalf("unexpected active profile: %+v", router.ActiveProfile())
+	}
+	if err := router.Route(context.Background(), "missing-profile"); err == nil {
+		t.Fatal("expected unknown blessed profile to fail")
+	}
+
+	mismatch := &EnginePinMismatchError{Field: "model", Got: "a", Want: "b"}
+	if mismatch.SafeDepHazardCode() != contracts.HazardEnginePinMismatch {
+		t.Fatalf("unexpected hazard code: %s", mismatch.SafeDepHazardCode())
+	}
+
+	for _, tc := range []struct {
+		provider ProviderType
+		baseURL  string
+		tools    bool
+	}{
+		{ProviderOllama, "http://localhost:11434", true},
+		{ProviderLlamaCPP, "http://localhost:8080", false},
+		{ProviderVLLM, "http://localhost:8000", true},
+		{ProviderLMStudio, "http://localhost:1234", true},
+	} {
+		t.Run(string(tc.provider), func(t *testing.T) {
+			r := NewGatewayRouter()
+			if err := r.RouteWithConfig(context.Background(), RouteConfig{Provider: tc.provider, ModelName: "model"}); err != nil {
+				t.Fatal(err)
+			}
+			if r.ActiveProfile().BaseURL != tc.baseURL {
+				t.Fatalf("default base URL = %s, want %s", r.ActiveProfile().BaseURL, tc.baseURL)
+			}
+			if r.ActiveProfile().Capabilities.SupportsTools != tc.tools {
+				t.Fatalf("supports tools = %v, want %v", r.ActiveProfile().Capabilities.SupportsTools, tc.tools)
+			}
+		})
+	}
+
+	for _, cfg := range []RouteConfig{
+		{ModelName: "model"},
+		{Provider: ProviderOllama},
+		{Provider: ProviderOllama, BaseURL: "not-a-url", ModelName: "model"},
+	} {
+		if err := NewGatewayRouter().RouteWithConfig(context.Background(), cfg); err == nil {
+			t.Fatalf("expected invalid route config to fail: %+v", cfg)
+		}
+	}
+}
+
+func TestGatewayHealthCheckBranches(t *testing.T) {
+	if err := NewGatewayRouter().HealthCheck(context.Background()); err == nil {
+		t.Fatal("expected health check without route to fail")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": ""})
+	})
+	mux.HandleFunc("/v1/models", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"id": "model"}}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	router := NewGatewayRouter()
+	if err := router.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderVLLM, BaseURL: srv.URL, ModelName: "model", ModelHash: "sha256:model"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := router.HealthCheck(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	version, err := router.runtimeVersion(context.Background(), *router.ActiveProfile())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "openai-compatible" {
+		t.Fatalf("expected fallback runtime version, got %q", version)
+	}
+
+	badHealth := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "down", http.StatusBadGateway)
+	}))
+	defer badHealth.Close()
+	if _, err := router.openAICompatibleHealth(context.Background(), Profile{Provider: ProviderLlamaCPP, BaseURL: badHealth.URL}); err == nil {
+		t.Fatal("expected non-2xx OpenAI-compatible health to fail")
+	}
+	if _, err := router.runtimeVersion(context.Background(), Profile{Provider: ProviderType("custom"), BaseURL: srv.URL}); err == nil {
+		t.Fatal("expected unsupported provider runtime version to fail")
+	}
+}
+
+func TestExecuteRejectsCapabilityAndInactiveRouter(t *testing.T) {
+	if _, err := NewGatewayRouter().Execute(context.Background(), ExecContext{Prompt: "hello"}); err == nil {
+		t.Fatal("expected inactive router execution to fail")
+	}
+
+	router := NewGatewayRouter()
+	router.activeProfile = &Profile{ID: "no-json", Capabilities: Capabilities{SupportsJSONMode: false}}
+	if _, err := router.Execute(context.Background(), ExecContext{Prompt: "hello", JSONMode: true}); err == nil {
+		t.Fatal("expected JSON mode capability violation")
+	}
+
+	router.activeProfile = &Profile{ID: "no-tools", Capabilities: Capabilities{SupportsJSONMode: true, SupportsTools: false}}
+	if _, err := router.Execute(context.Background(), ExecContext{Prompt: "hello", Tools: []string{"tool"}}); err == nil {
+		t.Fatal("expected tools capability violation")
+	}
+}
+
+func TestValidateEnginePinMismatchBranches(t *testing.T) {
+	profile := Profile{
+		Provider:            ProviderVLLM,
+		BaseURL:             "http://localhost:8000",
+		ModelName:           "model-a",
+		VerifierProfileID:   "verifier-a",
+		AttestedMeasurement: "measurement-a",
+		AlternateProfileID:  "alternate-a",
+	}
+
+	for _, tc := range []struct {
+		name string
+		pin  *EnginePin
+	}{
+		{name: "provider", pin: &EnginePin{Provider: ProviderOllama}},
+		{name: "base url invalid", pin: &EnginePin{BaseURL: "not-a-url"}},
+		{name: "base url mismatch", pin: &EnginePin{BaseURL: "http://localhost:9000"}},
+		{name: "model", pin: &EnginePin{ModelName: "model-b"}},
+		{name: "model hash", pin: &EnginePin{ModelHash: "sha256:want"}},
+		{name: "runtime version", pin: &EnginePin{RuntimeVersion: "runtime-b"}},
+		{name: "verifier", pin: &EnginePin{VerifierProfileID: "verifier-b"}},
+		{name: "measurement", pin: &EnginePin{AttestedMeasurement: "measurement-b"}},
+		{name: "alternate", pin: &EnginePin{ApprovedAlternateProfileID: "alternate-b"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEnginePin(Profile{
+				Provider:            profile.Provider,
+				BaseURL:             profile.BaseURL,
+				ModelName:           profile.ModelName,
+				VerifierProfileID:   profile.VerifierProfileID,
+				AttestedMeasurement: profile.AttestedMeasurement,
+				AlternateProfileID:  profile.AlternateProfileID,
+				EnginePin:           tc.pin,
+			}, "runtime-a", "sha256:got")
+			if err == nil {
+				t.Fatal("expected engine pin validation to fail")
+			}
+		})
+	}
+}
+
+func TestDiscoveryAndProviderErrorBranches(t *testing.T) {
+	router := NewGatewayRouter()
+	if hash, err := router.discoverModelHash(context.Background(), Profile{Provider: ProviderVLLM}); err != nil || hash != "" {
+		t.Fatalf("non-Ollama hash discovery = %q, err=%v", hash, err)
+	}
+
+	tags := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"models": []map[string]string{{"name": "other", "digest": "sha256:other"}}})
+	}))
+	defer tags.Close()
+	if hash, err := router.discoverModelHash(context.Background(), Profile{Provider: ProviderOllama, BaseURL: tags.URL, ModelName: "wanted"}); err != nil || hash != "" {
+		t.Fatalf("unexpected unmatched Ollama digest: %q err=%v", hash, err)
+	}
+
+	emptyOllama := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"message": map[string]string{"content": ""}})
+	}))
+	defer emptyOllama.Close()
+	if _, err := router.executeOllama(context.Background(), Profile{Provider: ProviderOllama, BaseURL: emptyOllama.URL, ModelName: "model"}, ExecContext{Prompt: "hello"}); err == nil {
+		t.Fatal("expected empty Ollama content to fail")
+	}
+
+	emptyOpenAI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"choices": []map[string]any{}})
+	}))
+	defer emptyOpenAI.Close()
+	if _, err := router.executeOpenAICompatible(context.Background(), Profile{Provider: ProviderVLLM, BaseURL: emptyOpenAI.URL, ModelName: "model"}, ExecContext{Prompt: "hello"}); err == nil {
+		t.Fatal("expected empty OpenAI-compatible content to fail")
+	}
+}
+
+func TestExecuteOpenAICompatibleSendsJSONModeToolsAndSystem(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"version": "server-version"})
+	})
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := payload["response_format"].(map[string]any); !ok {
+			t.Fatalf("expected JSON response format in payload: %#v", payload)
+		}
+		if tools, ok := payload["tools"].([]any); !ok || len(tools) != 1 {
+			t.Fatalf("expected tools in payload: %#v", payload)
+		}
+		messages, ok := payload["messages"].([]any)
+		if !ok || len(messages) != 2 {
+			t.Fatalf("expected system and user messages: %#v", payload)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]string{"content": "json-ok"}}},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	router := NewGatewayRouter()
+	if err := router.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderVLLM, BaseURL: srv.URL, ModelName: "model", ModelHash: "sha256:model"}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := router.Execute(context.Background(), ExecContext{
+		Prompt: "hello", System: "system", JSONMode: true, Tools: []string{"tool"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Content != "json-ok" {
+		t.Fatalf("unexpected content: %+v", result)
+	}
+}
+
+func TestGatewayHTTPHelpersReportErrors(t *testing.T) {
+	router := NewGatewayRouter()
+	var out map[string]any
+	if err := router.getJSON(context.Background(), "http://[::1", &out); err == nil {
+		t.Fatal("expected invalid GET endpoint to fail")
+	}
+	if err := router.postJSON(context.Background(), "http://example.test", map[string]float64{"bad": math.NaN()}, &out); err == nil {
+		t.Fatal("expected unmarshalable POST payload to fail")
+	}
+	if err := router.postJSON(context.Background(), "http://[::1", map[string]string{"ok": "ok"}, &out); err == nil {
+		t.Fatal("expected invalid POST endpoint to fail")
+	}
+
+	fail := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "provider failed", http.StatusInternalServerError)
+	}))
+	defer fail.Close()
+	if err := router.getJSON(context.Background(), fail.URL, &out); err == nil || !strings.Contains(err.Error(), "provider failed") {
+		t.Fatalf("expected GET HTTP error with body, got %v", err)
+	}
+	if err := router.postJSON(context.Background(), fail.URL, map[string]string{"ok": "ok"}, &out); err == nil || !strings.Contains(err.Error(), "provider failed") {
+		t.Fatalf("expected POST HTTP error with body, got %v", err)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,17 +10,17 @@ This tree is the canonical public documentation source for HELM AI Kernel. Publi
 - [Developer journey](DEVELOPER_JOURNEY.md)
 - [Community](../COMMUNITY.md)
 - [Ecosystem map](ECOSYSTEM.md)
-- [OSS traction playbook](TRACTION.md)
+- [HELM AI Kernel OSS traction plan](TRACTION.md)
 - [Architecture](ARCHITECTURE.md)
 - [Canonical diagrams](architecture/canonical-diagrams.md)
 
 ## Search-Intent Pages
 
-- [MCP execution firewall](use-cases/mcp-execution-firewall.md)
-- [AI agent security](use-cases/ai-agent-security.md)
-- [OpenAI-compatible AI gateway policy](use-cases/openai-compatible-ai-gateway-policy.md)
-- [LLM audit receipts](use-cases/llm-audit-receipts.md)
-- [Agent tool-call governance](use-cases/agent-tool-call-governance.md)
+- [MCP tool quarantine](use-cases/mcp-execution-firewall.md)
+- [AI agent execution firewall](use-cases/ai-agent-security.md)
+- [OpenAI-compatible execution boundary](use-cases/openai-compatible-ai-gateway-policy.md)
+- [Signed receipts for AI agent actions](use-cases/llm-audit-receipts.md)
+- [AI agent side-effect governance](use-cases/agent-tool-call-governance.md)
 
 ## Launch Posts
 

--- a/docs/TRACTION.md
+++ b/docs/TRACTION.md
@@ -1,17 +1,130 @@
 ---
-title: OSS Traction Playbook
+title: HELM AI Kernel OSS Traction Plan
 last_reviewed: 2026-06-02
 ---
 
-# OSS Traction Playbook
+# HELM AI Kernel OSS Traction Plan
 
-This page keeps public launch and community work tied to source-backed HELM AI Kernel behavior.
+This page keeps public launch and community work tied to source-backed HELM AI Kernel behavior. The goal is not maximum attention; it is maximum verified Kernel adoption.
 
-## Attention Goals
+Primary objective: drive verified adoption of HELM AI Kernel as the local-first fail-closed execution boundary for AI agents.
 
-- More GitHub stars, watchers, forks, discussions, first issues, and external contributors.
-- More docs and website visitors who run a local demo before evaluating hosted Mindburn Labs surfaces.
-- More ecosystem visibility in MCP, AI gateway, agent-framework, and LLM security communities.
+Primary conversion: visitor -> install -> run boundary -> trigger DENY or ESCALATE -> inspect signed receipt -> verify EvidencePack offline -> star, follow, discuss, or contribute.
+
+## Canonical Positioning
+
+- Public OSS name: HELM AI Kernel.
+- Repository: `Mindburn-Labs/helm-ai-kernel`.
+- Binary: `helm-ai-kernel`.
+- Disambiguation: Mindburn Labs' HELM execution kernel for AI agents, not the Kubernetes package manager.
+- Short description: Fail-closed execution firewall for AI agents: quarantine MCP tools, proxy OpenAI-compatible requests, emit signed receipts, and verify EvidencePacks offline.
+- Proof vocabulary: signed receipts, EvidencePack, ProofGraph, offline verification, ALLOW, DENY, ESCALATE.
+
+Avoid `HELM OSS`, `helm-oss`, `HELM Teams`, generic AI governance platform language, hosted-control-plane claims for Kernel, certification claims, or Enterprise features framed as Kernel features.
+
+## GitHub Metadata
+
+Repository topics should spend the 20 slots on the execution-boundary wedge:
+
+```text
+ai-agents
+agent-security
+mcp
+model-context-protocol
+tool-calling
+execution-firewall
+ai-security
+llm-security
+developer-tools
+self-hosted
+open-source
+policy-engine
+zero-trust
+sandbox
+signed-receipts
+cryptographic-receipts
+evidencepack
+openai-compatible
+llmops
+security
+```
+
+Do not use `saas`, `compliance`, `ai-governance`, `generative-ai`, `agentic-ai`, `helm`, `openai`, or `proof-receipts` as OSS repo topics.
+
+## README First Viewport
+
+The README must lead with mechanism and proof:
+
+```md
+# HELM AI Kernel
+
+HELM AI Kernel is the fail-closed execution firewall for AI agents.
+
+Mindburn Labs' HELM execution kernel for AI agents, not the Kubernetes package manager.
+
+Models propose. HELM governs execution. Every ALLOW / DENY / ESCALATE decision leaves proof.
+```
+
+The star CTA belongs after the local proof path:
+
+```text
+Star HELM AI Kernel if you want to follow fail-closed AI agent execution, MCP quarantine, signed receipts, and offline-verifiable EvidencePacks.
+```
+
+## Proof Assets
+
+Public proof assets are executable artifacts, not just polished images. Each asset must name:
+
+- asset name
+- command to generate
+- expected verdict: ALLOW, DENY, or ESCALATE
+- receipt path
+- EvidencePack path
+- offline verification command
+- expected verification output
+- screenshot or GIF source
+- last verified commit SHA
+
+Canonical demo ladder:
+
+1. Unknown MCP tool enters quarantine.
+2. Sensitive action returns DENY or ESCALATE.
+3. Signed receipt is produced.
+4. EvidencePack verifies offline.
+5. Tampered receipt fails verification.
+
+Current assets:
+
+- Social preview: [helm-social-preview.png](assets/helm-social-preview.png)
+- Social preview source: [helm-social-preview.svg](assets/helm-social-preview.svg)
+- MCP quarantine proof board: [helm-mcp-quarantine-demo.png](assets/helm-mcp-quarantine-demo.png)
+- MCP quarantine proof board source: [helm-mcp-quarantine-demo.svg](assets/helm-mcp-quarantine-demo.svg)
+- Sanitized transcripts: [examples/launch/assets](../examples/launch/assets)
+
+Render updated PNG files from SVG sources before publishing visual changes:
+
+```bash
+rsvg-convert docs/assets/helm-mcp-quarantine-demo.svg -w 1600 -h 900 -o docs/assets/helm-mcp-quarantine-demo.png
+rsvg-convert docs/assets/helm-social-preview.svg -w 1280 -h 640 -o docs/assets/helm-social-preview.png
+```
+
+## Launch Sequence
+
+Gate 1: GitHub readiness.
+README, repo description, topics, social preview, release assets, proof demos, docs, issue templates, security policy, and Discussions are source-backed and coherent.
+
+Gate 2: Technical launch.
+Use Show HN and targeted security/devtools Reddit only after the local proof path is clean.
+
+Gate 3: Ecosystem integration.
+Submit upstream fixtures and listings only after the repo has concrete MCP, proxy, receipt, and EvidencePack examples.
+
+Gate 4: Broader social.
+Use LinkedIn, X, Product Hunt, DEV, and Hashnode only after technical audiences have a proof artifact to reference.
+
+Show HN title: `Show HN: HELM AI Kernel, a fail-closed execution firewall for AI agents`
+
+Short description: HELM AI Kernel quarantines unknown MCP tools before dispatch, governs OpenAI-compatible requests through ALLOW, DENY, and ESCALATE decisions, emits signed receipts, and verifies EvidencePacks offline.
 
 ## UTM Links
 
@@ -20,31 +133,131 @@ This page keeps public launch and community work tied to source-backed HELM AI K
 | GitHub README | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=github&utm_medium=readme&utm_campaign=oss-traction` |
 | GitHub Discussions | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=github&utm_medium=discussions&utm_campaign=oss-traction` |
 | Hacker News | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=hackernews&utm_medium=showhn&utm_campaign=oss-traction` |
-| Product Hunt | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=producthunt&utm_medium=launch&utm_campaign=oss-traction` |
 | Reddit | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=reddit&utm_medium=community&utm_campaign=oss-traction` |
+| Product Hunt | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=producthunt&utm_medium=launch&utm_campaign=oss-traction` |
 | LinkedIn | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=linkedin&utm_medium=social&utm_campaign=oss-traction` |
 | X | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=x&utm_medium=social&utm_campaign=oss-traction` |
 
-## Launch Drafts
+## Discussions
 
-Show HN title: `Show HN: HELM, an execution firewall for AI agent tool calls`
+Use Discussions for high-signal participation:
 
-Short description: HELM AI Kernel is an open-source execution firewall for MCP and AI agents. It quarantines unknown tools before dispatch, evaluates ALLOW, DENY, and ESCALATE decisions, emits signed receipts, and verifies evidence offline.
+- Announcements
+- Proof demo help
+- MCP server quarantine proposals
+- Receipt and EvidencePack schema questions
+- Integration ideas
+- First contribution help
+- Show-and-tell
 
-## Proof Assets
+Triage flow: Discussion -> maintainer triage -> reproduction, fixture, or spec -> issue.
 
-- Social preview: [helm-social-preview.png](assets/helm-social-preview.png)
-- Social preview source: [helm-social-preview.svg](assets/helm-social-preview.svg)
-- MCP quarantine proof board: [helm-mcp-quarantine-demo.png](assets/helm-mcp-quarantine-demo.png)
-- MCP quarantine proof board source: [helm-mcp-quarantine-demo.svg](assets/helm-mcp-quarantine-demo.svg)
-- Sanitized transcripts: [examples/launch/assets](../examples/launch/assets)
+## Contributor Funnel
 
-Use the PNG files for README, launch posts, and link previews. Keep the SVG
-files as the editable sources when copy, layout, or proof framing changes.
+OSS-safe contribution streams:
 
-Render updated PNG files from the SVG sources before publishing visual changes:
+- docs: quickstart clarity, troubleshooting, examples
+- mcp: quarantine fixtures, server metadata, authorization examples
+- proxy: OpenAI-compatible client examples
+- receipts: offline verification examples, tamper tests
+- evidence: EvidencePack examples
+- sdk: small SDK polish and samples
+- security: negative tests and threat-model examples
+- ecosystem: factual integrations and listings
 
-```bash
-rsvg-convert docs/assets/helm-mcp-quarantine-demo.svg -w 1600 -h 900 -o docs/assets/helm-mcp-quarantine-demo.png
-rsvg-convert docs/assets/helm-social-preview.svg -w 1280 -h 640 -o docs/assets/helm-social-preview.png
+Every contributor issue should include context, exact file paths, expected output, validation command, acceptance criteria, and out-of-scope boundaries. Do not expose Enterprise implementation details in OSS issues.
+
+## Measurement
+
+Awareness:
+
+- GitHub visitors, referrers, and popular content
+- social, Hacker News, Reddit, and docs traffic
+
+Evaluation:
+
+- README and quickstart visits
+- Homebrew install interest or available formula analytics
+- clone count
+- release asset downloads
+
+Proof:
+
+- boundary started
+- proof demo run
+- DENY or ESCALATE receipt generated
+- EvidencePack exported
+- EvidencePack verified offline
+
+Engagement:
+
+- stars
+- watchers
+- discussions
+- issues
+- PRs
+- ecosystem mentions
+
+Commercial bridge:
+
+- HELM AI Enterprise Basic interest CTA clicks
+- docs path from Kernel to Basic
+- inbound team-use requests
+
+GitHub traffic windows are short, so export private analytics daily, publish a weekly channel cohort report, keep a launch-post UTM map, and log README hook changes.
+
+## Truth Gate
+
+Run this checklist before publishing README edits, launch posts, diagrams, videos, social previews, and website copy:
+
+- Uses HELM AI Kernel, not HELM OSS as the current public name.
+- Mentions not Kubernetes Helm when context is introductory.
+- Uses signed receipts, EvidencePack, and ProofGraph exactly.
+- Uses ALLOW, DENY, and ESCALATE.
+- Does not claim seccomp or eBPF unless current code proves it.
+- Does not claim a hosted control plane for OSS Kernel.
+- Does not claim certification unless certification exists.
+- Does not describe Enterprise features as Kernel features.
+- Does not imply Basic or Enterprise weakens or forks Kernel semantics.
+- Does not mention robot fleets, AGI OS, OrgDNA compiler, Titan, or physical-world control in OSS copy.
+
+## Diagram Doctrine
+
+OSS hero diagrams should use this shape:
+
+```text
+Agent / Model / Orchestrator
+  -> Action Proposal
+  -> HELM AI Kernel Boundary
+  -> ALLOW / DENY / ESCALATE
+  -> Signed Receipt
+  -> ProofGraph
+  -> EvidencePack
+  -> Offline Verification
 ```
+
+Keep CompanyArtifactGraph, GeneratedSpec, and Enterprise loop diagrams on Enterprise bridge pages, not the OSS hero.
+
+## Ecosystem Rule
+
+No listing PR without a working integration, fixture, or reproducible example. Prioritize:
+
+- MCP quarantine fixture
+- OpenAI-compatible proxy example
+- receipt verification fixture
+- EvidencePack tamper-negative test
+- policy DENY or ESCALATE example
+
+Submit listings after the proof exists.
+
+## Commercial Bridge
+
+Use this bridge after local Kernel proof:
+
+```text
+Try HELM AI Kernel locally.
+Use HELM AI Enterprise Basic for shared approvals, receipts, policies, and short-retention evidence.
+Talk to Mindburn Labs about production execution authority.
+```
+
+HELM AI Enterprise Basic gives teams a shared control plane for governed AI actions: workspaces, approvals, receipts, API access, custom policies, and short-retention evidence, all built on HELM AI Kernel.

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -56,7 +56,7 @@
     },
     {
       "slug": "helm-ai-kernel/oss-traction",
-      "title": "OSS Traction Playbook",
+      "title": "HELM AI Kernel OSS Traction Plan",
       "section": "start-here",
       "source_path": "docs/TRACTION.md",
       "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/oss-traction",
@@ -65,7 +65,7 @@
     },
     {
       "slug": "helm-ai-kernel/use-cases/mcp-execution-firewall",
-      "title": "MCP Execution Firewall",
+      "title": "MCP Tool Quarantine",
       "section": "use-cases",
       "source_path": "docs/use-cases/mcp-execution-firewall.md",
       "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/mcp-execution-firewall",
@@ -83,7 +83,7 @@
     },
     {
       "slug": "helm-ai-kernel/use-cases/openai-compatible-ai-gateway-policy",
-      "title": "OpenAI-Compatible AI Gateway Policy",
+      "title": "OpenAI-Compatible Execution Boundary",
       "section": "use-cases",
       "source_path": "docs/use-cases/openai-compatible-ai-gateway-policy.md",
       "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/openai-compatible-ai-gateway-policy",
@@ -92,7 +92,7 @@
     },
     {
       "slug": "helm-ai-kernel/use-cases/llm-audit-receipts",
-      "title": "LLM Audit Receipts",
+      "title": "Signed Receipts for AI Agent Actions",
       "section": "use-cases",
       "source_path": "docs/use-cases/llm-audit-receipts.md",
       "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/llm-audit-receipts",
@@ -101,7 +101,7 @@
     },
     {
       "slug": "helm-ai-kernel/use-cases/agent-tool-call-governance",
-      "title": "Agent Tool-Call Governance",
+      "title": "AI Agent Side-Effect Governance",
       "section": "use-cases",
       "source_path": "docs/use-cases/agent-tool-call-governance.md",
       "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/agent-tool-call-governance",

--- a/docs/use-cases/agent-tool-call-governance.md
+++ b/docs/use-cases/agent-tool-call-governance.md
@@ -1,9 +1,9 @@
 ---
-title: Agent Tool-Call Governance
+title: AI Agent Side-Effect Governance
 last_reviewed: 2026-06-01
 ---
 
-# Agent Tool-Call Governance
+# AI Agent Side-Effect Governance
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 

--- a/docs/use-cases/ai-agent-security.md
+++ b/docs/use-cases/ai-agent-security.md
@@ -1,9 +1,9 @@
 ---
-title: AI Agent Security
+title: AI Agent Execution Firewall
 last_reviewed: 2026-06-01
 ---
 
-# AI Agent Security
+# AI Agent Execution Firewall
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 

--- a/docs/use-cases/llm-audit-receipts.md
+++ b/docs/use-cases/llm-audit-receipts.md
@@ -1,9 +1,9 @@
 ---
-title: LLM Audit Receipts
+title: Signed Receipts for AI Agent Actions
 last_reviewed: 2026-06-01
 ---
 
-# LLM Audit Receipts
+# Signed Receipts for AI Agent Actions
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 

--- a/docs/use-cases/mcp-execution-firewall.md
+++ b/docs/use-cases/mcp-execution-firewall.md
@@ -1,9 +1,9 @@
 ---
-title: MCP Execution Firewall
+title: MCP Tool Quarantine
 last_reviewed: 2026-06-01
 ---
 
-# MCP Execution Firewall
+# MCP Tool Quarantine
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 

--- a/docs/use-cases/openai-compatible-ai-gateway-policy.md
+++ b/docs/use-cases/openai-compatible-ai-gateway-policy.md
@@ -1,9 +1,9 @@
 ---
-title: OpenAI-Compatible AI Gateway Policy
+title: OpenAI-Compatible Execution Boundary
 last_reviewed: 2026-06-01
 ---
 
-# OpenAI-Compatible AI Gateway Policy
+# OpenAI-Compatible Execution Boundary
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 


### PR DESCRIPTION
## Summary\n- sharpen README/docs positioning around HELM AI Kernel execution boundary\n- expand OSS traction plan and update public docs titles\n- add sandbox conformance/mock and gateway router coverage\n\n## Verification\n- go test ./pkg/conformance/sandbox ./pkg/llm/gateway -count=1\n- make docs-coverage docs-truth