### PR TITLE
Cover conform gates and kernel helpers

### DIFF
--- a/core/pkg/conform/gates/g1_receipt_edges_coverage_test.go
+++ b/core/pkg/conform/gates/g1_receipt_edges_coverage_test.go
@@ -1,0 +1,73 @@
+package gates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
+)
+
+func TestG1ProofReceiptsEmptyReceiptSetFails(t *testing.T) {
+	ctx := setupSparseGateContext(t)
+
+	result := (&G1ProofReceipts{}).Run(ctx)
+	if result.Pass || !reasonContains(result.Reasons, conform.ReasonReceiptChainBroken) {
+		t.Fatalf("empty receipt set result = %+v, want chain broken failure", result)
+	}
+}
+
+func TestG1LoadReceiptEnvelopesRejectsUnreadableAndInvalidFiles(t *testing.T) {
+	dir := t.TempDir()
+	invalidJSON := filepath.Join(dir, "invalid.json")
+	writeGateFile(t, invalidJSON, []byte("{"))
+
+	files := []string{invalidJSON}
+	brokenLink := filepath.Join(dir, "broken.json")
+	if err := os.Symlink(filepath.Join(dir, "missing-target"), brokenLink); err == nil {
+		files = append(files, brokenLink)
+	}
+
+	result := newReceiptGateResultForCoverage()
+	envelopes := (&G1ProofReceipts{}).loadReceiptEnvelopes(result, files)
+	if len(envelopes) != 0 {
+		t.Fatalf("malformed files produced envelopes: %+v", envelopes)
+	}
+	if result.Pass || !reasonContains(result.Reasons, conform.ReasonReceiptChainBroken) {
+		t.Fatalf("malformed file load result = %+v, want chain broken failure", result)
+	}
+}
+
+func TestG1ValidateEnvelopeRequiredFieldsAndSequenceEdges(t *testing.T) {
+	result := newReceiptGateResultForCoverage()
+	validateEnvelopeRequiredFields(result, &ReceiptEnvelope{})
+
+	if result.Pass {
+		t.Fatalf("missing required fields passed unexpectedly")
+	}
+	for _, want := range []string{
+		conform.ReasonReceiptChainBroken,
+		conform.ReasonTenantIsolationViolation,
+		conform.ReasonEnvelopeNotBound,
+	} {
+		if !reasonContains(result.Reasons, want) {
+			t.Fatalf("missing reason %q in %+v", want, result.Reasons)
+		}
+	}
+
+	result = newReceiptGateResultForCoverage()
+	validateEnvelopeMonotonicSeq(result, &ReceiptEnvelope{Seq: 2}, 2, true)
+	if result.Pass || !reasonContains(result.Reasons, conform.ReasonReceiptChainBroken) {
+		t.Fatalf("non-monotonic sequence result = %+v, want chain broken failure", result)
+	}
+}
+
+func newReceiptGateResultForCoverage() *conform.GateResult {
+	return &conform.GateResult{
+		GateID:        "G1",
+		Pass:          true,
+		Reasons:       []string{},
+		EvidencePaths: []string{},
+		Metrics:       conform.GateMetrics{Counts: make(map[string]int)},
+	}
+}

--- a/core/pkg/conform/gates/malformed_gate_evidence_coverage_test.go
+++ b/core/pkg/conform/gates/malformed_gate_evidence_coverage_test.go
@@ -1,0 +1,61 @@
+package gates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestG14BundleIntegrityMalformedEvidenceBranches(t *testing.T) {
+	ctx := setupSparseGateContext(t)
+	bundleDir := filepath.Join(ctx.EvidenceDir, "bundles")
+	mkdirGate(t, bundleDir)
+
+	result := (&G14BundleIntegrity{}).Run(ctx)
+	if result.Pass || !reasonContains(result.Reasons, "No policy bundle files found") {
+		t.Fatalf("empty bundle directory result = %+v, want missing bundle failure", result)
+	}
+
+	writeGateFile(t, filepath.Join(bundleDir, "invalid.yaml"), []byte("not: [yaml: {{"))
+	if err := os.Symlink(filepath.Join(bundleDir, "missing-target"), filepath.Join(bundleDir, "broken.yaml")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	result = (&G14BundleIntegrity{}).Run(ctx)
+	if result.Pass {
+		t.Fatalf("malformed bundles passed unexpectedly: %+v", result)
+	}
+	if !reasonContains(result.Reasons, "Invalid bundle: invalid.yaml") {
+		t.Fatalf("missing invalid bundle reason: %+v", result.Reasons)
+	}
+	if !reasonContains(result.Reasons, "Cannot read bundle: broken.yaml") {
+		t.Fatalf("missing broken bundle reason: %+v", result.Reasons)
+	}
+}
+
+func TestG15CondensationMalformedEvidenceBranches(t *testing.T) {
+	ctx := setupSparseGateContext(t)
+	checkpointDir := filepath.Join(ctx.EvidenceDir, "condensation")
+	mkdirGate(t, checkpointDir)
+
+	result := (&G15Condensation{}).Run(ctx)
+	if result.Pass || !reasonContains(result.Reasons, "No checkpoint files found") {
+		t.Fatalf("empty checkpoint directory result = %+v, want missing checkpoint failure", result)
+	}
+
+	writeGateFile(t, filepath.Join(checkpointDir, "invalid.json"), []byte("{"))
+	if err := os.Symlink(filepath.Join(checkpointDir, "missing-target"), filepath.Join(checkpointDir, "broken.json")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	result = (&G15Condensation{}).Run(ctx)
+	if result.Pass {
+		t.Fatalf("malformed checkpoints passed unexpectedly: %+v", result)
+	}
+	if !reasonContains(result.Reasons, "Invalid checkpoint format: invalid.json") {
+		t.Fatalf("missing invalid checkpoint reason: %+v", result.Reasons)
+	}
+	if !reasonContains(result.Reasons, "Cannot read checkpoint: broken.json") {
+		t.Fatalf("missing broken checkpoint reason: %+v", result.Reasons)
+	}
+}

--- a/core/pkg/kernel/event_log_coverage_test.go
+++ b/core/pkg/kernel/event_log_coverage_test.go
@@ -1,0 +1,83 @@
+package kernel
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+func TestEventLogRejectsUncanonicalPayload(t *testing.T) {
+	log := NewInMemoryEventLog()
+
+	_, err := log.Append(context.Background(), &EventEnvelope{
+		EventID:   "event-invalid",
+		EventType: "test.invalid",
+		Payload: map[string]interface{}{
+			"not_finite": math.Inf(1),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected invalid canonical payload to fail append")
+	}
+}
+
+func TestEventLogGetAndRangeEdges(t *testing.T) {
+	ctx := context.Background()
+	log := NewInMemoryEventLog()
+
+	appendEventForCoverage(t, log, "event-1")
+	appendEventForCoverage(t, log, "event-2")
+
+	if _, err := log.Get(ctx, 0); err == nil {
+		t.Fatal("expected sequence zero lookup to fail")
+	}
+	if _, err := log.Get(ctx, 3); err == nil {
+		t.Fatal("expected out-of-range lookup to fail")
+	}
+
+	if _, err := log.Range(ctx, 0, 1); err == nil {
+		t.Fatal("expected zero start range to fail")
+	}
+	if _, err := log.Range(ctx, 2, 1); err == nil {
+		t.Fatal("expected reversed range to fail")
+	}
+
+	empty, err := log.Range(ctx, 10, 12)
+	if err != nil {
+		t.Fatalf("start beyond log should return empty slice without error: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected empty slice for start beyond log, got %d events", len(empty))
+	}
+
+	clipped, err := log.Range(ctx, 1, 99)
+	if err != nil {
+		t.Fatalf("clipped range should succeed: %v", err)
+	}
+	if len(clipped) != 2 || clipped[0].EventID != "event-1" || clipped[1].EventID != "event-2" {
+		t.Fatalf("unexpected clipped range: %+v", clipped)
+	}
+
+	subset, err := log.Range(ctx, 2, 2)
+	if err != nil {
+		t.Fatalf("subset range should succeed: %v", err)
+	}
+	if len(subset) != 1 || subset[0].EventID != "event-2" {
+		t.Fatalf("unexpected subset range: %+v", subset)
+	}
+}
+
+func appendEventForCoverage(t *testing.T, log *InMemoryEventLog, eventID string) {
+	t.Helper()
+
+	_, err := log.Append(context.Background(), &EventEnvelope{
+		EventID:   eventID,
+		EventType: "test.event",
+		Payload: map[string]interface{}{
+			"id": eventID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("append %s failed: %v", eventID, err)
+	}
+}

--- a/core/pkg/kernel/pdp_adapter_coverage_test.go
+++ b/core/pkg/kernel/pdp_adapter_coverage_test.go
@@ -1,0 +1,157 @@
+package kernel
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/governance"
+)
+
+func TestGovernancePDPAdapterMapsRequestAndDecisions(t *testing.T) {
+	submittedAt := time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC)
+	baseReq := &EffectRequest{
+		EffectID:    "effect-1",
+		EffectType:  EffectTypeFundsTransfer,
+		SubmittedAt: submittedAt,
+		Subject: EffectSubject{
+			SubjectID:   "agent-1",
+			SubjectType: "agent",
+			SessionID:   "session-1",
+		},
+		Payload: EffectPayload{PayloadHash: "payload-hash"},
+		Idempotency: &IdempotencyConfig{
+			Key: "idempotency-key",
+		},
+		Context: &EffectContext{
+			ModeID:        "mode-1",
+			LoopID:        "loop-1",
+			PhenotypeHash: "phenotype-hash",
+			EnvironmentID: "environment-hash",
+		},
+	}
+
+	cases := []struct {
+		name         string
+		pdpDecision  governance.Decision
+		wantDecision string
+	}{
+		{"allow", governance.DecisionAllow, "ALLOW"},
+		{"deny", governance.DecisionDeny, "DENY"},
+		{"approval", governance.DecisionRequireApproval, "REQUIRE_APPROVAL"},
+		{"evidence", governance.DecisionRequireEvidence, "REQUIRE_EVIDENCE"},
+		{"defer", governance.DecisionDefer, "DEFER"},
+		{"unknown defaults deny", governance.Decision("UNKNOWN"), "DENY"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pdp := &fakeGovernancePDP{
+				decision:   tc.pdpDecision,
+				decisionID: "decision-" + tc.name,
+			}
+			adapter := NewGovernancePDPAdapter(pdp)
+
+			decision, decisionID, err := adapter.Evaluate(context.Background(), baseReq)
+			if err != nil {
+				t.Fatalf("Evaluate returned error: %v", err)
+			}
+			if decision != tc.wantDecision {
+				t.Fatalf("decision mismatch: got %s want %s", decision, tc.wantDecision)
+			}
+			if decisionID != pdp.decisionID {
+				t.Fatalf("decision ID mismatch: got %s want %s", decisionID, pdp.decisionID)
+			}
+
+			got := pdp.lastRequest
+			if got.RequestID != baseReq.EffectID ||
+				got.Effect.EffectID != baseReq.EffectID ||
+				got.Effect.EffectType != string(baseReq.EffectType) ||
+				got.Effect.EffectPayloadHash != baseReq.Payload.PayloadHash ||
+				got.Effect.IdempotencyKey != baseReq.Idempotency.Key {
+				t.Fatalf("effect mapping mismatch: %+v", got.Effect)
+			}
+			if got.Subject.ActorID != baseReq.Subject.SubjectID ||
+				got.Subject.ActorType != baseReq.Subject.SubjectType ||
+				got.Subject.AuthContext.SessionID != baseReq.Subject.SessionID {
+				t.Fatalf("subject mapping mismatch: %+v", got.Subject)
+			}
+			if got.Context.ModeID != baseReq.Context.ModeID ||
+				got.Context.LoopID != baseReq.Context.LoopID ||
+				got.Context.PhenotypeHash != baseReq.Context.PhenotypeHash ||
+				got.Context.EnvironmentSnapshotHash != baseReq.Context.EnvironmentID ||
+				got.Context.Time.DecisionTimeSource != "observed_at" ||
+				!got.Context.Time.Timestamp.Equal(submittedAt) {
+				t.Fatalf("context mapping mismatch: %+v", got.Context)
+			}
+		})
+	}
+}
+
+func TestGovernancePDPAdapterPropagatesErrors(t *testing.T) {
+	wantErr := errors.New("pdp unavailable")
+	adapter := NewGovernancePDPAdapter(&fakeGovernancePDP{err: wantErr})
+
+	decision, decisionID, err := adapter.Evaluate(context.Background(), &EffectRequest{
+		EffectID:   "effect-error",
+		EffectType: EffectTypeNotify,
+		Subject:    EffectSubject{SubjectID: "agent-1"},
+		Payload:    EffectPayload{PayloadHash: "payload-hash"},
+	})
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected wrapped PDP error, got %v", err)
+	}
+	if decision != "DENY" || decisionID != "" {
+		t.Fatalf("PDP errors should fail closed, got decision=%s decisionID=%s", decision, decisionID)
+	}
+}
+
+func TestNewWiredEffectBoundarySubmitsThroughGovernancePDP(t *testing.T) {
+	pdp := &fakeGovernancePDP{decision: governance.DecisionAllow, decisionID: "decision-allow"}
+	log := NewInMemoryEventLog()
+
+	boundary := NewWiredEffectBoundary(pdp, log)
+	if boundary.InMemoryEffectBoundary == nil || boundary.pdpAdapter == nil {
+		t.Fatalf("wired boundary missing components: %+v", boundary)
+	}
+
+	lifecycle, err := boundary.Submit(context.Background(), &EffectRequest{
+		EffectID:   "effect-allow",
+		EffectType: EffectTypeNotify,
+		Subject:    EffectSubject{SubjectID: "agent-1", SubjectType: "agent"},
+		Payload:    EffectPayload{PayloadHash: "payload-hash"},
+	})
+	if err != nil {
+		t.Fatalf("Submit returned error: %v", err)
+	}
+	if lifecycle.State != "approved" || lifecycle.PDPDecisionID != "decision-allow" {
+		t.Fatalf("unexpected lifecycle: %+v", lifecycle)
+	}
+	if log.LastSequence() != 1 {
+		t.Fatalf("expected submitted event to be logged, got last sequence %d", log.LastSequence())
+	}
+}
+
+type fakeGovernancePDP struct {
+	decision    governance.Decision
+	decisionID  string
+	err         error
+	lastRequest governance.PDPRequest
+}
+
+func (p *fakeGovernancePDP) Evaluate(_ context.Context, req governance.PDPRequest) (*governance.PDPResponse, error) {
+	p.lastRequest = req
+	if p.err != nil {
+		return nil, p.err
+	}
+	return &governance.PDPResponse{
+		Decision:   p.decision,
+		DecisionID: p.decisionID,
+	}, nil
+}
+
+func (p *fakeGovernancePDP) PolicyVersion() string {
+	return "test-policy"
+}

--- a/core/pkg/kernel/task_classifier_coverage_test.go
+++ b/core/pkg/kernel/task_classifier_coverage_test.go
@@ -1,0 +1,150 @@
+package kernel
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTaskClassifierClassifyFromDAG(t *testing.T) {
+	classifier := DefaultTaskClassifier()
+	if classifier.ParallelThreshold != 0.7 || classifier.HybridThreshold != 0.3 ||
+		classifier.MaxSequentialDepth != 8 || classifier.MinSubtasks != 3 {
+		t.Fatalf("unexpected default thresholds: %+v", classifier)
+	}
+
+	empty := classifier.ClassifyFromDAG(nil, nil)
+	if empty.Decomposability != 0 || empty.SequentialDepth != 0 {
+		t.Fatalf("empty DAG should have zeroed structural properties: %+v", empty)
+	}
+
+	independent := classifier.ClassifyFromDAG(
+		[]string{"a", "b", "c", "d", "e", "f", "g", "h"},
+		map[string][]string{},
+	)
+	if independent.SequentialDepth != 1 {
+		t.Fatalf("expected one-step depth, got %+v", independent)
+	}
+	assertFloatWithin(t, independent.Decomposability, 1.0, 0.0001)
+	assertFloatWithin(t, independent.ParallelizableFraction, 0.875, 0.0001)
+	assertFloatWithin(t, independent.ToolDensity, 1.0, 0.0001)
+	if independent.EstimatedSubtasks != 8 || independent.ErrorAmplificationRisk <= 0 {
+		t.Fatalf("unexpected independent properties: %+v", independent)
+	}
+
+	chain := classifier.ClassifyFromDAG(
+		[]string{"a", "b", "c"},
+		map[string][]string{
+			"a": {"b"},
+			"b": {"c"},
+			"c": {},
+		},
+	)
+	if chain.SequentialDepth != 3 {
+		t.Fatalf("expected full chain depth, got %+v", chain)
+	}
+	assertFloatWithin(t, chain.Decomposability, 1.0/3.0, 0.0001)
+	assertFloatWithin(t, chain.ParallelizableFraction, 0, 0.0001)
+
+	overdeep := classifier.ClassifyFromDAG(
+		[]string{"a", "x"},
+		map[string][]string{
+			"a": {"b"},
+			"b": {"c"},
+			"c": {"d"},
+			"d": {},
+			"x": {},
+		},
+	)
+	if overdeep.SequentialDepth != 4 {
+		t.Fatalf("expected external dependency chain to contribute depth, got %+v", overdeep)
+	}
+	assertFloatWithin(t, overdeep.ParallelizableFraction, 0, 0.0001)
+}
+
+func TestTaskClassifierSelectModeBranches(t *testing.T) {
+	classifier := DefaultTaskClassifier()
+
+	cases := []struct {
+		name      string
+		props     TaskProperties
+		wantMode  CoordinationMode
+		rationale string
+	}{
+		{
+			name:      "too few subtasks",
+			props:     TaskProperties{EstimatedSubtasks: 2, SequentialDepth: 1, ParallelizableFraction: 1},
+			wantMode:  ModeWaterfall,
+			rationale: "only 2 subtasks",
+		},
+		{
+			name:      "deep sequential chain",
+			props:     TaskProperties{EstimatedSubtasks: 9, SequentialDepth: 9, ParallelizableFraction: 1},
+			wantMode:  ModeWaterfall,
+			rationale: "sequential depth 9 exceeds max 8",
+		},
+		{
+			name:      "high error amplification",
+			props:     TaskProperties{EstimatedSubtasks: 4, SequentialDepth: 1, ParallelizableFraction: 1, ErrorAmplificationRisk: 0.31},
+			wantMode:  ModeHybrid,
+			rationale: "error amplification risk",
+		},
+		{
+			name:      "highly parallel",
+			props:     TaskProperties{EstimatedSubtasks: 4, SequentialDepth: 1, ParallelizableFraction: 0.8, ErrorAmplificationRisk: 0.1},
+			wantMode:  ModeParallel,
+			rationale: "parallelizable fraction exceeds threshold",
+		},
+		{
+			name:      "moderately parallel",
+			props:     TaskProperties{EstimatedSubtasks: 4, SequentialDepth: 1, ParallelizableFraction: 0.5, ErrorAmplificationRisk: 0.1},
+			wantMode:  ModeHybrid,
+			rationale: "between 30% and 70%",
+		},
+		{
+			name:      "mostly sequential",
+			props:     TaskProperties{EstimatedSubtasks: 4, SequentialDepth: 1, ParallelizableFraction: 0.1, ErrorAmplificationRisk: 0.1},
+			wantMode:  ModeWaterfall,
+			rationale: "below 30% threshold",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mode, rationale := classifier.SelectMode(tc.props)
+			if mode != tc.wantMode {
+				t.Fatalf("mode mismatch: got %s want %s; rationale=%s", mode, tc.wantMode, rationale)
+			}
+			if !strings.Contains(rationale, tc.rationale) {
+				t.Fatalf("rationale %q does not contain %q", rationale, tc.rationale)
+			}
+		})
+	}
+}
+
+func TestComputeCriticalPathSharedDependencies(t *testing.T) {
+	depth := computeCriticalPath(
+		[]string{"long", "wide", "short"},
+		map[string][]string{
+			"long":  {"mid", "leaf"},
+			"mid":   {"leaf"},
+			"leaf":  {},
+			"wide":  {"leaf"},
+			"short": {},
+		},
+	)
+	if depth != 3 {
+		t.Fatalf("expected longest chain length 3, got %d", depth)
+	}
+}
+
+func assertFloatWithin(t *testing.T, got, want, tolerance float64) {
+	t.Helper()
+
+	diff := got - want
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > tolerance {
+		t.Fatalf("got %f, want %f within %f", got, want, tolerance)
+	}
+}


### PR DESCRIPTION
Adds focused coverage for malformed conform gate evidence, G1 receipt edge cases, event log ranges, governance PDP adapter mapping, and task classifier branches.\n\nVerification:\n- go test ./pkg/conform/gates ./pkg/kernel -count=1\n- git diff --check