### PR TITLE
Cover conformance gate edge branches

### DIFF
--- a/core/pkg/conform/gates/g0_build_identity_edges_coverage_test.go
+++ b/core/pkg/conform/gates/g0_build_identity_edges_coverage_test.go
@@ -1,0 +1,69 @@
+package gates
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
+)
+
+func TestG0BuildIdentityEvidenceDirectoryFallbacks(t *testing.T) {
+	_, ctx := setupG0(t)
+	attestDir := filepath.Join(ctx.EvidenceDir, "07_ATTESTATIONS")
+
+	writeGateFile(t, filepath.Join(ctx.ProjectRoot, "go.sum"), []byte("dep-lock"))
+	writeGateFile(t, filepath.Join(attestDir, "build_identity.json"), []byte(`{"version":"1.0"}`))
+	writeGateFile(t, filepath.Join(attestDir, "sbom.xml"), []byte(`<sbom/>`))
+	writeGateFile(t, filepath.Join(attestDir, "provenance.jsonl"), []byte(`{"predicate":{}}`))
+	writeGateFile(t, filepath.Join(attestDir, "signing_keys.json"), []byte(`{"keys":[]}`))
+
+	result := (&G0BuildIdentity{}).Run(ctx)
+	if !result.Pass {
+		t.Fatalf("evidence fallback artifacts should pass: %+v", result)
+	}
+	if result.Metrics.Counts["build_identity"] != 1 ||
+		result.Metrics.Counts["dep_locks"] != 1 ||
+		result.Metrics.Counts["trust_roots"] != 1 {
+		t.Fatalf("unexpected metrics: %+v", result.Metrics.Counts)
+	}
+}
+
+func TestG0BuildIdentityInvalidAndMissingBuildIdentity(t *testing.T) {
+	_, invalidCtx := setupG0(t)
+	writeG0RequiredArtifactsExceptBuildIdentity(t, invalidCtx)
+	writeGateFile(t, filepath.Join(invalidCtx.ProjectRoot, "artifacts", "build_identity.json"), []byte("{"))
+
+	result := (&G0BuildIdentity{}).Run(invalidCtx)
+	if result.Pass || !reasonContains(result.Reasons, conform.ReasonBuildIdentityMissing) {
+		t.Fatalf("invalid build identity result = %+v, want build identity failure", result)
+	}
+
+	_, missingCtx := setupG0(t)
+	writeG0RequiredArtifactsExceptBuildIdentity(t, missingCtx)
+	result = (&G0BuildIdentity{}).Run(missingCtx)
+	if result.Pass || !reasonContains(result.Reasons, conform.ReasonBuildIdentityMissing) {
+		t.Fatalf("missing build identity result = %+v, want build identity failure", result)
+	}
+}
+
+func TestG0BuildIdentityHelperReadErrors(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.json")
+	if err := validateBuildIdentity(missing); err == nil {
+		t.Fatal("validateBuildIdentity should fail for a missing file")
+	}
+
+	dst := filepath.Join(t.TempDir(), "copied.json")
+	copyToEvidence(missing, dst)
+	if fileExists(dst) {
+		t.Fatalf("copyToEvidence created destination for missing source: %s", dst)
+	}
+}
+
+func writeG0RequiredArtifactsExceptBuildIdentity(t *testing.T, ctx *conform.RunContext) {
+	t.Helper()
+
+	writeGateFile(t, filepath.Join(ctx.ProjectRoot, "go.sum"), []byte("dep-lock"))
+	writeGateFile(t, filepath.Join(ctx.ProjectRoot, "artifacts", "sbom.json"), []byte(`{"components":[]}`))
+	writeGateFile(t, filepath.Join(ctx.ProjectRoot, "artifacts", "provenance.json"), []byte(`{"predicate":{}}`))
+	writeGateFile(t, filepath.Join(ctx.ProjectRoot, "artifacts", "trust_roots.json"), []byte(`{"keys":[]}`))
+}

--- a/core/pkg/conform/gates/g2_replay_edges_coverage_test.go
+++ b/core/pkg/conform/gates/g2_replay_edges_coverage_test.go
@@ -1,0 +1,52 @@
+package gates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
+)
+
+func TestG2ReplayMalformedEvidenceBranches(t *testing.T) {
+	ctx := setupSparseGateContext(t)
+
+	writeGateJSON(t, filepath.Join(ctx.EvidenceDir, "08_TAPES", "tape_manifest.json"), map[string]any{
+		"entries": []any{},
+	})
+	writeGateFile(t, filepath.Join(ctx.EvidenceDir, "05_DIFFS", "diff.txt"), []byte("changed"))
+	writeGateJSON(t, filepath.Join(ctx.EvidenceDir, "02_PROOFGRAPH", "determinism_manifest.json"), map[string]any{
+		"live_hash":   "sha256:live",
+		"replay_hash": "sha256:replay",
+	})
+
+	receiptsDir := filepath.Join(ctx.EvidenceDir, "02_PROOFGRAPH", "receipts")
+	writeGateJSON(t, filepath.Join(receiptsDir, "01.json"), map[string]any{"lamport_clock": 5})
+	writeGateJSON(t, filepath.Join(receiptsDir, "02.json"), map[string]any{"lamport_clock": 3})
+	writeGateFile(t, filepath.Join(receiptsDir, "03-invalid.json"), []byte("{"))
+	_ = os.Symlink(filepath.Join(receiptsDir, "missing-target"), filepath.Join(receiptsDir, "04-broken.json"))
+
+	decisionsDir := filepath.Join(ctx.EvidenceDir, "02_PROOFGRAPH", "decisions")
+	writeGateJSON(t, filepath.Join(decisionsDir, "01-missing-hash.json"), map[string]any{
+		"policy_backend": "rego",
+	})
+	writeGateFile(t, filepath.Join(decisionsDir, "02-invalid.json"), []byte("{"))
+	_ = os.Symlink(filepath.Join(decisionsDir, "missing-target"), filepath.Join(decisionsDir, "03-broken.json"))
+
+	result := (&G2Replay{}).Run(ctx)
+	if result.Pass {
+		t.Fatalf("malformed replay evidence passed unexpectedly: %+v", result)
+	}
+	for _, want := range []string{
+		conform.ReasonReplayHashDivergence,
+		"LAMPORT_NOT_MONOTONIC",
+		"POLICY_DECISION_HASH_MISSING",
+	} {
+		if !reasonContains(result.Reasons, want) {
+			t.Fatalf("missing reason %q in %+v", want, result.Reasons)
+		}
+	}
+	if result.Metrics.Counts["missing_decision_hashes"] != 1 {
+		t.Fatalf("unexpected missing decision hash count: %+v", result.Metrics.Counts)
+	}
+}

--- a/core/pkg/conformance/owasp_fixtures_edges_coverage_test.go
+++ b/core/pkg/conformance/owasp_fixtures_edges_coverage_test.go
@@ -1,0 +1,84 @@
+package conformance
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestOWASPFirewallSchemaAndNoSchemaBranches(t *testing.T) {
+	firewall := newOWASPFirewall()
+	firewall.AllowTool("with-schema", `{"type":"object","required":["target","mode"]}`)
+
+	if !firewall.allowedTools["with-schema"] || firewall.schemas["with-schema"] == "" {
+		t.Fatalf("AllowTool did not record non-empty schema")
+	}
+	if _, err := firewall.CallTool("with-schema", map[string]any{"target": "repo", "mode": "read"}); err != nil {
+		t.Fatalf("schema-valid tool call failed: %v", err)
+	}
+
+	firewall.AllowTool("without-schema", "")
+	if _, err := firewall.CallTool("without-schema", map[string]any{"anything": true}); err != nil {
+		t.Fatalf("schema-less tool call failed: %v", err)
+	}
+	if err := firewall.validateParams("without-required", `{"type":"object"}`, map[string]any{}); err != nil {
+		t.Fatalf("schema without required fields should validate: %v", err)
+	}
+	if fields := extractRequiredFields(`{"type":"object"}`); fields != nil {
+		t.Fatalf("schema without required returned fields: %+v", fields)
+	}
+	if fields := extractRequiredFields(`{"required":"not-an-array"}`); fields != nil {
+		t.Fatalf("malformed required declaration returned fields: %+v", fields)
+	}
+}
+
+func TestOWASPDelegationReDelegateErrorBranches(t *testing.T) {
+	ctx := context.Background()
+	dm := newOWASPDelegationManager()
+
+	if _, err := dm.ReDelegate(ctx, "missing", owaspDelegationRequest{}); err == nil {
+		t.Fatal("missing parent grant should fail")
+	}
+
+	dm.grants["revoked"] = &owaspDelegationGrant{
+		GrantID:       "revoked",
+		Capabilities:  []string{"read"},
+		MaxChainDepth: 2,
+		ExpiresAt:     time.Now().Add(time.Hour),
+		Revoked:       true,
+	}
+	if _, err := dm.ReDelegate(ctx, "revoked", owaspDelegationRequest{Capabilities: []string{"read"}}); err == nil {
+		t.Fatal("revoked parent grant should fail")
+	}
+
+	dm.grants["expired"] = &owaspDelegationGrant{
+		GrantID:       "expired",
+		Capabilities:  []string{"read"},
+		MaxChainDepth: 2,
+		ExpiresAt:     time.Now().Add(-time.Minute),
+	}
+	if _, err := dm.ReDelegate(ctx, "expired", owaspDelegationRequest{Capabilities: []string{"read"}}); err == nil {
+		t.Fatal("expired parent grant should fail")
+	}
+
+	dm.grants["max-depth"] = &owaspDelegationGrant{
+		GrantID:       "max-depth",
+		Capabilities:  []string{"read"},
+		MaxChainDepth: 1,
+		ChainDepth:    1,
+		ExpiresAt:     time.Now().Add(time.Hour),
+	}
+	if _, err := dm.ReDelegate(ctx, "max-depth", owaspDelegationRequest{Capabilities: []string{"read"}}); err == nil {
+		t.Fatal("max-depth parent grant should fail")
+	}
+
+	dm.grants["attenuated"] = &owaspDelegationGrant{
+		GrantID:       "attenuated",
+		Capabilities:  []string{"read"},
+		MaxChainDepth: 2,
+		ExpiresAt:     time.Now().Add(time.Hour),
+	}
+	if _, err := dm.ReDelegate(ctx, "attenuated", owaspDelegationRequest{Capabilities: []string{"write"}}); err == nil {
+		t.Fatal("capability expansion should fail")
+	}
+}

--- a/core/pkg/conformance/ton_acton_coverage_test.go
+++ b/core/pkg/conformance/ton_acton_coverage_test.go
@@ -1,0 +1,27 @@
+package conformance
+
+import "testing"
+
+func TestTONActonGoldenValidationLoadsCases(t *testing.T) {
+	ctx := &TestContext{Level: LevelL3, Category: "ton-acton"}
+
+	if err := validateTONActonGoldenPacks(ctx); err != nil {
+		t.Fatalf("validate TON Acton golden packs returned error: %v", err)
+	}
+	if ctx.Failed() {
+		t.Fatalf("TON Acton validation recorded failures: %+v", ctx.Errors)
+	}
+
+	cases := loadTONActonGoldenCases(ctx)
+	if len(cases) < 22 {
+		t.Fatalf("expected at least 22 cases, got %d", len(cases))
+	}
+	if _, ok := cases["build_ok"]; !ok {
+		t.Fatalf("build_ok case missing from loaded cases")
+	}
+
+	root, err := tonActonGoldenRoot()
+	if err != nil || root == "" {
+		t.Fatalf("tonActonGoldenRoot = %q, %v", root, err)
+	}
+}


### PR DESCRIPTION
Adds focused coverage for G0 build identity fallbacks, G2 replay malformed evidence, OWASP fixture branches, and TON Acton golden loading.\n\nVerification:\n- go test ./pkg/conform/gates ./pkg/conformance -count=1\n- git diff --check