### PR TITLE
Cover pack package edge cases

### DIFF
--- a/core/pkg/pack/fs_registry_edges_coverage_test.go
+++ b/core/pkg/pack/fs_registry_edges_coverage_test.go
@@ -1,0 +1,186 @@
+package pack
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCoverageFSRegistryEdges(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("GetPack reports missing and ListVersions errors", func(t *testing.T) {
+		root := t.TempDir()
+		registry := NewFSRegistry(root)
+		if _, err := registry.GetPack(ctx, "missing"); err == nil {
+			t.Fatal("expected missing pack to fail")
+		}
+
+		fileRoot := filepath.Join(root, "file-root")
+		if err := os.WriteFile(fileRoot, []byte("not a directory"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := NewFSRegistry(fileRoot).GetPack(ctx, "pack"); err == nil {
+			t.Fatal("expected non-directory registry root to fail")
+		}
+	})
+
+	t.Run("FindByCapability handles missing root errors skips and matches", func(t *testing.T) {
+		missing := NewFSRegistry(filepath.Join(t.TempDir(), "missing"))
+		packs, err := missing.FindByCapability(ctx, "capture")
+		if err != nil {
+			t.Fatalf("FindByCapability missing root: %v", err)
+		}
+		if len(packs) != 0 {
+			t.Fatalf("missing root packs = %#v", packs)
+		}
+
+		root := t.TempDir()
+		fileRoot := filepath.Join(root, "file-root")
+		if err := os.WriteFile(fileRoot, []byte("not a directory"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := NewFSRegistry(fileRoot).FindByCapability(ctx, "capture"); err == nil {
+			t.Fatal("expected non-directory root to fail")
+		}
+
+		if err := os.WriteFile(filepath.Join(root, "README"), []byte("skip me"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(root, "invalid-pack", "1.0.0"), 0700); err != nil {
+			t.Fatalf("MkdirAll invalid: %v", err)
+		}
+		writePackManifest(t, root, "version-mismatch", "1.0.0", PackManifest{
+			PackID:       "version-mismatch",
+			Name:         "version-mismatch",
+			Version:      "missing-version",
+			Capabilities: []string{"attest"},
+		})
+		writePackManifest(t, root, "good-pack", "1.0.0", PackManifest{
+			PackID:       "good-pack",
+			Name:         "good-pack",
+			Version:      "1.0.0",
+			Capabilities: []string{"capture", "attest"},
+		})
+		writePackManifest(t, root, "other-pack", "1.0.0", PackManifest{
+			PackID:       "other-pack",
+			Name:         "other-pack",
+			Version:      "1.0.0",
+			Capabilities: []string{"observe"},
+		})
+
+		found, err := NewFSRegistry(root).FindByCapability(ctx, "attest")
+		if err != nil {
+			t.Fatalf("FindByCapability: %v", err)
+		}
+		if len(found) != 1 || found[0].PackID != "good-pack" {
+			t.Fatalf("found = %#v", found)
+		}
+	})
+
+	t.Run("ListVersions skips invalid entries and sorts fallback versions", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.WriteFile(filepath.Join(root, "pack"), []byte("not a directory"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := NewFSRegistry(root).ListVersions(ctx, "pack"); err == nil {
+			t.Fatal("expected pack path file to fail")
+		}
+
+		writePackManifest(t, root, "versions", "2.0.0", PackManifest{
+			PackID: "versions", Name: "versions", Version: "2.0.0",
+		})
+		writePackManifest(t, root, "versions", "1.0.0", PackManifest{
+			PackID: "versions", Name: "versions", Version: "1.0.0",
+		})
+		writePackManifest(t, root, "versions", "bad-version", PackManifest{
+			PackID: "versions", Name: "versions", Version: "bad-version",
+		})
+		if err := os.WriteFile(filepath.Join(root, "versions", "README"), []byte("skip"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.MkdirAll(filepath.Join(root, "versions", "invalid", "nested"), 0700); err != nil {
+			t.Fatalf("MkdirAll invalid: %v", err)
+		}
+
+		versions, err := NewFSRegistry(root).ListVersions(ctx, "versions")
+		if err != nil {
+			t.Fatalf("ListVersions: %v", err)
+		}
+		if len(versions) != 3 {
+			t.Fatalf("versions = %#v", versions)
+		}
+		if versions[0].Version != "1.0.0" || versions[1].Version != "2.0.0" || versions[2].Version != "bad-version" {
+			t.Fatalf("unexpected version order: %#v", versions)
+		}
+	})
+
+	t.Run("loadPack and content hashing report malformed inputs", func(t *testing.T) {
+		root := t.TempDir()
+		registry := NewFSRegistry(root)
+		if _, err := registry.loadPack("missing", "1.0.0"); err == nil {
+			t.Fatal("expected missing manifest to fail")
+		}
+
+		badDir := filepath.Join(root, "bad", "1.0.0")
+		if err := os.MkdirAll(badDir, 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(badDir, "manifest.json"), []byte("{"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if _, err := registry.loadPack("bad", "1.0.0"); err == nil {
+			t.Fatal("expected malformed manifest to fail")
+		}
+
+		brokenDir := filepath.Join(root, "broken", "1.0.0")
+		if err := os.MkdirAll(brokenDir, 0700); err != nil {
+			t.Fatalf("MkdirAll broken: %v", err)
+		}
+		writePackManifest(t, root, "broken", "1.0.0", PackManifest{
+			PackID: "broken", Name: "broken", Version: "1.0.0",
+		})
+		if err := os.Symlink(filepath.Join(root, "does-not-exist"), filepath.Join(brokenDir, "broken-link")); err != nil {
+			t.Fatalf("Symlink broken pack: %v", err)
+		}
+		if _, err := registry.loadPack("broken", "1.0.0"); err == nil {
+			t.Fatal("expected content hash error from broken symlink")
+		}
+
+		if _, err := registry.computeContentHash(filepath.Join(root, "missing-dir")); err == nil {
+			t.Fatal("expected missing directory hash to fail")
+		}
+
+		hashDir := filepath.Join(root, "hash")
+		if err := os.MkdirAll(hashDir, 0700); err != nil {
+			t.Fatalf("MkdirAll hash: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(hashDir, ".DS_Store"), []byte("ignored"), 0600); err != nil {
+			t.Fatalf("WriteFile ds store: %v", err)
+		}
+		if err := os.Symlink(filepath.Join(root, "does-not-exist"), filepath.Join(hashDir, "broken-link")); err != nil {
+			t.Fatalf("Symlink: %v", err)
+		}
+		if _, err := registry.computeContentHash(hashDir); err == nil {
+			t.Fatal("expected broken symlink open to fail")
+		}
+	})
+}
+
+func writePackManifest(t *testing.T, root, name, version string, manifest PackManifest) {
+	t.Helper()
+
+	dir := filepath.Join(root, name, version)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll %s: %v", dir, err)
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+}

--- a/core/pkg/pack/misc_edges_coverage_test.go
+++ b/core/pkg/pack/misc_edges_coverage_test.go
@@ -1,0 +1,102 @@
+package pack
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCoveragePackDependencyEdges(t *testing.T) {
+	if err := CheckDependency(PackDependency{
+		PackName: "optional-missing",
+		Optional: true,
+	}, nil); err != nil {
+		t.Fatalf("optional missing dependency should pass: %v", err)
+	}
+
+	if err := CheckDependency(PackDependency{
+		PackName:    "dep",
+		VersionSpec: "not a constraint",
+	}, []PackVersion{{PackName: "dep", Version: "1.0.0"}}); err == nil {
+		t.Fatal("expected invalid dependency constraint to fail")
+	}
+
+	if err := CheckDependency(PackDependency{
+		PackName:    "dep",
+		VersionSpec: ">=1.0.0",
+	}, []PackVersion{{PackName: "dep", Version: "not-semver"}}); err == nil {
+		t.Fatal("expected invalid installed dependency version to fail")
+	}
+
+	if err := CheckDependency(PackDependency{
+		PackName:    "dep",
+		VersionSpec: ">=2.0.0",
+	}, []PackVersion{{PackName: "dep", Version: "1.0.0"}}); err == nil {
+		t.Fatal("expected dependency version mismatch to fail")
+	}
+}
+
+func TestCoverageResolverEdges(t *testing.T) {
+	ctx := context.Background()
+
+	resolver := NewResolver(coverageErrorPackRegistry{})
+	if _, err := resolver.resolveCapability(ctx, "capture", ResolutionConstraints{
+		PinnedVersions: map[string]string{"capture": "missing-pack"},
+	}); err == nil {
+		t.Fatal("expected pinned pack lookup error")
+	}
+
+	if _, err := resolver.resolveCapability(ctx, "capture", ResolutionConstraints{}); err == nil {
+		t.Fatal("expected capability search error")
+	}
+}
+
+func TestCoverageCapabilityVerifierOption(t *testing.T) {
+	defaultVerifier := NewCapabilityVerifier()
+	defaultResult, err := defaultVerifier.VerifyManifest("default-skill", nil, []byte("safe content"))
+	if err != nil {
+		t.Fatalf("default VerifyManifest: %v", err)
+	}
+	if defaultResult.VerifiedAt.IsZero() {
+		t.Fatal("default verifier should set VerifiedAt")
+	}
+
+	now := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+	verifier := NewCapabilityVerifier(WithClock(func() time.Time { return now }))
+	result, err := verifier.VerifyManifest("skill", []string{"network", "filesystem", "code_execution"}, []byte("safe content"))
+	if err != nil {
+		t.Fatalf("VerifyManifest: %v", err)
+	}
+	if !result.VerifiedAt.Equal(now) {
+		t.Fatalf("VerifiedAt = %s, want %s", result.VerifiedAt, now)
+	}
+}
+
+func TestCoverageVerifierPackSignatureFailure(t *testing.T) {
+	manifest := PackManifest{Name: "unsigned", Version: "1.0.0"}
+	p := &Pack{
+		PackID:      "unsigned",
+		Manifest:    manifest,
+		ContentHash: ComputePackHash(&Pack{Manifest: manifest}),
+	}
+
+	ok, err := NewVerifier(nil).VerifyPack(p)
+	if ok || err == nil {
+		t.Fatalf("VerifyPack ok=%v err=%v, want signature failure", ok, err)
+	}
+}
+
+type coverageErrorPackRegistry struct{}
+
+func (coverageErrorPackRegistry) GetPack(context.Context, string) (*Pack, error) {
+	return nil, errors.New("get pack failed")
+}
+
+func (coverageErrorPackRegistry) FindByCapability(context.Context, string) ([]Pack, error) {
+	return nil, errors.New("find capability failed")
+}
+
+func (coverageErrorPackRegistry) ListVersions(context.Context, string) ([]PackVersion, error) {
+	return nil, errors.New("list versions failed")
+}

--- a/core/pkg/pack/registry_adapter_matrix_coverage_test.go
+++ b/core/pkg/pack/registry_adapter_matrix_coverage_test.go
@@ -1,0 +1,157 @@
+package pack
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/manifest"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/registry"
+)
+
+func TestCoverageCompatibilityMatrix(t *testing.T) {
+	matrix := &CompatibilityMatrix{
+		Entries: []CompatibilityEntry{{
+			ComponentA: "kernel",
+			VersionA:   ">=1.0.0 <2.0.0",
+			ComponentB: "sdk-go",
+			VersionB:   "^1.4.0",
+			Status:     CompatFull,
+		}},
+	}
+
+	if got := matrix.IsCompatible("kernel", "1.5.0", "sdk-go", "1.4.3"); got != CompatFull {
+		t.Fatalf("forward compatibility = %s, want %s", got, CompatFull)
+	}
+	if got := matrix.IsCompatible("sdk-go", "1.4.3", "kernel", "1.5.0"); got != CompatFull {
+		t.Fatalf("reverse compatibility = %s, want %s", got, CompatFull)
+	}
+	if got := matrix.IsCompatible("kernel", "2.0.0", "sdk-go", "1.4.3"); got != CompatUntested {
+		t.Fatalf("version mismatch compatibility = %s, want %s", got, CompatUntested)
+	}
+	if got := matrix.IsCompatible("kernel", "1.5.0", "sdk-ts", "1.4.3"); got != CompatUntested {
+		t.Fatalf("component mismatch compatibility = %s, want %s", got, CompatUntested)
+	}
+
+	if matchesConstraint("not a constraint", "1.0.0") {
+		t.Fatal("invalid constraint should not match")
+	}
+	if matchesConstraint(">=1.0.0", "not-semver") {
+		t.Fatal("invalid version should not match")
+	}
+}
+
+func TestCoverageRegistryAdapter(t *testing.T) {
+	ctx := context.Background()
+	reg := registry.NewInMemoryRegistry()
+	adapter := NewRegistryAdapter(reg)
+	if adapter.reg != reg {
+		t.Fatal("adapter did not retain registry")
+	}
+
+	if _, err := adapter.GetPack(ctx, "missing"); err == nil {
+		t.Fatal("expected missing bundle lookup to fail")
+	}
+	if _, err := adapter.ListVersions(ctx, "missing"); err == nil {
+		t.Fatal("expected missing bundle version lookup to fail")
+	}
+
+	bundle := &manifest.Bundle{
+		Manifest: manifest.Module{
+			Name:        "core-pack",
+			Version:     "1.2.3",
+			Description: "core capabilities",
+			Capabilities: []manifest.CapabilityConfig{
+				{Name: "capture"},
+				{Name: "attest"},
+			},
+		},
+		Signature: "abc123",
+	}
+	if err := reg.Register(bundle); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	pack, err := adapter.GetPack(ctx, "core-pack")
+	if err != nil {
+		t.Fatalf("GetPack: %v", err)
+	}
+	if pack.PackID != "core-pack" || pack.Manifest.Version != "1.2.3" {
+		t.Fatalf("unexpected pack mapping: %+v", pack)
+	}
+	if len(pack.Manifest.Capabilities) != 2 || pack.Manifest.Capabilities[0] != "capture" {
+		t.Fatalf("capabilities = %#v", pack.Manifest.Capabilities)
+	}
+	if len(pack.Manifest.Signatures) != 1 || pack.Manifest.Signatures[0].Signature != "abc123" {
+		t.Fatalf("signature mapping = %#v", pack.Manifest.Signatures)
+	}
+
+	matches, err := adapter.FindByCapability(ctx, "attest")
+	if err != nil {
+		t.Fatalf("FindByCapability: %v", err)
+	}
+	if len(matches) != 1 || matches[0].PackID != "core-pack" {
+		t.Fatalf("matches = %#v", matches)
+	}
+	none, err := adapter.FindByCapability(ctx, "missing")
+	if err != nil {
+		t.Fatalf("FindByCapability missing: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("missing capability returned %#v", none)
+	}
+
+	versions, err := adapter.ListVersions(ctx, "core-pack")
+	if err != nil {
+		t.Fatalf("ListVersions: %v", err)
+	}
+	if len(versions) != 1 || versions[0].PackName != "core-pack" || versions[0].Version != "1.2.3" {
+		t.Fatalf("versions = %#v", versions)
+	}
+
+	signedPack := &Pack{
+		Manifest: PackManifest{
+			Name:         "published-pack",
+			Version:      "2.0.0",
+			Description:  "published from pack",
+			Capabilities: []string{"govern"},
+			Signatures: []Signature{{
+				Signature: "published-signature",
+				SignedAt:  time.Now().UTC(),
+			}},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := adapter.PublishPack(ctx, signedPack); err != nil {
+		t.Fatalf("PublishPack signed: %v", err)
+	}
+	published, err := reg.Get("published-pack")
+	if err != nil {
+		t.Fatalf("registry Get published: %v", err)
+	}
+	if published.Signature != "published-signature" {
+		t.Fatalf("published signature = %q", published.Signature)
+	}
+	if len(published.Manifest.Capabilities) != 1 || published.Manifest.Capabilities[0].Name != "govern" {
+		t.Fatalf("published capabilities = %#v", published.Manifest.Capabilities)
+	}
+
+	unsignedPack := &Pack{
+		Manifest: PackManifest{
+			Name:         "unsigned-pack",
+			Version:      "1.0.0",
+			Capabilities: []string{"observe"},
+		},
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := adapter.PublishPack(ctx, unsignedPack); err != nil {
+		t.Fatalf("PublishPack unsigned: %v", err)
+	}
+	unsigned, err := reg.Get("unsigned-pack")
+	if err != nil {
+		t.Fatalf("registry Get unsigned: %v", err)
+	}
+	if unsigned.Signature != "" {
+		t.Fatalf("unsigned signature = %q, want empty", unsigned.Signature)
+	}
+}

--- a/core/pkg/pack/verifier_telemetry_coverage_test.go
+++ b/core/pkg/pack/verifier_telemetry_coverage_test.go
@@ -1,0 +1,284 @@
+package pack
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCoverageVerifierSignatureEdges(t *testing.T) {
+	t.Run("VerifyPack rejects content hash mismatch", func(t *testing.T) {
+		verifier := NewVerifier(nil)
+		ok, err := verifier.VerifyPack(&Pack{
+			PackID:      "pack-1",
+			Manifest:    PackManifest{Name: "pack-1", Version: "1.0.0"},
+			ContentHash: "not-the-computed-hash",
+		})
+		if ok || err == nil {
+			t.Fatalf("VerifyPack ok=%v err=%v, want mismatch error", ok, err)
+		}
+	})
+
+	t.Run("VerifyPack succeeds with trusted Ed25519 signature", func(t *testing.T) {
+		p, anchor := coverageSignedVerifierPack(t)
+		verifier := NewVerifier(nil)
+		verifier.AddTrustAnchor(anchor)
+
+		ok, err := verifier.VerifyPack(p)
+		if err != nil {
+			t.Fatalf("VerifyPack: %v", err)
+		}
+		if !ok {
+			t.Fatal("VerifyPack returned false for valid signature")
+		}
+	})
+
+	t.Run("signature check reports no trust anchors", func(t *testing.T) {
+		check := NewVerifier(nil).verifySignature(ResolvedPack{
+			Manifest: PackManifest{Name: "pack-1", Version: "1.0.0"},
+		})
+		if check.Passed || check.Message != "No trust anchors configured" {
+			t.Fatalf("check = %+v", check)
+		}
+	})
+
+	t.Run("signature check reports missing signatures", func(t *testing.T) {
+		_, anchor := coverageSignedVerifierPack(t)
+		verifier := NewVerifier(nil)
+		verifier.AddTrustAnchor(anchor)
+
+		check := verifier.verifySignature(ResolvedPack{
+			Manifest: PackManifest{Name: "pack-1", Version: "1.0.0"},
+		})
+		if check.Passed || check.Message != "No signatures found on pack" {
+			t.Fatalf("check = %+v", check)
+		}
+	})
+
+	t.Run("signature check skips malformed anchor and signature encodings", func(t *testing.T) {
+		manifest := PackManifest{
+			Name:    "pack-1",
+			Version: "1.0.0",
+			Signatures: []Signature{{
+				SignerID:  "bad-anchor",
+				Signature: "00",
+			}, {
+				SignerID:  "good-anchor",
+				Signature: "not-hex",
+			}},
+		}
+		_, anchor := coverageSignedVerifierPack(t)
+		anchor.AnchorID = "good-anchor"
+
+		verifier := NewVerifier(nil)
+		verifier.AddTrustAnchor(TrustAnchor{AnchorID: "bad-anchor", PublicKey: "not-hex"})
+		verifier.AddTrustAnchor(anchor)
+
+		check := verifier.verifySignature(ResolvedPack{Manifest: manifest})
+		if check.Passed || check.Message != "No valid signature found from trusted anchors" {
+			t.Fatalf("check = %+v", check)
+		}
+	})
+
+	t.Run("signature check rejects wrong but well encoded signature", func(t *testing.T) {
+		_, anchor := coverageSignedVerifierPack(t)
+		manifest := PackManifest{
+			Name:    "pack-1",
+			Version: "1.0.0",
+			Signatures: []Signature{{
+				SignerID:  anchor.AnchorID,
+				Signature: hex.EncodeToString([]byte("wrong")),
+			}},
+		}
+		verifier := NewVerifier(nil)
+		verifier.AddTrustAnchor(anchor)
+
+		check := verifier.verifySignature(ResolvedPack{Manifest: manifest})
+		if check.Passed || check.Message != "No valid signature found from trusted anchors" {
+			t.Fatalf("check = %+v", check)
+		}
+	})
+}
+
+func TestCoverageTelemetryEdges(t *testing.T) {
+	t.Run("trust score clamps severe SLO violations at zero", func(t *testing.T) {
+		score := CalculateTrustScore(PackMetrics{
+			FailureRate:         10,
+			EvidenceSuccessRate: -1,
+			IncidentRate:        10,
+		}, &ServiceLevelObjectives{
+			MaxFailureRate:  0.01,
+			MinEvidenceRate: 0.99,
+			MaxIncidentRate: 0.01,
+		})
+		if score != 0 {
+			t.Fatalf("score = %f, want 0", score)
+		}
+	})
+
+	t.Run("ledger append reports open and marshal failures", func(t *testing.T) {
+		missingParent := filepath.Join(t.TempDir(), "missing", "ledger.jsonl")
+		if err := NewLedgerTelemetryHook(missingParent).append(&TelemetryEntry{}); err == nil {
+			t.Fatal("expected open failure for missing parent directory")
+		}
+
+		badDataPath := filepath.Join(t.TempDir(), "ledger.jsonl")
+		if err := NewLedgerTelemetryHook(badDataPath).append(&TelemetryEntry{Data: func() {}}); err == nil {
+			t.Fatal("expected initial marshal failure")
+		}
+
+		count := 0
+		flakyPath := filepath.Join(t.TempDir(), "ledger.jsonl")
+		if err := NewLedgerTelemetryHook(flakyPath).append(&TelemetryEntry{
+			Data: flakyJSON{count: &count},
+		}); err == nil {
+			t.Fatal("expected final marshal failure")
+		}
+	})
+
+	t.Run("ledger records evidence and returns metrics for missing and existing ledgers", func(t *testing.T) {
+		ctx := context.Background()
+		path := filepath.Join(t.TempDir(), "ledger.jsonl")
+		hook := NewLedgerTelemetryHook(path)
+		hook.RecordEvidenceGeneration(ctx, "pack-1", "1.0.0", "SOC2", true)
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile: %v", err)
+		}
+		if len(content) == 0 {
+			t.Fatal("expected evidence entry in ledger")
+		}
+
+		metrics, err := hook.GetMetrics(ctx, "pack-1", "1.0.0")
+		if err != nil {
+			t.Fatalf("GetMetrics existing: %v", err)
+		}
+		if metrics.PackID != "pack-1" || metrics.Version != "1.0.0" {
+			t.Fatalf("metrics = %+v", metrics)
+		}
+
+		missingMetrics, err := NewLedgerTelemetryHook(filepath.Join(t.TempDir(), "missing.jsonl")).
+			GetMetrics(ctx, "pack-2", "2.0.0")
+		if err != nil {
+			t.Fatalf("GetMetrics missing: %v", err)
+		}
+		if missingMetrics.PackID != "pack-2" || missingMetrics.Version != "2.0.0" {
+			t.Fatalf("missing metrics = %+v", missingMetrics)
+		}
+
+		noReadPath := filepath.Join(t.TempDir(), "no-read.jsonl")
+		if err := os.WriteFile(noReadPath, []byte("ledger"), 0600); err != nil {
+			t.Fatalf("WriteFile no-read: %v", err)
+		}
+		if err := os.Chmod(noReadPath, 0000); err != nil {
+			t.Fatalf("Chmod no-read: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(noReadPath, 0600) })
+		if _, err := NewLedgerTelemetryHook(noReadPath).GetMetrics(ctx, "pack-3", "3.0.0"); err == nil {
+			t.Fatal("expected unreadable ledger to fail")
+		}
+	})
+}
+
+func TestCoverageVerifierIntegrityEdges(t *testing.T) {
+	verifier := NewVerifier(nil)
+
+	empty, err := verifier.Verify(context.Background(), &VerificationRequest{
+		RequestID: "empty",
+		Packs:     []ResolvedPack{},
+		Options:   DefaultVerificationOptions(),
+	})
+	if err != nil {
+		t.Fatalf("Verify empty: %v", err)
+	}
+	if empty.Summary.AvgTrustScore != 0 {
+		t.Fatalf("empty average trust score = %f, want 0", empty.Summary.AvgTrustScore)
+	}
+
+	withDrill := ResolvedPack{
+		PackID: "pack-drill",
+		Manifest: PackManifest{
+			Name:    "pack-drill",
+			Version: "1.0.0",
+			Metadata: map[string]interface{}{
+				"drill:network-partition": "PASS",
+			},
+		},
+		ContentHash: "sha256:abc123",
+	}
+	result, err := verifier.Verify(context.Background(), &VerificationRequest{
+		RequestID: "drill",
+		Packs:     []ResolvedPack{withDrill},
+		Options: VerificationOptions{
+			RequiredChecks: []string{"integrity"},
+			RequiredDrills: []string{"network-partition"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Verify drill: %v", err)
+	}
+	foundDrill := false
+	for _, check := range result.PackResults[0].Checks {
+		if check.CheckType == CheckType("drill_network-partition") && check.Passed {
+			foundDrill = true
+		}
+	}
+	if !foundDrill {
+		t.Fatalf("drill check not verified: %+v", result.PackResults[0].Checks)
+	}
+}
+
+func coverageSignedVerifierPack(t *testing.T) (*Pack, TrustAnchor) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+
+	manifest := PackManifest{
+		Name:         "pack-1",
+		Version:      "1.0.0",
+		Capabilities: []string{"capture"},
+	}
+	hash := ComputePackHash(&Pack{Manifest: manifest})
+	signature := ed25519.Sign(priv, []byte(hash))
+	manifest.Signatures = []Signature{{
+		SignerID:  "anchor-1",
+		Signature: hex.EncodeToString(signature),
+		SignedAt:  time.Now().UTC(),
+		Algorithm: "ed25519",
+	}}
+
+	return &Pack{
+			PackID:      "pack-1",
+			Manifest:    manifest,
+			ContentHash: ComputePackHash(&Pack{Manifest: manifest}),
+		}, TrustAnchor{
+			AnchorID:   "anchor-1",
+			Name:       "HELM Signing Key",
+			PublicKey:  hex.EncodeToString(pub),
+			ValidFrom:  time.Now().Add(-time.Hour),
+			ValidUntil: time.Now().Add(time.Hour),
+			TrustLevel: 5,
+		}
+}
+
+type flakyJSON struct {
+	count *int
+}
+
+func (f flakyJSON) MarshalJSON() ([]byte, error) {
+	*f.count++
+	if *f.count == 1 {
+		return []byte(`"ok"`), nil
+	}
+	return nil, errors.New("flaky marshal failed")
+}


### PR DESCRIPTION
Adds focused pack package coverage for filesystem registry, dependency resolution, registry adapter mapping, verifier signature edges, telemetry ledger behavior, and compatibility matrix matching.

Verification:
- go test ./pkg/pack -count=1
- git diff --check