### PR TITLE
Cover governance edge cases

### DIFF
--- a/core/pkg/governance/arbitration_denial_coverage_test.go
+++ b/core/pkg/governance/arbitration_denial_coverage_test.go
@@ -1,0 +1,41 @@
+package governance
+
+import (
+	"testing"
+	"time"
+)
+
+func TestArbitrateFallbackAndTieBreakBranches(t *testing.T) {
+	inputs := []ArbitrationInput{
+		{RuleID: "allow-rule-a", Decision: "ALLOW"},
+		{RuleID: "allow-rule-b", Decision: "ALLOW"},
+	}
+	record := Arbitrate(inputs, "UNKNOWN")
+	if record == nil {
+		t.Fatal("expected fallback arbitration record")
+	}
+	if record.Strategy != StrategyStrictest {
+		t.Fatalf("Strategy=%s want %s", record.Strategy, StrategyStrictest)
+	}
+	if record.RuleBID != "allow-rule-b" {
+		t.Fatalf("RuleBID=%q want allow-rule-b", record.RuleBID)
+	}
+
+	escalated := Arbitrate([]ArbitrationInput{
+		{RuleID: "low-priority", Decision: "ALLOW", Priority: 1},
+		{RuleID: "high-priority", Decision: "DENY", Priority: 10},
+	}, StrategyEscalate)
+	if escalated.RuleAID != "high-priority" {
+		t.Fatalf("RuleAID=%q want high-priority", escalated.RuleAID)
+	}
+}
+
+func TestDenialLedgerWithClock(t *testing.T) {
+	ts := time.Date(2026, 6, 2, 12, 30, 0, 0, time.UTC)
+	ledger := NewDenialLedger().WithClock(func() time.Time { return ts })
+
+	receipt := ledger.Deny("agent-1", "deploy", DenialPolicy, "blocked")
+	if !receipt.DeniedAt.Equal(ts) {
+		t.Fatalf("DeniedAt=%v want %v", receipt.DeniedAt, ts)
+	}
+}

--- a/core/pkg/governance/components_test.go
+++ b/core/pkg/governance/components_test.go
@@ -72,6 +72,20 @@ func TestSignalController(t *testing.T) {
 	assert.Contains(t, string(env.Payload), "GREEN")
 }
 
+func TestSignalController_FailClosedEdges(t *testing.T) {
+	sc := NewSignalController("test-producer", &MockSigner{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := sc.Advise(ctx, "scale", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+
+	unsigned := NewSignalController("test-producer", nil)
+	_, err = unsigned.Advise(context.Background(), "scale", nil)
+	assert.Error(t, err)
+}
+
 func TestStateEstimator(t *testing.T) {
 	se := NewStateEstimator("test-producer", &MockSigner{})
 	assert.Equal(t, "state.estimator", se.Name())
@@ -79,6 +93,20 @@ func TestStateEstimator(t *testing.T) {
 	env, err := se.Advise(context.Background(), "scale", nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(env.Payload), "confidence")
+}
+
+func TestStateEstimator_FailClosedEdges(t *testing.T) {
+	se := NewStateEstimator("test-producer", &MockSigner{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := se.Advise(ctx, "scale", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+
+	unsigned := NewStateEstimator("test-producer", nil)
+	_, err = unsigned.Advise(context.Background(), "scale", nil)
+	assert.Error(t, err)
 }
 
 func TestComputePowerDelta(t *testing.T) {
@@ -100,6 +128,22 @@ func TestComputePowerDelta(t *testing.T) {
 	assert.Equal(t, 25, delta.RiskScoreDelta)
 }
 
+func TestComputePowerDelta_ScoresRemainingEffectClasses(t *testing.T) {
+	newModule := ModuleBundle{
+		Capabilities: []capabilities.Capability{
+			{ID: "cap-e3", EffectClass: "E3", Effects: []capabilities.EffectType{"write"}},
+			{ID: "cap-e1", EffectClass: "E1", Effects: []capabilities.EffectType{"read"}},
+			{ID: "cap-e0", EffectClass: "E0", Effects: []capabilities.EffectType{"observe"}},
+		},
+	}
+
+	delta := ComputePowerDelta(nil, newModule)
+
+	assert.Len(t, delta.NewCapabilities, 3)
+	assert.Equal(t, 13, delta.RiskScoreDelta)
+	assert.Equal(t, []capabilities.EffectType{"write", "read", "observe"}, delta.NewEffects)
+}
+
 func TestPolicyInductor(t *testing.T) {
 	pi := NewPolicyInductor("test-producer", &MockSigner{})
 	assert.Equal(t, "policy.inductor", pi.Name())
@@ -107,4 +151,10 @@ func TestPolicyInductor(t *testing.T) {
 	env, err := pi.Advise(context.Background(), "deploy", nil)
 	require.NoError(t, err)
 	assert.Contains(t, string(env.Payload), "pol-generic-allow")
+}
+
+func TestPolicyInductor_FailClosedSigning(t *testing.T) {
+	pi := NewPolicyInductor("test-producer", nil)
+	_, err := pi.Advise(context.Background(), "deploy", nil)
+	assert.Error(t, err)
 }

--- a/core/pkg/governance/decision_engine_coverage_test.go
+++ b/core/pkg/governance/decision_engine_coverage_test.go
@@ -1,0 +1,56 @@
+package governance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/capabilities"
+)
+
+func TestDecisionEngineEffectClassCoverage(t *testing.T) {
+	catalog := capabilities.NewToolCatalog()
+	catalog.Add(capabilities.Capability{ID: "read", EffectClass: string(EffectClassE1)})
+	catalog.Add(capabilities.Capability{ID: "invalid-effect", EffectClass: "E9"})
+
+	engine, err := NewDecisionEngine(catalog)
+	if err != nil {
+		t.Fatalf("NewDecisionEngine: %v", err)
+	}
+	if len(engine.PublicKey()) == 0 {
+		t.Fatal("PublicKey should return verifier material")
+	}
+
+	intent, err := engine.Evaluate(context.Background(), "intent-read", []byte(`{"action":"read"}`))
+	if err != nil {
+		t.Fatalf("E1 action should be permitted: %v", err)
+	}
+	if intent.TargetCapability != "read" {
+		t.Fatalf("TargetCapability=%q want read", intent.TargetCapability)
+	}
+
+	_, err = engine.Evaluate(context.Background(), "intent-missing", []byte(`{"action":"missing"}`))
+	if err == nil || !strings.Contains(err.Error(), "policy violation: E3 action 'missing'") {
+		t.Fatalf("missing catalog entry should default to E3 denial, got %v", err)
+	}
+
+	_, err = engine.Evaluate(context.Background(), "intent-invalid", []byte(`{"action":"invalid-effect"}`))
+	if err == nil || !strings.Contains(err.Error(), "policy violation: E3 action 'invalid-effect'") {
+		t.Fatalf("unknown effect class should default to E3 denial, got %v", err)
+	}
+}
+
+func TestDecisionEngineNilCatalogUsesLegacyPolicy(t *testing.T) {
+	engine, err := NewDecisionEngine(nil)
+	if err != nil {
+		t.Fatalf("NewDecisionEngine: %v", err)
+	}
+
+	intent, err := engine.Evaluate(context.Background(), "intent-deploy", []byte(`{"action":"deploy"}`))
+	if err != nil {
+		t.Fatalf("legacy allowlist should permit deploy with nil catalog: %v", err)
+	}
+	if intent.TargetCapability != "deploy" {
+		t.Fatalf("TargetCapability=%q want deploy", intent.TargetCapability)
+	}
+}

--- a/core/pkg/governance/edge_test.go
+++ b/core/pkg/governance/edge_test.go
@@ -1,0 +1,133 @@
+package governance
+
+import "testing"
+
+func TestEdgeAssistantShouldAllow(t *testing.T) {
+	tests := []struct {
+		name       string
+		assistant  EdgeAssistant
+		effectType string
+		riskLevel  string
+		want       bool
+	}{
+		{
+			name:       "full mode defers to complete pdp",
+			assistant:  EdgeAssistant{Config: EdgeConfig{Mode: EdgeFull}},
+			effectType: "any",
+			riskLevel:  "CRITICAL",
+			want:       true,
+		},
+		{
+			name: "reduced mode allows configured effect",
+			assistant: EdgeAssistant{Config: EdgeConfig{
+				Mode:           EdgeReduced,
+				AllowedEffects: []string{"DATA_READ"},
+			}},
+			effectType: "DATA_READ",
+			riskLevel:  "LOW",
+			want:       true,
+		},
+		{
+			name: "reduced mode denies unconfigured effect",
+			assistant: EdgeAssistant{Config: EdgeConfig{
+				Mode:           EdgeReduced,
+				AllowedEffects: []string{"DATA_READ"},
+			}},
+			effectType: "DATA_WRITE",
+			riskLevel:  "LOW",
+			want:       false,
+		},
+		{
+			name: "fallback deny all fails closed",
+			assistant: EdgeAssistant{
+				Config:   EdgeConfig{Mode: EdgeFallback},
+				Fallback: FallbackPolicy{Strategy: FallbackDenyAll},
+			},
+			effectType: "DATA_READ",
+			riskLevel:  "LOW",
+			want:       false,
+		},
+		{
+			name: "fallback ring fence allows matching low risk effect",
+			assistant: EdgeAssistant{
+				Config: EdgeConfig{Mode: EdgeFallback},
+				Fallback: FallbackPolicy{
+					Strategy:   FallbackRingFence,
+					AllowRules: []FallbackRule{{EffectType: "DATA_READ", MaxRisk: "MEDIUM"}},
+				},
+			},
+			effectType: "DATA_READ",
+			riskLevel:  "LOW",
+			want:       true,
+		},
+		{
+			name: "fallback ring fence denies excessive risk",
+			assistant: EdgeAssistant{
+				Config: EdgeConfig{Mode: EdgeFallback},
+				Fallback: FallbackPolicy{
+					Strategy:   FallbackRingFence,
+					AllowRules: []FallbackRule{{EffectType: "DATA_READ", MaxRisk: "LOW"}},
+				},
+			},
+			effectType: "DATA_READ",
+			riskLevel:  "HIGH",
+			want:       false,
+		},
+		{
+			name: "offline cached allow uses configured effects",
+			assistant: EdgeAssistant{
+				Config: EdgeConfig{
+					Mode:           EdgeOffline,
+					AllowedEffects: []string{"LOCAL_EXPLAIN"},
+				},
+				Fallback: FallbackPolicy{Strategy: FallbackCachedAllow},
+			},
+			effectType: "LOCAL_EXPLAIN",
+			riskLevel:  "LOW",
+			want:       true,
+		},
+		{
+			name: "offline cached allow denies unconfigured effect",
+			assistant: EdgeAssistant{
+				Config: EdgeConfig{
+					Mode:           EdgeOffline,
+					AllowedEffects: []string{"LOCAL_EXPLAIN"},
+				},
+				Fallback: FallbackPolicy{Strategy: FallbackCachedAllow},
+			},
+			effectType: "REMOTE_WRITE",
+			riskLevel:  "LOW",
+			want:       false,
+		},
+		{
+			name:       "unknown mode fails closed",
+			assistant:  EdgeAssistant{Config: EdgeConfig{Mode: "UNKNOWN"}},
+			effectType: "DATA_READ",
+			riskLevel:  "LOW",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.assistant.ShouldAllow(tt.effectType, tt.riskLevel); got != tt.want {
+				t.Fatalf("ShouldAllow()=%t want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRiskAtOrBelow(t *testing.T) {
+	if !isRiskAtOrBelow("MEDIUM", "HIGH") {
+		t.Fatal("MEDIUM should be at or below HIGH")
+	}
+	if isRiskAtOrBelow("CRITICAL", "HIGH") {
+		t.Fatal("CRITICAL should exceed HIGH")
+	}
+	if isRiskAtOrBelow("UNKNOWN", "LOW") {
+		t.Fatal("unknown actual risk should deny")
+	}
+	if isRiskAtOrBelow("LOW", "UNKNOWN") {
+		t.Fatal("unknown max risk should deny")
+	}
+}

--- a/core/pkg/governance/keyring_coverage_test.go
+++ b/core/pkg/governance/keyring_coverage_test.go
@@ -1,0 +1,23 @@
+package governance
+
+import "testing"
+
+func TestKeyringNilProviderFallbackAndMarshalError(t *testing.T) {
+	keyring := NewKeyring(nil)
+	if len(keyring.PublicKey()) == 0 {
+		t.Fatal("nil provider fallback should create a public key")
+	}
+
+	_, err := keyring.Sign(func() {})
+	if err == nil {
+		t.Fatal("non-marshalable payload should fail signing")
+	}
+}
+
+func TestKeyringDeriveForTenantRejectsEmptyTenant(t *testing.T) {
+	keyring := NewKeyring(nil)
+	_, err := keyring.DeriveForTenant("")
+	if err == nil {
+		t.Fatal("empty tenantID should fail")
+	}
+}

--- a/core/pkg/governance/lifecycle_test.go
+++ b/core/pkg/governance/lifecycle_test.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
@@ -56,6 +57,24 @@ func TestValidateModuleDependencies_CycleDetection(t *testing.T) {
 	assert.Contains(t, err.Error(), "cycle detected")
 }
 
+func TestValidateModuleDependencies_PolicyViolation(t *testing.T) {
+	mockPE := &MockPolicyEvaluator{}
+	lm := NewLifecycleManager(&MockRegistry{}, mockPE)
+	newModule := ModuleBundle{ID: "policy-blocked", Dependencies: []string{}}
+
+	mockPE.On("VerifyModulePolicy", mock.Anything, newModule).Return(errors.New("blocked by policy"))
+
+	err := lm.ValidateModuleDependencies(context.Background(), newModule, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "policy violation")
+	mockPE.AssertExpectations(t)
+}
+
+func TestSimplePolicyEvaluatorVerifyModulePolicy(t *testing.T) {
+	err := (&SimplePolicyEvaluator{}).VerifyModulePolicy(context.Background(), ModuleBundle{ID: "module"})
+	assert.NoError(t, err)
+}
+
 func TestExecuteActivation(t *testing.T) {
 	mockReg := &MockRegistry{}
 	mockPE := &MockPolicyEvaluator{}
@@ -81,6 +100,19 @@ func TestExecuteActivation(t *testing.T) {
 
 	mockReg.AssertExpectations(t)
 	mockPE.AssertExpectations(t)
+}
+
+func TestExecuteActivationDependencyValidationFailure(t *testing.T) {
+	lm := NewLifecycleManager(&MockRegistry{}, nil)
+	action := ActionActivateModule{
+		ModuleBundle: ModuleBundle{ID: "B", Dependencies: []string{"A"}},
+	}
+	decision := &contracts.DecisionRecord{Verdict: string(contracts.VerdictAllow)}
+	err := lm.ExecuteActivation(context.Background(), action, decision, map[string]ModuleBundle{
+		"A": {ID: "A", Dependencies: []string{"B"}},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "module dependency validation failed")
 }
 
 func TestMergeModuleSet_ReplacesExistingModuleDeterministically(t *testing.T) {

--- a/core/pkg/governance/liveness_test.go
+++ b/core/pkg/governance/liveness_test.go
@@ -189,6 +189,27 @@ func TestLivenessManagerActiveCount(t *testing.T) {
 	require.Equal(t, 1, lm.ActiveCount())
 }
 
+func TestLivenessManagerCleanupExpired(t *testing.T) {
+	lm := NewLivenessManager()
+	defer lm.Shutdown()
+
+	active := NewApprovalState("active", 1*time.Minute)
+	expired := NewApprovalState("expired", 1*time.Minute)
+	require.NoError(t, lm.Register(active))
+	require.NoError(t, lm.Register(expired))
+
+	expired.Expire()
+	require.Equal(t, 1, lm.CleanupExpired())
+
+	_, err := lm.Get("expired")
+	require.Error(t, err)
+
+	retained, err := lm.Get("active")
+	require.NoError(t, err)
+	require.Equal(t, LivenessStatePending, retained.State)
+	require.NotContains(t, lm.watchers, "expired")
+}
+
 // TestLivenessManagerPendingApprovals verifies filtering.
 func TestLivenessManagerPendingApprovals(t *testing.T) {
 	lm := NewLivenessManager()

--- a/core/pkg/governance/plan_commit_test.go
+++ b/core/pkg/governance/plan_commit_test.go
@@ -189,3 +189,14 @@ func TestPlanCommitController_HashMismatch(t *testing.T) {
 		t.Error("wrong hash should error")
 	}
 }
+
+func TestPlanCommitController_ApproveRejectUnknownPlan(t *testing.T) {
+	pc := NewPlanCommitController()
+
+	if err := pc.Approve("missing", "admin"); err == nil {
+		t.Fatal("approving unknown plan should fail")
+	}
+	if err := pc.Reject("missing", "admin", "not found"); err == nil {
+		t.Fatal("rejecting unknown plan should fail")
+	}
+}

--- a/core/pkg/governance/policy_engine_inline_coverage_test.go
+++ b/core/pkg/governance/policy_engine_inline_coverage_test.go
@@ -1,0 +1,80 @@
+package governance
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func TestPolicyEngineEvaluateRuntimeErrorFailsClosed(t *testing.T) {
+	engine, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+	if err := engine.LoadPolicy("runtime-error", `context.risk / 0 == 1`); err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+
+	decision, err := engine.Evaluate(context.Background(), "runtime-error", contracts.AccessRequest{
+		PrincipalID: "user-1",
+		Action:      "read",
+		ResourceID:  "doc-1",
+		Context:     map[string]interface{}{"risk": 10},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision.Verdict != "DENY" {
+		t.Fatalf("runtime errors should fail closed, got %s", decision.Verdict)
+	}
+	if !strings.Contains(decision.Reason, "Evaluation error:") {
+		t.Fatalf("expected evaluation error reason, got %q", decision.Reason)
+	}
+}
+
+func TestPolicyEngineEvaluateInlineErrors(t *testing.T) {
+	engine, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatalf("NewPolicyEngine: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		expr    string
+		vars    map[string]interface{}
+		wantErr string
+	}{
+		{
+			name:    "compile error",
+			expr:    "risk_score <",
+			vars:    map[string]interface{}{"risk_score": 50},
+			wantErr: "inline policy compilation failed:",
+		},
+		{
+			name:    "eval error",
+			expr:    "risk_score / zero == 1",
+			vars:    map[string]interface{}{"risk_score": 50, "zero": 0},
+			wantErr: "inline evaluation failed:",
+		},
+		{
+			name:    "non bool",
+			expr:    "risk_score",
+			vars:    map[string]interface{}{"risk_score": 50},
+			wantErr: "inline expression did not evaluate to bool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, err := engine.EvaluateInline(tt.expr, tt.vars)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected %q error, allowed=%t err=%v", tt.wantErr, allowed, err)
+			}
+			if allowed {
+				t.Fatal("error cases must fail closed")
+			}
+		})
+	}
+}

--- a/core/pkg/governance/security_test.go
+++ b/core/pkg/governance/security_test.go
@@ -118,6 +118,14 @@ func TestCompensationState(t *testing.T) {
 		require.Equal(t, CompensationOutcomeFallback, outcome)
 		require.True(t, cs.FallbackExecuted)
 	})
+
+	t.Run("unknown policy escalates by default", func(t *testing.T) {
+		cs := NewCompensationState("tx-1", "op-1", "UNKNOWN")
+		cs.AttemptCount = MaxCompensationAttempts - 1
+
+		outcome := cs.RecordAttempt(false, "")
+		require.Equal(t, CompensationOutcomeEscalate, outcome)
+	})
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- add focused governance tests for arbitration, edge assistant, decision engine, keyring, policy engine, liveness, lifecycle, and component fail-closed branches
- cover unknown-plan approval/rejection and compensation escalation defaults

## Validation
- git diff --check
- cd core && go test ./pkg/governance -count=1
- make verify-boundary