### PR TITLE
Cover executor evidence edge cases

### DIFF
--- a/core/pkg/executor/evidence_pack_test.go
+++ b/core/pkg/executor/evidence_pack_test.go
@@ -242,6 +242,27 @@ func TestEvidencePackValidation_RequiredFields(t *testing.T) {
 			},
 			wantErr: "effect.effect_id is required",
 		},
+		{
+			name: "missing execution_id",
+			pack: &contracts.EvidencePack{
+				PackID:   "pack-1",
+				Identity: contracts.EvidencePackIdentity{ActorID: "user-1"},
+				Policy:   contracts.EvidencePackPolicy{DecisionID: "dec-1"},
+				Effect:   contracts.EvidencePackEffect{EffectID: "effect-1"},
+			},
+			wantErr: "execution.execution_id is required",
+		},
+		{
+			name: "missing execution status",
+			pack: &contracts.EvidencePack{
+				PackID:    "pack-1",
+				Identity:  contracts.EvidencePackIdentity{ActorID: "user-1"},
+				Policy:    contracts.EvidencePackPolicy{DecisionID: "dec-1"},
+				Effect:    contracts.EvidencePackEffect{EffectID: "effect-1"},
+				Execution: contracts.EvidencePackExecution{ExecutionID: "exec-1"},
+			},
+			wantErr: "execution.status is required",
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/pkg/executor/evidence_visualizer_coverage_test.go
+++ b/core/pkg/executor/evidence_visualizer_coverage_test.go
@@ -1,0 +1,118 @@
+package executor
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateVisualEvidenceAndReasoningErrors(t *testing.T) {
+	verifier := NewVisualEvidenceVerifier(&VisualEvidenceConfig{
+		MaxSnapshotsPerPack:  2,
+		MaxReasoningSteps:    1,
+		EnableDiffTracking:   true,
+		VerifyReasoningChain: true,
+	})
+
+	_, err := verifier.CreateVisualEvidence(nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "evidence pack is required")
+
+	evidence, err := verifier.CreateVisualEvidence(createTestPack(), nil)
+	require.NoError(t, err)
+	_, err = verifier.AttachReasoningChain(evidence, []ReasoningStep{
+		{StepID: "step-1", Timestamp: time.Now()},
+		{StepID: "step-2", Timestamp: time.Now().Add(time.Second)},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many reasoning steps")
+}
+
+func TestVisualEvidenceVerifyFailureBranches(t *testing.T) {
+	verifier := NewVisualEvidenceVerifier(DefaultVisualEvidenceConfig())
+	pack := createTestPack()
+	now := time.Now()
+	content := map[string]interface{}{"key": "value"}
+
+	evidence := &VisualEvidence{
+		Pack: pack,
+		Snapshots: []VisualSnapshot{
+			{
+				SnapshotID:  "snap-1",
+				SequenceNum: 2,
+				Timestamp:   now,
+				Content:     content,
+				ContentHash: "wrong",
+			},
+			{
+				SnapshotID:   "snap-2",
+				SequenceNum:  3,
+				Timestamp:    now.Add(time.Second),
+				Content:      map[string]interface{}{"key": "value2"},
+				ContentHash:  computeContentHash(map[string]interface{}{"key": "value2"}),
+				DiffFromPrev: &SnapshotDiff{PreviousSnapshotID: "not-snap-1"},
+			},
+		},
+		CreatedAt: now,
+	}
+	evidence.VisualHash = computeVisualHash(evidence)
+
+	result, err := verifier.Verify(context.Background(), evidence)
+	require.NoError(t, err)
+	require.False(t, result.Verified)
+	require.Contains(t, failureCheckIDs(result), "snapshot_sequence")
+	require.Contains(t, failureCheckIDs(result), "snapshot_content_hashes")
+	require.Contains(t, failureCheckIDs(result), "diff_chain")
+}
+
+func TestVisualEvidenceReasoningVerifierBranches(t *testing.T) {
+	verifier := NewVisualEvidenceVerifier(nil)
+	snapshots := []VisualSnapshot{{SnapshotID: "snap-1"}}
+
+	require.True(t, verifier.verifyReasoningChain(&ReasoningChain{}, snapshots))
+
+	require.False(t, verifier.verifyReasoningChain(&ReasoningChain{
+		Steps: []ReasoningStep{{StepID: "after-missing", SequenceNum: 1, SnapshotAfter: "missing"}},
+	}, snapshots))
+
+	require.False(t, verifier.verifyReasoningChain(&ReasoningChain{
+		Steps: []ReasoningStep{{StepID: "bad-sequence", SequenceNum: 2}},
+	}, snapshots))
+
+	chain := &ReasoningChain{
+		ChainID: "chain-1",
+		PackID:  "pack-1",
+		Steps:   []ReasoningStep{{StepID: "step-1", SequenceNum: 1}},
+	}
+	chain.ChainHash = "wrong"
+	require.False(t, verifier.verifyReasoningChain(chain, snapshots))
+}
+
+func TestVisualEvidenceHelperEdges(t *testing.T) {
+	verifier := NewVisualEvidenceVerifier(nil)
+	require.True(t, verifier.verifyDiffChain([]VisualSnapshot{
+		{SnapshotID: "snap-1"},
+		{SnapshotID: "snap-2"},
+	}))
+
+	diff := computeSnapshotDiff(&VisualSnapshot{SnapshotID: "prev"}, &VisualSnapshot{SnapshotID: "curr"})
+	require.Equal(t, "prev", diff.PreviousSnapshotID)
+	require.NotEmpty(t, diff.DiffHash)
+
+	require.Equal(t, "marshal-error", computeVisualHash(&VisualEvidence{
+		Pack:      createTestPack(),
+		Snapshots: []VisualSnapshot{{Content: map[string]interface{}{"bad": math.Inf(1)}}},
+	}))
+	require.Equal(t, "marshal-error", computeContentHash(map[string]interface{}{"bad": math.Inf(1)}))
+}
+
+func failureCheckIDs(result *VerificationResult) []string {
+	ids := make([]string, 0, len(result.ChecksFailed))
+	for _, failure := range result.ChecksFailed {
+		ids = append(ids, failure.CheckID)
+	}
+	return ids
+}

--- a/core/pkg/executor/merkle_coverage_test.go
+++ b/core/pkg/executor/merkle_coverage_test.go
@@ -1,0 +1,131 @@
+package executor
+
+import (
+	"errors"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerkleBuilderAddLeafCanonicalError(t *testing.T) {
+	builder := NewMerkleBuilder()
+	err := builder.AddLeaf("/bad", math.Inf(1), false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to serialize leaf")
+}
+
+func TestVerifyProofRejectsMalformedHashes(t *testing.T) {
+	tests := []struct {
+		name  string
+		proof *MerkleProof
+		want  string
+	}{
+		{
+			name:  "leaf hash",
+			proof: &MerkleProof{LeafHash: "not-hex", Root: strings.Repeat("0", 64)},
+			want:  "invalid leaf hash",
+		},
+		{
+			name: "sibling hash",
+			proof: &MerkleProof{
+				LeafHash: strings.Repeat("0", 64),
+				Root:     strings.Repeat("0", 64),
+				Siblings: []MerkleSibling{{Hash: "not-hex", Position: "right"}},
+			},
+			want: "invalid sibling hash",
+		},
+		{
+			name:  "root hash",
+			proof: &MerkleProof{LeafHash: strings.Repeat("0", 64), Root: "not-hex"},
+			want:  "invalid root hash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid, err := VerifyProof(tt.proof)
+			require.False(t, valid)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestEvidenceViewDeriveAndVerifyErrors(t *testing.T) {
+	builder := NewMerkleBuilder()
+	require.NoError(t, builder.AddLeaf("/identity", map[string]any{"id": "test"}, false))
+	require.NoError(t, builder.AddLeaf("/policy", map[string]any{"policy": "default"}, false))
+	tree, err := builder.Build()
+	require.NoError(t, err)
+
+	_, err = tree.DeriveView("view-err", "pack-1", []string{"/identity"}, func(string) (any, error) {
+		return nil, errors.New("data unavailable")
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to get data")
+
+	view, err := tree.DeriveView("view-root-mismatch", "pack-1", []string{"/identity"}, nil)
+	require.NoError(t, err)
+	view.Proofs[0].Root = strings.Repeat("0", 64)
+	valid, err := VerifyView(view)
+	require.False(t, valid)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "proof root mismatch")
+
+	view, err = tree.DeriveView("view-invalid-proof", "pack-1", []string{"/identity"}, nil)
+	require.NoError(t, err)
+	view.Proofs[0].LeafHash = "not-hex"
+	valid, err = VerifyView(view)
+	require.False(t, valid)
+	require.Error(t, err)
+
+	malformedTree := &MerkleTree{
+		Root:   []byte{0x01},
+		Leaves: []MerkleLeaf{{Index: 3, Path: "/bad", Hash: []byte{0x01}}},
+		Levels: [][][]byte{{{0x01}}},
+	}
+	_, err = malformedTree.DeriveView("view-bad-index", "pack-1", []string{"/bad"}, nil)
+	require.Error(t, err)
+
+	falseProofView := &EvidenceView{
+		RootHash: strings.Repeat("f", 64),
+		Proofs: []MerkleProof{{
+			LeafPath: "/false",
+			LeafHash: strings.Repeat("0", 64),
+			Root:     strings.Repeat("f", 64),
+		}},
+	}
+	valid, err = VerifyView(falseProofView)
+	require.False(t, valid)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid proof")
+}
+
+func TestMerkleCanonicalHelpersPropagateErrors(t *testing.T) {
+	_, err := canonicalJSON(math.Inf(1))
+	require.Error(t, err)
+
+	_, err = canonicalJSON(invalidJSONBytes{})
+	require.Error(t, err)
+
+	_, err = marshalCanonical(map[string]any{"bad": math.Inf(1)})
+	require.Error(t, err)
+
+	_, err = marshalCanonical([]any{"ok", math.Inf(1)})
+	require.Error(t, err)
+
+	_, err = marshalCanonical(math.Inf(1))
+	require.Error(t, err)
+
+	canonicalArray, err := marshalCanonical([]any{"ok", float64(2)})
+	require.NoError(t, err)
+	require.Equal(t, `["ok",2]`, string(canonicalArray))
+}
+
+type invalidJSONBytes struct{}
+
+func (invalidJSONBytes) MarshalJSON() ([]byte, error) {
+	return []byte("{"), nil
+}

--- a/core/pkg/executor/pack_exporter_coverage_test.go
+++ b/core/pkg/executor/pack_exporter_coverage_test.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func TestPackExporter_AccessReviewAndVendorExports(t *testing.T) {
+	exporter := NewPackExporter("test-signer", mustSigner(t))
+	ctx := context.Background()
+	reviewedAt := time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC)
+
+	accessPack, err := exporter.ExportAccessReviewPack(ctx, &contracts.AccessReviewPack{
+		PackID:     "access-1",
+		PackType:   "ACCESS_REVIEW_PACK",
+		Scope:      "prod",
+		ReviewedAt: reviewedAt,
+		Reviews: []contracts.AccessReviewItem{{
+			SubjectID:  "agent-1",
+			Resource:   "database",
+			Permission: "read",
+			Decision:   "APPROVED",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ExportAccessReviewPack: %v", err)
+	}
+	if accessPack.Attestation.GeneratedAt.IsZero() {
+		t.Fatal("access review GeneratedAt should be populated")
+	}
+	if accessPack.Attestation.PackHash == "" || accessPack.Attestation.Signature == "" {
+		t.Fatal("access review attestation should include hash and signature")
+	}
+
+	vendorPack, err := exporter.ExportVendorDueDiligencePack(ctx, &contracts.VendorDueDiligencePack{
+		PackID:         "vendor-1",
+		PackType:       "VENDOR_DUE_DILIGENCE_PACK",
+		VendorName:     "Example Vendor",
+		AssessmentDate: reviewedAt,
+		ComplianceChecks: []contracts.VendorComplianceCheck{{
+			Standard: "SOC2",
+			Status:   "COMPLIANT",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ExportVendorDueDiligencePack: %v", err)
+	}
+	if vendorPack.Attestation.GeneratedAt.IsZero() {
+		t.Fatal("vendor GeneratedAt should be populated")
+	}
+	if vendorPack.Attestation.PackHash == "" || vendorPack.Attestation.Signature == "" {
+		t.Fatal("vendor attestation should include hash and signature")
+	}
+}
+
+func TestPackExporter_SignFailures(t *testing.T) {
+	exporter := NewPackExporter("test-signer", failingPackSigner{})
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "change",
+			run: func() error {
+				_, err := exporter.ExportChangePack(ctx, &contracts.ChangePack{PackID: "change-1"})
+				return err
+			},
+		},
+		{
+			name: "incident",
+			run: func() error {
+				_, err := exporter.ExportIncidentPack(ctx, &contracts.IncidentPack{PackID: "incident-1"})
+				return err
+			},
+		},
+		{
+			name: "access review",
+			run: func() error {
+				_, err := exporter.ExportAccessReviewPack(ctx, &contracts.AccessReviewPack{PackID: "access-1"})
+				return err
+			},
+		},
+		{
+			name: "vendor",
+			run: func() error {
+				_, err := exporter.ExportVendorDueDiligencePack(ctx, &contracts.VendorDueDiligencePack{PackID: "vendor-1"})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil || !strings.Contains(err.Error(), "failed to sign pack") {
+				t.Fatalf("expected signing failure, got %v", err)
+			}
+		})
+	}
+}
+
+func TestPackExporter_ComputePackHashErrors(t *testing.T) {
+	exporter := &packExporter{}
+
+	if _, err := exporter.computePackHash(map[string]any{"bad": math.Inf(1)}); err == nil {
+		t.Fatal("unsupported JSON values should fail hash computation")
+	}
+	if _, err := exporter.computePackHash([]string{"not", "an", "object"}); err == nil {
+		t.Fatal("non-object JSON should fail map decode")
+	}
+}
+
+type failingPackSigner struct{}
+
+func (failingPackSigner) Sign([]byte) (string, error) {
+	return "", errors.New("sign failed")
+}
+
+func (failingPackSigner) PublicKey() string { return "test-key" }
+
+func (failingPackSigner) PublicKeyBytes() []byte { return []byte("test-key") }
+
+func (failingPackSigner) SignDecision(*contracts.DecisionRecord) error { return nil }
+
+func (failingPackSigner) SignIntent(*contracts.AuthorizedExecutionIntent) error { return nil }
+
+func (failingPackSigner) SignReceipt(*contracts.Receipt) error { return nil }


### PR DESCRIPTION
## Summary
- cover executor EvidencePack required-field validation branches
- add visual evidence verification error branch tests
- cover Merkle proof/canonicalization failures and pack exporter signing/hash failures

## Validation
- git diff --check
- cd core && go test ./pkg/executor -count=1
- make verify-boundary