### PR TITLE
Cover trust edge cases

### DIFF
--- a/core/pkg/trust/compliance_pipeline_test.go
+++ b/core/pkg/trust/compliance_pipeline_test.go
@@ -62,6 +62,13 @@ func TestCompliancePipeline_IngestMapping(t *testing.T) {
 	if len(updatedCtrl.EvidenceIDs) != 1 || updatedCtrl.EvidenceIDs[0] != "ev-log-001" {
 		t.Errorf("evidence not linked correctly")
 	}
+
+	if err := pipeline.IngestMapping(bytes); err != nil {
+		t.Fatalf("second IngestMapping failed: %v", err)
+	}
+	if len(updatedCtrl.EvidenceIDs) != 1 {
+		t.Fatalf("duplicate evidence should not be linked twice: %#v", updatedCtrl.EvidenceIDs)
+	}
 }
 
 func TestCompliancePipeline_ScanForStaleControls(t *testing.T) {

--- a/core/pkg/trust/compliance_test.go
+++ b/core/pkg/trust/compliance_test.go
@@ -126,6 +126,12 @@ func TestComplianceMatrix_GetFrameworkCompliance(t *testing.T) {
 	assert.Equal(t, 0.5, compliance.ComplianceScore)
 }
 
+func TestComplianceMatrix_GetFrameworkComplianceMissing(t *testing.T) {
+	matrix := NewComplianceMatrix()
+	_, err := matrix.GetFrameworkCompliance("missing")
+	assert.Error(t, err)
+}
+
 func TestComplianceMatrix_Hash(t *testing.T) {
 	matrix := NewComplianceMatrix()
 

--- a/core/pkg/trust/eu_trusted_list_test.go
+++ b/core/pkg/trust/eu_trusted_list_test.go
@@ -3,6 +3,7 @@ package trust
 import (
 	"context"
 	"encoding/xml"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -139,6 +140,46 @@ func TestEUTrustedList_RefreshHTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "status 500")
 }
 
+func TestEUTrustedList_RefreshRequestAndReadErrors(t *testing.T) {
+	t.Run("request build error", func(t *testing.T) {
+		list := NewEUTrustedListWithConfig(EUTrustedListConfig{Endpoint: "http://[::1"})
+		err := list.Refresh(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build request")
+	})
+
+	t.Run("transport error", func(t *testing.T) {
+		list := NewEUTrustedListWithConfig(EUTrustedListConfig{
+			Endpoint: "https://example.invalid/lotl.xml",
+			HTTPClient: &http.Client{
+				Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return nil, errors.New("transport failed")
+				}),
+			},
+		})
+		err := list.Refresh(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "transport failed")
+	})
+
+	t.Run("body read error", func(t *testing.T) {
+		list := NewEUTrustedListWithConfig(EUTrustedListConfig{
+			Endpoint: "https://example.invalid/lotl.xml",
+			HTTPClient: &http.Client{
+				Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       errorReadCloser{},
+					}, nil
+				}),
+			},
+		})
+		err := list.Refresh(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read body")
+	})
+}
+
 func TestEUTrustedList_RefreshMalformedXML(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/xml")
@@ -165,6 +206,42 @@ func TestParseLOTL_RejectsEmpty(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEUTrustedList_LoadFromBytesRejectsMalformedXML(t *testing.T) {
+	list := NewEUTrustedList()
+	err := list.LoadFromBytes([]byte("<"))
+	require.Error(t, err)
+}
+
+func TestParseLOTL_SkipsNonQualifiedAndUsesFallbackNames(t *testing.T) {
+	doc := lotlDocument{
+		SchemeOperator: lotlMultiLangName{Name: []struct {
+			Lang  string `xml:"lang,attr"`
+			Value string `xml:",chardata"`
+		}{{Lang: "fr", Value: "Commission europeenne"}}},
+		TSPs: []lotlTSP{{
+			Country: "nl",
+			Services: []lotlService{
+				{ServiceTypeIdentifier: "other", ServiceStatus: grantedStatusURI},
+				{
+					ServiceTypeIdentifier: qualifiedTimestampingService,
+					ServiceStatus:         grantedStatusURI,
+					ServiceDigitalIdentity: lotlServiceDigitalIdentity{DigitalID: []struct {
+						X509Certificate    string `xml:"X509Certificate"`
+						X509SubjectName    string `xml:"X509SubjectName"`
+						X509CertificateSHA string `xml:"X509CertificateSHA256"`
+					}{{X509Certificate: "aGVsbG8="}}},
+				},
+			},
+		}},
+	}
+	body, err := xml.Marshal(doc)
+	require.NoError(t, err)
+	parsed, err := parseLOTL(body)
+	require.NoError(t, err)
+	assert.Equal(t, "Commission europeenne", parsed.schemeOperator)
+	assert.Len(t, parsed.thumbprints, 1)
+}
+
 func TestComputeThumbprint_PrefersProvidedSHA(t *testing.T) {
 	tp := computeThumbprint("ZZZ-not-base64", "ABC123")
 	assert.Equal(t, "abc123", tp)
@@ -179,6 +256,27 @@ func TestComputeThumbprint_DerivesFromBase64(t *testing.T) {
 
 func TestComputeThumbprint_EmptyInputReturnsEmpty(t *testing.T) {
 	assert.Equal(t, "", computeThumbprint("", ""))
+}
+
+func TestComputeThumbprint_URLSafeAndInvalidBase64(t *testing.T) {
+	assert.NotEmpty(t, computeThumbprint("-_8=", ""))
+	assert.Equal(t, "", computeThumbprint("not valid base64!", ""))
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type errorReadCloser struct{}
+
+func (errorReadCloser) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}
+
+func (errorReadCloser) Close() error {
+	return nil
 }
 
 // atomicClock is a tiny test helper for monotonic UTC time advancement

--- a/core/pkg/trust/leaderboard_test.go
+++ b/core/pkg/trust/leaderboard_test.go
@@ -118,6 +118,18 @@ func TestLeaderboard_UpdateAndRerank(t *testing.T) {
 	assert.Equal(t, 1, lb.Entries[0].Rank)
 }
 
+func TestLeaderboard_RankUsesOrgIDWhenNameMissing(t *testing.T) {
+	lb := NewLeaderboard()
+	lb.UpdateScore("org-no-name", "", &TrustScore{
+		ScoreID:      "s1",
+		OverallScore: 0.70,
+		ComputedAt:   time.Now(),
+	})
+	lb.Rank()
+	require.Len(t, lb.Entries, 1)
+	assert.Equal(t, "org-no-name", lb.Entries[0].OrgName)
+}
+
 func TestLeaderboard_GetTopN(t *testing.T) {
 	scores := map[string]*TrustScore{
 		"org-1": {ScoreID: "s1", OverallScore: 0.90, ComputedAt: time.Now()},

--- a/core/pkg/trust/rekor_client_test.go
+++ b/core/pkg/trust/rekor_client_test.go
@@ -3,6 +3,8 @@ package trust
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -235,4 +237,258 @@ func TestGetCheckpointRef(t *testing.T) {
 	if ref.VerifiedAt.IsZero() {
 		t.Error("VerifiedAt should be set")
 	}
+}
+
+func TestRekorClientHTTPFlows(t *testing.T) {
+	body := RekorBody{Kind: "helmpack", APIVersion: "v1"}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafHash := computeLeafHash(bodyBytes)
+	entry := RekorEntry{
+		LogID:          RekorLogID,
+		LogIndex:       0,
+		IntegratedTime: 1700000000,
+		Body:           body,
+		InclusionProof: &InclusionProof{
+			LogIndex: 0,
+			RootHash: leafHash,
+			TreeSize: 1,
+			Hashes:   []string{},
+		},
+	}
+
+	t.Run("VerifyEntry succeeds through search and fetch", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/index/retrieve":
+				if r.Method != http.MethodPost {
+					t.Fatalf("search method = %s", r.Method)
+				}
+				_ = json.NewEncoder(w).Encode([]string{"entry-1"})
+			case "/api/v1/log/entries/entry-1":
+				_ = json.NewEncoder(w).Encode(map[string]RekorEntry{"entry-1": entry})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		client, err := NewRekorClient(RekorClientConfig{LogURL: server.URL})
+		if err != nil {
+			t.Fatalf("NewRekorClient: %v", err)
+		}
+		got, err := client.VerifyEntry("sha256:abc")
+		if err != nil {
+			t.Fatalf("VerifyEntry: %v", err)
+		}
+		if got.LogID != RekorLogID {
+			t.Fatalf("entry = %+v", got)
+		}
+	})
+
+	t.Run("search handles non-success bad json and empty ids", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			handler http.HandlerFunc
+		}{
+			{
+				name: "server error",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "broken", http.StatusInternalServerError)
+				},
+			},
+			{
+				name: "bad json",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte("{"))
+				},
+			},
+			{
+				name: "empty ids",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					_ = json.NewEncoder(w).Encode([]string{})
+				},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				server := httptest.NewServer(tt.handler)
+				defer server.Close()
+				client, err := NewRekorClient(RekorClientConfig{LogURL: server.URL})
+				if err != nil {
+					t.Fatalf("NewRekorClient: %v", err)
+				}
+				if _, err := client.searchByHash("sha256:abc"); err == nil {
+					t.Fatal("expected search error")
+				}
+			})
+		}
+	})
+
+	t.Run("search handles request construction and transport errors", func(t *testing.T) {
+		badRequest := &RekorClient{logURL: "http://[::1", httpClient: http.DefaultClient}
+		if _, err := badRequest.searchByHash("sha256:abc"); err == nil {
+			t.Fatal("expected request construction error")
+		}
+
+		transportError := &RekorClient{
+			logURL: "https://rekor.invalid",
+			httpClient: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, assertAnError{}
+			})},
+		}
+		if _, err := transportError.searchByHash("sha256:abc"); err == nil {
+			t.Fatal("expected transport error")
+		}
+	})
+
+	t.Run("fetch handles non-success bad json fallback and missing entry", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			handler http.HandlerFunc
+			wantOK  bool
+		}{
+			{
+				name: "server error",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					http.Error(w, "missing", http.StatusNotFound)
+				},
+			},
+			{
+				name: "bad json",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					_, _ = w.Write([]byte("{"))
+				},
+			},
+			{
+				name: "fallback first entry",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					_ = json.NewEncoder(w).Encode(map[string]RekorEntry{"other": entry})
+				},
+				wantOK: true,
+			},
+			{
+				name: "empty map",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					_ = json.NewEncoder(w).Encode(map[string]RekorEntry{})
+				},
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				server := httptest.NewServer(tt.handler)
+				defer server.Close()
+				client, err := NewRekorClient(RekorClientConfig{LogURL: server.URL})
+				if err != nil {
+					t.Fatalf("NewRekorClient: %v", err)
+				}
+				got, err := client.fetchEntry("entry-1")
+				if tt.wantOK {
+					if err != nil || got == nil {
+						t.Fatalf("fetchEntry got %+v err=%v", got, err)
+					}
+					return
+				}
+				if err == nil {
+					t.Fatal("expected fetch error")
+				}
+			})
+		}
+	})
+
+	t.Run("VerifyEntry reports inclusion and tree-head failures", func(t *testing.T) {
+		noProof := entry
+		noProof.InclusionProof = nil
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/index/retrieve":
+				_ = json.NewEncoder(w).Encode([]string{"entry-1"})
+			case "/api/v1/log/entries/entry-1":
+				_ = json.NewEncoder(w).Encode(map[string]RekorEntry{"entry-1": noProof})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+		client, err := NewRekorClient(RekorClientConfig{LogURL: server.URL})
+		if err != nil {
+			t.Fatalf("NewRekorClient: %v", err)
+		}
+		if _, err := client.VerifyEntry("sha256:abc"); err == nil {
+			t.Fatal("expected inclusion proof failure")
+		}
+
+		regressionServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v1/index/retrieve":
+				_ = json.NewEncoder(w).Encode([]string{"entry-1"})
+			case "/api/v1/log/entries/entry-1":
+				_ = json.NewEncoder(w).Encode(map[string]RekorEntry{"entry-1": entry})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer regressionServer.Close()
+		client, err = NewRekorClient(RekorClientConfig{
+			LogURL:      regressionServer.URL,
+			TrustedRoot: &SignedTreeHead{TreeSize: 2},
+		})
+		if err != nil {
+			t.Fatalf("NewRekorClient regression: %v", err)
+		}
+		if _, err := client.VerifyEntry("sha256:abc"); err == nil {
+			t.Fatal("expected signed tree head failure")
+		}
+	})
+}
+
+func TestRekorClientAdditionalProofEdges(t *testing.T) {
+	client := &RekorClient{}
+
+	if err := client.verifySignedTreeHead(&RekorEntry{}); err == nil {
+		t.Fatal("expected missing proof error")
+	}
+	if _, err := computeRootFromProof(0, 1, "not-base64", []string{"also-not-base64"}); err == nil {
+		t.Fatal("expected leaf decode error")
+	}
+	leafHash := computeLeafHash([]byte("right"))
+	if _, err := computeRootFromProof(1, 2, leafHash, []string{"not-base64"}); err == nil {
+		t.Fatal("expected proof decode error")
+	}
+
+	left := computeLeafHash([]byte("left"))
+	right := computeLeafHash([]byte("right"))
+	if _, err := computeRootFromProof(1, 2, right, []string{left}); err != nil {
+		t.Fatalf("odd-index proof: %v", err)
+	}
+
+	if err := VerifyInclusionProofBytes([]byte("leaf"), &InclusionProof{
+		LogIndex: 0,
+		RootHash: "unused",
+		TreeSize: 1,
+		Hashes:   []string{"not-base64"},
+	}); err == nil {
+		t.Fatal("expected proof decode error")
+	}
+
+	mismatch := &RekorEntry{
+		Body: RekorBody{Kind: "helmpack"},
+		InclusionProof: &InclusionProof{
+			LogIndex: 0,
+			RootHash: "wrong-root",
+			TreeSize: 1,
+			Hashes:   []string{},
+		},
+	}
+	if err := client.verifyInclusionProof(mismatch); err == nil {
+		t.Fatal("expected inclusion root mismatch")
+	}
+}
+
+type assertAnError struct{}
+
+func (assertAnError) Error() string {
+	return "transport failed"
 }

--- a/core/pkg/trust/signature_verifier_test.go
+++ b/core/pkg/trust/signature_verifier_test.go
@@ -2,10 +2,14 @@ package trust
 
 import (
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"testing"
 )
 
@@ -101,5 +105,110 @@ func TestVerifySignatures_TamperedContent(t *testing.T) {
 	// 4. Verify -> Should fail
 	if err := verifier.VerifySignatures(role, 1); err == nil {
 		t.Error("Expected failure for tampered content, got success")
+	}
+}
+
+func TestVerifySignatures_EdgeCases(t *testing.T) {
+	verifier := NewSignatureVerifier(map[string]crypto.PublicKey{})
+	if err := verifier.VerifySignatures(nil, 1); err == nil {
+		t.Fatal("expected nil signed role error")
+	}
+	if err := verifier.VerifySignatures(&SignedRole{}, 1); err == nil {
+		t.Fatal("expected missing signatures error")
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := []byte(`{"test":"content"}`)
+	hash := sha256.Sum256(content)
+	sig := ed25519.Sign(priv, hash[:])
+	verifier = NewSignatureVerifier(map[string]crypto.PublicKey{"key-1": pub})
+	role := &SignedRole{
+		Signed: content,
+		Signatures: []TUFSignature{
+			{KeyID: "key-1", Signature: base64.StdEncoding.EncodeToString(sig)},
+			{KeyID: "key-1", Signature: base64.StdEncoding.EncodeToString(sig)},
+			{KeyID: "key-1", Signature: "not-decodable"},
+		},
+	}
+	if err := verifier.VerifySignatures(role, 0); err != nil {
+		t.Fatalf("threshold default with duplicate signature: %v", err)
+	}
+	if data, err := decodeSignature("ff"); err != nil || len(data) != 1 || data[0] != 0xff {
+		t.Fatalf("hex decode got %x err=%v", data, err)
+	}
+	if _, err := decodeSignature("!"); err == nil {
+		t.Fatal("expected undecodable signature error")
+	}
+
+	unsupported := NewSignatureVerifier(map[string]crypto.PublicKey{"key-1": struct{}{}})
+	if err := unsupported.VerifySignatures(&SignedRole{
+		Signed:     content,
+		Signatures: []TUFSignature{{KeyID: "key-1", Signature: hex.EncodeToString([]byte("sig"))}},
+	}, 1); err == nil {
+		t.Fatal("expected unsupported key type to fail")
+	}
+
+	pub2, priv2, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig2 := ed25519.Sign(priv2, hash[:])
+	twoKeys := NewSignatureVerifier(map[string]crypto.PublicKey{"key-1": pub, "key-2": pub2})
+	duplicateRole := &SignedRole{
+		Signed: content,
+		Signatures: []TUFSignature{
+			{KeyID: "key-1", Signature: base64.StdEncoding.EncodeToString(sig)},
+			{KeyID: "key-1", Signature: base64.StdEncoding.EncodeToString(sig)},
+			{KeyID: "key-2", Signature: base64.StdEncoding.EncodeToString(sig2)},
+		},
+	}
+	if err := twoKeys.VerifySignatures(duplicateRole, 2); err != nil {
+		t.Fatalf("duplicate key skip with second key: %v", err)
+	}
+
+	invalidEncoding := NewSignatureVerifier(map[string]crypto.PublicKey{"key-1": pub})
+	if err := invalidEncoding.VerifySignatures(&SignedRole{
+		Signed:     content,
+		Signatures: []TUFSignature{{KeyID: "key-1", Signature: "!"}},
+	}, 1); err == nil {
+		t.Fatal("expected invalid signature encoding to fail")
+	}
+}
+
+func TestVerifySignature_RSAAndECDSA(t *testing.T) {
+	content := []byte(`{"test":"content"}`)
+	hash := sha256.Sum256(content)
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsaSig, err := rsa.SignPKCS1v15(rand.Reader, rsaKey, crypto.SHA256, hash[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifySignature(&rsaKey.PublicKey, hash[:], rsaSig); err != nil {
+		t.Fatalf("RSA verify: %v", err)
+	}
+	if err := verifySignature(&rsaKey.PublicKey, hash[:], []byte("wrong")); err == nil {
+		t.Fatal("expected bad RSA signature to fail")
+	}
+
+	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecdsaSig, err := ecdsa.SignASN1(rand.Reader, ecdsaKey, hash[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := verifySignature(&ecdsaKey.PublicKey, hash[:], ecdsaSig); err != nil {
+		t.Fatalf("ECDSA verify: %v", err)
+	}
+	if err := verifySignature(&ecdsaKey.PublicKey, hash[:], []byte("wrong")); err == nil {
+		t.Fatal("expected bad ECDSA signature to fail")
 	}
 }

--- a/core/pkg/trust/slsa_verifier.go
+++ b/core/pkg/trust/slsa_verifier.go
@@ -216,12 +216,11 @@ func (v *SLSAVerifier) verifySourceRepo(externalParams json.RawMessage) error {
 		} `json:"source"`
 	}
 	if err := json.Unmarshal(externalParams, &params); err != nil {
-		// If we can't parse, we can't verify - warn but don't fail
-		return nil
+		return fmt.Errorf("failed to parse source external parameters: %w", err)
 	}
 
 	if params.Source.URI == "" {
-		return nil // No source specified
+		return fmt.Errorf("source repository is required by policy")
 	}
 
 	for _, allowed := range v.Policy.RequiredSourceRepos {

--- a/core/pkg/trust/slsa_verifier_test.go
+++ b/core/pkg/trust/slsa_verifier_test.go
@@ -103,6 +103,17 @@ func TestSLSAVerifier_VerifyAttestation(t *testing.T) {
 			t.Error("expected error for unauthorized builder")
 		}
 	})
+
+	t.Run("rejects malformed predicate", func(t *testing.T) {
+		statement := &InTotoStatement{
+			Type:          InTotoStatementType,
+			PredicateType: SLSAProvenancePredicateType,
+			Predicate:     []byte(`{`),
+		}
+		if err := verifier.VerifyAttestation(statement); err == nil {
+			t.Fatal("expected malformed predicate error")
+		}
+	})
 }
 
 func TestSLSAVerifier_verifyDependencies(t *testing.T) {
@@ -152,6 +163,110 @@ func TestSLSAVerifier_verifyDependencies(t *testing.T) {
 		err := verifier.verifyDependencies(deps)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects pinned dependency missing sha256", func(t *testing.T) {
+		deps := []ResourceDescriptor{
+			{
+				URI:    "pkg:npm/lodash@4.17.21",
+				Digest: map[string]string{"sha512": "abc123"},
+			},
+		}
+
+		err := verifier.verifyDependencies(deps)
+		if err == nil {
+			t.Error("expected error for missing sha256 digest")
+		}
+	})
+}
+
+func TestSLSAVerifier_verifySourceRepo(t *testing.T) {
+	verifier := NewSLSAVerifier(&ProvenancePolicy{})
+	if err := verifier.verifySourceRepo([]byte(`{`)); err != nil {
+		t.Fatalf("unrestricted malformed params should not fail: %v", err)
+	}
+
+	verifier = NewSLSAVerifier(&ProvenancePolicy{RequiredSourceRepos: []string{"https://github.com/Mindburn-Labs/"}})
+	if err := verifier.verifySourceRepo([]byte(`{`)); err == nil {
+		t.Fatal("expected malformed params to fail closed")
+	}
+	if err := verifier.verifySourceRepo([]byte(`{"source":{}}`)); err == nil {
+		t.Fatal("expected missing source URI to fail closed")
+	}
+	if err := verifier.verifySourceRepo([]byte(`{"source":{"uri":"https://github.com/Mindburn-Labs/helm-ai-kernel"}}`)); err != nil {
+		t.Fatalf("allowed source URI: %v", err)
+	}
+	if err := verifier.verifySourceRepo([]byte(`{"source":{"uri":"https://evil.example/repo"}}`)); err == nil {
+		t.Fatal("expected disallowed source URI error")
+	}
+}
+
+func TestSLSAVerifier_VerifyAttestationDependencyAndSourceFailures(t *testing.T) {
+	t.Run("dependency failure is returned", func(t *testing.T) {
+		verifier := NewSLSAVerifier(&ProvenancePolicy{
+			RequiredSLSAVersion: SLSAProvenancePredicateType,
+			PinnedDependencies:  map[string]string{"pkg:npm/lodash@4.17.21": "abc123"},
+		})
+		provenance := SLSAProvenance{
+			BuildDefinition: BuildDefinition{
+				ResolvedDependencies: []ResourceDescriptor{{URI: "pkg:npm/lodash@4.17.21", Digest: map[string]string{"sha256": "wrong"}}},
+			},
+		}
+		predicate, err := json.Marshal(provenance)
+		if err != nil {
+			t.Fatal(err)
+		}
+		statement := &InTotoStatement{Type: InTotoStatementType, PredicateType: SLSAProvenancePredicateType, Predicate: predicate}
+		if err := verifier.VerifyAttestation(statement); err == nil {
+			t.Fatal("expected dependency failure")
+		}
+	})
+
+	t.Run("source failure is returned", func(t *testing.T) {
+		verifier := NewSLSAVerifier(&ProvenancePolicy{
+			RequiredSLSAVersion: SLSAProvenancePredicateType,
+			RequiredSourceRepos: []string{"https://github.com/Mindburn-Labs/"},
+		})
+		provenance := SLSAProvenance{
+			BuildDefinition: BuildDefinition{
+				ExternalParameters: []byte(`{"source":{"uri":"https://evil.example/repo"}}`),
+			},
+		}
+		predicate, err := json.Marshal(provenance)
+		if err != nil {
+			t.Fatal(err)
+		}
+		statement := &InTotoStatement{Type: InTotoStatementType, PredicateType: SLSAProvenancePredicateType, Predicate: predicate}
+		if err := verifier.VerifyAttestation(statement); err == nil {
+			t.Fatal("expected source failure")
+		}
+	})
+
+	t.Run("malformed source parameters fail closed", func(t *testing.T) {
+		verifier := NewSLSAVerifier(&ProvenancePolicy{
+			RequiredSLSAVersion: SLSAProvenancePredicateType,
+			RequiredSourceRepos: []string{"https://github.com/Mindburn-Labs/"},
+		})
+		provenance := SLSAProvenance{
+			BuildDefinition: BuildDefinition{
+				ExternalParameters: []byte(`"not-object"`),
+			},
+		}
+		predicate, err := json.Marshal(provenance)
+		if err != nil {
+			t.Fatal(err)
+		}
+		statement := &InTotoStatement{Type: InTotoStatementType, PredicateType: SLSAProvenancePredicateType, Predicate: predicate}
+		if err := verifier.VerifyAttestation(statement); err == nil {
+			t.Fatal("expected malformed source parameters to fail closed")
+		}
+	})
+
+	t.Run("empty builder allowlist skips builder restrictions", func(t *testing.T) {
+		verifier := NewSLSAVerifier(&ProvenancePolicy{})
+		if err := verifier.verifyBuilder(Builder{ID: "anything"}); err != nil {
+			t.Fatalf("unrestricted builder should pass: %v", err)
 		}
 	})
 }

--- a/core/pkg/trust/trust_sql_coverage_test.go
+++ b/core/pkg/trust/trust_sql_coverage_test.go
@@ -66,6 +66,24 @@ func TestCoveragePostgresTrustStoreMetadata(t *testing.T) {
 	if err := store.Save(&TUFMetadata{Root: root}); err == nil {
 		t.Fatal("expected metadata save error")
 	}
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("root", sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("timestamp", sqlmock.AnyArg()).WillReturnError(errors.New("timestamp failed"))
+	if err := store.Save(&TUFMetadata{Root: root, Timestamp: timestamp}); err == nil {
+		t.Fatal("expected timestamp save error")
+	}
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("root", sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("timestamp", sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("snapshot", sqlmock.AnyArg()).WillReturnError(errors.New("snapshot failed"))
+	if err := store.Save(&TUFMetadata{Root: root, Timestamp: timestamp, Snapshot: snapshot}); err == nil {
+		t.Fatal("expected snapshot save error")
+	}
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("root", sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("timestamp", sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("snapshot", sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO trust_metadata").WithArgs("targets", sqlmock.AnyArg()).WillReturnError(errors.New("targets failed"))
+	if err := store.Save(&TUFMetadata{Root: root, Timestamp: timestamp, Snapshot: snapshot, Targets: targets}); err == nil {
+		t.Fatal("expected targets save error")
+	}
 	if err := store.Save(&TUFMetadata{Root: &SignedRole{Signed: json.RawMessage(`{`)}}); err == nil {
 		t.Fatal("expected metadata marshal error")
 	}

--- a/core/pkg/trust/tuf_client.go
+++ b/core/pkg/trust/tuf_client.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -234,8 +233,8 @@ func (c *TUFClient) Update() error {
 		return fmt.Errorf("targets verification failed: %w", err)
 	}
 
-	// 6. Update local metadata
-	c.localMetadata = &TUFMetadata{
+	// 6. Prepare updated local metadata
+	newMetadata := &TUFMetadata{
 		Timestamp: newTimestamp,
 		Snapshot:  newSnapshot,
 		Targets:   newTargets,
@@ -243,11 +242,13 @@ func (c *TUFClient) Update() error {
 
 	// 7. Persist to trust store
 	if c.trustStore != nil {
-		if err := c.trustStore.Save(c.localMetadata); err != nil {
-			// Log but don't fail - metadata is still valid in memory
-			slog.Warn("trust: failed to persist TUF metadata", "error", err)
+		if err := c.trustStore.Save(newMetadata); err != nil {
+			return fmt.Errorf("failed to persist TUF metadata: %w", err)
 		}
 	}
+
+	// 8. Update local metadata only after persistence succeeds.
+	c.localMetadata = newMetadata
 
 	return nil
 }

--- a/core/pkg/trust/tuf_client_test.go
+++ b/core/pkg/trust/tuf_client_test.go
@@ -3,6 +3,10 @@ package trust
 import (
 	"crypto"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -34,6 +38,21 @@ func TestNewTUFClient(t *testing.T) {
 		}
 		if client == nil {
 			t.Error("expected non-nil client")
+		}
+	})
+
+	t.Run("loads metadata from trust store", func(t *testing.T) {
+		stored := &TUFMetadata{Targets: &SignedRole{Signed: mustMarshal(TargetsMetadata{})}}
+		client, err := NewTUFClient(TUFClientConfig{
+			RemoteURL:  "https://example.com/tuf",
+			RootKeys:   []crypto.PublicKey{mockPublicKey{}},
+			TrustStore: &memoryTUFTrustStore{metadata: stored},
+		})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if client.localMetadata != stored {
+			t.Fatal("expected stored metadata to be loaded")
 		}
 	})
 }
@@ -85,10 +104,36 @@ func TestTUFClient_GetTargetInfo(t *testing.T) {
 			t.Error("expected error for missing target")
 		}
 	})
+
+	t.Run("returns error without targets metadata", func(t *testing.T) {
+		_, err := (&TUFClient{}).GetTargetInfo("org.example/my-pack")
+		if err == nil {
+			t.Fatal("expected missing metadata error")
+		}
+	})
+
+	t.Run("returns error for malformed targets metadata", func(t *testing.T) {
+		bad := &TUFClient{localMetadata: &TUFMetadata{Targets: &SignedRole{Signed: []byte(`{`)}}}
+		if _, err := bad.GetTargetInfo("org.example/my-pack"); err == nil {
+			t.Fatal("expected malformed targets error")
+		}
+	})
 }
 
 func TestTUFClient_checkFreshness(t *testing.T) {
 	client := &TUFClient{}
+
+	t.Run("rejects nil role", func(t *testing.T) {
+		if err := client.checkFreshness(nil); err == nil {
+			t.Fatal("expected nil role error")
+		}
+	})
+
+	t.Run("rejects malformed role", func(t *testing.T) {
+		if err := client.checkFreshness(&SignedRole{Signed: []byte(`{`)}); err == nil {
+			t.Fatal("expected malformed role error")
+		}
+	})
 
 	t.Run("accepts fresh metadata", func(t *testing.T) {
 		future := time.Now().Add(24 * time.Hour)
@@ -125,6 +170,27 @@ func TestTUFClient_checkFreshness(t *testing.T) {
 
 func TestTUFClient_verifyVersionIncrease(t *testing.T) {
 	client := &TUFClient{}
+
+	t.Run("allows nil existing role", func(t *testing.T) {
+		err := client.verifyVersionIncrease(&SignedRole{Signed: mustMarshal(RoleMetadata{Version: 1})}, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rejects malformed new role", func(t *testing.T) {
+		err := client.verifyVersionIncrease(&SignedRole{Signed: []byte(`{`)}, &SignedRole{Signed: mustMarshal(RoleMetadata{Version: 1})})
+		if err == nil {
+			t.Fatal("expected malformed new role error")
+		}
+	})
+
+	t.Run("rejects malformed existing role", func(t *testing.T) {
+		err := client.verifyVersionIncrease(&SignedRole{Signed: mustMarshal(RoleMetadata{Version: 2})}, &SignedRole{Signed: []byte(`{`)})
+		if err == nil {
+			t.Fatal("expected malformed existing role error")
+		}
+	})
 
 	t.Run("allows version increase", func(t *testing.T) {
 		oldRole := &SignedRole{
@@ -177,10 +243,223 @@ func TestMatchesPattern(t *testing.T) {
 	}
 }
 
+func TestTUFClient_UpdateEdges(t *testing.T) {
+	t.Run("fails on expired timestamp", func(t *testing.T) {
+		server := newTUFMetadataServer(t, map[string]*SignedRole{
+			"timestamp": signedRoleForTUFTest("timestamp", 1, time.Now().Add(-time.Hour), nil),
+		})
+		client := newTUFHTTPClientForTest(server.URL)
+		if err := client.Update(); err == nil {
+			t.Fatal("expected expired timestamp error")
+		}
+	})
+
+	t.Run("fails on snapshot fetch error", func(t *testing.T) {
+		server := newTUFMetadataServer(t, map[string]*SignedRole{
+			"timestamp": signedRoleForTUFTest("timestamp", 1, time.Now().Add(time.Hour), nil),
+		})
+		client := newTUFHTTPClientForTest(server.URL)
+		if err := client.Update(); err == nil {
+			t.Fatal("expected snapshot fetch error")
+		}
+	})
+
+	t.Run("fails on targets fetch error", func(t *testing.T) {
+		server := newTUFMetadataServer(t, map[string]*SignedRole{
+			"timestamp": signedRoleForTUFTest("timestamp", 1, time.Now().Add(time.Hour), nil),
+			"snapshot":  signedRoleForTUFTest("snapshot", 1, time.Now().Add(time.Hour), nil),
+		})
+		client := newTUFHTTPClientForTest(server.URL)
+		if err := client.Update(); err == nil {
+			t.Fatal("expected targets fetch error")
+		}
+	})
+
+	t.Run("detects snapshot rollback", func(t *testing.T) {
+		server := newTUFMetadataServer(t, map[string]*SignedRole{
+			"timestamp": signedRoleForTUFTest("timestamp", 1, time.Now().Add(time.Hour), nil),
+			"snapshot":  signedRoleForTUFTest("snapshot", 1, time.Now().Add(time.Hour), nil),
+		})
+		client := newTUFHTTPClientForTest(server.URL)
+		client.localMetadata = &TUFMetadata{Snapshot: signedRoleForTUFTest("snapshot", 5, time.Now().Add(time.Hour), nil)}
+		if err := client.Update(); err == nil {
+			t.Fatal("expected rollback error")
+		}
+	})
+
+	t.Run("fails when trust store save fails", func(t *testing.T) {
+		targets := TargetsMetadata{
+			RoleMetadata: RoleMetadata{Type: "targets", Version: 1, Expires: time.Now().Add(time.Hour)},
+			Targets:      map[string]TargetInfo{},
+		}
+		server := newTUFMetadataServer(t, map[string]*SignedRole{
+			"timestamp": signedRoleForTUFTest("timestamp", 1, time.Now().Add(time.Hour), nil),
+			"snapshot":  signedRoleForTUFTest("snapshot", 1, time.Now().Add(time.Hour), nil),
+			"targets":   signedRoleForTUFTest("targets", 1, time.Now().Add(time.Hour), targets),
+		})
+		store := &memoryTUFTrustStore{saveErr: errors.New("save failed")}
+		client := newTUFHTTPClientForTest(server.URL)
+		client.trustStore = store
+		previousMetadata := &TUFMetadata{Snapshot: signedRoleForTUFTest("snapshot", 0, time.Now().Add(time.Hour), nil)}
+		client.localMetadata = previousMetadata
+		if err := client.Update(); err == nil {
+			t.Fatal("expected save error")
+		}
+		if !store.saved {
+			t.Fatal("expected save to be attempted")
+		}
+		if client.localMetadata != previousMetadata {
+			t.Fatal("local metadata should not advance when persistence fails")
+		}
+	})
+}
+
+func TestTUFClient_fetchAndVerifyEdges(t *testing.T) {
+	tests := []struct {
+		name     string
+		response func(http.ResponseWriter, *http.Request)
+		noKeys   bool
+	}{
+		{
+			name: "non-success status",
+			response: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "broken", http.StatusInternalServerError)
+			},
+		},
+		{
+			name: "bad response json",
+			response: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("{"))
+			},
+		},
+		{
+			name: "missing signed payload",
+			response: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"signatures":[{"keyid":"root","sig":"sig"}]}`))
+			},
+		},
+		{
+			name: "missing signatures",
+			response: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(SignedRole{Signed: mustMarshal(RoleMetadata{Type: "timestamp", Expires: time.Now().Add(time.Hour)})})
+			},
+		},
+		{
+			name: "malformed role metadata",
+			response: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(SignedRole{Signed: []byte(`"not-object"`), Signatures: []TUFSignature{{KeyID: "root", Signature: "sig"}}})
+			},
+		},
+		{
+			name: "type mismatch",
+			response: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(SignedRole{Signed: mustMarshal(RoleMetadata{Type: "snapshot", Expires: time.Now().Add(time.Hour)}), Signatures: []TUFSignature{{KeyID: "root", Signature: "sig"}}})
+			},
+		},
+		{
+			name: "missing root keys",
+			response: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(SignedRole{Signed: mustMarshal(RoleMetadata{Type: "timestamp", Expires: time.Now().Add(time.Hour)}), Signatures: []TUFSignature{{KeyID: "root", Signature: "sig"}}})
+			},
+			noKeys: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(tt.response))
+			defer server.Close()
+			client := newTUFHTTPClientForTest(server.URL)
+			if tt.noKeys {
+				client.rootKeys = nil
+			}
+			if _, err := client.fetchAndVerify(TUFRoleTimestamp); err == nil {
+				t.Fatal("expected fetchAndVerify error")
+			}
+		})
+	}
+}
+
+func TestTUFClient_VerifyDelegationEdges(t *testing.T) {
+	if err := (&TUFClient{}).VerifyDelegation("certified", "pack"); err == nil {
+		t.Fatal("expected missing metadata error")
+	}
+	bad := &TUFClient{localMetadata: &TUFMetadata{Targets: &SignedRole{Signed: []byte(`{`)}}}
+	if err := bad.VerifyDelegation("certified", "pack"); err == nil {
+		t.Fatal("expected malformed targets error")
+	}
+	noDelegations := &TUFClient{localMetadata: &TUFMetadata{Targets: &SignedRole{Signed: mustMarshal(TargetsMetadata{})}}}
+	if err := noDelegations.VerifyDelegation("certified", "pack"); err == nil {
+		t.Fatal("expected missing delegations error")
+	}
+	missingRole := &TUFClient{localMetadata: &TUFMetadata{Targets: &SignedRole{Signed: mustMarshal(TargetsMetadata{Delegations: &Delegations{Roles: []DelegatedRole{{Name: "community", Paths: []string{"*"}}}}})}}}
+	if err := missingRole.VerifyDelegation("certified", "pack"); err == nil {
+		t.Fatal("expected missing delegation role error")
+	}
+	pathMismatch := &TUFClient{localMetadata: &TUFMetadata{Targets: &SignedRole{Signed: mustMarshal(TargetsMetadata{Delegations: &Delegations{Roles: []DelegatedRole{{Name: "certified", Paths: []string{"other"}}}}})}}}
+	if err := pathMismatch.VerifyDelegation("certified", "pack"); err == nil {
+		t.Fatal("expected delegation path mismatch error")
+	}
+}
+
 func mustMarshal(v interface{}) json.RawMessage {
 	data, err := json.Marshal(v)
 	if err != nil {
 		panic(err)
 	}
 	return data
+}
+
+type memoryTUFTrustStore struct {
+	metadata *TUFMetadata
+	loadErr  error
+	saveErr  error
+	saved    bool
+}
+
+func (s *memoryTUFTrustStore) Load() (*TUFMetadata, error) {
+	return s.metadata, s.loadErr
+}
+
+func (s *memoryTUFTrustStore) Save(metadata *TUFMetadata) error {
+	s.saved = true
+	s.metadata = metadata
+	return s.saveErr
+}
+
+func newTUFHTTPClientForTest(remoteURL string) *TUFClient {
+	return &TUFClient{
+		remoteURL:  remoteURL,
+		rootKeys:   []crypto.PublicKey{mockPublicKey{}},
+		httpClient: http.DefaultClient,
+	}
+}
+
+func signedRoleForTUFTest(role string, version int, expires time.Time, metadata interface{}) *SignedRole {
+	var signed json.RawMessage
+	if metadata != nil {
+		signed = mustMarshal(metadata)
+	} else {
+		signed = mustMarshal(RoleMetadata{Type: role, Version: version, Expires: expires})
+	}
+	return &SignedRole{
+		Signed:     signed,
+		Signatures: []TUFSignature{{KeyID: "root", Signature: "sig"}},
+	}
+}
+
+func newTUFMetadataServer(t *testing.T, roles map[string]*SignedRole) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		role := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/"), ".json")
+		signed, ok := roles[role]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(signed); err != nil {
+			t.Errorf("Encode %s: %v", role, err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
 }

--- a/core/pkg/trust/upgrade_test.go
+++ b/core/pkg/trust/upgrade_test.go
@@ -62,4 +62,8 @@ func TestUpgradeGetReceipt(t *testing.T) {
 	if got.ToVersion != "2.0" {
 		t.Fatal("version mismatch")
 	}
+
+	if _, err := r.Get("missing"); err == nil {
+		t.Fatal("expected missing receipt error")
+	}
 }

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-02T20:01:34Z
-# Commit: 6f0775697145016cb84f7d8a7505e0437241461f
+# Generated: 2026-06-02T20:58:48Z
+# Commit: 73fd988e8c3ec6bed499dfb82479b6f8f8f81442
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md


### PR DESCRIPTION
## Summary
- add focused trust package coverage for compliance, EU trusted lists, Rekor, signature/SLSA verification, TUF client behavior, leaderboard, and upgrade edge cases
- preserve fail-closed and malformed-input branch coverage in existing trust tests

## Validation
- git diff --check
- cd core && go test ./pkg/trust -count=1
- make verify-boundary