### PR TITLE
Cover MCP edge cases

### DIFF
--- a/core/pkg/mcp/gateway_protocol_test.go
+++ b/core/pkg/mcp/gateway_protocol_test.go
@@ -373,3 +373,126 @@ func TestGateway_InvalidSessionIdRejected(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, rec.Code)
 	assert.Contains(t, rec.Body.String(), "invalid or expired MCP session")
 }
+
+func TestGateway_TransportEdgeBranches(t *testing.T) {
+	catalog := NewInMemoryCatalog()
+	gateway := NewGateway(catalog, GatewayConfig{})
+
+	nonFlushing := &gatewayNonFlushingWriter{header: http.Header{}}
+	req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+	req.Header.Set("Accept", "text/event-stream")
+	gateway.handleTransportGET(nonFlushing, req)
+	assert.Equal(t, http.StatusInternalServerError, nonFlushing.status)
+	assert.Contains(t, nonFlushing.body.String(), "streaming unsupported")
+
+	mux := newProtocolTestMux(t, GatewayConfig{}, nil)
+	badJSON := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewBufferString("{"))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, badJSON)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	initUnsupported := performJSONRPCRequest(t, mux, http.MethodPost, "/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "1900-01-01",
+		},
+	}, nil)
+	assert.Equal(t, http.StatusBadRequest, initUnsupported.Code)
+
+	notification := performJSONRPCRequest(t, mux, http.MethodPost, "/mcp", map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	}, nil)
+	assert.Equal(t, http.StatusAccepted, notification.Code)
+	assert.Empty(t, notification.Body.String())
+}
+
+func TestGateway_RESTExecutePropagatesDelegationHeaders(t *testing.T) {
+	exec := func(_ context.Context, req ToolExecutionRequest) (ToolExecutionResponse, error) {
+		assert.Equal(t, "file_read", req.ToolName)
+		assert.Equal(t, "delegation-1", req.DelegationSessionID)
+		assert.Equal(t, "did:example:verifier", req.DelegationVerifier)
+		assert.Equal(t, []string{"file_read", "file_write"}, req.DelegationAllowedTools)
+		return ToolExecutionResponse{Content: "delegated"}, nil
+	}
+	mux := newProtocolTestMux(t, GatewayConfig{}, exec)
+
+	body, err := json.Marshal(MCPToolCallRequest{
+		Method: "file_read",
+		Params: map[string]any{"path": "/tmp/demo.txt"},
+	})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1/execute", bytes.NewReader(body))
+	req.Header.Set("X-HELM-Delegation-Session-ID", "delegation-1")
+	req.Header.Set("X-HELM-Delegation-Verifier", "did:example:verifier")
+	req.Header.Set("X-HELM-Delegation-Allowed-Tools", " file_read, ,file_write ")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "delegated")
+}
+
+func TestGateway_JSONRPCAndSchemaFallbackEdges(t *testing.T) {
+	errGateway := NewGateway(errorCatalog{}, GatewayConfig{})
+	resp, respond, status := errGateway.handleJSONRPCRequest(context.Background(), 1, "tools/list", nil, LatestProtocolVersion)
+	require.True(t, respond)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Contains(t, marshalMCPTestValue(t, resp), "catalog failed")
+
+	catalog := NewInMemoryCatalog()
+	require.NoError(t, catalog.Register(context.Background(), ToolRef{
+		Name:           "scoped",
+		Description:    "scoped jsonrpc tool",
+		Schema:         map[string]any{"type": "object"},
+		RequiredScopes: []string{"mcp:tool:scoped"},
+	}))
+	execGateway := NewGateway(catalog, GatewayConfig{}, WithExecutor(func(_ context.Context, req ToolExecutionRequest) (ToolExecutionResponse, error) {
+		assert.Equal(t, []string{"mcp:tool:scoped"}, req.RequiredScopes)
+		assert.Equal(t, []string{"mcp:tool:scoped"}, req.OAuthScopes)
+		assert.Equal(t, []string{"https://resource.example/mcp"}, req.OAuthResources)
+		return ToolExecutionResponse{Content: "ok"}, nil
+	}))
+	ctx := WithOAuthAuthorization(context.Background(), OAuthAuthorization{
+		Scopes:    []string{"mcp:tool:scoped"},
+		Resources: []string{"https://resource.example/mcp"},
+	})
+	resp, respond, status = execGateway.handleJSONRPCRequest(ctx, 2, "tools/call", json.RawMessage(`{"name":"scoped","arguments":{}}`), LatestProtocolVersion)
+	require.True(t, respond)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Contains(t, marshalMCPTestValue(t, resp), "ok")
+
+	schema := catalogSchemaToArgSchema(map[string]any{
+		"properties": map[string]any{
+			"payload": map[string]any{},
+		},
+		"required": []any{"payload", 42},
+	})
+	require.NotNil(t, schema)
+	field := schema.Fields["payload"]
+	assert.Equal(t, "any", field.Type)
+	assert.True(t, field.Required)
+}
+
+type gatewayNonFlushingWriter struct {
+	header http.Header
+	status int
+	body   bytes.Buffer
+}
+
+func (w *gatewayNonFlushingWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *gatewayNonFlushingWriter) Write(data []byte) (int, error) {
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+	return w.body.Write(data)
+}
+
+func (w *gatewayNonFlushingWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+}

--- a/core/pkg/mcp/quarantine_test.go
+++ b/core/pkg/mcp/quarantine_test.go
@@ -93,3 +93,114 @@ func TestQuarantineRegistryRevokedServerDenied(t *testing.T) {
 		t.Fatal("revoked server should fail closed")
 	}
 }
+
+func TestQuarantineRegistryLifecycleEdges(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 3, 9, 0, 0, 0, time.UTC)
+	registry := NewQuarantineRegistry()
+
+	if _, err := registry.Discover(ctx, DiscoverServerRequest{}); err == nil {
+		t.Fatal("discover without server id should fail")
+	}
+	discovered, err := registry.Discover(ctx, DiscoverServerRequest{
+		ServerID:  "srv-b",
+		ToolNames: []string{"write", "read"},
+	})
+	if err != nil {
+		t.Fatalf("discover defaulted server: %v", err)
+	}
+	if discovered.Risk != ServerRiskUnknown {
+		t.Fatalf("default risk = %s, want unknown", discovered.Risk)
+	}
+	if discovered.DiscoveredAt.IsZero() {
+		t.Fatal("discover without timestamp should set DiscoveredAt")
+	}
+	if got := discovered.ToolNames; len(got) != 2 || got[0] != "read" || got[1] != "write" {
+		t.Fatalf("tool names were not sorted: %#v", got)
+	}
+
+	updated, err := registry.Discover(ctx, DiscoverServerRequest{
+		ServerID:  "srv-b",
+		ToolNames: []string{"execute"},
+		Risk:      ServerRiskMedium,
+		Reason:    "new tool observed",
+	})
+	if err != nil {
+		t.Fatalf("rediscover quarantined server: %v", err)
+	}
+	if updated.State != QuarantineQuarantined || updated.Risk != ServerRiskMedium || updated.Reason != "new tool observed" {
+		t.Fatalf("rediscover updated record = %+v", updated)
+	}
+	if len(updated.ToolNames) != 1 || updated.ToolNames[0] != "execute" {
+		t.Fatalf("rediscover tools = %#v", updated.ToolNames)
+	}
+
+	if _, err := registry.Discover(ctx, DiscoverServerRequest{ServerID: "srv-a", DiscoveredAt: now}); err != nil {
+		t.Fatalf("discover srv-a: %v", err)
+	}
+	listed := registry.List(ctx)
+	if len(listed) != 2 || listed[0].ServerID != "srv-a" || listed[1].ServerID != "srv-b" {
+		t.Fatalf("list ordering = %#v", listed)
+	}
+
+	if _, err := registry.Approve(ctx, ApprovalDecision{}); err == nil {
+		t.Fatal("approve without server id should fail")
+	}
+	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "missing", ApproverID: "user", ApprovalReceiptID: "receipt"}); err == nil {
+		t.Fatal("approve missing server should fail")
+	}
+	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-a", ApprovalReceiptID: "receipt"}); err == nil {
+		t.Fatal("approve without approver should fail")
+	}
+	approved, err := registry.Approve(ctx, ApprovalDecision{
+		ServerID:          "srv-a",
+		ApproverID:        "user:alice",
+		ApprovalReceiptID: "receipt-a",
+		ApprovedAt:        now,
+		Reason:            "reviewed",
+	})
+	if err != nil {
+		t.Fatalf("approve srv-a: %v", err)
+	}
+	if approved.ApprovedAt != now || approved.ApprovedBy != "user:alice" || approved.Reason != "reviewed" {
+		t.Fatalf("approved record = %+v", approved)
+	}
+	rediscoveredApproved, err := registry.Discover(ctx, DiscoverServerRequest{
+		ServerID: "srv-a",
+		Risk:     ServerRiskCritical,
+		Reason:   "should not overwrite approval",
+	})
+	if err != nil {
+		t.Fatalf("rediscover approved server: %v", err)
+	}
+	if rediscoveredApproved.State != QuarantineApproved || rediscoveredApproved.Risk == ServerRiskCritical {
+		t.Fatalf("approved rediscovery should return existing approval, got %+v", rediscoveredApproved)
+	}
+	if err := registry.RequireApproved(ctx, "srv-a", time.Time{}); err != nil {
+		t.Fatalf("approved server without expiry should pass with default time: %v", err)
+	}
+	if err := registry.RequireApproved(ctx, "missing", now); err == nil {
+		t.Fatal("unknown server should fail approval check")
+	}
+
+	if _, err := registry.Revoke(ctx, "", "missing id", now); err == nil {
+		t.Fatal("revoke without server id should fail")
+	}
+	if _, err := registry.Revoke(ctx, "missing", "unknown", now); err == nil {
+		t.Fatal("revoke missing server should fail")
+	}
+	revoked, err := registry.Revoke(ctx, "srv-b", "manual block", time.Time{})
+	if err != nil {
+		t.Fatalf("revoke srv-b: %v", err)
+	}
+	if revoked.State != QuarantineRevoked || revoked.RevokedAt.IsZero() || revoked.Reason != "manual block" {
+		t.Fatalf("revoked record = %+v", revoked)
+	}
+	if _, err := registry.Approve(ctx, ApprovalDecision{
+		ServerID:          "srv-b",
+		ApproverID:        "user:alice",
+		ApprovalReceiptID: "receipt-b",
+	}); err == nil {
+		t.Fatal("revoked server should not be approvable")
+	}
+}


### PR DESCRIPTION
## Summary
- cover MCP transport edge branches, malformed JSON-RPC initialize handling, notifications, and delegation headers
- cover JSON-RPC catalog/executor/schema fallback behavior
- cover quarantine registry discovery, approval, rediscovery, listing, revocation, and failure paths

## Validation
- cd core && go test ./pkg/mcp/... -count=1
- make verify-boundary
- git diff --check
