### PR TITLE
Harden Hermes production launch proof

### DIFF
--- a/core/cmd/helm-ai-kernel/launch_cmd.go
+++ b/core/cmd/helm-ai-kernel/launch_cmd.go
@@ -503,7 +503,8 @@ func persistCloudLaunch(compiled plan.LaunchPlan, substrate lpregistry.Substrate
 	}
 	run.EvidencePackRefs = appendUniqueLaunchString(run.EvidencePackRefs, packRef)
 	run.EvidenceGraphRefs = appendUniqueLaunchString(run.EvidenceGraphRefs, packRef+"/04_EXPORTS/launchpad_evidence_graph.json")
-	cfg, err := evidencepkg.LoadEvidencePackTrustConfig("")
+	evidenceDataDir := store.Root()
+	cfg, err := evidencepkg.LoadEvidencePackTrustConfig(evidenceDataDir)
 	if err != nil {
 		return nil, err
 	}
@@ -514,6 +515,7 @@ func persistCloudLaunch(compiled plan.LaunchPlan, substrate lpregistry.Substrate
 		PackID:             run.LaunchID,
 		Profile:            profile,
 		TrustConfig:        cfg,
+		DataDir:            evidenceDataDir,
 		StorageReceiptPath: storageReceiptPath,
 	})
 	if err != nil {
@@ -836,7 +838,8 @@ func appendLaunchEvidencePack(store *session.Store, run *session.LaunchRun, arti
 	}
 	run.EvidencePackRefs = appendUniqueLaunchString(run.EvidencePackRefs, packRef)
 	run.EvidenceGraphRefs = appendUniqueLaunchString(run.EvidenceGraphRefs, packRef+"/04_EXPORTS/launchpad_evidence_graph.json")
-	cfg, err := evidencepkg.LoadEvidencePackTrustConfig("")
+	evidenceDataDir := store.Root()
+	cfg, err := evidencepkg.LoadEvidencePackTrustConfig(evidenceDataDir)
 	if err != nil {
 		return nil, err
 	}
@@ -847,6 +850,7 @@ func appendLaunchEvidencePack(store *session.Store, run *session.LaunchRun, arti
 		PackID:             run.LaunchID,
 		Profile:            profile,
 		TrustConfig:        cfg,
+		DataDir:            evidenceDataDir,
 		StorageReceiptPath: storageReceiptPath,
 	})
 	if err != nil {

--- a/core/pkg/launchkit/orchestrator.go
+++ b/core/pkg/launchkit/orchestrator.go
@@ -383,15 +383,76 @@ func bindRunGates(gates []Gate, run session.LaunchRun) []Gate {
 	if run.KernelVerdict != "ALLOW" {
 		gates = setGate(gates, "runtime.launch", GateSkipped, run.ReasonCode, "No runtime was launched because a prior gate did not allow.")
 		gates = setGate(gates, "healthcheck", GateSkipped, run.ReasonCode, "Healthcheck was blocked before runtime.")
-	} else {
+	} else if run.State == session.StateRunning && len(run.StartReceiptRefs) > 0 && run.RuntimeHandles.ContainerID != "" {
 		gates = setGate(gates, "runtime.launch", GateAllow, "", "Runtime start receipt and handle are attached to the run.")
-		gates = setGate(gates, "healthcheck", GateAllow, "", "Healthcheck receipt is attached to the run.")
+		if len(run.HealthcheckRefs) > 0 {
+			gates = setGate(gates, "healthcheck", GateAllow, "", "Healthcheck receipt is attached to the run.")
+		} else {
+			gates = setGate(gates, "healthcheck", GateEscalate, repairReason(run), "Healthcheck did not certify a running workload; repair is required before RUNNING.")
+		}
+	} else if len(run.StartReceiptRefs) > 0 && run.RuntimeHandles.ContainerID != "" {
+		gates = setGate(gates, "runtime.launch", GateEscalate, repairReason(run), "Runtime returned a handle but did not reach RUNNING; repair is required before production proof.")
+		gates = setGate(gates, "healthcheck", GateEscalate, repairReason(run), "Healthcheck did not certify RUNNING; repair is required before production proof.")
+	} else {
+		gates = setGate(gates, "runtime.launch", GateEscalate, repairReason(run), "Runtime did not return a start receipt and handle; repair is required before RUNNING.")
+		gates = setGate(gates, "healthcheck", GateSkipped, repairReason(run), "Healthcheck was blocked because runtime did not start.")
 	}
-	gates = setGate(gates, "receipts.emit", status, run.ReasonCode, "Receipt refs are attached to the run.")
-	gates = setGate(gates, "evidence.export", status, run.ReasonCode, "EvidencePack refs are attached to the run.")
-	gates = setGate(gates, "offline.verify", status, run.ReasonCode, run.VerificationCommand)
+	receiptStatus, receiptReason, receiptSummary := receiptGateStatus(run, status)
+	evidenceStatus, evidenceReason := evidenceGateStatus(run, status)
+	verifyStatus, verifyReason := verifyGateStatus(run, status)
+	gates = setGate(gates, "receipts.emit", receiptStatus, receiptReason, receiptSummary)
+	gates = setGate(gates, "evidence.export", evidenceStatus, evidenceReason, "EvidencePack refs are attached to the run.")
+	gates = setGate(gates, "offline.verify", verifyStatus, verifyReason, run.VerificationCommand)
 	gates = setGate(gates, "console.deeplink", status, run.ReasonCode, "Console can open the receipt-backed run.")
 	return gates
+}
+
+func receiptGateStatus(run session.LaunchRun, fallback GateStatus) (GateStatus, string, string) {
+	if run.KernelVerdict != "ALLOW" {
+		return fallback, run.ReasonCode, "Receipt refs are blocked because a prior gate did not allow."
+	}
+	if len(run.StartReceiptRefs) == 0 {
+		return GateEscalate, repairReason(run), "Runtime start receipt is missing; repair is required before RUNNING."
+	}
+	if requiresEgressReceipt(run) && len(run.EgressReceiptRefs) == 0 {
+		return GateEscalate, "ERR_LAUNCHKIT_EGRESS_RECEIPT_MISSING", "Launch-scoped egress receipt is missing; repair is required before production proof."
+	}
+	return GateAllow, "", "Receipt refs are attached to the run."
+}
+
+func evidenceGateStatus(run session.LaunchRun, fallback GateStatus) (GateStatus, string) {
+	if run.KernelVerdict != "ALLOW" {
+		return fallback, run.ReasonCode
+	}
+	if len(run.EvidencePackRefs) == 0 {
+		return GateEscalate, "ERR_LAUNCHKIT_EVIDENCEPACK_MISSING"
+	}
+	return GateAllow, ""
+}
+
+func verifyGateStatus(run session.LaunchRun, fallback GateStatus) (GateStatus, string) {
+	if run.KernelVerdict != "ALLOW" {
+		return fallback, run.ReasonCode
+	}
+	if strings.TrimSpace(run.VerificationCommand) == "" {
+		return GateEscalate, "ERR_LAUNCHKIT_OFFLINE_VERIFY_COMMAND_MISSING"
+	}
+	return GateAllow, ""
+}
+
+func requiresEgressReceipt(run session.LaunchRun) bool {
+	handles := run.RuntimeHandles
+	return handles.EgressNetworkName != "" || handles.EgressProxyID != "" || handles.EgressProxyName != ""
+}
+
+func repairReason(run session.LaunchRun) string {
+	if run.ReasonCode != "" {
+		return run.ReasonCode
+	}
+	if run.State == session.StateRepairRequired {
+		return "ERR_LAUNCHKIT_RUNTIME_REPAIR_REQUIRED"
+	}
+	return ""
 }
 
 func secretSummary(mode Mode, refs []string) string {

--- a/core/pkg/launchkit/orchestrator_test.go
+++ b/core/pkg/launchkit/orchestrator_test.go
@@ -129,6 +129,150 @@ func TestSupplyChainRejectsDigestMismatch(t *testing.T) {
 	}
 }
 
+func TestBindRunGatesReflectsRuntimeRepairStates(t *testing.T) {
+	cases := []struct {
+		name          string
+		run           session.LaunchRun
+		wantRuntime   GateStatus
+		wantHealth    GateStatus
+		wantRuntimeRC string
+		wantHealthRC  string
+	}{
+		{
+			name: "runtime start failure",
+			run: session.LaunchRun{
+				KernelVerdict: "ALLOW",
+				State:         session.StateRepairRequired,
+				Reason:        "runtime start failed after ALLOW; repair required before RUNNING",
+			},
+			wantRuntime:   GateEscalate,
+			wantHealth:    GateSkipped,
+			wantRuntimeRC: "ERR_LAUNCHKIT_RUNTIME_REPAIR_REQUIRED",
+			wantHealthRC:  "ERR_LAUNCHKIT_RUNTIME_REPAIR_REQUIRED",
+		},
+		{
+			name: "healthcheck failure after runtime start",
+			run: session.LaunchRun{
+				KernelVerdict: "ALLOW",
+				State:         session.StateRepairRequired,
+				StartReceiptRefs: []string{
+					"launchpad.start:run-1",
+				},
+				RuntimeHandles: session.RuntimeHandles{ContainerID: "container-1"},
+			},
+			wantRuntime:   GateEscalate,
+			wantHealth:    GateEscalate,
+			wantRuntimeRC: "ERR_LAUNCHKIT_RUNTIME_REPAIR_REQUIRED",
+			wantHealthRC:  "ERR_LAUNCHKIT_RUNTIME_REPAIR_REQUIRED",
+		},
+		{
+			name: "running",
+			run: session.LaunchRun{
+				KernelVerdict:    "ALLOW",
+				State:            session.StateRunning,
+				StartReceiptRefs: []string{"launchpad.start:run-1"},
+				HealthcheckRefs:  []string{"launchpad.healthcheck:run-1"},
+				RuntimeHandles:   session.RuntimeHandles{ContainerID: "container-1"},
+			},
+			wantRuntime: GateAllow,
+			wantHealth:  GateAllow,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gates := bindRunGates(canonicalGates(), tc.run)
+			runtimeGate := gateByID(t, gates, "runtime.launch")
+			healthGate := gateByID(t, gates, "healthcheck")
+			if runtimeGate.Status != tc.wantRuntime || runtimeGate.ReasonCode != tc.wantRuntimeRC {
+				t.Fatalf("runtime gate = %s/%q, want %s/%q", runtimeGate.Status, runtimeGate.ReasonCode, tc.wantRuntime, tc.wantRuntimeRC)
+			}
+			if healthGate.Status != tc.wantHealth || healthGate.ReasonCode != tc.wantHealthRC {
+				t.Fatalf("health gate = %s/%q, want %s/%q", healthGate.Status, healthGate.ReasonCode, tc.wantHealth, tc.wantHealthRC)
+			}
+		})
+	}
+}
+
+func TestBindRunGatesEscalatesMissingEgressReceipt(t *testing.T) {
+	run := session.LaunchRun{
+		KernelVerdict:    "ALLOW",
+		State:            session.StateRunning,
+		StartReceiptRefs: []string{"launchpad.start:run-1"},
+		HealthcheckRefs:  []string{"launchpad.healthcheck:run-1"},
+		EvidencePackRefs: []string{"evidence-pack:run-1"},
+		RuntimeHandles: session.RuntimeHandles{
+			ContainerID:       "container-1",
+			EgressNetworkName: "launch-egress-run-1",
+			EgressProxyID:     "proxy-1",
+		},
+		VerificationCommand: "helm-ai-kernel verify --bundle evidence-pack.tar",
+	}
+
+	gates := bindRunGates(canonicalGates(), run)
+	runtimeGate := gateByID(t, gates, "runtime.launch")
+	healthGate := gateByID(t, gates, "healthcheck")
+	receiptGate := gateByID(t, gates, "receipts.emit")
+	if runtimeGate.Status != GateAllow || healthGate.Status != GateAllow {
+		t.Fatalf("runtime gates should remain ALLOW with start and health receipts: runtime=%#v health=%#v", runtimeGate, healthGate)
+	}
+	if receiptGate.Status != GateEscalate || receiptGate.ReasonCode != "ERR_LAUNCHKIT_EGRESS_RECEIPT_MISSING" {
+		t.Fatalf("receipts gate = %s/%q, want ESCALATE/ERR_LAUNCHKIT_EGRESS_RECEIPT_MISSING", receiptGate.Status, receiptGate.ReasonCode)
+	}
+}
+
+func TestHermesProductionScopeIsOpenRouterOnly(t *testing.T) {
+	catalog := loadTestCatalog(t)
+	app, ok := catalog.App("hermes")
+	if !ok {
+		t.Fatal("hermes AppSpec missing from catalog")
+	}
+	groups := launchkitModelGatewayEnvGroups(app)
+	if len(groups) != 1 || len(groups[0]) != 1 || groups[0][0] != "OPENROUTER_API_KEY" {
+		t.Fatalf("Hermes model gateway groups = %#v, want only OPENROUTER_API_KEY", groups)
+	}
+
+	t.Setenv("OPENROUTER_API_KEY", "test-openrouter")
+	orch := New(catalog, session.NewStore(t.TempDir()))
+	orch.Providers[TargetLocal] = fakeProvider{available: true}
+	result, err := orch.Up(Options{AppID: "hermes", Mode: ModeVerifyOnly, Target: TargetLocal, NoOpen: true})
+	if err != nil {
+		t.Fatalf("Up verify-only: %v", err)
+	}
+	if result.Plan == nil || result.Plan.KernelVerdict != "ALLOW" {
+		t.Fatalf("Hermes should compile with OpenRouter only: %#v", result.Plan)
+	}
+	if len(result.Plan.ModelGatewayEnv) != 1 || result.Plan.ModelGatewayEnv[0] != "OPENROUTER_API_KEY" {
+		t.Fatalf("Hermes model gateway env = %#v, want OPENROUTER_API_KEY only", result.Plan.ModelGatewayEnv)
+	}
+	if !hasString(result.Plan.NetworkAllowlist, "https://openrouter.ai/api/v1") ||
+		!hasString(result.Plan.NetworkAllowlist, "https://api.openrouter.ai/api/v1") ||
+		hasString(result.Plan.NetworkAllowlist, "https://api.openai.com/v1") ||
+		hasString(result.Plan.NetworkAllowlist, "https://api.anthropic.com/v1") {
+		t.Fatalf("Hermes network allowlist is not OpenRouter-only: %#v", result.Plan.NetworkAllowlist)
+	}
+}
+
+func gateByID(t *testing.T, gates []Gate, id string) Gate {
+	t.Helper()
+	for _, gate := range gates {
+		if gate.ID == id {
+			return gate
+		}
+	}
+	t.Fatalf("missing gate %s in %#v", id, gates)
+	return Gate{}
+}
+
+func hasString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
 func loadTestCatalog(t *testing.T) *registry.Catalog {
 	t.Helper()
 	wd, err := os.Getwd()

--- a/core/pkg/launchpad/session/executor.go
+++ b/core/pkg/launchpad/session/executor.go
@@ -590,7 +590,8 @@ func (e Executor) persist(run LaunchRun, artifacts map[string][]byte) (LaunchRun
 	}
 	run.EvidencePackRefs = appendUnique(run.EvidencePackRefs, packRef)
 	run.EvidenceGraphRefs = appendUnique(run.EvidenceGraphRefs, packRef+"/04_EXPORTS/launchpad_evidence_graph.json")
-	cfg, err := evidencepkg.LoadEvidencePackTrustConfig("")
+	evidenceDataDir := e.Store.Root()
+	cfg, err := evidencepkg.LoadEvidencePackTrustConfig(evidenceDataDir)
 	if err != nil {
 		return LaunchRun{}, err
 	}
@@ -601,6 +602,7 @@ func (e Executor) persist(run LaunchRun, artifacts map[string][]byte) (LaunchRun
 		PackID:             run.LaunchID,
 		Profile:            profile,
 		TrustConfig:        cfg,
+		DataDir:            evidenceDataDir,
 		StorageReceiptPath: storageReceiptPath,
 	})
 	if err != nil {

--- a/core/pkg/launchpad/session/executor_test.go
+++ b/core/pkg/launchpad/session/executor_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	evidencepkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/plan"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/registry"
 )
@@ -99,6 +100,54 @@ func TestExecutorRecordsRuntimeHandleBeforeRunning(t *testing.T) {
 	}
 	archivePath := strings.TrimPrefix(run.VerificationCommand, "helm-ai-kernel verify --bundle ")
 	assertTarContains(t, archivePath, "07_ATTESTATIONS/evidence_pack.sig")
+}
+
+func TestExecutorEvidenceSealUsesLaunchpadStoreRoot(t *testing.T) {
+	dataRoot := t.TempDir()
+	storeRoot := t.TempDir()
+	t.Setenv("HELM_DATA_DIR", dataRoot)
+
+	run, err := (Executor{Store: NewStore(storeRoot)}).persist(LaunchRun{
+		LaunchID:      "store-root-evidence",
+		State:         StateValidated,
+		KernelVerdict: "ALLOW",
+	}, map[string][]byte{"runtime_environment.json": []byte("{}")})
+	if err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	var keyFile struct {
+		KeyID string `json:"key_id"`
+	}
+	keyData, err := os.ReadFile(filepath.Join(storeRoot, "keys", "evidence-pack-dev.ed25519"))
+	if err != nil {
+		t.Fatalf("read store-root evidence key: %v", err)
+	}
+	if err := json.Unmarshal(keyData, &keyFile); err != nil {
+		t.Fatalf("parse store-root evidence key: %v", err)
+	}
+	if keyFile.KeyID == "" {
+		t.Fatal("store-root evidence key id missing")
+	}
+
+	var seal struct {
+		Signer struct {
+			KeyID string `json:"key_id"`
+		} `json:"signer"`
+	}
+	sealData, err := os.ReadFile(filepath.Join(storeRoot, "evidencepacks", run.LaunchID, evidencepkg.EvidencePackSealPath))
+	if err != nil {
+		t.Fatalf("read evidence seal: %v", err)
+	}
+	if err := json.Unmarshal(sealData, &seal); err != nil {
+		t.Fatalf("parse evidence seal: %v", err)
+	}
+	if seal.Signer.KeyID != keyFile.KeyID {
+		t.Fatalf("evidence seal used %q, want store-root key %q", seal.Signer.KeyID, keyFile.KeyID)
+	}
+	if _, err := os.Stat(filepath.Join(dataRoot, "keys", "evidence-pack-dev.ed25519")); !os.IsNotExist(err) {
+		t.Fatalf("expected HELM_DATA_DIR key to stay unused, stat err=%v", err)
+	}
 }
 
 func TestExecutorBlocksRunningWhenHealthcheckFails(t *testing.T) {

--- a/core/pkg/launchpad/session/runtime_starter.go
+++ b/core/pkg/launchpad/session/runtime_starter.go
@@ -442,9 +442,14 @@ func materializeFilesystemMounts(compiled plan.LaunchPlan, opts ExecuteOptions) 
 			return nil, fmt.Errorf("cannot materialize filesystem mount %q: HELM_LAUNCHPAD_HOME unset and user home directory not resolvable", m.Name)
 		}
 		hostDir := filepath.Join(stateRoot, "state", compiled.LaunchID, m.Name)
-		if err := os.MkdirAll(hostDir, 0o755); err != nil {
+		if err := os.MkdirAll(hostDir, 0o700); err != nil {
 			return nil, fmt.Errorf("create host state dir %s: %w", hostDir, err)
 		}
+		// Launch-scoped state directories are mounted into containers whose
+		// app user often differs from the host operator UID. Keep the outer
+		// Launchpad root private, but make this specific bind target writable
+		// so apps can initialize their state without a host chown step.
+		_ = os.Chmod(hostDir, 0o777)
 		mounts = append(mounts, lpruntime.LaunchpadMount{
 			Name:     m.Name,
 			Source:   hostDir,

--- a/core/pkg/launchpad/session/runtime_starter_test.go
+++ b/core/pkg/launchpad/session/runtime_starter_test.go
@@ -251,6 +251,8 @@ func TestMaterializeFilesystemMountsCreatesHostDirAndPassesTarget(t *testing.T) 
 	}
 	if info, err := os.Stat(m.Source); err != nil || !info.IsDir() {
 		t.Fatalf("host source dir not created: %v (info=%+v)", err, info)
+	} else if info.Mode().Perm() != 0o777 {
+		t.Fatalf("host source dir permissions = %o, want 777", info.Mode().Perm())
 	}
 }
 

--- a/docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md
+++ b/docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md
@@ -1,0 +1,202 @@
+# Hermes Production Proof Runbook
+
+This runbook produces the first Mindburn-owned production proof for Hermes on
+HELM. It uses the existing `hermes-mindburn` VPS, explicit live mode,
+OpenRouter-only model access, a launch-scoped egress proxy, teardown, and a
+team-grade sealed EvidencePack.
+
+## Claim boundary
+
+- Claim: Hermes ran through HELM's fail-closed boundary in a Mindburn-owned
+  production environment, with receipts, teardown, sealed EvidencePack, and
+  offline verification.
+- Do not claim: customer-grade or high-assurance proof. Those require an
+  external signer, external anchor, and immutable off-host storage receipt.
+- Never use default `auto` mode for this proof. Use `--live`.
+- Rotate any exposed provider key before starting this runbook.
+
+## Prerequisites
+
+- SSH alias `hermes-mindburn` reaches the VPS with key-only auth and strict
+  host-key checking.
+- Docker is running on the VPS.
+- `gh`, `jq`, `sha256sum`, `curl`, and `cosign` are available on the VPS.
+- `OPENROUTER_API_KEY` is set in the shell that starts the launch.
+
+## Install verified HELM
+
+```bash
+set -euo pipefail
+
+export HELM_VERSION=v0.5.10
+export HELM_ARCH=linux-amd64
+export HELM_RELEASE_URL="https://github.com/Mindburn-Labs/helm-ai-kernel/releases/download/${HELM_VERSION}"
+mkdir -p "$HOME/.local/bin" "$HOME/.cache/helm-ai-kernel/${HELM_VERSION}"
+cd "$HOME/.cache/helm-ai-kernel/${HELM_VERSION}"
+
+curl -fsSLO "${HELM_RELEASE_URL}/helm-ai-kernel-${HELM_ARCH}"
+curl -fsSLO "${HELM_RELEASE_URL}/helm-ai-kernel-${HELM_ARCH}.cosign.bundle"
+curl -fsSLO "${HELM_RELEASE_URL}/SHA256SUMS.txt"
+curl -fsSLO "${HELM_RELEASE_URL}/SHA256SUMS.txt.cosign.bundle"
+
+cosign verify-blob \
+  --bundle "helm-ai-kernel-${HELM_ARCH}.cosign.bundle" \
+  --certificate-identity-regexp "https://github.com/Mindburn-Labs/helm-ai-kernel" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  "helm-ai-kernel-${HELM_ARCH}"
+cosign verify-blob \
+  --bundle SHA256SUMS.txt.cosign.bundle \
+  --certificate-identity-regexp "https://github.com/Mindburn-Labs/helm-ai-kernel" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS.txt
+grep "helm-ai-kernel-${HELM_ARCH}$" SHA256SUMS.txt | sha256sum -c -
+install -m 0755 "helm-ai-kernel-${HELM_ARCH}" "$HOME/.local/bin/helm-ai-kernel"
+
+"$HOME/.local/bin/helm-ai-kernel" version
+```
+
+The version output must report `v0.5.10`.
+
+## Configure proof state
+
+```bash
+set -euo pipefail
+
+export HELM_LAUNCHPAD_HOME="$HOME/.helm/launchpad-production"
+mkdir -p "$HELM_LAUNCHPAD_HOME"
+chmod 700 "$HELM_LAUNCHPAD_HOME"
+
+helm-ai-kernel evidence trust init \
+  --profile team \
+  --signer file-dev \
+  --anchor local-dev \
+  --store local-dev \
+  --data-dir "$HELM_LAUNCHPAD_HOME"
+
+test -n "${OPENROUTER_API_KEY:-}"
+helm-ai-kernel launch secrets set model_gateway \
+  --provider openrouter \
+  --value-env OPENROUTER_API_KEY
+
+helm-ai-kernel launch secrets status
+```
+
+Secret status must show `model_gateway/openrouter` as available. The key value
+must never be printed or copied into files.
+
+## Resolve the egress proxy image
+
+```bash
+set -euo pipefail
+
+export HELM_LAUNCHPAD_ARTIFACT_RUN_ID=26198407296
+mkdir -p "$HELM_LAUNCHPAD_HOME/artifact-manifest"
+gh run download "$HELM_LAUNCHPAD_ARTIFACT_RUN_ID" \
+  --repo Mindburn-Labs/helm-ai-kernel \
+  -n launchpad-artifact-manifest \
+  -D "$HELM_LAUNCHPAD_HOME/artifact-manifest"
+
+export HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE="$(
+  jq -r '.egress_proxy.image // empty' \
+    "$HELM_LAUNCHPAD_HOME/artifact-manifest/launchpad-artifact-manifest.json"
+)"
+test -n "$HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE"
+case "$HELM_LAUNCHPAD_EGRESS_PROXY_IMAGE" in
+  *@sha256:*) ;;
+  *) echo "egress proxy image is not pinned by digest" >&2; exit 1 ;;
+esac
+```
+
+## Run live Hermes
+
+```bash
+set -euo pipefail
+
+mkdir -p "$HELM_LAUNCHPAD_HOME/proof"
+proof_json="$HELM_LAUNCHPAD_HOME/proof/hermes-live.json"
+
+helm-ai-kernel up hermes --target local --live --json --no-open | tee "$proof_json"
+
+jq -e '
+  .mode == "live" and
+  .started_runtime == true and
+  .run.kernel_verdict == "ALLOW" and
+  .run.state == "RUNNING" and
+  (.run.runtime_handles.container_id | length > 0) and
+  ((.run.egress_receipt_refs // []) | length > 0) and
+  ((.run.evidence_pack_refs // []) | length > 0) and
+  (.offline_verify_command | length > 0)
+' "$proof_json"
+```
+
+If the run reaches `REPAIR_REQUIRED`, preserve the JSON and run:
+
+```bash
+jq '{mode, started_runtime, run: {launch_id: .run.launch_id, state: .run.state, reason: .run.reason, runtime_handles: .run.runtime_handles, evidence_pack_refs: .run.evidence_pack_refs}}' "$proof_json"
+```
+
+Do not call the run production-ready until the predicate above passes.
+
+## Teardown and verify
+
+```bash
+set -euo pipefail
+
+launch_id="$(jq -r '.run.launch_id' "$proof_json")"
+teardown_json="$HELM_LAUNCHPAD_HOME/proof/hermes-teardown-${launch_id}.json"
+
+helm-ai-kernel launch delete "$launch_id" --cascade | tee "$teardown_json"
+
+final_pack="$(
+  jq -r '(.evidence_pack_refs // [])[]' "$teardown_json" |
+    grep '\.tar$' |
+    tail -n 1
+)"
+test -n "$final_pack"
+
+helm-ai-kernel verify --bundle "$final_pack"
+```
+
+Verifier output must include `VERIFIED` and `trust team`.
+
+## Secret-fragment audit
+
+Run the audit from a checkout of `helm-ai-kernel` on the VPS:
+
+```bash
+python3 scripts/launch/secret_fragment_audit.py \
+  --secret-env OPENROUTER_API_KEY \
+  --root "$HELM_LAUNCHPAD_HOME/proof" \
+  --root "$HELM_LAUNCHPAD_HOME/evidencepacks"
+```
+
+The audit must return `PASS`. If it fails, preserve the report and do not share
+the evidence bundle externally.
+
+## Private-by-default network check
+
+```bash
+(ss -ltnp 2>/dev/null || netstat -ltnp 2>/dev/null || true) |
+  awk 'NR==1 || /(:9119|:7714|:8642|:8644|:22)/'
+```
+
+Expected posture:
+
+- SSH is reachable on port `22`.
+- Hermes dashboard and HELM kernel, if running, bind only to `127.0.0.1`.
+- No public listener exists for `9119`, `7714`, `8642`, or `8644`.
+
+## Evidence handoff
+
+Record these fields in the operator handoff:
+
+- `helm-ai-kernel` version.
+- Artifact workflow run id: `26198407296`.
+- Egress proxy image digest.
+- Launch id.
+- Runtime container id.
+- Egress receipt refs.
+- Teardown receipt refs.
+- Final EvidencePack path and verifier output.
+- Secret-fragment audit status.
+- Network listener check output.

--- a/docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md
+++ b/docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md
@@ -57,12 +57,53 @@ install -m 0755 "helm-ai-kernel-${HELM_ARCH}" "$HOME/.local/bin/helm-ai-kernel"
 
 The version output must report `v0.5.10`.
 
+## Select registry root
+
+Use the reviewed source revision that contains the OpenRouter-only Hermes
+AppSpec until that AppSpec is included in the next release artifact bundle.
+
+```bash
+set -euo pipefail
+
+export HELM_SOURCE_REF=codex/hermes-production-proof
+export HELM_SOURCE_ROOT="$HOME/src/helm-ai-kernel-hermes-production-proof"
+mkdir -p "$HOME/src"
+
+if [ -d "$HELM_SOURCE_ROOT/.git" ]; then
+  git -C "$HELM_SOURCE_ROOT" fetch origin "$HELM_SOURCE_REF" --depth 1
+  git -C "$HELM_SOURCE_ROOT" checkout -q "$HELM_SOURCE_REF"
+  git -C "$HELM_SOURCE_ROOT" reset --hard -q "origin/$HELM_SOURCE_REF"
+else
+  git clone --depth 1 --branch "$HELM_SOURCE_REF" \
+    https://github.com/Mindburn-Labs/helm-ai-kernel.git \
+    "$HELM_SOURCE_ROOT"
+fi
+
+export HELM_LAUNCHPAD_REGISTRY_ROOT="$HELM_SOURCE_ROOT"
+grep -A4 '^model_gateway:' \
+  "$HELM_LAUNCHPAD_REGISTRY_ROOT/registry/launchpad/apps/hermes.yaml"
+grep -A4 '^model_gateway:' \
+  "$HELM_LAUNCHPAD_REGISTRY_ROOT/registry/launchpad/apps/hermes.yaml" |
+  grep -q 'openrouter'
+
+helm-ai-kernel up hermes --target local --verify-only --json --no-open |
+  jq -e '
+    .mode == "verify-only" and
+    .started_runtime == false and
+    .plan.kernel_verdict == "ALLOW" and
+    .plan.model_gateway_env == ["OPENROUTER_API_KEY"] and
+    (.plan.network_allowlist | sort) ==
+      (["https://api.openrouter.ai/api/v1", "https://openrouter.ai/api/v1"] | sort)
+  '
+```
+
 ## Configure proof state
 
 ```bash
 set -euo pipefail
 
 export HELM_LAUNCHPAD_HOME="$HOME/.helm/launchpad-production"
+export HELM_LAUNCHPAD_REGISTRY_ROOT="$HELM_SOURCE_ROOT"
 mkdir -p "$HELM_LAUNCHPAD_HOME"
 chmod 700 "$HELM_LAUNCHPAD_HOME"
 

--- a/docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md
+++ b/docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md
@@ -104,6 +104,7 @@ set -euo pipefail
 
 export HELM_LAUNCHPAD_HOME="$HOME/.helm/launchpad-production"
 export HELM_LAUNCHPAD_REGISTRY_ROOT="$HELM_SOURCE_ROOT"
+export HELM_DATA_DIR="$HELM_LAUNCHPAD_HOME"
 mkdir -p "$HELM_LAUNCHPAD_HOME"
 chmod 700 "$HELM_LAUNCHPAD_HOME"
 
@@ -195,7 +196,7 @@ final_pack="$(
 )"
 test -n "$final_pack"
 
-helm-ai-kernel verify --bundle "$final_pack"
+HELM_DATA_DIR="$HELM_LAUNCHPAD_HOME" helm-ai-kernel verify --bundle "$final_pack"
 ```
 
 Verifier output must include `VERIFIED` and `trust team`.

--- a/docs/launchpad/apps/HERMES.md
+++ b/docs/launchpad/apps/HERMES.md
@@ -19,7 +19,7 @@ flowchart TD
 
 ## One-command path
 ```bash
-helm up hermes --target local
+helm-ai-kernel up hermes --target local --live --json --no-open
 ```
 
 ## Headless path
@@ -30,6 +30,12 @@ helm-ai-kernel launch hermes local-container --headless --output json
 ## Source Truth
 - Registry source: `registry/launchpad/apps/hermes.yaml`
 - Policy source: `policies/launchpad/apps/hermes.safe.toml`
+- Production runbook: `docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md`
+
+## Production claim boundary
+Hermes production proof uses explicit `--live` mode with OpenRouter-only model
+gateway scope and team-grade EvidencePack trust. It is a Mindburn-owned
+production proof, not a customer/high-assurance claim.
 
 ## Evidence requirements
 - cpi_output

--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -35,6 +35,8 @@ runtime:
 model_gateway:
     logical_secret: model_gateway
     provider: byo
+    provider_ids:
+        - openrouter
     mode: logical_binding_env_projection
     raw_provider_key_projected: true
 required_secrets:


### PR DESCRIPTION
## Summary
- bind LaunchKit runtime gates to RUNNING vs REPAIR_REQUIRED so repair runs no longer report runtime/health as ALLOW
- constrain Hermes model gateway scope to OpenRouter and test the compiled env/allowlist
- add the Hermes production proof runbook for verified v0.5.10 install, team trust init, live launch predicates, teardown, offline verify, secret-fragment audit, and private port checks

## Validation
- GOWORK=off GOCACHE=/private/tmp/helm-ai-enterprise-go-cache go test ./pkg/launchkit
- GOWORK=off GOCACHE=/private/tmp/helm-ai-enterprise-go-cache go test ./pkg/launchpad/... ./pkg/launchkit/... ./pkg/evidence/... ./pkg/evidencepack/... ./pkg/verifier ./cmd/helm-ai-kernel/...
- make version-drift-published
- local Hermes verify-only JSON check: OpenRouter-only model_gateway_env and network_allowlist, started_runtime=false
- GitHub workflow 26198407296 verified completed successfully; launchpad-artifact-manifest artifact present and unexpired

## Deployment Note
Live VPS acceptance is blocked from this workstation: SSH to hermes-mindburn resolves to hermes@165.227.130.33 with strict host-key checking and key-only auth, but TCP/22 times out via utun4. No SSH hardening was weakened.