### PR TITLE
MIN-467 Require spend verdict before LLM dispatch

### DIFF
--- a/core/pkg/contracts/economic/spend_authority.go
+++ b/core/pkg/contracts/economic/spend_authority.go
@@ -314,6 +314,17 @@ func (d SpendAuthorityDecision) computeHash() string {
 	}{d.Verdict, d.ReasonCode, d.RemainingCents, d.EnvelopeHash})
 }
 
+// CanonicalContentHash returns the deterministic hash for the decision fields.
+func (d SpendAuthorityDecision) CanonicalContentHash() string {
+	return d.computeHash()
+}
+
+// HasCanonicalContentHash reports whether ContentHash matches the canonical
+// decision fields, excluding mutable explanation text.
+func (d SpendAuthorityDecision) HasCanonicalContentHash() bool {
+	return d.ContentHash != "" && d.ContentHash == d.computeHash()
+}
+
 // ModelRoute identifies an allowed or fallback provider/model route.
 type ModelRoute struct {
 	ProviderID        string `json:"provider_id"`

--- a/core/pkg/contracts/economic/spend_authority_test.go
+++ b/core/pkg/contracts/economic/spend_authority_test.go
@@ -38,6 +38,20 @@ func TestAgentSpendEnvelopeEvaluateSpend(t *testing.T) {
 	}
 }
 
+func TestSpendAuthorityDecisionCanonicalContentHash(t *testing.T) {
+	decision := spendAuthorityTestEnvelope().EvaluateSpend(100, "openai", "gpt-5-mini")
+	if decision.CanonicalContentHash() != decision.ContentHash {
+		t.Fatalf("canonical decision hash = %s, want %s", decision.CanonicalContentHash(), decision.ContentHash)
+	}
+	if !decision.HasCanonicalContentHash() {
+		t.Fatal("decision should report a canonical content hash")
+	}
+	decision.ContentHash = "sha256:tampered"
+	if decision.HasCanonicalContentHash() {
+		t.Fatal("tampered decision hash should not validate")
+	}
+}
+
 func TestAgentSpendEnvelopeEvaluateSpendValidityWindow(t *testing.T) {
 	envelope := spendAuthorityTestEnvelope()
 	envelope.EffectiveAt = time.Now().UTC().Add(time.Hour)

--- a/core/pkg/llm/gateway/router.go
+++ b/core/pkg/llm/gateway/router.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
 )
 
 // GatewayRouter normalizes capability requests across providers.
@@ -34,6 +35,21 @@ func (e *EnginePinMismatchError) Error() string {
 
 func (e *EnginePinMismatchError) SafeDepHazardCode() contracts.SafeDepHazardCode {
 	return contracts.HazardEnginePinMismatch
+}
+
+type SpendVerdictError struct {
+	Decision *economic.SpendAuthorityDecision
+	Reason   string
+}
+
+func (e *SpendVerdictError) Error() string {
+	if e == nil {
+		return "lig: spend authority verdict unavailable"
+	}
+	if e.Decision == nil {
+		return "lig: spend authority decision required before provider dispatch"
+	}
+	return fmt.Sprintf("lig: spend authority verdict %s/%s: %s", e.Decision.Verdict, e.Decision.ReasonCode, e.Reason)
 }
 
 // NewGatewayRouter creates a new Local Inference Gateway router.
@@ -134,21 +150,25 @@ func (r *GatewayRouter) HealthCheck(ctx context.Context) error {
 
 // ExecContext represents normalized LLM execution parameters within HELM.
 type ExecContext struct {
-	Prompt      string
-	Temperature float32
-	System      string
-	JSONMode    bool
-	Tools       []string
+	Prompt        string
+	Temperature   float32
+	System        string
+	JSONMode      bool
+	Tools         []string
+	SpendDecision *economic.SpendAuthorityDecision
 }
 
 // ExecResult encapsulates normalized output and telemetry for receipts.
 type ExecResult struct {
-	Content        string
-	GatewayID      string
-	RuntimeType    ProviderType
-	RuntimeVersion string
-	ModelHash      string
-	Duration       time.Duration
+	Content           string
+	GatewayID         string
+	RuntimeType       ProviderType
+	RuntimeVersion    string
+	ModelHash         string
+	BudgetVerdict     economic.BudgetVerdict
+	SpendReasonCode   economic.SpendReasonCode
+	SpendDecisionHash string
+	Duration          time.Duration
 }
 
 // Execute performs an inference request, enforcing LIG constraints.
@@ -162,6 +182,9 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 	}
 	if len(req.Tools) > 0 && !r.activeProfile.Capabilities.SupportsTools {
 		return nil, fmt.Errorf("lig: capability constraint violation; model %s does not support tools", r.activeProfile.ID)
+	}
+	if err := requireSpendAuthorityAllow(req.SpendDecision); err != nil {
+		return nil, err
 	}
 
 	modelHash := r.activeProfile.ModelHash
@@ -190,13 +213,35 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 	}
 
 	return &ExecResult{
-		Content:        content,
-		GatewayID:      r.activeProfile.ID,
-		RuntimeType:    r.activeProfile.Provider,
-		RuntimeVersion: version,
-		ModelHash:      modelHash,
-		Duration:       time.Since(start),
+		Content:           content,
+		GatewayID:         r.activeProfile.ID,
+		RuntimeType:       r.activeProfile.Provider,
+		RuntimeVersion:    version,
+		ModelHash:         modelHash,
+		BudgetVerdict:     req.SpendDecision.Verdict,
+		SpendReasonCode:   req.SpendDecision.ReasonCode,
+		SpendDecisionHash: req.SpendDecision.ContentHash,
+		Duration:          time.Since(start),
 	}, nil
+}
+
+func requireSpendAuthorityAllow(decision *economic.SpendAuthorityDecision) error {
+	if decision == nil {
+		return &SpendVerdictError{Reason: "missing spend authority decision"}
+	}
+	if decision.Verdict == "" {
+		return &SpendVerdictError{Decision: decision, Reason: "spend authority verdict is required"}
+	}
+	if decision.ReasonCode == "" {
+		return &SpendVerdictError{Decision: decision, Reason: "spend authority reason code is required"}
+	}
+	if decision.ContentHash == "" {
+		return &SpendVerdictError{Decision: decision, Reason: "spend authority decision hash is required"}
+	}
+	if decision.Verdict != economic.BudgetVerdictAllow {
+		return &SpendVerdictError{Decision: decision, Reason: "provider dispatch requires ALLOW"}
+	}
+	return nil
 }
 
 func defaultBaseURL(provider ProviderType) string {

--- a/core/pkg/llm/gateway/router.go
+++ b/core/pkg/llm/gateway/router.go
@@ -241,7 +241,17 @@ func requireSpendAuthorityAllow(decision *economic.SpendAuthorityDecision) error
 	if decision.Verdict != economic.BudgetVerdictAllow {
 		return &SpendVerdictError{Decision: decision, Reason: "provider dispatch requires ALLOW"}
 	}
+	if !isAllowSpendReasonCode(decision.ReasonCode) {
+		return &SpendVerdictError{Decision: decision, Reason: "ALLOW spend authority reason code is invalid"}
+	}
+	if !decision.HasCanonicalContentHash() {
+		return &SpendVerdictError{Decision: decision, Reason: "spend authority decision hash mismatch"}
+	}
 	return nil
+}
+
+func isAllowSpendReasonCode(code economic.SpendReasonCode) bool {
+	return code == economic.SpendReasonOKWithinEnvelope || code == economic.SpendReasonOKApproved
 }
 
 func defaultBaseURL(provider ProviderType) string {

--- a/core/pkg/llm/gateway/router_core_coverage_test.go
+++ b/core/pkg/llm/gateway/router_core_coverage_test.go
@@ -232,7 +232,7 @@ func TestExecuteOpenAICompatibleSendsJSONModeToolsAndSystem(t *testing.T) {
 		t.Fatal(err)
 	}
 	result, err := router.Execute(context.Background(), ExecContext{
-		Prompt: "hello", System: "system", JSONMode: true, Tools: []string{"tool"},
+		Prompt: "hello", System: "system", JSONMode: true, Tools: []string{"tool"}, SpendDecision: gatewayAllowSpendDecision(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/core/pkg/llm/gateway/router_test.go
+++ b/core/pkg/llm/gateway/router_test.go
@@ -166,6 +166,8 @@ func TestExecuteRequiresSpendAuthorityAllowBeforeProviderDispatch(t *testing.T) 
 		{name: "missing", decision: nil, want: "spend authority decision required"},
 		{name: "deny", decision: gatewaySpendDecision(economic.BudgetVerdictDeny, economic.SpendReasonBalanceInsufficient), want: "provider dispatch requires ALLOW"},
 		{name: "escalate", decision: gatewaySpendDecision(economic.BudgetVerdictEscalate, economic.SpendReasonApprovalRequired), want: "provider dispatch requires ALLOW"},
+		{name: "allow with deny reason", decision: gatewaySpendDecision(economic.BudgetVerdictAllow, economic.SpendReasonBalanceInsufficient), want: "ALLOW spend authority reason code is invalid"},
+		{name: "allow with tampered hash", decision: gatewayTamperedAllowSpendDecision(), want: "spend authority decision hash mismatch"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dispatched := false
@@ -224,12 +226,19 @@ func gatewayAllowSpendDecision() *economic.SpendAuthorityDecision {
 }
 
 func gatewaySpendDecision(verdict economic.BudgetVerdict, reason economic.SpendReasonCode) *economic.SpendAuthorityDecision {
-	return &economic.SpendAuthorityDecision{
+	decision := &economic.SpendAuthorityDecision{
 		Verdict:        verdict,
 		ReasonCode:     reason,
 		Reason:         "test spend decision",
 		RemainingCents: 1000,
 		EnvelopeHash:   "sha256:envelope",
-		ContentHash:    "sha256:decision",
 	}
+	decision.ContentHash = decision.CanonicalContentHash()
+	return decision
+}
+
+func gatewayTamperedAllowSpendDecision() *economic.SpendAuthorityDecision {
+	decision := gatewayAllowSpendDecision()
+	decision.ContentHash = "sha256:tampered"
+	return decision
 }

--- a/core/pkg/llm/gateway/router_test.go
+++ b/core/pkg/llm/gateway/router_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
 )
 
 func TestExecuteOllamaDiscoversDigestAndCallsAPI(t *testing.T) {
@@ -27,12 +29,15 @@ func TestExecuteOllamaDiscoversDigestAndCallsAPI(t *testing.T) {
 	if err := r.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderOllama, BaseURL: srv.URL, ModelName: "test-model"}); err != nil {
 		t.Fatal(err)
 	}
-	res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", JSONMode: true})
+	res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", JSONMode: true, SpendDecision: gatewayAllowSpendDecision()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if res.Content != "ok" || res.ModelHash != "sha256:abc" || res.RuntimeVersion != "0.5.0" {
 		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.BudgetVerdict != economic.BudgetVerdictAllow || res.SpendDecisionHash == "" {
+		t.Fatalf("missing spend decision evidence on result: %+v", res)
 	}
 }
 
@@ -44,7 +49,7 @@ func TestExecuteOpenAICompatibleRequiresModelHash(t *testing.T) {
 	if err := r.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderVLLM, BaseURL: srv.URL, ModelName: "test-model"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Execute(context.Background(), ExecContext{Prompt: "hello"}); err == nil {
+	if _, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()}); err == nil {
 		t.Fatal("expected model hash error")
 	}
 }
@@ -64,7 +69,7 @@ func TestExecuteOpenAICompatibleProviders(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err)
 			}
-			res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello"})
+			res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -106,7 +111,7 @@ func TestExecuteRejectsEnginePinMismatchBeforeDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = r.Execute(context.Background(), ExecContext{Prompt: "hello"})
+	_, err = r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()})
 	if err == nil || !strings.Contains(err.Error(), "engine pin mismatch") {
 		t.Fatalf("expected engine pin mismatch, got %v", err)
 	}
@@ -143,12 +148,56 @@ func TestExecuteAcceptsEnginePinWithVerifierAndMeasurement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello"})
+	res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if res.Content != "ok" || res.RuntimeVersion != "server-version" || res.ModelHash != "sha256:def" {
 		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+func TestExecuteRequiresSpendAuthorityAllowBeforeProviderDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		decision *economic.SpendAuthorityDecision
+		want     string
+	}{
+		{name: "missing", decision: nil, want: "spend authority decision required"},
+		{name: "deny", decision: gatewaySpendDecision(economic.BudgetVerdictDeny, economic.SpendReasonBalanceInsufficient), want: "provider dispatch requires ALLOW"},
+		{name: "escalate", decision: gatewaySpendDecision(economic.BudgetVerdictEscalate, economic.SpendReasonApprovalRequired), want: "provider dispatch requires ALLOW"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatched := false
+			mux := http.NewServeMux()
+			mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+				dispatched = true
+				_ = json.NewEncoder(w).Encode(map[string]string{"version": "server-version"})
+			})
+			mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, _ *http.Request) {
+				dispatched = true
+				_ = json.NewEncoder(w).Encode(map[string]any{"choices": []map[string]any{{"message": map[string]string{"content": "ok"}}}})
+			})
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			r := NewGatewayRouter()
+			if err := r.RouteWithConfig(context.Background(), RouteConfig{
+				Provider:  ProviderVLLM,
+				BaseURL:   srv.URL,
+				ModelName: "test-model",
+				ModelHash: "sha256:def",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			_, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: tc.decision})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected spend verdict error containing %q, got %v", tc.want, err)
+			}
+			if dispatched {
+				t.Fatal("provider dispatch occurred before spend authority ALLOW")
+			}
+		})
 	}
 }
 
@@ -168,4 +217,19 @@ func newOpenAICompatibleServer(t *testing.T, version string) *httptest.Server {
 		})
 	})
 	return httptest.NewServer(mux)
+}
+
+func gatewayAllowSpendDecision() *economic.SpendAuthorityDecision {
+	return gatewaySpendDecision(economic.BudgetVerdictAllow, economic.SpendReasonOKWithinEnvelope)
+}
+
+func gatewaySpendDecision(verdict economic.BudgetVerdict, reason economic.SpendReasonCode) *economic.SpendAuthorityDecision {
+	return &economic.SpendAuthorityDecision{
+		Verdict:        verdict,
+		ReasonCode:     reason,
+		Reason:         "test spend decision",
+		RemainingCents: 1000,
+		EnvelopeHash:   "sha256:envelope",
+		ContentHash:    "sha256:decision",
+	}
 }

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-08T16:31:08Z
-# Commit: 9b2dd48b23366c5f159e8e50e24453c8f33c99c7
+# Generated: 2026-06-08T17:02:58Z
+# Commit: 0eb64a55ebeb681a9449f17ddca272b516ecfb9d
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md
@@ -156,10 +156,10 @@ daa5d9844d49d92004ed79bc292b1638adf11a876c702aafe578a387c967aba6  core/pkg/contr
 5fcbb041c39a4f5e1752aa07f806fd82e50100b32722e7253980e6fd2861179b  core/pkg/contracts/economic/org_budget.go
 23a788e681c240f5a0b4c19b82df1dd18b8c44442ca69c526e1ba36c0e16a674  core/pkg/contracts/economic/procurement.go
 74f527420a813365f34b9ed1861d6107169414256f0eb154e59ec9f5a66dbd90  core/pkg/contracts/economic/reconciliation.go
-495eb6bff9a33e705024bb7db57793966581feef7feec1f7bd9ce4e8808e7fa2  core/pkg/contracts/economic/spend_authority.go
+75e38653d39ee249fc6cfb9cf1401bd21d8a8a85f5d6d0d29c41cee549fbc4ee  core/pkg/contracts/economic/spend_authority.go
 b2efddcd68b8ed03f424acb3cd01733e8539003c78a0a927abecf97840ebbb17  core/pkg/contracts/economic/spend_authority_financial.go
 efa7332a9fedf60766463654e224f336beeabb54c926fc512500de295c6bc37c  core/pkg/contracts/economic/spend_authority_financial_test.go
-95753f2e0900d25222213eda29cc703ce368879fb0014fc6610b74905393dc98  core/pkg/contracts/economic/spend_authority_test.go
+fb59084b0bd2ccc5d27cf4300ac962c9329c9c84e803db3c4ffd323e0ad691a2  core/pkg/contracts/economic/spend_authority_test.go
 98bc2a2891d56d764d84c357656b454695174ac352b2eb0208befe7e5c85b9bb  core/pkg/contracts/economic/spend_intent.go
 6c292cd4db2d7bac15002fed6be93912381349526177325ce097133ffb3db002  core/pkg/contracts/economic/transaction_manifest.go
 e1c9fbfd2bf7b04450d17b79ed61ec6a2710c7b13e179adb84c88f8bbdbea612  core/pkg/contracts/economic/treasury.go


### PR DESCRIPTION
## Summary
- Requires a Spend Authority decision on `gateway.ExecContext` before Local Inference Gateway provider dispatch.
- Fails closed on missing, DENY, ESCALATE, or malformed spend decisions before any provider network call.
- Carries the BudgetVerdict, reason code, and decision hash onto `ExecResult` for downstream receipt/evidence binding.
- Adds regression coverage proving provider dispatch is not reached without ALLOW.

## Validation
- `cd core && GOROOT=/usr/local/go GOCACHE=/tmp/helm-spend-go-build-cache /usr/local/go/bin/go test ./pkg/llm/gateway`
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin make verify-boundary`
- `git diff --check`
- `cd core && GOROOT=/usr/local/go GOCACHE=/tmp/helm-spend-go-build-cache /usr/local/go/bin/go test ./pkg/...`

## Scope Note
This is the first MIN-467 implementation slice for the concrete LIG provider-dispatch choke point. It does not yet close full signed BudgetVerdict receipt emission or every PEP/CPI runtime path, so the Linear issue should remain open after merge.