### PR TITLE
MIN-481 Add signed BudgetVerdict receipts

### DIFF
--- a/core/pkg/contracts/economic/spend_authority.go
+++ b/core/pkg/contracts/economic/spend_authority.go
@@ -6,11 +6,13 @@
 package economic
 
 import (
+	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -474,6 +476,272 @@ func (q *RouteQuote) computeHash() string {
 		ReasonCode                SpendReasonCode `json:"reason_code"`
 		ReceiptHash               string          `json:"receipt_hash,omitempty"`
 	}{q.ID, q.TenantID, q.SpendIntentID, q.EnvelopeID, q.AgentID, q.SelectedProviderID, q.SelectedModelID, q.ProviderPriceSnapshotHash, q.QuotedAmountCents, q.MaxAmountCents, q.Currency, q.RoutePolicyHash, q.BudgetVerdict, q.ReasonCode, q.ReceiptHash})
+}
+
+// BudgetVerdictReceipt is the signed pre-dispatch proof for a spend verdict.
+type BudgetVerdictReceipt struct {
+	ID                        string          `json:"id"`
+	TenantID                  string          `json:"tenant_id"`
+	SpendIntentID             string          `json:"spend_intent_id"`
+	EnvelopeID                string          `json:"envelope_id"`
+	AgentID                   string          `json:"agent_id"`
+	PrincipalID               string          `json:"principal_id,omitempty"`
+	ProviderID                string          `json:"provider_id"`
+	ModelID                   string          `json:"model_id"`
+	ProviderPriceSnapshotHash string          `json:"provider_price_snapshot_hash"`
+	QuotedAmountCents         int64           `json:"quoted_amount_cents"`
+	MaxAmountCents            int64           `json:"max_amount_cents"`
+	Currency                  string          `json:"currency"`
+	BudgetVerdict             BudgetVerdict   `json:"budget_verdict"`
+	ReasonCode                SpendReasonCode `json:"reason_code"`
+	DecisionHash              string          `json:"decision_hash"`
+	EnvelopeHash              string          `json:"envelope_hash,omitempty"`
+	RoutePolicyHash           string          `json:"route_policy_hash"`
+	EvidencePackRef           string          `json:"evidence_pack_ref"`
+	CreatedAt                 time.Time       `json:"created_at"`
+	ContentHash               string          `json:"content_hash"`
+	SignatureKeyID            string          `json:"signature_key_id"`
+	Signature                 string          `json:"signature"`
+}
+
+// NewBudgetVerdictReceipt creates an unsigned pre-dispatch receipt.
+func NewBudgetVerdictReceipt(id, tenantID, spendIntentID, envelopeID, agentID, providerID, modelID string, quotedAmountCents, maxAmountCents int64, currency, providerPriceSnapshotHash, routePolicyHash, evidencePackRef string, decision SpendAuthorityDecision) *BudgetVerdictReceipt {
+	r := &BudgetVerdictReceipt{
+		ID:                        id,
+		TenantID:                  tenantID,
+		SpendIntentID:             spendIntentID,
+		EnvelopeID:                envelopeID,
+		AgentID:                   agentID,
+		ProviderID:                providerID,
+		ModelID:                   modelID,
+		ProviderPriceSnapshotHash: providerPriceSnapshotHash,
+		QuotedAmountCents:         quotedAmountCents,
+		MaxAmountCents:            maxAmountCents,
+		Currency:                  currency,
+		BudgetVerdict:             decision.Verdict,
+		ReasonCode:                decision.ReasonCode,
+		DecisionHash:              decision.ContentHash,
+		EnvelopeHash:              decision.EnvelopeHash,
+		RoutePolicyHash:           routePolicyHash,
+		EvidencePackRef:           evidencePackRef,
+		CreatedAt:                 time.Now().UTC(),
+	}
+	r.ContentHash = r.computeHash()
+	return r
+}
+
+// Seal signs the canonical receipt hash with an Ed25519 key.
+func (r *BudgetVerdictReceipt) Seal(keyID string, privateKey ed25519.PrivateKey) error {
+	if r == nil {
+		return errors.New("budget_verdict_receipt: receipt is nil")
+	}
+	if keyID == "" {
+		return errors.New("budget_verdict_receipt: signature_key_id is required")
+	}
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return fmt.Errorf("budget_verdict_receipt: ed25519 private key must be %d bytes", ed25519.PrivateKeySize)
+	}
+	r.ContentHash = r.computeHash()
+	hashBytes, err := decodeSHA256Hash(r.ContentHash)
+	if err != nil {
+		return err
+	}
+	r.SignatureKeyID = keyID
+	r.Signature = "ed25519:" + hex.EncodeToString(ed25519.Sign(privateKey, hashBytes))
+	return r.Validate()
+}
+
+// Validate ensures the receipt is signed and internally consistent.
+func (r *BudgetVerdictReceipt) Validate() error {
+	if err := r.validateCore(); err != nil {
+		return err
+	}
+	if r.SignatureKeyID == "" {
+		return errors.New("budget_verdict_receipt: signature_key_id is required")
+	}
+	if _, err := decodeEd25519Signature(r.Signature); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ValidateForDecision checks that the receipt binds the canonical spend decision.
+func (r *BudgetVerdictReceipt) ValidateForDecision(decision SpendAuthorityDecision) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	if !decision.HasCanonicalContentHash() {
+		return errors.New("budget_verdict_receipt: spend authority decision hash mismatch")
+	}
+	if r.BudgetVerdict != decision.Verdict {
+		return errors.New("budget_verdict_receipt: budget_verdict does not match decision")
+	}
+	if r.ReasonCode != decision.ReasonCode {
+		return errors.New("budget_verdict_receipt: reason_code does not match decision")
+	}
+	if r.DecisionHash != decision.ContentHash {
+		return errors.New("budget_verdict_receipt: decision_hash does not match decision")
+	}
+	if r.EnvelopeHash != decision.EnvelopeHash {
+		return errors.New("budget_verdict_receipt: envelope_hash does not match decision")
+	}
+	return nil
+}
+
+// VerifySignature validates the Ed25519 signature over the canonical receipt hash.
+func (r *BudgetVerdictReceipt) VerifySignature(publicKey ed25519.PublicKey) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+	if len(publicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("budget_verdict_receipt: ed25519 public key must be %d bytes", ed25519.PublicKeySize)
+	}
+	hashBytes, err := decodeSHA256Hash(r.ContentHash)
+	if err != nil {
+		return err
+	}
+	sig, err := decodeEd25519Signature(r.Signature)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(publicKey, hashBytes, sig) {
+		return errors.New("budget_verdict_receipt: signature verification failed")
+	}
+	return nil
+}
+
+// HasCanonicalContentHash reports whether ContentHash matches the receipt body.
+func (r *BudgetVerdictReceipt) HasCanonicalContentHash() bool {
+	return r != nil && r.ContentHash != "" && r.ContentHash == r.computeHash()
+}
+
+// CanonicalContentHash returns the deterministic hash for the receipt body.
+func (r *BudgetVerdictReceipt) CanonicalContentHash() string {
+	if r == nil {
+		return ""
+	}
+	return r.computeHash()
+}
+
+func (r *BudgetVerdictReceipt) validateCore() error {
+	if r == nil {
+		return errors.New("budget_verdict_receipt: receipt is nil")
+	}
+	if r.ID == "" {
+		return errors.New("budget_verdict_receipt: id is required")
+	}
+	if r.TenantID == "" {
+		return errors.New("budget_verdict_receipt: tenant_id is required")
+	}
+	if r.SpendIntentID == "" {
+		return errors.New("budget_verdict_receipt: spend_intent_id is required")
+	}
+	if r.EnvelopeID == "" {
+		return errors.New("budget_verdict_receipt: envelope_id is required")
+	}
+	if r.AgentID == "" {
+		return errors.New("budget_verdict_receipt: agent_id is required")
+	}
+	if r.ProviderID == "" {
+		return errors.New("budget_verdict_receipt: provider_id is required")
+	}
+	if r.ModelID == "" {
+		return errors.New("budget_verdict_receipt: model_id is required")
+	}
+	if r.ProviderPriceSnapshotHash == "" {
+		return errors.New("budget_verdict_receipt: provider_price_snapshot_hash is required")
+	}
+	if r.QuotedAmountCents <= 0 {
+		return errors.New("budget_verdict_receipt: quoted_amount_cents must be positive")
+	}
+	if r.MaxAmountCents <= 0 {
+		return errors.New("budget_verdict_receipt: max_amount_cents must be positive")
+	}
+	if r.QuotedAmountCents > r.MaxAmountCents {
+		return errors.New("budget_verdict_receipt: quoted_amount_cents exceeds max_amount_cents")
+	}
+	if r.Currency == "" {
+		return errors.New("budget_verdict_receipt: currency is required")
+	}
+	if r.BudgetVerdict == "" {
+		return errors.New("budget_verdict_receipt: budget_verdict is required")
+	}
+	if r.ReasonCode == "" {
+		return errors.New("budget_verdict_receipt: reason_code is required")
+	}
+	if r.DecisionHash == "" {
+		return errors.New("budget_verdict_receipt: decision_hash is required")
+	}
+	if r.RoutePolicyHash == "" {
+		return errors.New("budget_verdict_receipt: route_policy_hash is required")
+	}
+	if r.EvidencePackRef == "" {
+		return errors.New("budget_verdict_receipt: evidence_pack_ref is required")
+	}
+	if r.CreatedAt.IsZero() {
+		return errors.New("budget_verdict_receipt: created_at is required")
+	}
+	if r.ContentHash == "" {
+		return errors.New("budget_verdict_receipt: content_hash is required")
+	}
+	if !r.HasCanonicalContentHash() {
+		return errors.New("budget_verdict_receipt: content_hash mismatch")
+	}
+	return nil
+}
+
+func (r *BudgetVerdictReceipt) computeHash() string {
+	return hashSpendAuthorityCanonical(struct {
+		ID                        string          `json:"id"`
+		TenantID                  string          `json:"tenant_id"`
+		SpendIntentID             string          `json:"spend_intent_id"`
+		EnvelopeID                string          `json:"envelope_id"`
+		AgentID                   string          `json:"agent_id"`
+		PrincipalID               string          `json:"principal_id,omitempty"`
+		ProviderID                string          `json:"provider_id"`
+		ModelID                   string          `json:"model_id"`
+		ProviderPriceSnapshotHash string          `json:"provider_price_snapshot_hash"`
+		QuotedAmountCents         int64           `json:"quoted_amount_cents"`
+		MaxAmountCents            int64           `json:"max_amount_cents"`
+		Currency                  string          `json:"currency"`
+		BudgetVerdict             BudgetVerdict   `json:"budget_verdict"`
+		ReasonCode                SpendReasonCode `json:"reason_code"`
+		DecisionHash              string          `json:"decision_hash"`
+		EnvelopeHash              string          `json:"envelope_hash,omitempty"`
+		RoutePolicyHash           string          `json:"route_policy_hash"`
+		EvidencePackRef           string          `json:"evidence_pack_ref"`
+		CreatedAt                 time.Time       `json:"created_at"`
+	}{r.ID, r.TenantID, r.SpendIntentID, r.EnvelopeID, r.AgentID, r.PrincipalID, r.ProviderID, r.ModelID, r.ProviderPriceSnapshotHash, r.QuotedAmountCents, r.MaxAmountCents, r.Currency, r.BudgetVerdict, r.ReasonCode, r.DecisionHash, r.EnvelopeHash, r.RoutePolicyHash, r.EvidencePackRef, r.CreatedAt})
+}
+
+func decodeSHA256Hash(hash string) ([]byte, error) {
+	raw := strings.TrimPrefix(hash, "sha256:")
+	if raw == hash {
+		return nil, errors.New("budget_verdict_receipt: content_hash must use sha256 prefix")
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("budget_verdict_receipt: invalid sha256 content_hash: %w", err)
+	}
+	if len(decoded) != sha256.Size {
+		return nil, fmt.Errorf("budget_verdict_receipt: sha256 content_hash must decode to %d bytes", sha256.Size)
+	}
+	return decoded, nil
+}
+
+func decodeEd25519Signature(signature string) ([]byte, error) {
+	raw := strings.TrimPrefix(signature, "ed25519:")
+	if raw == signature {
+		return nil, errors.New("budget_verdict_receipt: signature must use ed25519 prefix")
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("budget_verdict_receipt: invalid ed25519 signature: %w", err)
+	}
+	if len(decoded) != ed25519.SignatureSize {
+		return nil, fmt.Errorf("budget_verdict_receipt: ed25519 signature must decode to %d bytes", ed25519.SignatureSize)
+	}
+	return decoded, nil
 }
 
 // UsageReceipt records the actual provider usage and balance debit after dispatch.

--- a/core/pkg/contracts/economic/spend_authority_test.go
+++ b/core/pkg/contracts/economic/spend_authority_test.go
@@ -1,6 +1,8 @@
 package economic
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"strings"
 	"testing"
 	"time"
@@ -137,6 +139,50 @@ func TestRouteQuoteValidationAndExpiry(t *testing.T) {
 	requireEconomicErrorContains(t, quote.Validate(), "fallback_chain is required")
 }
 
+func TestBudgetVerdictReceiptSigningAndDecisionBinding(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision := spendAuthorityTestEnvelope().EvaluateSpend(100, "openai", "gpt-5-mini")
+	receipt := spendAuthorityTestBudgetVerdictReceipt(decision)
+	if err := receipt.Seal("spend-test-key", privateKey); err != nil {
+		t.Fatalf("Seal() = %v, want nil", err)
+	}
+	if err := receipt.ValidateForDecision(decision); err != nil {
+		t.Fatalf("ValidateForDecision() = %v, want nil", err)
+	}
+	if err := receipt.VerifySignature(privateKey.Public().(ed25519.PublicKey)); err != nil {
+		t.Fatalf("VerifySignature() = %v, want nil", err)
+	}
+
+	tampered := *receipt
+	tampered.DecisionHash = "sha256:other"
+	tampered.ContentHash = tampered.computeHash()
+	if err := tampered.ValidateForDecision(decision); err == nil || !strings.Contains(err.Error(), "decision_hash does not match") {
+		t.Fatalf("expected decision hash mismatch, got %v", err)
+	}
+
+	tampered = *receipt
+	tampered.ModelID = "other-model"
+	tampered.ContentHash = tampered.computeHash()
+	if err := tampered.VerifySignature(privateKey.Public().(ed25519.PublicKey)); err == nil || !strings.Contains(err.Error(), "signature verification failed") {
+		t.Fatalf("expected signature verification failure, got %v", err)
+	}
+
+	tampered = *receipt
+	tampered.ContentHash = "sha256:tampered"
+	if err := tampered.Validate(); err == nil || !strings.Contains(err.Error(), "content_hash mismatch") {
+		t.Fatalf("expected content hash mismatch, got %v", err)
+	}
+
+	tampered = *receipt
+	tampered.CreatedAt = tampered.CreatedAt.Add(time.Minute)
+	if err := tampered.Validate(); err == nil || !strings.Contains(err.Error(), "content_hash mismatch") {
+		t.Fatalf("expected timestamp content hash mismatch, got %v", err)
+	}
+}
+
 func TestUsageReceiptValidationAndSettlementRequirements(t *testing.T) {
 	receipt := spendAuthorityTestUsageReceipt()
 	receipt.SettlementReceiptHash = "sha256:settlement"
@@ -215,6 +261,25 @@ func spendAuthorityTestQuote(decision SpendAuthorityDecision) *RouteQuote {
 		"USD",
 		"sha256:route-policy",
 		time.Now().UTC().Add(5*time.Minute),
+		decision,
+	)
+}
+
+func spendAuthorityTestBudgetVerdictReceipt(decision SpendAuthorityDecision) *BudgetVerdictReceipt {
+	return NewBudgetVerdictReceipt(
+		"verdict-1",
+		"tenant-1",
+		"spend-1",
+		"env-1",
+		"agent-1",
+		"openai",
+		"gpt-5-mini",
+		100,
+		200,
+		"USD",
+		"sha256:price",
+		"sha256:route-policy",
+		"evidence://pack-1",
 		decision,
 	)
 }

--- a/core/pkg/llm/gateway/router.go
+++ b/core/pkg/llm/gateway/router.go
@@ -4,6 +4,7 @@ package gateway
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,8 +20,9 @@ import (
 
 // GatewayRouter normalizes capability requests across providers.
 type GatewayRouter struct {
-	activeProfile *Profile
-	client        *http.Client
+	activeProfile           *Profile
+	client                  *http.Client
+	budgetVerdictReceiptKey map[string]ed25519.PublicKey
 }
 
 type EnginePinMismatchError struct {
@@ -55,6 +57,22 @@ func (e *SpendVerdictError) Error() string {
 // NewGatewayRouter creates a new Local Inference Gateway router.
 func NewGatewayRouter() *GatewayRouter {
 	return &GatewayRouter{client: &http.Client{Timeout: 30 * time.Second}}
+}
+
+// TrustBudgetVerdictReceiptKey registers a trusted signer for pre-dispatch spend receipts.
+func (r *GatewayRouter) TrustBudgetVerdictReceiptKey(keyID string, publicKey ed25519.PublicKey) error {
+	if keyID == "" {
+		return errors.New("lig: BudgetVerdict receipt key id is required")
+	}
+	if len(publicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("lig: BudgetVerdict receipt public key must be %d bytes", ed25519.PublicKeySize)
+	}
+	if r.budgetVerdictReceiptKey == nil {
+		r.budgetVerdictReceiptKey = make(map[string]ed25519.PublicKey)
+	}
+	keyCopy := append(ed25519.PublicKey(nil), publicKey...)
+	r.budgetVerdictReceiptKey[keyID] = keyCopy
+	return nil
 }
 
 type RouteConfig struct {
@@ -188,7 +206,7 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 	if err := requireSpendAuthorityAllow(req.SpendDecision); err != nil {
 		return nil, err
 	}
-	if err := requireBudgetVerdictReceipt(req.SpendDecision, req.SpendReceipt, *r.activeProfile); err != nil {
+	if err := requireBudgetVerdictReceipt(req.SpendDecision, req.SpendReceipt, *r.activeProfile, r.budgetVerdictReceiptKey); err != nil {
 		return nil, err
 	}
 
@@ -260,7 +278,7 @@ func isAllowSpendReasonCode(code economic.SpendReasonCode) bool {
 	return code == economic.SpendReasonOKWithinEnvelope || code == economic.SpendReasonOKApproved
 }
 
-func requireBudgetVerdictReceipt(decision *economic.SpendAuthorityDecision, receipt *economic.BudgetVerdictReceipt, profile Profile) error {
+func requireBudgetVerdictReceipt(decision *economic.SpendAuthorityDecision, receipt *economic.BudgetVerdictReceipt, profile Profile, trustedKeys map[string]ed25519.PublicKey) error {
 	if receipt == nil {
 		return &SpendVerdictError{Decision: decision, Reason: "signed BudgetVerdict receipt is required"}
 	}
@@ -268,6 +286,13 @@ func requireBudgetVerdictReceipt(decision *economic.SpendAuthorityDecision, rece
 		return &SpendVerdictError{Reason: "missing spend authority decision"}
 	}
 	if err := receipt.ValidateForDecision(*decision); err != nil {
+		return &SpendVerdictError{Decision: decision, Reason: err.Error()}
+	}
+	trustedKey, ok := trustedKeys[receipt.SignatureKeyID]
+	if !ok {
+		return &SpendVerdictError{Decision: decision, Reason: "trusted BudgetVerdict receipt key not found"}
+	}
+	if err := receipt.VerifySignature(trustedKey); err != nil {
 		return &SpendVerdictError{Decision: decision, Reason: err.Error()}
 	}
 	if receipt.ProviderID != string(profile.Provider) {

--- a/core/pkg/llm/gateway/router.go
+++ b/core/pkg/llm/gateway/router.go
@@ -156,6 +156,7 @@ type ExecContext struct {
 	JSONMode      bool
 	Tools         []string
 	SpendDecision *economic.SpendAuthorityDecision
+	SpendReceipt  *economic.BudgetVerdictReceipt
 }
 
 // ExecResult encapsulates normalized output and telemetry for receipts.
@@ -168,6 +169,7 @@ type ExecResult struct {
 	BudgetVerdict     economic.BudgetVerdict
 	SpendReasonCode   economic.SpendReasonCode
 	SpendDecisionHash string
+	SpendReceiptHash  string
 	Duration          time.Duration
 }
 
@@ -184,6 +186,9 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 		return nil, fmt.Errorf("lig: capability constraint violation; model %s does not support tools", r.activeProfile.ID)
 	}
 	if err := requireSpendAuthorityAllow(req.SpendDecision); err != nil {
+		return nil, err
+	}
+	if err := requireBudgetVerdictReceipt(req.SpendDecision, req.SpendReceipt, *r.activeProfile); err != nil {
 		return nil, err
 	}
 
@@ -221,6 +226,7 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 		BudgetVerdict:     req.SpendDecision.Verdict,
 		SpendReasonCode:   req.SpendDecision.ReasonCode,
 		SpendDecisionHash: req.SpendDecision.ContentHash,
+		SpendReceiptHash:  req.SpendReceipt.ContentHash,
 		Duration:          time.Since(start),
 	}, nil
 }
@@ -252,6 +258,25 @@ func requireSpendAuthorityAllow(decision *economic.SpendAuthorityDecision) error
 
 func isAllowSpendReasonCode(code economic.SpendReasonCode) bool {
 	return code == economic.SpendReasonOKWithinEnvelope || code == economic.SpendReasonOKApproved
+}
+
+func requireBudgetVerdictReceipt(decision *economic.SpendAuthorityDecision, receipt *economic.BudgetVerdictReceipt, profile Profile) error {
+	if receipt == nil {
+		return &SpendVerdictError{Decision: decision, Reason: "signed BudgetVerdict receipt is required"}
+	}
+	if decision == nil {
+		return &SpendVerdictError{Reason: "missing spend authority decision"}
+	}
+	if err := receipt.ValidateForDecision(*decision); err != nil {
+		return &SpendVerdictError{Decision: decision, Reason: err.Error()}
+	}
+	if receipt.ProviderID != string(profile.Provider) {
+		return &SpendVerdictError{Decision: decision, Reason: "BudgetVerdict receipt provider does not match active profile"}
+	}
+	if receipt.ModelID != profile.ModelName {
+		return &SpendVerdictError{Decision: decision, Reason: "BudgetVerdict receipt model does not match active profile"}
+	}
+	return nil
 }
 
 func defaultBaseURL(provider ProviderType) string {

--- a/core/pkg/llm/gateway/router_core_coverage_test.go
+++ b/core/pkg/llm/gateway/router_core_coverage_test.go
@@ -227,7 +227,7 @@ func TestExecuteOpenAICompatibleSendsJSONModeToolsAndSystem(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	router := NewGatewayRouter()
+	router := newGatewayRouterWithReceiptTrust()
 	if err := router.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderVLLM, BaseURL: srv.URL, ModelName: "model", ModelHash: "sha256:model"}); err != nil {
 		t.Fatal(err)
 	}

--- a/core/pkg/llm/gateway/router_core_coverage_test.go
+++ b/core/pkg/llm/gateway/router_core_coverage_test.go
@@ -231,9 +231,9 @@ func TestExecuteOpenAICompatibleSendsJSONModeToolsAndSystem(t *testing.T) {
 	if err := router.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderVLLM, BaseURL: srv.URL, ModelName: "model", ModelHash: "sha256:model"}); err != nil {
 		t.Fatal(err)
 	}
-	result, err := router.Execute(context.Background(), ExecContext{
-		Prompt: "hello", System: "system", JSONMode: true, Tools: []string{"tool"}, SpendDecision: gatewayAllowSpendDecision(),
-	})
+	result, err := router.Execute(context.Background(), gatewayExecContext(ProviderVLLM, "model", gatewayAllowSpendDecision(), ExecContext{
+		Prompt: "hello", System: "system", JSONMode: true, Tools: []string{"tool"},
+	}))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/pkg/llm/gateway/router_test.go
+++ b/core/pkg/llm/gateway/router_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -29,7 +30,7 @@ func TestExecuteOllamaDiscoversDigestAndCallsAPI(t *testing.T) {
 	if err := r.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderOllama, BaseURL: srv.URL, ModelName: "test-model"}); err != nil {
 		t.Fatal(err)
 	}
-	res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", JSONMode: true, SpendDecision: gatewayAllowSpendDecision()})
+	res, err := r.Execute(context.Background(), gatewayExecContext(ProviderOllama, "test-model", gatewayAllowSpendDecision(), ExecContext{Prompt: "hello", JSONMode: true}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,6 +39,9 @@ func TestExecuteOllamaDiscoversDigestAndCallsAPI(t *testing.T) {
 	}
 	if res.BudgetVerdict != economic.BudgetVerdictAllow || res.SpendDecisionHash == "" {
 		t.Fatalf("missing spend decision evidence on result: %+v", res)
+	}
+	if res.SpendReceiptHash == "" {
+		t.Fatalf("missing spend receipt evidence on result: %+v", res)
 	}
 }
 
@@ -49,7 +53,7 @@ func TestExecuteOpenAICompatibleRequiresModelHash(t *testing.T) {
 	if err := r.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderVLLM, BaseURL: srv.URL, ModelName: "test-model"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()}); err == nil {
+	if _, err := r.Execute(context.Background(), gatewayExecContext(ProviderVLLM, "test-model", gatewayAllowSpendDecision(), ExecContext{Prompt: "hello"})); err == nil {
 		t.Fatal("expected model hash error")
 	}
 }
@@ -69,7 +73,7 @@ func TestExecuteOpenAICompatibleProviders(t *testing.T) {
 			}); err != nil {
 				t.Fatal(err)
 			}
-			res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()})
+			res, err := r.Execute(context.Background(), gatewayExecContext(provider, "test-model", gatewayAllowSpendDecision(), ExecContext{Prompt: "hello"}))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -111,7 +115,7 @@ func TestExecuteRejectsEnginePinMismatchBeforeDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()})
+	_, err = r.Execute(context.Background(), gatewayExecContext(ProviderVLLM, "test-model", gatewayAllowSpendDecision(), ExecContext{Prompt: "hello"}))
 	if err == nil || !strings.Contains(err.Error(), "engine pin mismatch") {
 		t.Fatalf("expected engine pin mismatch, got %v", err)
 	}
@@ -148,7 +152,7 @@ func TestExecuteAcceptsEnginePinWithVerifierAndMeasurement(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: gatewayAllowSpendDecision()})
+	res, err := r.Execute(context.Background(), gatewayExecContext(ProviderVLLM, "test-model", gatewayAllowSpendDecision(), ExecContext{Prompt: "hello"}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,6 +207,69 @@ func TestExecuteRequiresSpendAuthorityAllowBeforeProviderDispatch(t *testing.T) 
 	}
 }
 
+func TestExecuteRequiresSignedBudgetVerdictReceiptBeforeProviderDispatch(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*economic.BudgetVerdictReceipt)
+		receipt *economic.BudgetVerdictReceipt
+		want    string
+	}{
+		{name: "missing", receipt: nil, want: "signed BudgetVerdict receipt is required"},
+		{name: "unsigned", receipt: gatewayUnsignedSpendReceipt(ProviderVLLM, "test-model", gatewayAllowSpendDecision()), want: "signature_key_id is required"},
+		{name: "wrong provider", mutate: func(r *economic.BudgetVerdictReceipt) {
+			r.ProviderID = string(ProviderOllama)
+			sealGatewayReceipt(r)
+		}, want: "BudgetVerdict receipt provider does not match active profile"},
+		{name: "wrong model", mutate: func(r *economic.BudgetVerdictReceipt) {
+			r.ModelID = "other-model"
+			sealGatewayReceipt(r)
+		}, want: "BudgetVerdict receipt model does not match active profile"},
+		{name: "decision hash mismatch", mutate: func(r *economic.BudgetVerdictReceipt) {
+			r.DecisionHash = "sha256:other"
+			sealGatewayReceipt(r)
+		}, want: "decision_hash does not match decision"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatched := false
+			mux := http.NewServeMux()
+			mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
+				dispatched = true
+				_ = json.NewEncoder(w).Encode(map[string]string{"version": "server-version"})
+			})
+			mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, _ *http.Request) {
+				dispatched = true
+				_ = json.NewEncoder(w).Encode(map[string]any{"choices": []map[string]any{{"message": map[string]string{"content": "ok"}}}})
+			})
+			srv := httptest.NewServer(mux)
+			defer srv.Close()
+
+			decision := gatewayAllowSpendDecision()
+			receipt := tc.receipt
+			if tc.mutate != nil {
+				receipt = gatewaySpendReceipt(ProviderVLLM, "test-model", decision)
+				tc.mutate(receipt)
+			}
+
+			r := NewGatewayRouter()
+			if err := r.RouteWithConfig(context.Background(), RouteConfig{
+				Provider:  ProviderVLLM,
+				BaseURL:   srv.URL,
+				ModelName: "test-model",
+				ModelHash: "sha256:def",
+			}); err != nil {
+				t.Fatal(err)
+			}
+			_, err := r.Execute(context.Background(), ExecContext{Prompt: "hello", SpendDecision: decision, SpendReceipt: receipt})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected spend receipt error containing %q, got %v", tc.want, err)
+			}
+			if dispatched {
+				t.Fatal("provider endpoint was touched before signed BudgetVerdict receipt")
+			}
+		})
+	}
+}
+
 func newOpenAICompatibleServer(t *testing.T, version string) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -241,4 +308,49 @@ func gatewayTamperedAllowSpendDecision() *economic.SpendAuthorityDecision {
 	decision := gatewayAllowSpendDecision()
 	decision.ContentHash = "sha256:tampered"
 	return decision
+}
+
+var gatewayReceiptPrivateKey = ed25519.NewKeyFromSeed([]byte("0123456789abcdef0123456789abcdef"))
+
+func gatewayExecContext(provider ProviderType, model string, decision *economic.SpendAuthorityDecision, req ExecContext) ExecContext {
+	req.SpendDecision = decision
+	req.SpendReceipt = gatewaySpendReceipt(provider, model, decision)
+	return req
+}
+
+func gatewaySpendReceipt(provider ProviderType, model string, decision *economic.SpendAuthorityDecision) *economic.BudgetVerdictReceipt {
+	receipt := gatewayUnsignedSpendReceipt(provider, model, decision)
+	sealGatewayReceipt(receipt)
+	return receipt
+}
+
+func gatewayUnsignedSpendReceipt(provider ProviderType, model string, decision *economic.SpendAuthorityDecision) *economic.BudgetVerdictReceipt {
+	if decision == nil {
+		return nil
+	}
+	return economic.NewBudgetVerdictReceipt(
+		"verdict-1",
+		"tenant-1",
+		"spend-1",
+		"env-1",
+		"agent-1",
+		string(provider),
+		model,
+		100,
+		200,
+		"USD",
+		"sha256:price",
+		"sha256:route-policy",
+		"evidence://pack-1",
+		*decision,
+	)
+}
+
+func sealGatewayReceipt(receipt *economic.BudgetVerdictReceipt) {
+	if receipt == nil {
+		return
+	}
+	if err := receipt.Seal("gateway-test-key", gatewayReceiptPrivateKey); err != nil {
+		panic(err)
+	}
 }

--- a/core/pkg/llm/gateway/router_test.go
+++ b/core/pkg/llm/gateway/router_test.go
@@ -26,7 +26,7 @@ func TestExecuteOllamaDiscoversDigestAndCallsAPI(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	r := NewGatewayRouter()
+	r := newGatewayRouterWithReceiptTrust()
 	if err := r.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderOllama, BaseURL: srv.URL, ModelName: "test-model"}); err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestExecuteOpenAICompatibleRequiresModelHash(t *testing.T) {
 	srv := newOpenAICompatibleServer(t, "server-version")
 	defer srv.Close()
 
-	r := NewGatewayRouter()
+	r := newGatewayRouterWithReceiptTrust()
 	if err := r.RouteWithConfig(context.Background(), RouteConfig{Provider: ProviderVLLM, BaseURL: srv.URL, ModelName: "test-model"}); err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestExecuteOpenAICompatibleProviders(t *testing.T) {
 			srv := newOpenAICompatibleServer(t, "server-version")
 			defer srv.Close()
 
-			r := NewGatewayRouter()
+			r := newGatewayRouterWithReceiptTrust()
 			if err := r.RouteWithConfig(context.Background(), RouteConfig{
 				Provider:  provider,
 				BaseURL:   srv.URL,
@@ -97,7 +97,7 @@ func TestExecuteRejectsEnginePinMismatchBeforeDispatch(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	r := NewGatewayRouter()
+	r := newGatewayRouterWithReceiptTrust()
 	err := r.RouteWithConfig(context.Background(), RouteConfig{
 		Provider:       ProviderVLLM,
 		BaseURL:        srv.URL,
@@ -128,7 +128,7 @@ func TestExecuteAcceptsEnginePinWithVerifierAndMeasurement(t *testing.T) {
 	srv := newOpenAICompatibleServer(t, "server-version")
 	defer srv.Close()
 
-	r := NewGatewayRouter()
+	r := newGatewayRouterWithReceiptTrust()
 	err := r.RouteWithConfig(context.Background(), RouteConfig{
 		Provider:            ProviderVLLM,
 		BaseURL:             srv.URL,
@@ -228,6 +228,12 @@ func TestExecuteRequiresSignedBudgetVerdictReceiptBeforeProviderDispatch(t *test
 			r.DecisionHash = "sha256:other"
 			sealGatewayReceipt(r)
 		}, want: "decision_hash does not match decision"},
+		{name: "untrusted key id", mutate: func(r *economic.BudgetVerdictReceipt) {
+			sealGatewayReceiptWithKey(r, "other-key", gatewayUntrustedReceiptPrivateKey)
+		}, want: "trusted BudgetVerdict receipt key not found"},
+		{name: "forged trusted key id", mutate: func(r *economic.BudgetVerdictReceipt) {
+			sealGatewayReceiptWithKey(r, "gateway-test-key", gatewayUntrustedReceiptPrivateKey)
+		}, want: "signature verification failed"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dispatched := false
@@ -250,7 +256,7 @@ func TestExecuteRequiresSignedBudgetVerdictReceiptBeforeProviderDispatch(t *test
 				tc.mutate(receipt)
 			}
 
-			r := NewGatewayRouter()
+			r := newGatewayRouterWithReceiptTrust()
 			if err := r.RouteWithConfig(context.Background(), RouteConfig{
 				Provider:  ProviderVLLM,
 				BaseURL:   srv.URL,
@@ -310,7 +316,18 @@ func gatewayTamperedAllowSpendDecision() *economic.SpendAuthorityDecision {
 	return decision
 }
 
-var gatewayReceiptPrivateKey = ed25519.NewKeyFromSeed([]byte("0123456789abcdef0123456789abcdef"))
+var (
+	gatewayReceiptPrivateKey          = ed25519.NewKeyFromSeed([]byte("0123456789abcdef0123456789abcdef"))
+	gatewayUntrustedReceiptPrivateKey = ed25519.NewKeyFromSeed([]byte("fedcba9876543210fedcba9876543210"))
+)
+
+func newGatewayRouterWithReceiptTrust() *GatewayRouter {
+	router := NewGatewayRouter()
+	if err := router.TrustBudgetVerdictReceiptKey("gateway-test-key", gatewayReceiptPrivateKey.Public().(ed25519.PublicKey)); err != nil {
+		panic(err)
+	}
+	return router
+}
 
 func gatewayExecContext(provider ProviderType, model string, decision *economic.SpendAuthorityDecision, req ExecContext) ExecContext {
 	req.SpendDecision = decision
@@ -347,10 +364,14 @@ func gatewayUnsignedSpendReceipt(provider ProviderType, model string, decision *
 }
 
 func sealGatewayReceipt(receipt *economic.BudgetVerdictReceipt) {
+	sealGatewayReceiptWithKey(receipt, "gateway-test-key", gatewayReceiptPrivateKey)
+}
+
+func sealGatewayReceiptWithKey(receipt *economic.BudgetVerdictReceipt, keyID string, key ed25519.PrivateKey) {
 	if receipt == nil {
 		return
 	}
-	if err := receipt.Seal("gateway-test-key", gatewayReceiptPrivateKey); err != nil {
+	if err := receipt.Seal(keyID, key); err != nil {
 		panic(err)
 	}
 }

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-08T17:02:58Z
-# Commit: 0eb64a55ebeb681a9449f17ddca272b516ecfb9d
+# Generated: 2026-06-08T17:23:34Z
+# Commit: 42c72213a5bf143f144f74bf46c1bfb7c1bee87e
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md
@@ -156,10 +156,10 @@ daa5d9844d49d92004ed79bc292b1638adf11a876c702aafe578a387c967aba6  core/pkg/contr
 5fcbb041c39a4f5e1752aa07f806fd82e50100b32722e7253980e6fd2861179b  core/pkg/contracts/economic/org_budget.go
 23a788e681c240f5a0b4c19b82df1dd18b8c44442ca69c526e1ba36c0e16a674  core/pkg/contracts/economic/procurement.go
 74f527420a813365f34b9ed1861d6107169414256f0eb154e59ec9f5a66dbd90  core/pkg/contracts/economic/reconciliation.go
-75e38653d39ee249fc6cfb9cf1401bd21d8a8a85f5d6d0d29c41cee549fbc4ee  core/pkg/contracts/economic/spend_authority.go
+32961a5716809d4cd0111d5134b6bbe3fbfcb9b24ee2c8d6e149e152b528e597  core/pkg/contracts/economic/spend_authority.go
 b2efddcd68b8ed03f424acb3cd01733e8539003c78a0a927abecf97840ebbb17  core/pkg/contracts/economic/spend_authority_financial.go
 efa7332a9fedf60766463654e224f336beeabb54c926fc512500de295c6bc37c  core/pkg/contracts/economic/spend_authority_financial_test.go
-fb59084b0bd2ccc5d27cf4300ac962c9329c9c84e803db3c4ffd323e0ad691a2  core/pkg/contracts/economic/spend_authority_test.go
+1eabb5ab1b04136ce2c2898178be165e8697781bf38a99b79d54ce962a991ed0  core/pkg/contracts/economic/spend_authority_test.go
 98bc2a2891d56d764d84c357656b454695174ac352b2eb0208befe7e5c85b9bb  core/pkg/contracts/economic/spend_intent.go
 6c292cd4db2d7bac15002fed6be93912381349526177325ce097133ffb3db002  core/pkg/contracts/economic/transaction_manifest.go
 e1c9fbfd2bf7b04450d17b79ed61ec6a2710c7b13e179adb84c88f8bbdbea612  core/pkg/contracts/economic/treasury.go


### PR DESCRIPTION
## Summary
- add signed `BudgetVerdictReceipt` contract with canonical content hash, Ed25519 seal/verify helpers, and decision binding checks
- require a signed BudgetVerdict receipt before LLM gateway provider dispatch and expose the receipt hash on `ExecResult`
- cover missing, unsigned, provider/model-mismatched, and decision-detached receipts with fail-closed gateway tests
- regenerate the protected boundary manifest for the touched economic contract files

## Validation
- `cd core && GOROOT=/usr/local/go GOCACHE=/tmp/helm-spend-go-build-cache /usr/local/go/bin/go test ./pkg/contracts/economic ./pkg/llm/gateway`
- `cd core && GOROOT=/usr/local/go GOCACHE=/tmp/helm-spend-go-build-cache /usr/local/go/bin/go test ./pkg/...`
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin make verify-boundary`
- `git diff --check`

Linear: MIN-481