### PR TITLE
MIN-482 Require spend verdict permit for provider dispatch

### DIFF
--- a/core/pkg/llm/gateway/router.go
+++ b/core/pkg/llm/gateway/router.go
@@ -114,6 +114,9 @@ func (r *GatewayRouter) RouteWithConfig(_ context.Context, cfg RouteConfig) erro
 	if cfg.Provider == "" {
 		return errors.New("lig: provider is required")
 	}
+	if !isKnownProvider(cfg.Provider) {
+		return fmt.Errorf("lig: unsupported provider %q", cfg.Provider)
+	}
 	if cfg.ModelName == "" {
 		return errors.New("lig: model is required")
 	}
@@ -206,7 +209,8 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 	if err := requireSpendAuthorityAllow(req.SpendDecision); err != nil {
 		return nil, err
 	}
-	if err := requireBudgetVerdictReceipt(req.SpendDecision, req.SpendReceipt, *r.activeProfile, r.budgetVerdictReceiptKey); err != nil {
+	dispatchPermit, err := requireBudgetVerdictReceipt(req.SpendDecision, req.SpendReceipt, *r.activeProfile, r.budgetVerdictReceiptKey)
+	if err != nil {
 		return nil, err
 	}
 
@@ -230,7 +234,7 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 	if err := validateEnginePin(*r.activeProfile, version, modelHash); err != nil {
 		return nil, err
 	}
-	content, err := r.executeProvider(ctx, *r.activeProfile, req)
+	content, err := r.executeProvider(ctx, *r.activeProfile, req, dispatchPermit)
 	if err != nil {
 		return nil, err
 	}
@@ -243,8 +247,8 @@ func (r *GatewayRouter) Execute(ctx context.Context, req ExecContext) (*ExecResu
 		ModelHash:         modelHash,
 		BudgetVerdict:     req.SpendDecision.Verdict,
 		SpendReasonCode:   req.SpendDecision.ReasonCode,
-		SpendDecisionHash: req.SpendDecision.ContentHash,
-		SpendReceiptHash:  req.SpendReceipt.ContentHash,
+		SpendDecisionHash: dispatchPermit.decisionHash,
+		SpendReceiptHash:  dispatchPermit.receiptHash,
 		Duration:          time.Since(start),
 	}, nil
 }
@@ -278,30 +282,51 @@ func isAllowSpendReasonCode(code economic.SpendReasonCode) bool {
 	return code == economic.SpendReasonOKWithinEnvelope || code == economic.SpendReasonOKApproved
 }
 
-func requireBudgetVerdictReceipt(decision *economic.SpendAuthorityDecision, receipt *economic.BudgetVerdictReceipt, profile Profile, trustedKeys map[string]ed25519.PublicKey) error {
+type budgetVerdictDispatchPermit struct {
+	decisionHash string
+	receiptHash  string
+}
+
+func (p budgetVerdictDispatchPermit) require() error {
+	if p.decisionHash == "" || p.receiptHash == "" {
+		return errors.New("lig: authorized BudgetVerdict dispatch permit required")
+	}
+	return nil
+}
+
+func requireBudgetVerdictReceipt(decision *economic.SpendAuthorityDecision, receipt *economic.BudgetVerdictReceipt, profile Profile, trustedKeys map[string]ed25519.PublicKey) (budgetVerdictDispatchPermit, error) {
 	if receipt == nil {
-		return &SpendVerdictError{Decision: decision, Reason: "signed BudgetVerdict receipt is required"}
+		return budgetVerdictDispatchPermit{}, &SpendVerdictError{Decision: decision, Reason: "signed BudgetVerdict receipt is required"}
 	}
 	if decision == nil {
-		return &SpendVerdictError{Reason: "missing spend authority decision"}
+		return budgetVerdictDispatchPermit{}, &SpendVerdictError{Reason: "missing spend authority decision"}
 	}
 	if err := receipt.ValidateForDecision(*decision); err != nil {
-		return &SpendVerdictError{Decision: decision, Reason: err.Error()}
+		return budgetVerdictDispatchPermit{}, &SpendVerdictError{Decision: decision, Reason: err.Error()}
 	}
 	trustedKey, ok := trustedKeys[receipt.SignatureKeyID]
 	if !ok {
-		return &SpendVerdictError{Decision: decision, Reason: "trusted BudgetVerdict receipt key not found"}
+		return budgetVerdictDispatchPermit{}, &SpendVerdictError{Decision: decision, Reason: "trusted BudgetVerdict receipt key not found"}
 	}
 	if err := receipt.VerifySignature(trustedKey); err != nil {
-		return &SpendVerdictError{Decision: decision, Reason: err.Error()}
+		return budgetVerdictDispatchPermit{}, &SpendVerdictError{Decision: decision, Reason: err.Error()}
 	}
 	if receipt.ProviderID != string(profile.Provider) {
-		return &SpendVerdictError{Decision: decision, Reason: "BudgetVerdict receipt provider does not match active profile"}
+		return budgetVerdictDispatchPermit{}, &SpendVerdictError{Decision: decision, Reason: "BudgetVerdict receipt provider does not match active profile"}
 	}
 	if receipt.ModelID != profile.ModelName {
-		return &SpendVerdictError{Decision: decision, Reason: "BudgetVerdict receipt model does not match active profile"}
+		return budgetVerdictDispatchPermit{}, &SpendVerdictError{Decision: decision, Reason: "BudgetVerdict receipt model does not match active profile"}
 	}
-	return nil
+	return budgetVerdictDispatchPermit{decisionHash: decision.ContentHash, receiptHash: receipt.ContentHash}, nil
+}
+
+func isKnownProvider(provider ProviderType) bool {
+	switch provider {
+	case ProviderOllama, ProviderLlamaCPP, ProviderVLLM, ProviderLMStudio:
+		return true
+	default:
+		return false
+	}
 }
 
 func defaultBaseURL(provider ProviderType) string {
@@ -441,14 +466,21 @@ func (r *GatewayRouter) discoverModelHash(ctx context.Context, profile Profile) 
 	return "", nil
 }
 
-func (r *GatewayRouter) executeProvider(ctx context.Context, profile Profile, req ExecContext) (string, error) {
-	if profile.Provider == ProviderOllama {
-		return r.executeOllama(ctx, profile, req)
+func (r *GatewayRouter) executeProvider(ctx context.Context, profile Profile, req ExecContext, permit budgetVerdictDispatchPermit) (string, error) {
+	switch profile.Provider {
+	case ProviderOllama:
+		return r.executeOllama(ctx, profile, req, permit)
+	case ProviderLlamaCPP, ProviderVLLM, ProviderLMStudio:
+		return r.executeOpenAICompatible(ctx, profile, req, permit)
+	default:
+		return "", fmt.Errorf("lig: unsupported provider %q", profile.Provider)
 	}
-	return r.executeOpenAICompatible(ctx, profile, req)
 }
 
-func (r *GatewayRouter) executeOllama(ctx context.Context, profile Profile, req ExecContext) (string, error) {
+func (r *GatewayRouter) executeOllama(ctx context.Context, profile Profile, req ExecContext, permit budgetVerdictDispatchPermit) (string, error) {
+	if err := permit.require(); err != nil {
+		return "", err
+	}
 	payload := map[string]any{
 		"model":  profile.ModelName,
 		"stream": false,
@@ -475,7 +507,10 @@ func (r *GatewayRouter) executeOllama(ctx context.Context, profile Profile, req 
 	return out.Message.Content, nil
 }
 
-func (r *GatewayRouter) executeOpenAICompatible(ctx context.Context, profile Profile, req ExecContext) (string, error) {
+func (r *GatewayRouter) executeOpenAICompatible(ctx context.Context, profile Profile, req ExecContext, permit budgetVerdictDispatchPermit) (string, error) {
+	if err := permit.require(); err != nil {
+		return "", err
+	}
 	messages := []map[string]string{}
 	if req.System != "" {
 		messages = append(messages, map[string]string{"role": "system", "content": req.System})

--- a/core/pkg/llm/gateway/router_core_coverage_test.go
+++ b/core/pkg/llm/gateway/router_core_coverage_test.go
@@ -62,6 +62,7 @@ func TestBlessedProfileRoutingAndDefaults(t *testing.T) {
 		{ModelName: "model"},
 		{Provider: ProviderOllama},
 		{Provider: ProviderOllama, BaseURL: "not-a-url", ModelName: "model"},
+		{Provider: ProviderType("unknown"), BaseURL: "http://localhost:9999", ModelName: "model"},
 	} {
 		if err := NewGatewayRouter().RouteWithConfig(context.Background(), cfg); err == nil {
 			t.Fatalf("expected invalid route config to fail: %+v", cfg)
@@ -187,7 +188,7 @@ func TestDiscoveryAndProviderErrorBranches(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"message": map[string]string{"content": ""}})
 	}))
 	defer emptyOllama.Close()
-	if _, err := router.executeOllama(context.Background(), Profile{Provider: ProviderOllama, BaseURL: emptyOllama.URL, ModelName: "model"}, ExecContext{Prompt: "hello"}); err == nil {
+	if _, err := router.executeOllama(context.Background(), Profile{Provider: ProviderOllama, BaseURL: emptyOllama.URL, ModelName: "model"}, ExecContext{Prompt: "hello"}, gatewayDispatchPermit()); err == nil {
 		t.Fatal("expected empty Ollama content to fail")
 	}
 
@@ -195,8 +196,69 @@ func TestDiscoveryAndProviderErrorBranches(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"choices": []map[string]any{}})
 	}))
 	defer emptyOpenAI.Close()
-	if _, err := router.executeOpenAICompatible(context.Background(), Profile{Provider: ProviderVLLM, BaseURL: emptyOpenAI.URL, ModelName: "model"}, ExecContext{Prompt: "hello"}); err == nil {
+	if _, err := router.executeOpenAICompatible(context.Background(), Profile{Provider: ProviderVLLM, BaseURL: emptyOpenAI.URL, ModelName: "model"}, ExecContext{Prompt: "hello"}, gatewayDispatchPermit()); err == nil {
 		t.Fatal("expected empty OpenAI-compatible content to fail")
+	}
+}
+
+func TestProviderExecutorsRequireBudgetVerdictDispatchPermitBeforeNetwork(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider ProviderType
+		call     func(*GatewayRouter, string) (string, error)
+	}{
+		{
+			name:     "ollama",
+			provider: ProviderOllama,
+			call: func(router *GatewayRouter, baseURL string) (string, error) {
+				return router.executeOllama(context.Background(), Profile{Provider: ProviderOllama, BaseURL: baseURL, ModelName: "model"}, ExecContext{Prompt: "hello"}, budgetVerdictDispatchPermit{})
+			},
+		},
+		{
+			name:     "openai-compatible",
+			provider: ProviderVLLM,
+			call: func(router *GatewayRouter, baseURL string) (string, error) {
+				return router.executeOpenAICompatible(context.Background(), Profile{Provider: ProviderVLLM, BaseURL: baseURL, ModelName: "model"}, ExecContext{Prompt: "hello"}, budgetVerdictDispatchPermit{})
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dispatched := false
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				dispatched = true
+				_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+			}))
+			defer srv.Close()
+
+			_, err := tc.call(NewGatewayRouter(), srv.URL)
+			if err == nil || !strings.Contains(err.Error(), "authorized BudgetVerdict dispatch permit required") {
+				t.Fatalf("expected dispatch permit error, got %v", err)
+			}
+			if dispatched {
+				t.Fatalf("%s provider endpoint was touched without BudgetVerdict permit", tc.provider)
+			}
+		})
+	}
+}
+
+func TestExecuteProviderRejectsUnknownProviderBeforeNetwork(t *testing.T) {
+	dispatched := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		dispatched = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer srv.Close()
+
+	_, err := NewGatewayRouter().executeProvider(context.Background(), Profile{
+		Provider:  ProviderType("unknown"),
+		BaseURL:   srv.URL,
+		ModelName: "model",
+	}, ExecContext{Prompt: "hello"}, gatewayDispatchPermit())
+	if err == nil || !strings.Contains(err.Error(), "unsupported provider") {
+		t.Fatalf("expected unsupported provider error, got %v", err)
+	}
+	if dispatched {
+		t.Fatal("unknown provider endpoint was touched")
 	}
 }
 

--- a/core/pkg/llm/gateway/router_test.go
+++ b/core/pkg/llm/gateway/router_test.go
@@ -341,6 +341,12 @@ func gatewaySpendReceipt(provider ProviderType, model string, decision *economic
 	return receipt
 }
 
+func gatewayDispatchPermit() budgetVerdictDispatchPermit {
+	decision := gatewayAllowSpendDecision()
+	receipt := gatewaySpendReceipt(ProviderVLLM, "model", decision)
+	return budgetVerdictDispatchPermit{decisionHash: decision.ContentHash, receiptHash: receipt.ContentHash}
+}
+
 func gatewayUnsignedSpendReceipt(provider ProviderType, model string, decision *economic.SpendAuthorityDecision) *economic.BudgetVerdictReceipt {
 	if decision == nil {
 		return nil


### PR DESCRIPTION
## Summary
- inventory result: provider/model network dispatch is concentrated in `core/pkg/llm/gateway`; CPI and runtime adapters do not call provider model APIs directly in this slice
- turn the verified BudgetVerdict receipt gate into a private dispatch permit used by the gateway provider executors
- require the permit in `executeOllama` and OpenAI-compatible executors so package-internal calls cannot bypass `Execute`
- reject unknown provider ids in routing and direct provider execution before any network call
- add tests proving provider endpoints are not touched without a BudgetVerdict permit and unknown providers are denied before network dispatch

## Validation
- `cd core && GOROOT=/usr/local/go GOCACHE=/tmp/helm-spend-go-build-cache /usr/local/go/bin/go test ./pkg/llm/gateway`
- `cd core && GOROOT=/usr/local/go GOCACHE=/tmp/helm-spend-go-build-cache /usr/local/go/bin/go test ./pkg/llm/gateway ./pkg/kernel/cpi ./pkg/runtimeadapters/...`
- `cd core && GOROOT=/usr/local/go GOCACHE=/tmp/helm-spend-go-build-cache /usr/local/go/bin/go test ./pkg/...`
- `PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/homebrew/bin make verify-boundary`
- `git diff --check`

Linear: MIN-482