### PR TITLE
Add HELM public docs diagrams

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -4,6 +4,17 @@ HELM AI Kernel is open for developers who care about AI agent security, MCP tool
 
 Star the repo to follow the MCP execution-firewall roadmap: <https://github.com/Mindburn-Labs/helm-ai-kernel/stargazers>
 
+## Contribution Flow
+
+```mermaid
+flowchart LR
+    Interest["Contributor interest"] --> ProofPath["Run local proof path"]
+    ProofPath --> Lane["Pick a contribution lane"]
+    Lane --> Fixture["Add docs, fixture, SDK, or receipt proof"]
+    Fixture --> Validation["Run focused validation"]
+    Validation --> Review["Open PR with evidence"]
+```
+
 ## Start Here
 
 - Run the local proof path: [Quickstart](docs/QUICKSTART.md).

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -7,6 +7,18 @@ last_reviewed: 2026-06-01
 
 This map helps contributors find high-value integration and upstream contribution targets.
 
+## Integration Map
+
+```mermaid
+flowchart LR
+    MCP["MCP registries and docs"] --> Kernel["HELM execution boundary"]
+    Gateway["AI gateway projects"] --> Kernel
+    Guardrails["Security scanners and guardrails"] --> Kernel
+    Frameworks["Agent frameworks"] --> Kernel
+    Kernel --> Proof["Receipts and EvidencePacks"]
+    Proof --> Listings["Awesome lists and ecosystem docs"]
+```
+
 | Lane | Adjacent projects | HELM contribution angle |
 | --- | --- | --- |
 | MCP registries and docs | [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry), [modelcontextprotocol/docs](https://github.com/modelcontextprotocol/docs), [modelcontextprotocol/servers](https://github.com/modelcontextprotocol/servers) | Tool metadata, schema-pin, authz, and fail-closed examples. |

--- a/docs/TRACTION.md
+++ b/docs/TRACTION.md
@@ -11,6 +11,18 @@ Primary objective: drive verified adoption of HELM AI Kernel as the local-first 
 
 Primary conversion: visitor -> install -> run boundary -> trigger DENY or ESCALATE -> inspect signed receipt -> verify EvidencePack offline -> star, follow, discuss, or contribute.
 
+## Adoption Path
+
+```mermaid
+flowchart LR
+    Visitor["Visitor"] --> Install["Install or clone"]
+    Install --> Boundary["Run local boundary"]
+    Boundary --> Verdict["Trigger DENY or ESCALATE"]
+    Verdict --> Receipt["Inspect signed receipt"]
+    Receipt --> EvidencePack["Verify EvidencePack offline"]
+    EvidencePack --> Community["Star, discuss, or contribute"]
+```
+
 ## Canonical Positioning
 
 - Public OSS name: HELM AI Kernel.

--- a/docs/posts/how-to-fail-closed-on-agent-tool-calls.md
+++ b/docs/posts/how-to-fail-closed-on-agent-tool-calls.md
@@ -18,6 +18,19 @@ HELM AI Kernel demonstrates the pattern locally:
 - dangerous shell fixture: DENY with a signed receipt
 - flipped-verdict receipt: verification failure
 
+## Fail-Closed Path
+
+```mermaid
+flowchart LR
+    Proposal["Agent proposes tool call"] --> Boundary["HELM boundary"]
+    Boundary --> Context{"Known identity, policy, and schema?"}
+    Context -->|No| Deny["DENY or ESCALATE"]
+    Context -->|Yes| Allow["ALLOW fixture dispatch"]
+    Deny --> Receipt["Signed receipt"]
+    Allow --> Receipt
+    Receipt --> Verify["Offline verification"]
+```
+
 ![HELM MCP quarantine and receipt proof board](../assets/helm-mcp-quarantine-demo.svg)
 
 Run the local demos:

--- a/docs/posts/mcp-quarantine-before-tool-dispatch.md
+++ b/docs/posts/mcp-quarantine-before-tool-dispatch.md
@@ -13,6 +13,20 @@ HELM AI Kernel treats that state as quarantine. Unknown servers, unknown tools,
 and missing schema pins return DENY or ESCALATE before fixture dispatch. A
 known schema-pinned call can be allowed.
 
+## Quarantine Flow
+
+```mermaid
+flowchart LR
+    Discovery["MCP discovery"] --> Registry["HELM registry check"]
+    Registry --> Server{"Known server?"}
+    Server -->|No| Quarantine["Quarantine"]
+    Server -->|Yes| Tool{"Known tool and schema pin?"}
+    Tool -->|No| Quarantine
+    Tool -->|Yes| Permit["Authorize fixture call"]
+    Quarantine --> Receipt["DENY or ESCALATE receipt"]
+    Permit --> Receipt
+```
+
 ![HELM MCP quarantine and receipt proof board](../assets/helm-mcp-quarantine-demo.svg)
 
 The local MCP launch demo exercises the path end to end:

--- a/docs/posts/receipts-beat-logs-for-agent-audit-trails.md
+++ b/docs/posts/receipts-beat-logs-for-agent-audit-trails.md
@@ -15,6 +15,18 @@ HELM AI Kernel emits signed receipts for execution-boundary decisions. The
 local proof demo creates a signed DENY receipt, verifies it, then submits a
 flipped-verdict copy and confirms the tamper attempt fails verification.
 
+## Receipt Evidence Path
+
+```mermaid
+flowchart LR
+    Request["Tool-call request"] --> Decision["ALLOW, DENY, or ESCALATE"]
+    Decision --> Receipt["Signed receipt"]
+    Receipt --> EvidencePack["EvidencePack"]
+    EvidencePack --> Verify["Offline verifier"]
+    Receipt --> Tamper["Tampered copy"]
+    Tamper --> Reject["Verification failure"]
+```
+
 ![HELM MCP quarantine and receipt proof board](../assets/helm-mcp-quarantine-demo.svg)
 
 A useful agent receipt should make these checks boring:

--- a/docs/posts/why-ai-agents-need-an-execution-firewall.md
+++ b/docs/posts/why-ai-agents-need-an-execution-firewall.md
@@ -15,6 +15,19 @@ intercepts proposed tool calls, evaluates policy before dispatch, records
 ALLOW, DENY, or ESCALATE decisions, and emits signed receipts that can be
 verified offline.
 
+## Execution Firewall Flow
+
+```mermaid
+flowchart LR
+    Agent["AI agent"] --> Proposal["Proposed side effect"]
+    Proposal --> Kernel["HELM AI Kernel"]
+    Kernel --> Policy["Policy and schema evaluation"]
+    Policy --> Verdict["ALLOW, DENY, or ESCALATE"]
+    Verdict --> Dispatch["Dispatch only when allowed"]
+    Verdict --> Receipt["Signed receipt"]
+    Receipt --> Verifier["Offline verification"]
+```
+
 ![HELM MCP quarantine and receipt proof board](../assets/helm-mcp-quarantine-demo.svg)
 
 The key idea is simple: the agent can propose, but HELM decides whether the

--- a/docs/use-cases/agent-tool-call-governance.md
+++ b/docs/use-cases/agent-tool-call-governance.md
@@ -7,6 +7,17 @@ last_reviewed: 2026-06-01
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 
+## Governance Path
+
+```mermaid
+flowchart LR
+    Agent["Agent request"] --> Boundary["HELM boundary"]
+    Boundary --> Policy["Policy evaluation"]
+    Policy --> Verdict["ALLOW, DENY, or ESCALATE"]
+    Verdict --> Receipt["Signed receipt"]
+    Receipt --> Audit["Audit and replay"]
+```
+
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel

--- a/docs/use-cases/ai-agent-security.md
+++ b/docs/use-cases/ai-agent-security.md
@@ -7,6 +7,17 @@ last_reviewed: 2026-06-01
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 
+## Security Boundary
+
+```mermaid
+flowchart LR
+    Prompt["Agent prompt"] --> Proposal["Tool proposal"]
+    Proposal --> Kernel["HELM execution firewall"]
+    Kernel --> Decision["Fail-closed decision"]
+    Decision --> Receipt["Receipt"]
+    Receipt --> Verify["Offline verify"]
+```
+
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel

--- a/docs/use-cases/llm-audit-receipts.md
+++ b/docs/use-cases/llm-audit-receipts.md
@@ -7,6 +7,17 @@ last_reviewed: 2026-06-01
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 
+## Audit Receipt Chain
+
+```mermaid
+flowchart LR
+    Request["LLM action request"] --> Verdict["Boundary verdict"]
+    Verdict --> Receipt["Signed receipt"]
+    Receipt --> Hash["Receipt hash"]
+    Hash --> EvidencePack["EvidencePack"]
+    EvidencePack --> Auditor["Auditor verification"]
+```
+
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel

--- a/docs/use-cases/mcp-execution-firewall.md
+++ b/docs/use-cases/mcp-execution-firewall.md
@@ -7,6 +7,17 @@ last_reviewed: 2026-06-01
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 
+## MCP Firewall Path
+
+```mermaid
+flowchart LR
+    Server["MCP server"] --> Tool["Tool call"]
+    Tool --> Registry["HELM registry"]
+    Registry --> Pin["Schema pin check"]
+    Pin --> Verdict["DENY, ESCALATE, or ALLOW"]
+    Verdict --> Receipt["Receipt"]
+```
+
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel

--- a/docs/use-cases/openai-compatible-ai-gateway-policy.md
+++ b/docs/use-cases/openai-compatible-ai-gateway-policy.md
@@ -7,6 +7,18 @@ last_reviewed: 2026-06-01
 
 HELM AI Kernel documents this search intent with a local, source-backed proof path.
 
+## Gateway Policy Path
+
+```mermaid
+flowchart LR
+    Client["OpenAI-compatible client"] --> Proxy["HELM proxy"]
+    Proxy --> Policy["Policy and receipt boundary"]
+    Policy --> Upstream["Upstream model when allowed"]
+    Policy --> Denial["DENY or ESCALATE"]
+    Upstream --> Receipt["Receipt metadata"]
+    Denial --> Receipt
+```
+
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel


### PR DESCRIPTION
Adds concise Mermaid diagrams to the public HELM Kernel pages that are required by the docs platform source coverage gate.\n\nValidation:\n- make docs-truth\n- npm run helm-source:check (from app-docs-platform against this branch)