### PR TITLE
Align HELM public docs accuracy metadata

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,3 +1,8 @@
+---
+title: HELM AI Kernel Community
+last_reviewed: 2026-06-09
+---
+
 # Community
 
 HELM AI Kernel is open for developers who care about AI agent security, MCP tool-call governance, signed receipts, and offline-verifiable evidence.
@@ -41,3 +46,10 @@ flowchart LR
 - `maintainer-task` requires maintainer, operator, or release access and is not externally claimable.
 
 Large changes should start in Discussions before a PR. Do not post provider keys, customer data, private prompts, unredacted production receipts, or live tenant metadata.
+
+## Source Truth
+
+- [Quickstart](docs/QUICKSTART.md)
+- [Developer journey](docs/DEVELOPER_JOURNEY.md)
+- [SDK index](docs/sdks/00_INDEX.md)
+- [Documentation coverage ledger](docs/documentation-coverage.csv)

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -26,3 +26,10 @@ flowchart LR
 | Security scanners and guardrails | [promptfoo/promptfoo](https://github.com/promptfoo/promptfoo), [NVIDIA/garak](https://github.com/NVIDIA/garak), [NVIDIA-NeMo/Guardrails](https://github.com/NVIDIA-NeMo/Guardrails), [guardrails-ai/guardrails](https://github.com/guardrails-ai/guardrails) | Deny/escalate examples, reproducible security tests, and evidence outputs for agent tool execution. |
 | Agent frameworks | [openai/openai-agents-python](https://github.com/openai/openai-agents-python), [pydantic/pydantic-ai](https://github.com/pydantic/pydantic-ai), [agno-agi/agno](https://github.com/agno-agi/agno), [crewAIInc/crewAI](https://github.com/crewAIInc/crewAI) | Minimal integration guides for routing proposed tool calls through HELM before dispatch. |
 | Awesome lists | [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers), [appcypher/awesome-mcp-servers](https://github.com/appcypher/awesome-mcp-servers), [wong2/awesome-mcp-servers](https://github.com/wong2/awesome-mcp-servers), [corca-ai/awesome-llm-security](https://github.com/corca-ai/awesome-llm-security), [ProjectRecon/awesome-ai-agents-security](https://github.com/ProjectRecon/awesome-ai-agents-security), [e2b-dev/awesome-ai-agents](https://github.com/e2b-dev/awesome-ai-agents) | Submit concise listings after the quickstart, demo asset, and contributor backlog are visible. |
+
+## Source Truth
+
+- [MCP integration](INTEGRATIONS/mcp.md)
+- [OpenAI-compatible proxy example](EXAMPLES.md#openai-compatible-proxy)
+- [Execution security model](EXECUTION_SECURITY_MODEL.md)
+- [Launch proof assets](../examples/launch/assets/README.md)

--- a/docs/TRACTION.md
+++ b/docs/TRACTION.md
@@ -32,7 +32,7 @@ flowchart LR
 - Short description: Fail-closed execution firewall for AI agents: quarantine MCP tools, proxy OpenAI-compatible requests, emit signed receipts, and verify EvidencePacks offline.
 - Proof vocabulary: signed receipts, EvidencePack, ProofGraph, offline verification, ALLOW, DENY, ESCALATE.
 
-Avoid `HELM OSS`, `helm-oss`, `HELM Teams`, generic AI governance platform language, hosted-control-plane claims for Kernel, certification claims, or Enterprise features framed as Kernel features.
+Avoid stale product-family names, generic AI governance platform language, hosted-control-plane claims for Kernel, certification claims, or Enterprise features framed as Kernel features.
 
 ## GitHub Metadata
 
@@ -202,8 +202,8 @@ Engagement:
 
 Commercial bridge:
 
-- HELM AI Enterprise Basic interest CTA clicks
-- docs path from Kernel to Basic
+- HELM AI Enterprise Individual interest CTA clicks
+- docs path from Kernel to Individual
 - inbound team-use requests
 
 GitHub traffic windows are short, so export private analytics daily, publish a weekly channel cohort report, keep a launch-post UTM map, and log README hook changes.
@@ -212,7 +212,7 @@ GitHub traffic windows are short, so export private analytics daily, publish a w
 
 Run this checklist before publishing README edits, launch posts, diagrams, videos, social previews, and website copy:
 
-- Uses HELM AI Kernel, not HELM OSS as the current public name.
+- Uses HELM AI Kernel as the current public name.
 - Mentions not Kubernetes Helm when context is introductory.
 - Uses signed receipts, EvidencePack, and ProofGraph exactly.
 - Uses ALLOW, DENY, and ESCALATE.
@@ -220,7 +220,7 @@ Run this checklist before publishing README edits, launch posts, diagrams, video
 - Does not claim a hosted control plane for OSS Kernel.
 - Does not claim certification unless certification exists.
 - Does not describe Enterprise features as Kernel features.
-- Does not imply Basic or Enterprise weakens or forks Kernel semantics.
+- Does not imply Individual or Enterprise weakens or forks Kernel semantics.
 - Does not mention robot fleets, AGI OS, OrgDNA compiler, Titan, or physical-world control in OSS copy.
 
 ## Diagram Doctrine
@@ -258,8 +258,16 @@ Use this bridge after local Kernel proof:
 
 ```text
 Try HELM AI Kernel locally.
-Use HELM AI Enterprise Basic for shared approvals, receipts, policies, and short-retention evidence.
+Use HELM AI Enterprise Individual for shared approvals, receipts, policies, and short-retention evidence.
 Talk to Mindburn Labs about production execution authority.
 ```
 
-HELM AI Enterprise Basic gives teams a shared control plane for governed AI actions: workspaces, approvals, receipts, API access, custom policies, and short-retention evidence, all built on HELM AI Kernel.
+HELM AI Enterprise Individual gives operators a shared control plane for governed AI actions: workspaces, approvals, receipts, API access, custom policies, and short-retention evidence, all built on HELM AI Kernel.
+
+## Source Truth
+
+- [Quickstart](QUICKSTART.md)
+- [Developer journey](DEVELOPER_JOURNEY.md)
+- [Execution security model](EXECUTION_SECURITY_MODEL.md)
+- [Publishing runbook](PUBLISHING.md)
+- [Version surfaces contract](../release/version-surfaces.yaml)

--- a/docs/posts/how-to-fail-closed-on-agent-tool-calls.md
+++ b/docs/posts/how-to-fail-closed-on-agent-tool-calls.md
@@ -47,3 +47,10 @@ Use the pattern when integrating agent frameworks, MCP servers, or
 OpenAI-compatible clients: intercept before dispatch, bind approval to the
 schema and identity you inspected, emit a receipt, and verify the evidence
 offline.
+
+## Source Truth
+
+- [MCP integration](../INTEGRATIONS/mcp.md)
+- [Execution security model](../EXECUTION_SECURITY_MODEL.md)
+- [Verification](../VERIFICATION.md)
+- [MCP launch demo](../../scripts/launch/demo-mcp.sh)

--- a/docs/posts/mcp-quarantine-before-tool-dispatch.md
+++ b/docs/posts/mcp-quarantine-before-tool-dispatch.md
@@ -48,3 +48,10 @@ bash scripts/launch/demo-mcp.sh
 
 The sanitized transcript is checked in at
 [`examples/launch/assets/mcp-quarantine.transcript.txt`](../../examples/launch/assets/mcp-quarantine.transcript.txt).
+
+## Source Truth
+
+- [MCP integration](../INTEGRATIONS/mcp.md)
+- [MCP launch demo](../../scripts/launch/demo-mcp.sh)
+- [MCP fixture server](../../scripts/launch/mcp-fixture-server.py)
+- [Launch assets](../../examples/launch/assets/README.md)

--- a/docs/posts/receipts-beat-logs-for-agent-audit-trails.md
+++ b/docs/posts/receipts-beat-logs-for-agent-audit-trails.md
@@ -48,3 +48,10 @@ bash scripts/launch/demo-proof.sh
 ```
 
 The demo uses localhost fixtures and sample policy data only.
+
+## Source Truth
+
+- [Verification](../VERIFICATION.md)
+- [Execution security model](../EXECUTION_SECURITY_MODEL.md)
+- [Proof launch demo](../../scripts/launch/demo-proof.sh)
+- [Receipt schemas](../../protocols/json-schemas/SCHEMA_INDEX.md)

--- a/docs/posts/why-ai-agents-need-an-execution-firewall.md
+++ b/docs/posts/why-ai-agents-need-an-execution-firewall.md
@@ -47,3 +47,10 @@ bash scripts/launch/demo-proof.sh
 
 Star the repo if you want to follow the MCP execution-firewall roadmap:
 <https://github.com/Mindburn-Labs/helm-ai-kernel>
+
+## Source Truth
+
+- [Quickstart](../QUICKSTART.md)
+- [Execution security model](../EXECUTION_SECURITY_MODEL.md)
+- [MCP integration](../INTEGRATIONS/mcp.md)
+- [Verification](../VERIFICATION.md)

--- a/docs/use-cases/agent-tool-call-governance.md
+++ b/docs/use-cases/agent-tool-call-governance.md
@@ -25,7 +25,7 @@ make build
 bash scripts/launch/demo-local.sh
 ```
 
-## Source-Backed Docs
+## Source Truth
 
 - [Quickstart](../QUICKSTART.md)
 - [Execution security model](../EXECUTION_SECURITY_MODEL.md)

--- a/docs/use-cases/ai-agent-security.md
+++ b/docs/use-cases/ai-agent-security.md
@@ -25,7 +25,7 @@ make build
 bash scripts/launch/demo-proof.sh
 ```
 
-## Source-Backed Docs
+## Source Truth
 
 - [Quickstart](../QUICKSTART.md)
 - [Execution security model](../EXECUTION_SECURITY_MODEL.md)

--- a/docs/use-cases/llm-audit-receipts.md
+++ b/docs/use-cases/llm-audit-receipts.md
@@ -25,7 +25,7 @@ make build
 bash scripts/launch/demo-proof.sh
 ```
 
-## Source-Backed Docs
+## Source Truth
 
 - [Quickstart](../QUICKSTART.md)
 - [Execution security model](../EXECUTION_SECURITY_MODEL.md)

--- a/docs/use-cases/mcp-execution-firewall.md
+++ b/docs/use-cases/mcp-execution-firewall.md
@@ -25,7 +25,7 @@ make build
 bash scripts/launch/demo-mcp.sh
 ```
 
-## Source-Backed Docs
+## Source Truth
 
 - [Quickstart](../QUICKSTART.md)
 - [Execution security model](../EXECUTION_SECURITY_MODEL.md)

--- a/docs/use-cases/openai-compatible-ai-gateway-policy.md
+++ b/docs/use-cases/openai-compatible-ai-gateway-policy.md
@@ -26,7 +26,7 @@ make build
 bash scripts/launch/demo-openai-proxy.sh
 ```
 
-## Source-Backed Docs
+## Source Truth
 
 - [Quickstart](../QUICKSTART.md)
 - [Execution security model](../EXECUTION_SECURITY_MODEL.md)


### PR DESCRIPTION
Adds Source Truth sections, normalized community metadata, and current Individual/Enterprise bridge labels required by the docs platform public accuracy gate.\n\nValidation:\n- make docs-truth\n- npm run helm-source:check (from app-docs-platform)\n- npm run helm-public:accuracy (from app-docs-platform)