### PR TITLE
Fix HELM public docs launch asset links

### DIFF
--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -32,4 +32,4 @@ flowchart LR
 - [MCP integration](INTEGRATIONS/mcp.md)
 - [OpenAI-compatible proxy example](EXAMPLES.md#openai-compatible-proxy)
 - [Execution security model](EXECUTION_SECURITY_MODEL.md)
-- [Launch proof assets](../examples/launch/assets/README.md)
+- [Launch proof assets](../examples/launch/README.md)

--- a/docs/posts/mcp-quarantine-before-tool-dispatch.md
+++ b/docs/posts/mcp-quarantine-before-tool-dispatch.md
@@ -54,4 +54,4 @@ The sanitized transcript is checked in at
 - [MCP integration](../INTEGRATIONS/mcp.md)
 - [MCP launch demo](../../scripts/launch/demo-mcp.sh)
 - [MCP fixture server](../../scripts/launch/mcp-fixture-server.py)
-- [Launch assets](../../examples/launch/assets/README.md)
+- [Launch assets](../../examples/launch/README.md)


### PR DESCRIPTION
Fixes two public HELM docs links that pointed at a nonexistent examples/launch/assets README. The docs-platform manifest gate now resolves both links to the existing launch proof README.