### PR TITLE
Fix launchpad smoke GHCR image pulls

### DIFF
--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -77,7 +77,6 @@ jobs:
           LAUNCHPAD_SMOKE_KERNEL_IMAGE: "ghcr.io/mindburn-labs/helm-ai-kernel:smoke"
           LAUNCHPAD_SMOKE_KEEP_CLUSTER: "1"
           LAUNCHPAD_SMOKE_PROFILE: minikube
-          LAUNCHPAD_SMOKE_PRE_PULL: "0"
         run: bash scripts/ci/launchpad_k8s_smoke.sh --mode baseline
 
   launchpad-positive:
@@ -127,6 +126,8 @@ jobs:
           LAUNCHPAD_SMOKE_KERNEL_IMAGE: "ghcr.io/mindburn-labs/helm-ai-kernel:smoke"
           LAUNCHPAD_SMOKE_KEEP_CLUSTER: "1"
           LAUNCHPAD_SMOKE_PROFILE: minikube
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ github.token }}
         run: |
           if [[ -z "${OPENROUTER_API_KEY}" ]]; then
             echo "::warning::HELM_LAUNCHPAD_CI_OPENROUTER_API_KEY secret not configured — skipping positive scenario"
@@ -179,4 +180,6 @@ jobs:
           LAUNCHPAD_SMOKE_KERNEL_IMAGE: "ghcr.io/mindburn-labs/helm-ai-kernel:smoke"
           LAUNCHPAD_SMOKE_KEEP_CLUSTER: "1"
           LAUNCHPAD_SMOKE_PROFILE: minikube
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ github.token }}
         run: bash scripts/ci/launchpad_k8s_smoke.sh --mode negative

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -51,6 +51,7 @@ flowchart TD
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/mindburn-labs/helm-ai-kernel` | Container image repository. |
 | `image.tag` | chart `appVersion` | Container image tag. |
+| `imagePullSecrets` | `[]` | Pull secrets applied to the kernel and optional launchpad app Pods/Jobs/test Pod. |
 | `helm.*` | retained | Legacy values root retained for one compatibility window. |
 | `helm.bindAddr` | `0.0.0.0` | Required inside Kubernetes pods. |
 | `helm.production` | `false` | Refuses generated signing/auth material when set to `true`. |

--- a/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
@@ -25,6 +25,10 @@ spec:
         {{- include "helm-ai-kernel.launchpadApp.labels" (dict "ctx" . "app" $app) | nindent 8 }}
     spec:
       restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.launchpadApps.nodeSelector | nindent 8 }}
       securityContext:

--- a/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         {{- include "helm-ai-kernel.launchpadApp.labels" (dict "ctx" . "app" $app) | nindent 8 }}
     spec:
       restartPolicy: Always
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.launchpadApps.nodeSelector | nindent 8 }}
       securityContext:

--- a/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
+++ b/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
@@ -12,6 +12,10 @@ metadata:
     helm.ai/test-intent: "kernel health + launchpad-app Pod presence"
 spec:
   restartPolicy: Never
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   nodeSelector:
     {{- toYaml .Values.launchpadApps.nodeSelector | nindent 4 }}
   securityContext:

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -37,7 +37,7 @@
     },
     "imagePullSecrets": {
       "type": "array",
-      "description": "References to Kubernetes Secrets used to pull the container image from a private registry. Each entry must be a {name: <secret>} object.",
+      "description": "References to Kubernetes Secrets used to pull chart-managed images from private registries. Applied to the kernel Deployment and optional launchpad app Pods/Jobs/test Pod. Each entry must be a {name: <secret>} object.",
       "items": {
         "type": "object",
         "additionalProperties": true,

--- a/docs/launchpad/K8S_SMOKE.md
+++ b/docs/launchpad/K8S_SMOKE.md
@@ -104,6 +104,8 @@ eval "$(minikube docker-env)"
 docker build -t ghcr.io/mindburn-labs/helm-ai-kernel:smoke -f Dockerfile .
 
 # Real-key positive scenario
+export GHCR_USERNAME=<github-user>
+export GHCR_TOKEN=<github-token-with-read-packages>
 export OPENROUTER_API_KEY=<your-key>
 bash scripts/ci/launchpad_k8s_smoke.sh --mode positive
 
@@ -118,6 +120,14 @@ bash scripts/ci/launchpad_k8s_smoke.sh --mode baseline
 The driver always starts from a fresh minikube cluster (`minikube delete`
 then `minikube start`). Set `LAUNCHPAD_SMOKE_KEEP_CLUSTER=1` to skip the
 final delete during iteration.
+
+For `positive` and `negative`, the launchpad app images stay pinned as
+`repo@sha256` and are pulled by kubelet from GHCR through a docker-registry
+Secret named `ghcr-read` by default. Provide `GHCR_USERNAME` and `GHCR_TOKEN`
+(`read:packages`) before running those modes. Do not rely on `minikube image
+load` for private digest refs; `LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_IMAGES=1`
+exists only as a debug path and fails if the digest is not resolvable inside
+the minikube node.
 
 ## Scenario matrix
 
@@ -156,7 +166,8 @@ on the cluster — the k8s analogue of the docker sandbox-leak audit.
 
 | Symptom | First check |
 | --- | --- |
-| openclaw Pod never reaches Ready on positive | `kubectl logs <pod> -c egress-proxy`, then `kubectl logs <pod> -c openclaw`. Common causes: missing `HELM_LAUNCHPAD_CI_OPENROUTER_API_KEY` Secret, OpenRouter rate-limit, kernel pulling images on a slow link. |
+| `ErrImagePull` / `ImagePullBackOff` on openclaw, hermes, or egress-proxy | Confirm Secret `ghcr-read` exists in the release namespace and that `GHCR_TOKEN` has `read:packages` for `ghcr.io/mindburn-labs/helm-launchpad/*`. |
+| openclaw Pod never reaches Ready on positive | `kubectl logs <pod> -c egress-proxy`, then `kubectl logs <pod> -c openclaw`. Common causes: missing `OPENROUTER_API_KEY`, OpenRouter rate-limit, private GHCR pull-secret failure, or kernel pulling images on a slow link. |
 | hermes Job hangs at Running | `shareProcessNamespace` and the workload's `preStop` SIGTERM are how the sidecar exits. If the sidecar image changes its process name from `egress-proxy`, the `pkill` pattern in `hermes-job.yaml` needs updating. |
 | Leftover resources after uninstall | The leak audit query `kubectl get all -A -l app.kubernetes.io/part-of=helm-ai-kernel`. Any non-empty result means something other than helm owns the resource — start with `kubectl describe` to see ownerReferences. |
 | `helm test` reports `no hooks for test`  | Either both launchpad apps were disabled or the chart was installed without rendering the test Pod. The test Pod is gated on `openclaw.enabled || hermes.enabled`. |

--- a/scripts/ci/launchpad_k8s_smoke.sh
+++ b/scripts/ci/launchpad_k8s_smoke.sh
@@ -16,7 +16,7 @@
 #               Expects hermes Job failed; openclaw either CrashLoopBackOff or
 #               never reaches Ready within the timeout.
 #
-# Required tools: minikube, kubectl, helm. The driver fails fast if any are
+# Required tools: minikube, kubectl, helm, docker, python3. The driver fails fast if any are
 # missing.
 set -euo pipefail
 
@@ -33,7 +33,10 @@ OPENROUTER_KEY_REAL="${OPENROUTER_API_KEY:-}"
 OPENROUTER_KEY_FAKE="sk-fake-1234567890"
 KEEP_CLUSTER="${LAUNCHPAD_SMOKE_KEEP_CLUSTER:-0}"
 FRESH_CLUSTER="${LAUNCHPAD_SMOKE_FRESH_CLUSTER:-1}"
-PRE_PULL="${LAUNCHPAD_SMOKE_PRE_PULL:-1}"
+PRE_LOAD_LAUNCHPAD_IMAGES="${LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_IMAGES:-0}"
+GHCR_SECRET_NAME="${LAUNCHPAD_SMOKE_GHCR_SECRET_NAME:-ghcr-read}"
+GHCR_USERNAME="${GHCR_USERNAME:-}"
+GHCR_TOKEN="${GHCR_TOKEN:-}"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/launchpad-k8s-smoke.XXXXXX")"
 
 usage() {
@@ -48,7 +51,10 @@ Environment overrides:
   LAUNCHPAD_SMOKE_KERNEL_IMAGE  kernel image to load into minikube (default ghcr.io/mindburn-labs/helm-ai-kernel:local)
   LAUNCHPAD_SMOKE_KEEP_CLUSTER  set to 1 to skip the final minikube delete
   LAUNCHPAD_SMOKE_FRESH_CLUSTER set to 0 to reuse an existing minikube profile (assumes the cluster is already running and kernel image is loaded)
-  LAUNCHPAD_SMOKE_PRE_PULL      set to 0 to skip pulling openclaw/hermes/egress-proxy
+  LAUNCHPAD_SMOKE_GHCR_SECRET_NAME Secret name for private GHCR pulls (default ghcr-read)
+  LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_IMAGES set to 1 for debug-only host pull + minikube image load verification
+  GHCR_USERNAME                  GitHub/GHCR username for positive/negative launchpad app image pulls
+  GHCR_TOKEN                     GitHub token with read:packages for private GHCR launchpad app image pulls
   OPENROUTER_API_KEY            real key for the positive scenario; ignored on negative
 EOF
 }
@@ -78,9 +84,50 @@ require minikube
 require kubectl
 require helm
 require docker
+require python3
+
+apply_ghcr_pull_secret() {
+    GHCR_USERNAME="$GHCR_USERNAME" GHCR_TOKEN="$GHCR_TOKEN" \
+        python3 - "$GHCR_SECRET_NAME" <<'PY' | kubectl -n "$NAMESPACE" apply -f -
+import base64
+import json
+import os
+import sys
+
+name = sys.argv[1]
+username = os.environ["GHCR_USERNAME"]
+token = os.environ["GHCR_TOKEN"]
+auth = base64.b64encode(f"{username}:{token}".encode()).decode()
+dockerconfig = {
+    "auths": {
+        "ghcr.io": {
+            "username": username,
+            "password": token,
+            "auth": auth,
+        }
+    }
+}
+manifest = {
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "metadata": {"name": name},
+    "type": "kubernetes.io/dockerconfigjson",
+    "data": {
+        ".dockerconfigjson": base64.b64encode(
+            json.dumps(dockerconfig, separators=(",", ":")).encode()
+        ).decode()
+    },
+}
+print(json.dumps(manifest))
+PY
+}
 
 if [ "$MODE" = "positive" ] && [ -z "$OPENROUTER_KEY_REAL" ]; then
     echo "::error::OPENROUTER_API_KEY env var is required for --mode positive" >&2
+    exit 1
+fi
+if [ "$MODE" != "baseline" ] && { [ -z "$GHCR_USERNAME" ] || [ -z "$GHCR_TOKEN" ]; }; then
+    echo "::error::GHCR_USERNAME and GHCR_TOKEN are required for launchpad app image pulls in --mode ${MODE}" >&2
     exit 1
 fi
 
@@ -133,7 +180,7 @@ kubectl config use-context "$PROFILE"
 kubectl cluster-info
 echo "::endgroup::"
 
-echo "::group::stage 2 — load images into minikube"
+echo "::group::stage 2 — local kernel image + optional launchpad image debug"
 # Kernel image: built locally by the caller (CI step or developer make target).
 # Skip the load if it is already inside minikube (common when the caller built
 # directly inside the minikube docker daemon via `eval $(minikube docker-env)`).
@@ -145,20 +192,24 @@ else
     echo "::warning::kernel image $KERNEL_IMAGE not in local docker; relying on imagePullPolicy=IfNotPresent against registry"
 fi
 
-if [ "$PRE_PULL" = "1" ] && [ "$MODE" != "baseline" ]; then
-    # Cold-pull on minikube is slow and prone to timing out helm install.
-    # Pull on the host first, then load into the cluster.
+if [ "$PRE_LOAD_LAUNCHPAD_IMAGES" = "1" ] && [ "$MODE" != "baseline" ]; then
+    # Debug-only path. Private digest-pinned GHCR refs have proven unreliable
+    # through `minikube image load`; the normal path below uses imagePullSecrets.
     for img in \
         "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995" \
         "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652" \
         "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:e09e0aec1e0e1f926f4cd18444e88310656b85551cbc10a6c340acb979a42e03"; do
         docker pull --platform=linux/amd64 "$img"
         minikube -p "$PROFILE" image load "$img"
+        if ! minikube -p "$PROFILE" image ls 2>/dev/null | grep -qF "$img"; then
+            echo "::error::minikube image load did not make $img resolvable in the node; use the GHCR imagePullSecret path" >&2
+            exit 1
+        fi
     done
 fi
 echo "::endgroup::"
 
-echo "::group::stage 3 — namespace + OpenRouter secret"
+echo "::group::stage 3 — namespace + runtime secrets"
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
 if [ "$MODE" != "baseline" ]; then
@@ -169,6 +220,7 @@ if [ "$MODE" != "baseline" ]; then
     kubectl -n "$NAMESPACE" create secret generic openrouter-key \
         --from-literal=OPENROUTER_API_KEY="$key" \
         --dry-run=client -o yaml | kubectl apply -f -
+    apply_ghcr_pull_secret
 fi
 echo "::endgroup::"
 
@@ -191,6 +243,7 @@ case "$MODE" in
         helm_args+=(
             --set "launchpadApps.openclaw.enabled=true"
             --set "launchpadApps.hermes.enabled=true"
+            --set "imagePullSecrets[0].name=${GHCR_SECRET_NAME}"
         )
         ;;
 esac


### PR DESCRIPTION
## Summary
- extend the chart-level `imagePullSecrets` value to the optional OpenClaw Deployment, Hermes Job, and launchpad test Pod while keeping launchpad app images digest-pinned
- update `launchpad_k8s_smoke.sh` positive/negative modes to create a `ghcr-read` docker-registry Secret from `GHCR_USERNAME` + `GHCR_TOKEN` and pass it into the chart
- wire the launchpad positive/negative GitHub Actions jobs to pass `GHCR_USERNAME=${{ github.actor }}` and `GHCR_TOKEN=${{ github.token }}` into the smoke driver
- make launchpad digest image pre-loading debug-only, with explicit node-resolution verification, and document the GHCR pull-secret path

## Validation
- `bash -n scripts/ci/launchpad_k8s_smoke.sh scripts/ci/helm_chart_smoke.sh`
- `/usr/bin/ruby -e 'require "yaml"; YAML.load_file(".github/workflows/helm-integration.yml")'`
- `bash scripts/ci/helm_chart_smoke.sh`
- `helm template` via `alpine/helm:3.15.4`, then parsed rendered YAML to assert `imagePullSecrets: [{name: ghcr-read}]` on the kernel Deployment, OpenClaw Deployment, Hermes Job, and launchpad test Pod

## Not Run
- Live positive/negative Intel minikube smoke was not run in this session because `OPENROUTER_API_KEY`, `GHCR_USERNAME`, and `GHCR_TOKEN` are not present in the local environment.
- This does not close MIN-494; the issue should stay `Merged/Verifying` until Hermes completes a real LLM co-deploy smoke and burns measurable tokens.
