### PR TITLE
Add HELM quickstart evidence paths

### DIFF
--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -19,6 +19,8 @@ After this page you should know what this surface is for, which source files own
 - Source document: `helm-ai-kernel/docs/INTEGRATIONS/mcp.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
+- Launch demo: `scripts/launch/demo-mcp.sh`
+- Shell policy fixture: `examples/launch/policies/shell_mcp_server_boundary.json`
 - Validation: `make docs-coverage`, `make docs-truth`, and `npm run coverage:inventory` from `docs-platform`
 
 Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the inventory manifest points to code, schemas, tests, examples, or an owner doc that proves the claim.
@@ -64,6 +66,53 @@ The local boundary quickstart remains the entry point:
 
 ```bash
 helm-ai-kernel serve --policy ./release.high_risk.v3.toml
+```
+
+## Shell MCP Server Quickstart
+
+This example puts HELM in front of an upstream `shell-mcp-server` for local
+Claude/Cursor-style MCP usage. `shell-mcp-server` is not a HELM implementation;
+it is the upstream server identity that HELM discovers, quarantines, approves,
+and authorizes before each tool call.
+
+Create a wrapper profile:
+
+```bash
+./bin/helm-ai-kernel mcp wrap \
+  --server-id shell-mcp-server \
+  --upstream-command "npx -y shell-mcp-server" \
+  --require-pinned-schema=true \
+  --json
+```
+
+Install or print client configuration:
+
+```bash
+./bin/helm-ai-kernel mcp install --client claude-code
+./bin/helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb
+./bin/helm-ai-kernel mcp print-config --client cursor
+```
+
+The minimal shell fixture is
+`examples/launch/policies/shell_mcp_server_boundary.json`. It documents the
+intended quickstart policy shape:
+
+| Command class | Verdict | Reason |
+| --- | --- | --- |
+| `ls` | `ALLOW` | Read-only directory listing |
+| `cat <path>` | `ALLOW` | Read-only file inspection |
+| `git status` | `ALLOW` | Read-only worktree status |
+| `rm -rf` and equivalent recursive force delete patterns | `DENY` | Destructive deletion |
+| `dd`, `mkfs`, and raw-device write patterns | `DENY` | Disk or filesystem destruction |
+| `git clean -f`, `git clean -fd`, `git clean -fdx`, `git clean --force` | `DENY` | Destructive worktree cleanup |
+
+The active policy bundle still decides enforcement. The fixture keeps docs and
+review discussion concrete without creating a second policy language.
+
+Receipt-bearing MCP decisions can be inspected with:
+
+```bash
+./bin/helm-ai-kernel receipts tail --agent mcp-demo-agent --server http://127.0.0.1:7714
 ```
 
 ## Run the Server

--- a/docs/INTEGRATIONS/openai_baseurl.md
+++ b/docs/INTEGRATIONS/openai_baseurl.md
@@ -42,6 +42,7 @@ flowchart TD
 - CLI proxy implementation: [`core/cmd/helm-ai-kernel/proxy_cmd.go`](../../core/cmd/helm-ai-kernel/proxy_cmd.go)
 - Local boundary command: [`core/cmd/helm-ai-kernel/server_cmd.go`](../../core/cmd/helm-ai-kernel/server_cmd.go), [`core/cmd/helm-ai-kernel/serve_policy.go`](../../core/cmd/helm-ai-kernel/serve_policy.go)
 - Receipt routes: [`core/cmd/helm-ai-kernel/receipt_routes.go`](../../core/cmd/helm-ai-kernel/receipt_routes.go)
+- Local proxy demo: [`scripts/launch/demo-openai-proxy.sh`](../../scripts/launch/demo-openai-proxy.sh), [`scripts/launch/mock-openai-upstream.py`](../../scripts/launch/mock-openai-upstream.py)
 - Source-backed examples: [`examples/python_openai_baseurl/`](../../examples/python_openai_baseurl/), [`examples/ts_openai_baseurl/`](../../examples/ts_openai_baseurl/), [`examples/js_openai_baseurl/`](../../examples/js_openai_baseurl/)
 
 The proxy is an OpenAI-compatible request boundary. It is not hosted operations and it does not certify provider SDK behavior.
@@ -86,6 +87,55 @@ http://127.0.0.1:9090/v1
 
 Do not document `3000` as a default. Use it only when the local command explicitly binds that port.
 
+## Agent Runtime Endpoint Examples
+
+The integration point is the OpenAI-compatible endpoint, not a framework-specific
+adapter. Configure the client or framework to use HELM as the base URL.
+
+Environment-only setup:
+
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:9090/v1
+export OPENAI_API_KEY=local-dev-key
+```
+
+OpenAI Agents SDK setup:
+
+```python
+from openai import AsyncOpenAI
+from agents import Agent, Runner, set_default_openai_api, set_default_openai_client
+
+set_default_openai_client(
+    AsyncOpenAI(base_url="http://127.0.0.1:9090/v1", api_key="local-dev-key"),
+    use_for_tracing=False,
+)
+set_default_openai_api("chat_completions")
+
+agent = Agent(name="governed", instructions="Route tool effects through HELM.")
+result = await Runner.run(agent, "summarize the current task")
+```
+
+LangGraph or LangChain setup through `langchain-openai`:
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="helm-local-mock",
+    base_url="http://127.0.0.1:9090/v1",
+    api_key="local-dev-key",
+)
+```
+
+Custom runtime setup:
+
+```bash
+curl -sS http://127.0.0.1:9090/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -H 'authorization: Bearer local-dev-key' \
+  -d '{"model":"helm-local-mock","messages":[{"role":"user","content":"hello through HELM"}]}'
+```
+
 ## Python Example
 
 ```bash
@@ -127,6 +177,39 @@ The HTTP route `GET /api/v1/receipts/tail` can be used directly when an unfilter
 | `X-Helm-Correlation-ID` | Trace and receipt correlation value |
 
 Some OpenAI-compatible clients hide raw response headers. In that case, inspect the receipt stream or use a HELM SDK path that exposes receipt metadata.
+
+### Risky Tool-Call Denial
+
+The local mock upstream has a deny fixture: request model
+`helm-local-tool-fixture` and it returns an OpenAI-shaped assistant message
+containing `tool_calls`. The proxy must stop that response before the caller can
+execute the tool.
+
+```bash
+curl -sS -D headers.txt -o denied.json -w '%{http_code}\n' \
+  http://127.0.0.1:9090/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -H 'authorization: Bearer local-dev-key' \
+  -d '{"model":"helm-local-tool-fixture","messages":[{"role":"user","content":"call a denied tool"}]}'
+```
+
+Expected result:
+
+- HTTP status is `403`.
+- `X-Helm-Status` is `DENIED`.
+- `X-Helm-Receipt-ID` is present.
+- `denied.json` contains a HELM error body and no executable `tool_calls`.
+- The latest proxy receipt has `status: "DENIED"` and `tool_calls_intercepted: 1`.
+
+Run the maintained proof:
+
+```bash
+./scripts/launch/demo-openai-proxy.sh
+```
+
+The receipt can later be included in an EvidencePack. The EvidencePack verifier
+then checks the indexed receipt bytes, root hashes, and seal instead of trusting
+the proxy process that produced the denial.
 
 ## Verification
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -64,6 +64,9 @@ flowchart TD
 - `core/cmd/helm-ai-kernel/verify_cmd.go`
 - `api/openapi/helm.openapi.yaml`
 - `release.high_risk.v3.toml`
+- `scripts/launch/demo-mcp.sh`
+- `scripts/launch/demo-openai-proxy.sh`
+- `examples/launch/policies/shell_mcp_server_boundary.json`
 
 The quickstart uses Console registration as the primary adoption path. Console
 provides the dashboard for receipts, evidence, and run history. The local CLI
@@ -163,7 +166,54 @@ Run the basic boundary checks in another shell:
 
 The MCP authorization example should fail closed until the server identity, tool schema, scopes, and policy state are approved.
 
-## 4. Run The Built-In Proof Demo
+## 4. Shell + MCP Quickstart
+
+Use this path when Claude Code, Claude Desktop, Cursor, or another MCP-capable
+client needs shell access through an upstream `shell-mcp-server`. The upstream
+server remains third-party; HELM sits in front of it as the MCP execution
+boundary.
+
+Generate a wrapper profile for the upstream stdio server:
+
+```bash
+./bin/helm-ai-kernel mcp wrap \
+  --server-id shell-mcp-server \
+  --upstream-command "npx -y shell-mcp-server" \
+  --require-pinned-schema=true \
+  --json
+```
+
+Install or print a local client configuration:
+
+```bash
+./bin/helm-ai-kernel mcp install --client claude-code
+./bin/helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb
+./bin/helm-ai-kernel mcp print-config --client cursor
+```
+
+The minimal shell policy fixture is
+`examples/launch/policies/shell_mcp_server_boundary.json`. It allows read-only
+`ls`, `cat <path>`, and `git status`; it blocks destructive shell patterns
+including `rm -rf`, `dd`, `mkfs`, destructive `git clean` forms, and equivalent
+raw disk or worktree deletion attempts.
+
+Before a real tool dispatch, the HELM path must produce an MCP authorization
+decision and a receipt. Inspect it with:
+
+```bash
+./bin/helm-ai-kernel receipts tail --agent mcp-demo-agent --server http://127.0.0.1:7714
+```
+
+Run the maintained local proof:
+
+```bash
+./scripts/launch/demo-mcp.sh
+```
+
+The demo proves unknown servers, unknown tools, and missing schema pins return
+`DENY` or `ESCALATE` before fixture dispatch.
+
+## 5. Run The Built-In Proof Demo
 
 The local demo routes are implemented in the CLI server and exercise receipt verification without requiring a hosted service.
 
@@ -189,9 +239,9 @@ curl http://127.0.0.1:7714/api/demo/tamper \
   -d '{"receipt":{...},"expected_receipt_hash":"<receipt_hash>","mutation":"flip_verdict"}'
 ```
 
-## 5. Optional OpenAI-Compatible Proxy
+## 6. OpenAI-Compatible Proxy Quickstart
 
-Start the proxy only when an existing client can set an OpenAI-style base URL:
+Start the proxy when an existing client can set an OpenAI-style base URL:
 
 ```bash
 python3 scripts/launch/mock-openai-upstream.py --port 19090
@@ -212,9 +262,64 @@ Point the client at:
 http://localhost:9090/v1
 ```
 
-The retained source examples under `examples/*_openai_baseurl/` are HELM HTTP/SDK examples, not verified OpenAI SDK examples. Use [OpenAI-Compatible Proxy Integration](INTEGRATIONS/openai_baseurl.md) for the proxy contract.
+Frameworks use the same switch: configure the OpenAI-compatible endpoint to
+`http://127.0.0.1:9090/v1` instead of calling OpenAI directly.
 
-## 6. Inspect Receipts
+```bash
+export OPENAI_BASE_URL=http://127.0.0.1:9090/v1
+export OPENAI_API_KEY=local-dev-key
+```
+
+Agents SDK can use a default OpenAI client pointed at HELM:
+
+```python
+from openai import AsyncOpenAI
+from agents import Agent, Runner, set_default_openai_api, set_default_openai_client
+
+set_default_openai_client(
+    AsyncOpenAI(base_url="http://127.0.0.1:9090/v1", api_key="local-dev-key"),
+    use_for_tracing=False,
+)
+set_default_openai_api("chat_completions")
+
+agent = Agent(name="quickstart", instructions="Use governed tool calls only.")
+result = await Runner.run(agent, "hello through HELM")
+```
+
+LangGraph/LangChain apps can point `ChatOpenAI` at the same endpoint:
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="helm-local-mock",
+    base_url="http://127.0.0.1:9090/v1",
+    api_key="local-dev-key",
+)
+```
+
+A custom runtime can call the proxy directly:
+
+```bash
+curl -sS http://127.0.0.1:9090/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -H 'authorization: Bearer local-dev-key' \
+  -d '{"model":"helm-local-mock","messages":[{"role":"user","content":"hello"}]}'
+```
+
+Risky upstream tool calls are denied by the proxy before the caller can execute
+them. The maintained demo sends a local fixture that returns an OpenAI-shaped
+`tool_calls` response; HELM returns `403`, sets `X-Helm-Status: DENIED`, removes
+executable `tool_calls` from the response body, and persists a denied receipt
+that can be exported into an EvidencePack.
+
+```bash
+./scripts/launch/demo-openai-proxy.sh
+```
+
+The retained source examples under `examples/*_openai_baseurl/` are HELM HTTP/SDK examples. Use [OpenAI-Compatible Proxy Integration](INTEGRATIONS/openai_baseurl.md) for the proxy contract.
+
+## 7. Inspect Receipts
 
 The CLI receipt tail requires an agent id:
 
@@ -228,7 +333,7 @@ For an unfiltered local list, use the HTTP API:
 curl 'http://127.0.0.1:7714/api/v1/receipts?limit=20'
 ```
 
-## 7. Verify Evidence
+## 8. Verify Evidence
 
 `helm-ai-kernel verify` is offline-first and succeeds only when the EvidencePack contains the required roots, proof material, and receipts.
 
@@ -239,7 +344,7 @@ curl 'http://127.0.0.1:7714/api/v1/receipts?limit=20'
 
 Use the `v0.5.10` release `evidence-pack.tar` after `version-status.json` confirms all lockstep channels, or use an operator-generated pack known to contain ProofGraph and receipt material. Do not treat the local onboarding demo export as verified unless it includes those records.
 
-## 8. Validate The Checkout
+## 9. Validate The Checkout
 
 ```bash
 make docs-coverage

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -152,6 +152,47 @@ retention mode, and `retain_until` timestamp. When verification runs against a
 tar archive, the verifier compares the receipt object hash with the local
 archive bytes.
 
+## Receipt Tail Output
+
+Use `receipts tail` while an integration is running to prove the request crossed
+the HELM boundary:
+
+```bash
+helm-ai-kernel receipts tail --agent agent.demo.exec --server http://127.0.0.1:7714
+```
+
+The command prints durable receipt events for the selected agent. In compact
+output, the fields to read first are:
+
+| Field | What it tells the operator |
+| --- | --- |
+| `receipt_id` | The durable receipt to cite in an issue, audit note, or EvidencePack |
+| `decision_id` | The policy decision that produced the receipt |
+| `verdict` or `status` | `ALLOW`, `DENY`, `ESCALATE`, or proxy status such as `DENIED` |
+| `reason_code` | Why the boundary allowed, denied, or escalated the effect |
+| `output_hash` | The hash that binds the governed result or denial body |
+| `signature` | Receipt-level signature material; absence means the event is not audit-ready |
+
+For a denied shell or proxy tool-call test, the receipt should show a deny
+status/reason and the effect should not be dispatched. That receipt is the
+operator-facing handle that later appears inside the EvidencePack.
+
+## EvidencePack Verify Output
+
+Use offline verification for archives:
+
+```bash
+helm-ai-kernel verify evidence-pack.tar
+```
+
+The command succeeds only after the verifier has checked the archive/index
+shape, content hashes, required receipt material, root hash, and available
+signatures. A passing dev-local pack may report `anchor offline`; that means no
+external timestamp/transparency anchor was embedded, not that verification was
+skipped. Customer/high-assurance packs should additionally report a trusted seal
+signer, external anchor, and storage receipt verification when those inputs are
+provided.
+
 ## Online Proof Check
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -115,6 +115,33 @@ This table documents registered top-level `helm-ai-kernel` command families and 
 | `helm-ai-kernel evidence prove-entry` | Requires `--manifest <manifest.json>` and `--entry <path>`; writes a self-contained inclusion proof to `--out` (default stdout) for redacted single-entry verification. |
 | `helm-ai-kernel boundary` | Uses `status`, `capabilities`, `records`, `get`, `verify`, and `checkpoint` subcommands. |
 
+## Receipt And Verification Output
+
+`helm-ai-kernel receipts tail --agent <id>` is the live operator view over
+durable boundary events. The command is useful when proving that Claude, Cursor,
+LangGraph, or a custom runtime crossed HELM instead of calling a tool or model
+endpoint directly.
+
+Read the output as:
+
+| Output field | Meaning |
+| --- | --- |
+| `receipt_id` | Stable handle for the governed request; cite this in issues, reviews, and EvidencePacks |
+| `decision_id` | Policy decision that produced the receipt |
+| `verdict` / `status` | Boundary result such as `ALLOW`, `DENY`, `ESCALATE`, `APPROVED`, or `DENIED` |
+| `reason_code` | Machine-readable reason for the decision |
+| `effect_id` | Proposed or denied side effect when the runtime records one |
+| `output_hash` | Hash of the governed response, denial body, or completion |
+| `signature` | Receipt signature material; required before treating the event as audit evidence |
+
+`helm-ai-kernel verify evidence-pack.tar` is the offline archive verifier. A
+successful run means the verifier accepted the archive/index shape, checked the
+indexed content hashes, found required receipt/proof material, and verified the
+available seal/signature material. If the output says `anchor offline`, no
+external anchor was embedded; the local pack can still pass hash and signature
+checks, but customer/high-assurance review should add the trusted signer,
+external anchor, and storage receipt inputs.
+
 ## Boundary And API References
 
 - [HTTP API Reference](http-api.md) covers the route registry, auth classes, OpenAPI contract, and local API behavior.

--- a/examples/launch/policies/shell_mcp_server_boundary.json
+++ b/examples/launch/policies/shell_mcp_server_boundary.json
@@ -1,0 +1,73 @@
+{
+  "pack_id": "shell-mcp-server-boundary-v1",
+  "label": "Shell MCP Server Boundary",
+  "version": 1,
+  "scope": {
+    "mcp_server_id": "shell-mcp-server",
+    "upstream": "third-party shell-mcp-server behind HELM"
+  },
+  "actions": [
+    {
+      "action": "shell.ls",
+      "enabled": true,
+      "effect": "read",
+      "command_patterns": [
+        "^ls(\\s|$)"
+      ],
+      "reason_code": "SHELL_READ_ALLOW"
+    },
+    {
+      "action": "shell.cat",
+      "enabled": true,
+      "effect": "read",
+      "command_patterns": [
+        "^cat\\s+[^|;&`$]+$"
+      ],
+      "reason_code": "SHELL_READ_ALLOW"
+    },
+    {
+      "action": "git.status",
+      "enabled": true,
+      "effect": "read",
+      "command_patterns": [
+        "^git\\s+status(\\s|$)"
+      ],
+      "reason_code": "GIT_STATUS_ALLOW"
+    },
+    {
+      "action": "shell.rm_rf",
+      "enabled": false,
+      "effect": "destructive_write",
+      "command_patterns": [
+        "\\brm\\s+-[^\\n]*r[^\\n]*f\\b",
+        "\\brm\\s+-[^\\n]*f[^\\n]*r\\b"
+      ],
+      "reason_code": "SHELL_DESTRUCTIVE_DELETE"
+    },
+    {
+      "action": "shell.raw_disk_write",
+      "enabled": false,
+      "effect": "destructive_write",
+      "command_patterns": [
+        "\\bdd\\s+",
+        "\\bmkfs(\\.[a-z0-9]+)?\\b"
+      ],
+      "reason_code": "SHELL_RAW_DEVICE_WRITE"
+    },
+    {
+      "action": "git.clean.destructive",
+      "enabled": false,
+      "effect": "destructive_write",
+      "command_patterns": [
+        "^git\\s+clean\\s+-[^\\n]*f",
+        "^git\\s+clean\\s+-[^\\n]*x",
+        "^git\\s+clean\\s+.*--force"
+      ],
+      "reason_code": "GIT_WORKTREE_DESTRUCTIVE_CLEAN"
+    }
+  ],
+  "notes": [
+    "Example fixture for quickstart documentation only; use the generated HELM wrapper and active policy bundle for enforcement.",
+    "shell-mcp-server is an upstream MCP server identity. HELM owns discovery, quarantine, schema-pin, authorization, receipt, and EvidencePack capture."
+  ]
+}

--- a/protocols/spec/evidence-pack-v1.md
+++ b/protocols/spec/evidence-pack-v1.md
@@ -148,6 +148,51 @@ Launchpad numbered EvidencePacks map native host evidence to
 `11_HOST_EVIDENCE/`. Verifiers MUST accept both `host_evidence/<source>/...`
 and `11_HOST_EVIDENCE/<source>/...` when validating imported host evidence.
 
+### 3.4 Minimal HELM Execution Pack
+
+A minimal HELM execution EvidencePack records enough material for an offline
+reviewer to answer four questions: what was requested, which tool effect was
+considered, which policy decision was made, and what result or denial was
+returned.
+
+The minimal event set is:
+
+| Event | Required evidence | Typical path |
+| --- | --- | --- |
+| Prompt or intent | User prompt summary, normalized intent id, actor/agent id, input content hash | `policy/` or native `01_INTENT/` |
+| Tool call | Tool/server id, action name, argument hash, proposed effect class | `transcripts/` or native `03_EFFECTS/` |
+| Policy decision | `decision_id`, policy id/hash, verdict, reason code, evaluated rules | `policy/` |
+| Result or completion | Output hash, completion status, upstream status when applicable | `transcripts/` |
+| Denied effect, when applicable | Denied tool/action, `effect_id`, reason code, `side_effect_dispatched: false` | `transcripts/` or native `03_EFFECTS/` |
+| Receipt | `receipt_id`, `decision_id`, verdict, timestamp, output hash, signature | `receipts/` or native `02_PROOFGRAPH/receipts/` |
+
+Every event that is stored as a file MUST be represented by a manifest entry
+with a `content_hash`. Related events SHOULD share stable identifiers:
+
+- `pack_id` identifies the archive as a whole.
+- `receipt_id` identifies the signed governance receipt.
+- `decision_id` identifies one policy decision.
+- `effect_id` identifies one proposed or denied side effect.
+- `content_hash` binds a manifest entry to its bytes.
+- `manifest_hash`, `entries_merkle_root`, or a native root hash binds the set
+  of indexed entries.
+
+HELM native packs MAY use the numbered layout with `00_INDEX.json` as the root
+index. In that layout the pack seal is stored at
+`07_ATTESTATIONS/evidence_pack.sig`; the verifier still checks indexed file
+hashes and the pack/root hash before accepting the seal.
+
+The minimal signature profile is:
+
+- Each receipt carries its own signature over the receipt signing payload.
+- The EvidencePack carries a pack-level seal over the root hash or manifest
+  hash.
+- A dev-local profile MAY use a local Ed25519 signer and report `anchor
+  offline`.
+- Customer or high-assurance profiles SHOULD bind the seal to an external
+  signer key and an external timestamp or transparency anchor, then retain a
+  storage receipt for the archived bytes.
+
 ## 4. Entry Types
 
 ### 4.1 Receipts (ATTESTATION)

--- a/scripts/launch/demo-mcp.sh
+++ b/scripts/launch/demo-mcp.sh
@@ -42,7 +42,11 @@ PROFILE_JSON="$(./bin/helm-ai-kernel mcp wrap \
 printf '%s\n' "$PROFILE_JSON" | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p["server_id"]=="local-fixture-mcp"; assert p["quarantine_default"]=="quarantined"; assert p["upstream_command"][:2]==["python3","scripts/launch/mcp-fixture-server.py"]; print(json.dumps({"wrapper":p["server_id"],"quarantine_default":p["quarantine_default"]}, sort_keys=True))'
 
 echo "==> Starting local HELM boundary"
-HELM_ADMIN_API_KEY="$ADMIN_KEY" HELM_HEALTH_PORT="$HEALTH_PORT" ./bin/helm-ai-kernel serve \
+env HELM_ADMIN_API_KEY="$ADMIN_KEY" \
+  HELM_HEALTH_PORT="$HEALTH_PORT" \
+  HELM_RUNTIME_TENANT_ID="$TENANT_ID" \
+  HELM_RUNTIME_PRINCIPAL_ID="mcp-demo-agent" \
+  ./bin/helm-ai-kernel serve \
   --policy examples/launch/policies/agent_tool_call_boundary.toml \
   --addr 127.0.0.1 \
   --port "$PORT" \

--- a/scripts/launch/demo-openai-proxy.sh
+++ b/scripts/launch/demo-openai-proxy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 echo "==> HELM Launch Demo: OpenAI Governance Proxy"
 echo "Demonstrating how HELM acts as a transparent, governed proxy for the OpenAI SDK."
@@ -78,3 +78,49 @@ echo ""
 receipt_file="$(find "$TMP_DIR/proxy-receipts" -name '*.jsonl' -type f | sort | tail -n 1)"
 test -s "$receipt_file"
 tail -n 1 "$receipt_file" | python3 -c 'import json,sys; payload=json.load(sys.stdin); assert payload["status"] == "APPROVED"; assert payload["upstream"].startswith("http://127.0.0.1:")'
+
+echo ""
+echo "==> 5. Sending risky tool-call fixture via proxy"
+echo "The mock upstream returns an OpenAI-shaped tool_calls response; HELM must deny it before the caller can execute the tool."
+echo ""
+
+DENY_STATUS="$(curl -sS -o "$TMP_DIR/proxy-deny-response.json" -D "$TMP_DIR/proxy-deny-headers.txt" -w '%{http_code}' -X POST "http://127.0.0.1:$PROXY_PORT/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer mock-key" \
+  -d '{
+    "model": "helm-local-tool-fixture",
+    "messages": [{"role": "user", "content": "call a denied tool"}]
+  }')"
+
+python3 - "$DENY_STATUS" "$TMP_DIR/proxy-deny-headers.txt" "$TMP_DIR/proxy-deny-response.json" <<'PY'
+import json
+import sys
+
+status, headers_path, body_path = sys.argv[1:4]
+assert status == "403", status
+headers = {}
+for raw in open(headers_path, encoding="utf-8"):
+    if ":" not in raw:
+        continue
+    name, value = raw.split(":", 1)
+    headers[name.strip().lower()] = value.strip()
+assert headers.get("x-helm-status") == "DENIED", headers
+assert headers.get("x-helm-receipt-id"), headers
+raw_body = open(body_path, encoding="utf-8").read()
+assert "tool_calls" not in raw_body, raw_body
+body = json.loads(raw_body)
+assert body["helm"]["status"] == "DENIED", body
+assert body["error"]["type"] == "helm_governance_denied", body
+print(json.dumps({
+    "http_status": int(status),
+    "x_helm_status": headers["x-helm-status"],
+    "receipt_id": headers["x-helm-receipt-id"],
+    "tool_calls_redacted": True,
+}, sort_keys=True))
+PY
+
+receipt_file="$(find "$TMP_DIR/proxy-receipts" -name '*.jsonl' -type f | sort | tail -n 1)"
+tail -n 1 "$receipt_file" | python3 -c 'import json,sys; payload=json.load(sys.stdin); assert payload["status"] == "DENIED"; assert payload["tool_calls_intercepted"] == 1; print(json.dumps({"receipt_status":payload["status"],"tool_calls_intercepted":payload["tool_calls_intercepted"],"receipt_id":payload["receipt_id"]}, sort_keys=True))'
+
+echo ""
+echo "==> OpenAI proxy demo complete: approved request and denied tool-call receipt verified."

--- a/scripts/launch/mock-openai-upstream.py
+++ b/scripts/launch/mock-openai-upstream.py
@@ -42,6 +42,10 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         model = request.get("model") or "helm-local-mock"
+        if model == "helm-local-tool-fixture" or _contains_deny_fixture_trigger(request):
+            self._json(200, deny_tool_call_fixture(model))
+            return
+
         self._json(
             200,
             {
@@ -66,6 +70,49 @@ class Handler(BaseHTTPRequestHandler):
                 },
             },
         )
+
+
+def _contains_deny_fixture_trigger(request: dict) -> bool:
+    for message in request.get("messages", []):
+        if not isinstance(message, dict):
+            continue
+        content = str(message.get("content", "")).lower()
+        if "denied tool" in content or "dangerous tool" in content:
+            return True
+    return False
+
+
+def deny_tool_call_fixture(model: str) -> dict:
+    return {
+        "id": "chatcmpl-helm-local-deny-fixture",
+        "object": "chat.completion",
+        "created": 1778587200,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": "call_helm_denied",
+                            "type": "function",
+                            "function": {
+                                "name": "credential_export",
+                                "arguments": "{\"path\":\"/etc/passwd\"}",
+                            },
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        },
+    }
 
 
 def main() -> None:

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-11T15:23:45Z
-# Commit: 3e10d0bb2bd8157b8935d2ae9d8106f40b29be28
+# Generated: 2026-06-11T15:47:55Z
+# Commit: 1e3e72f00a4c6e0cd7f8c08755fbc077e0cc7647
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md
@@ -871,7 +871,7 @@ c28f8d64a15c801dff22c984b977f5a3f899684653ab4307386b842cd0b467bb  protocols/prot
 a3b4957fbf92a0950e4dccbe6d48037b8b88b56c0ba5d36ac3cbab1695b92b58  protocols/proto/helm/kernel/v1/helm.proto
 f294ad5b8fcc429072bd16a1dcef407e4884e843c6099c5de8d1ce8ec3cc0f2c  protocols/proto/helm/truth/v1/truth.proto
 6e2ee245f428faa27dbb15747f17cace76a0edabc72d1023b99120aa2a29f925  protocols/spec/PROTOCOL.md
-de3bb001d879885ab923bc3556d4c3c1b406cac3115c4f5338a819f16549d81f  protocols/spec/evidence-pack-v1.md
+231da2405cb5750a50e493703c0ac960b60da1fb35069311e4a3fa0031883373  protocols/spec/evidence-pack-v1.md
 6709408084e33158dfe9baf079e5a66b99c33c04362aa2dd76c832e3c5af7d21  protocols/spec/external-evidence-receipt-profile-v0.1.md
 b5b0ad4ea4a936f16ab4bd82e6cfed5e8b52c3c1a9eb2ce30d5043f0c1939aa3  protocols/specs/README.md
 59854984853104df5c353e2f681a15fc7924742f9a2e468c29af248dce45ce03  protocols/specs/SPEC_VERSION


### PR DESCRIPTION
## Summary
- Adds Shell + MCP quickstart coverage for Claude/Cursor-style clients using HELM in front of an upstream `shell-mcp-server`.
- Adds an OpenAI-compatible proxy quickstart with Agents SDK, LangGraph/LangChain, and custom runtime endpoint examples.
- Adds a local proxy deny fixture path that returns a risky OpenAI-shaped `tool_calls` response and proves HELM returns `403`, `X-Helm-Status: DENIED`, redacts executable `tool_calls`, and persists a denied receipt.
- Tightens EvidencePack, verification, and CLI docs around minimal events, IDs, signatures, receipt tailing, and offline verification output.
- Adds a shell MCP policy fixture under `examples/launch/policies/` without introducing a new enforcement model.

## Validation
- `PATH="/usr/bin:/opt/homebrew/bin:/bin:/usr/sbin:/sbin:$PATH" env -u GOROOT -u GOTOOLDIR -u GOTOOLCHAIN make docs-coverage docs-truth`
- `cd core && PATH="/usr/bin:/opt/homebrew/bin:/bin:/usr/sbin:/sbin:$PATH" env -u GOROOT -u GOTOOLDIR -u GOTOOLCHAIN go test ./cmd/helm-ai-kernel -run 'TestVerifyCmd|TestReceiptsTail|TestProxy|TestMCPMediationProof' -count=1`
- `PATH="/usr/bin:/opt/homebrew/bin:/bin:/usr/sbin:/sbin:$PATH" env -u GOROOT -u GOTOOLDIR -u GOTOOLCHAIN bash scripts/launch/demo-mcp.sh`
- `PATH="/usr/bin:/opt/homebrew/bin:/bin:/usr/sbin:/sbin:$PATH" env -u GOROOT -u GOTOOLDIR -u GOTOOLCHAIN bash scripts/launch/demo-openai-proxy.sh`
- `gh label list --repo Mindburn-Labs/helm-ai-kernel --limit 200`
- GraphQL `discussionCategories` query confirms Discussions are enabled and currently only default categories exist.

## GitHub Community Setup
- Created the requested labels on `Mindburn-Labs/helm-ai-kernel` with `gh label create --force`.
- Discussion category creation remains blocked in this environment: Opera Browser Connector is not connected, REST `repos/.../discussions/categories` returns 404, and GraphQL exposes discussion create/update/comment mutations but no category creation mutation. The five requested categories still need repo-admin UI creation.
