### PR TITLE
fix(helm-chart): re-pin egress-proxy digest to a build with iptables

### DIFF
--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -337,7 +337,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:e09e0aec1e0e1f926f4cd18444e88310656b85551cbc10a6c340acb979a42e03"
+        digest: "sha256:c55a277a350ee715cb1cbfb017aa20025df5b4f717b283e0144b1c3bf0887537"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:
@@ -378,7 +378,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:e09e0aec1e0e1f926f4cd18444e88310656b85551cbc10a6c340acb979a42e03"
+        digest: "sha256:c55a277a350ee715cb1cbfb017aa20025df5b4f717b283e0144b1c3bf0887537"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:


### PR DESCRIPTION
## Problem

PR #275 introduced the `egress-init` transparent-proxy step (runs `iptables ... REDIRECT`) and added `RUN apk add --no-cache iptables` to `egress-proxy.Dockerfile`. But the **same commit** (`be62955e`) pinned `launchpadApps.{hermes,openclaw}.egressSidecar.image.digest` to `sha256:e09e0aec…` — a build made *before* that Dockerfile change.

The deployed `egress-init` therefore fails immediately:

```
/bin/sh: iptables: not found     # exit 127
```

It never installs the redirect rules → pod goes `Init:Error` → **every launchpad app with an egress sidecar (hermes, openclaw) fails to start.**

## Fix

Re-pin both `egressSidecar` digests to `sha256:c55a277a35…` (tag `enforce`), the current published egress-proxy image that **does** include iptables. No rebuild needed — the correct image is already in GHCR.

## Found by

functional-test run `2026-06-12_ftmain-bcef_smoke-llm-containerd` (containerd telemetry validation). Re-run case 03 (agent-bootstrap) after merge to confirm `egress-init` passes and hermes reaches the model provider.

## Follow-up

Digest-drift prevention (auto-pin launchpad image digests from CI) tracked separately.
