### PR TITLE
fix(helm-chart): correct egress-proxy digest to the published build (22d78073)

### DIFF
--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -337,7 +337,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:c55a277a350ee715cb1cbfb017aa20025df5b4f717b283e0144b1c3bf0887537"
+        digest: "sha256:22d78073a11b911f372cd27fa7886101d319b60d367441b18208f2be9d9dfb34"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:
@@ -378,7 +378,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:c55a277a350ee715cb1cbfb017aa20025df5b4f717b283e0144b1c3bf0887537"
+        digest: "sha256:22d78073a11b911f372cd27fa7886101d319b60d367441b18208f2be9d9dfb34"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:


### PR DESCRIPTION
## Why

PR #326 merged `egress-proxy@sha256:c55a277…` into `main` — a **stand-local** egress-proxy
image that was never pushed to GHCR. The node pulls **anonymously by digest** and gets
`NotFound` → `ImagePullBackOff` for every launchpad app with an egress sidecar (hermes,
openclaw). **`main` is currently broken** for those apps.

## Fix

Re-pin both `egressSidecar` digests to `sha256:22d78073…` — the egress-proxy image that the
**PR #275 merge build** actually built and published (tag `be62955e0692…` = the merge commit
SHA; built 2026-06-10; `/usr/sbin/iptables` present; anonymously pullable). Single-commit,
supersedes the digest landed by #326.

## Verified

minikube / containerd: `egress-init` → `Completed (0)` for **hermes and openclaw** (was
`exit 127: iptables: not found`); case 03 (agent-bootstrap) graceful degrade — Node.js install
blocked by the egress allowlist (`curl (35) nodejs.org:443`), agent still answered via
`gemini-3.5-flash`.

Full report:
https://github.com/Mindburn-Labs/docs_for_team/blob/main/REPORTS/2026-06-12_pr326_egress-digest-fix-verify/REPORT.md

Follow-up to auto-pin launchpad digests from CI tracked separately (digest drift, root cause of #326).
