### PR TITLE
fix(launchpad): route openclaw agent model through OpenRouter

### DIFF
--- a/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
@@ -80,6 +80,22 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.openrouter.apiKeySecretRef.name | quote }}
                   key: {{ .Values.openrouter.apiKeySecretRef.key | quote }}
+            # Route openclaw's OpenAI-compatible agent calls through OpenRouter —
+            # the only host the egress allowlist permits. openclaw's built-in agent
+            # model defaults to the `openai/*` provider, which dials api.openai.com
+            # directly; under the transparent-egress REDIRECT that connection is
+            # dropped ("stream disconnected before completion"), so the embedded
+            # agent fails. OpenRouter is OpenAI-API-compatible, so pointing
+            # OPENAI_BASE_URL at it (authenticated with the same OpenRouter key)
+            # makes those calls leave through the allowed host. Mirrors hermes,
+            # which already runs `--provider openrouter`.
+            - name: OPENAI_BASE_URL
+              value: "https://openrouter.ai/api/v1"
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.openrouter.apiKeySecretRef.name | quote }}
+                  key: {{ .Values.openrouter.apiKeySecretRef.key | quote }}
           ports:
             - name: gateway
               containerPort: {{ $cfg.gatewayPort }}


### PR DESCRIPTION
## Problem

The **`Helm Integration — Launchpad k8s smoke`** workflow has been red on `main` for days. The failing job is **`openclaw + hermes positive (real OPENROUTER_API_KEY)`** → step *Run positive smoke* (exit 1). `chart-only baseline` and `openclaw + hermes negative (fake key)` are green; hermes itself works (it runs `--provider openrouter`).

This is **not** a regression from a single PR — it is a long-standing blocker that surfaced after the egress-init `iptables` fixes (#326/#327) let the run progress far enough to reach the model call.

## Root cause

openclaw's gateway starts `--allow-unconfigured` and falls back to its built-in default **agent model `openai/gpt-5.5`**, which resolves to the **`openai/*` provider and dials `api.openai.com` directly**:

```
[gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
[agent/embedded] embedded run failover ... from=openai/gpt-5.5
  rawError=stream disconnected before completion:
  error sending request for url (https://api.openai.com/v1/responses)
Embedded agent failed before reply: stream disconnected before completion ...
```

But openclaw's egress allowlist is **openrouter-only** (`policies/launchpad/apps/openclaw.safe.toml` → `network_allowlist = ["https://openrouter.ai/api/v1"]`), enforced by the transparent-egress iptables REDIRECT. So the call to `api.openai.com` is dropped and the embedded agent fails. The launchpad wires up OpenRouter (key, allowlist, readiness probe) but never tells the openclaw **agent** to route through it.

## Fix

Point openclaw's OpenAI-compatible client at OpenRouter (which is OpenAI-API-compatible) and authenticate with the same OpenRouter key, in `openclaw-deployment.yaml`:

```yaml
- name: OPENAI_BASE_URL
  value: "https://openrouter.ai/api/v1"
- name: OPENAI_API_KEY
  valueFrom:
    secretKeyRef:
      name: {{ .Values.openrouter.apiKeySecretRef.name }}
      key: {{ .Values.openrouter.apiKeySecretRef.key }}
```

Now openclaw's agent calls leave through the only allowlisted host. This mirrors **hermes**, which already runs `--provider openrouter` and passes.

## Open item / validation

This redirect is the necessary routing fix. One thing to confirm on CI: openclaw's default model slug `openai/gpt-5.5` must resolve on OpenRouter. If OpenRouter returns `400 model not found`, a follow-up must pin a known slug (e.g. `openai/gpt-4o-mini`, as hermes uses) — but openclaw's model-selection knob is not exposed in this repo (external image, `--allow-unconfigured`), so that would need an openclaw config/env from the upstream image.

**Validation:** the `Helm Integration — Launchpad k8s smoke` workflow (positive job) is the authoritative check. Also run locally on the intel stand via `/functional-test helm-ai-kernel minikube` before merge.
