### PR TITLE
feat(chart): configure hermes launchpad mode

### DIFF
--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -54,6 +54,11 @@ flowchart TD
 | `image.repository` | `ghcr.io/mindburn-labs/helm-ai-kernel` | Container image repository. |
 | `image.tag` | chart `appVersion` | Container image tag. |
 | `imagePullSecrets` | `[]` | Pull secrets applied to the kernel and optional launchpad app Pods/Jobs/test Pod. |
+| `launchpadApps.hermes.mode` | `job` | `job` renders the promoted single-query smoke Job; `deployment` renders a long-lived Hermes gateway Deployment without claiming live F2 promotion. |
+| `launchpadApps.hermes.provider` | `openrouter` | Provider passed to the default Hermes Job command. |
+| `launchpadApps.hermes.model` | `openai/gpt-4o-mini` | Model passed to the default Hermes Job command. |
+| `launchpadApps.hermes.query` | `ping` | Single query passed to the default Hermes Job command. |
+| `launchpadApps.hermes.commandOverride` | `[]` | Full command array replacement for operator-specific Hermes runtime evidence. |
 | `helm.*` | retained | Legacy values root retained for one compatibility window. |
 | `helm.bindAddr` | `0.0.0.0` | Required inside Kubernetes pods. |
 | `helm.production` | `false` | Refuses generated signing/auth material when set to `true`. |

--- a/deploy/helm-chart/templates/launchpad-apps/_helpers.tpl
+++ b/deploy/helm-chart/templates/launchpad-apps/_helpers.tpl
@@ -47,6 +47,32 @@ Usage: {{ include "helm-ai-kernel.launchpadApp.image" (dict "image" .Values.laun
 {{- end -}}
 
 {{/*
+Hermes command renderer.
+Defaults stay mode-specific: Job runs the promoted single-query smoke path;
+Deployment runs the long-lived gateway process. commandOverride replaces the
+entire command array for operators with provider-specific runtime evidence.
+*/}}
+{{- define "helm-ai-kernel.launchpadApp.hermesCommand" -}}
+{{- $cfg := .cfg -}}
+{{- $mode := .mode -}}
+{{- if $cfg.commandOverride -}}
+{{- toYaml $cfg.commandOverride -}}
+{{- else if eq $mode "deployment" -}}
+- "/bin/sh"
+- "-c"
+- "HOME=/var/lib/hermes exec hermes --gateway"
+{{- else -}}
+{{- $query := $cfg.query | default "ping" -}}
+{{- $provider := $cfg.provider | default "openrouter" -}}
+{{- $model := $cfg.model | default "openai/gpt-4o-mini" -}}
+{{- $shellCommand := printf "HOME=/var/lib/hermes hermes --q %s --provider %s --model %s --ignore_user_config --quiet" ($query | quote) ($provider | quote) ($model | quote) -}}
+- "/bin/sh"
+- "-c"
+- {{ $shellCommand | quote }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Egress sidecar container spec shared by openclaw and hermes Pods.
 The sidecar runs as a TRANSPARENT proxy: the companion init-container (see
 `helm-ai-kernel.launchpadApp.egressInit`) installs an iptables REDIRECT that

--- a/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
@@ -1,6 +1,89 @@
 {{- if .Values.launchpadApps.hermes.enabled -}}
 {{- $app := "hermes" -}}
 {{- $cfg := .Values.launchpadApps.hermes -}}
+{{- $mode := $cfg.mode | default "job" -}}
+{{- if not (has $mode (list "job" "deployment")) -}}
+{{- fail (printf "launchpadApps.hermes.mode must be one of job or deployment, got %q" $mode) -}}
+{{- end -}}
+{{- if eq $mode "deployment" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helm-ai-kernel.launchpadApp.fullname" (dict "ctx" . "app" $app) }}
+  labels:
+    {{- include "helm-ai-kernel.launchpadApp.labels" (dict "ctx" . "app" $app) | nindent 4 }}
+  annotations:
+    helm.ai/upstream-source: "https://github.com/NousResearch/hermes-agent"
+    helm.ai/registry-ref: "registry/launchpad/apps/hermes.yaml"
+    helm.ai/runtime-evidence: "gateway-mode-not-live-f2-promoted"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "helm-ai-kernel.launchpadApp.selectorLabels" (dict "ctx" . "app" $app) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "helm-ai-kernel.launchpadApp.labels" (dict "ctx" . "app" $app) | nindent 8 }}
+    spec:
+      restartPolicy: Always
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.launchpadApps.nodeSelector | nindent 8 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+      initContainers:
+        {{- include "helm-ai-kernel.launchpadApp.egressInit" (dict "sidecar" $cfg.egressSidecar) | nindent 8 }}
+      containers:
+        - name: {{ $app }}
+          image: {{ include "helm-ai-kernel.launchpadApp.image" (dict "image" $cfg.image) | quote }}
+          imagePullPolicy: {{ $cfg.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          command:
+            {{- include "helm-ai-kernel.launchpadApp.hermesCommand" (dict "cfg" $cfg "mode" $mode) | nindent 12 }}
+          env:
+            - name: HOME
+              value: /var/lib/hermes
+            # No HTTP_PROXY/HTTPS_PROXY: egress is enforced transparently by the
+            # egress-init iptables REDIRECT, not by the workload honoring proxy env.
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.openrouter.apiKeySecretRef.name | quote }}
+                  key: {{ .Values.openrouter.apiKeySecretRef.key | quote }}
+          resources:
+            {{- toYaml $cfg.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: app-state
+              mountPath: /var/lib/hermes
+        {{- include "helm-ai-kernel.launchpadApp.egressSidecar" (dict "sidecar" $cfg.egressSidecar) | nindent 8 }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ $cfg.tmpfsSize | default "128Mi" }}
+        - name: app-state
+          emptyDir:
+            sizeLimit: {{ $cfg.appStateSize }}
+        - name: egress-receipts
+          emptyDir:
+            sizeLimit: 64Mi
+{{- else -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -55,7 +138,7 @@ spec:
               drop:
                 - ALL
           command:
-            {{- toYaml $cfg.command | nindent 12 }}
+            {{- include "helm-ai-kernel.launchpadApp.hermesCommand" (dict "cfg" $cfg "mode" $mode) | nindent 12 }}
           env:
             - name: HOME
               value: /var/lib/hermes
@@ -84,4 +167,5 @@ spec:
         - name: egress-receipts
           emptyDir:
             sizeLimit: 64Mi
+{{- end -}}
 {{- end }}

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -986,19 +986,42 @@
     "launchpadAppJob": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Short-lived launchpad app deployed as a Kubernetes Job.",
+      "description": "Hermes launchpad app deployed either as the proven short-lived smoke Job or as a long-lived gateway Deployment.",
       "properties": {
         "enabled": {
           "type": "boolean",
           "default": false,
-          "description": "Render the Job and supporting resources for this app."
+          "description": "Render the selected Hermes workload mode and supporting resources."
         },
         "image": { "$ref": "#/$defs/launchpadAppImage" },
-        "command": {
+        "mode": {
+          "type": "string",
+          "enum": ["job", "deployment"],
+          "default": "job",
+          "description": "Hermes workload shape. `job` runs the single-query smoke path; `deployment` runs the long-lived Hermes gateway process."
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "default": "openrouter",
+          "description": "Provider passed to the default Hermes Job command."
+        },
+        "model": {
+          "type": "string",
+          "minLength": 1,
+          "default": "openai/gpt-4o-mini",
+          "description": "Model passed to the default Hermes Job command."
+        },
+        "query": {
+          "type": "string",
+          "minLength": 1,
+          "default": "ping",
+          "description": "Single query passed to the default Hermes Job command."
+        },
+        "commandOverride": {
           "type": "array",
-          "minItems": 1,
           "items": { "type": "string" },
-          "description": "Command and args for the workload container. Mirrors the runtime.command field in registry/launchpad/apps/<id>.yaml verbatim."
+          "description": "Full command array replacement. Leave empty to use the chart-managed command for the selected Hermes mode."
         },
         "backoffLimit": {
           "type": "integer",

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -356,13 +356,17 @@ launchpadApps:
       repository: "ghcr.io/mindburn-labs/helm-launchpad/hermes"
       digest: "sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652"
       pullPolicy: "IfNotPresent"
-    # Mirror registry/launchpad/apps/hermes.yaml verbatim. The /bin/sh wrapper
-    # bypasses a broken shebang in the published venv and pins HOME into the
-    # writable app_state mount.
-    command:
-      - "/bin/sh"
-      - "-c"
-      - "HOME=/var/lib/hermes hermes --q ping --provider openrouter --model openai/gpt-4o-mini --ignore_user_config --quiet"
+    # job runs the proven single-query smoke path; deployment runs the
+    # long-lived Hermes gateway process. Gateway mode is not live-F2-promoted
+    # until separate runtime evidence lands.
+    mode: "job"
+    provider: "openrouter"
+    model: "openai/gpt-4o-mini"
+    query: "ping"
+    # Full command replacement for operators who need a provider-specific or
+    # custom Hermes invocation. Leave empty to use the chart-managed command
+    # for the selected mode.
+    commandOverride: []
     backoffLimit: 0
     activeDeadlineSeconds: 240
     ttlSecondsAfterFinished: 3600

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -95,6 +95,47 @@ assert_not_contains "$default_rendered" "kind: CustomResourceDefinition"
 assert_not_contains "$default_rendered" "HelmPolicyBundle"
 assert_not_contains "$default_rendered" "policy-reader"
 
+hermes_job_rendered="$RENDER_DIR/rendered-hermes-job.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set launchpadApps.hermes.enabled=true \
+    --set launchpadApps.hermes.provider=anthropic \
+    --set-string launchpadApps.hermes.model=anthropic/claude-3-5-haiku \
+    --set-string launchpadApps.hermes.query="chart smoke" >"$hermes_job_rendered"
+assert_contains "$hermes_job_rendered" "kind: Job"
+assert_contains "$hermes_job_rendered" "helm-ai-kernel-hermes"
+assert_contains "$hermes_job_rendered" "anthropic/claude-3-5-haiku"
+assert_contains "$hermes_job_rendered" "chart smoke"
+assert_contains "$hermes_job_rendered" "--provider"
+
+hermes_deployment_rendered="$RENDER_DIR/rendered-hermes-deployment.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set launchpadApps.hermes.enabled=true \
+    --set launchpadApps.hermes.mode=deployment >"$hermes_deployment_rendered"
+assert_contains "$hermes_deployment_rendered" "kind: Deployment"
+assert_contains "$hermes_deployment_rendered" "gateway-mode-not-live-f2-promoted"
+assert_contains "$hermes_deployment_rendered" "HOME=/var/lib/hermes exec hermes --gateway"
+assert_contains "$hermes_deployment_rendered" "name: egress-proxy"
+
+hermes_override_rendered="$RENDER_DIR/rendered-hermes-command-override.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set launchpadApps.hermes.enabled=true \
+    --set-json 'launchpadApps.hermes.commandOverride=["/bin/sh","-c","echo custom-hermes-command"]' >"$hermes_override_rendered"
+assert_contains "$hermes_override_rendered" "custom-hermes-command"
+assert_not_contains "$hermes_override_rendered" "--provider"
+
+hermes_mode_fail_log="$RENDER_DIR/hermes-invalid-mode.log"
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set launchpadApps.hermes.enabled=true \
+    --set launchpadApps.hermes.mode=daemon >"$RENDER_DIR/hermes-invalid-mode.yaml" 2>"$hermes_mode_fail_log"; then
+    echo "::error::Hermes render with invalid mode unexpectedly succeeded"
+    exit 1
+fi
+assert_contains "$hermes_mode_fail_log" "launchpadApps.hermes.mode"
+
 fail_log="$RENDER_DIR/production-missing-key.log"
 if helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \


### PR DESCRIPTION
## Summary
- expose Hermes launchpad provider/model/query values and a commandOverride escape hatch
- add `launchpadApps.hermes.mode` with existing Job behavior as the default and a new Deployment gateway render path
- keep gateway mode truth-scoped with an explicit annotation instead of claiming live F2 promotion
- expand Helm chart smoke coverage for Hermes job, deployment, command override, and invalid mode

Fixes #278
Fixes #279

## Validation
- `HELM_CHART_RENDER_DIR=/tmp/helm-chart-sergey-hermes make helm-chart-smoke`
- `python3 -m json.tool deploy/helm-chart/values.schema.json >/dev/null`
- `git diff --check`
