### PR TITLE
fix(launchpad): automate immutable image promotion refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
         run: bash scripts/ci/go_module_tests.sh
       - name: Command tests
         run: go test ./core/cmd/helm-ai-kernel -count=1
+      - name: Launchpad promotion drift
+        run: make launchpad-promotion-check
       - name: Fetch main ref for proto compatibility checks
         run: |
           if [ "$(git symbolic-ref --short -q HEAD || true)" = "main" ]; then

--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -22,10 +22,6 @@ on:
     branches: ["main"]
     paths:
       - ".github/workflows/launchpad-artifacts.yml"
-      - "registry/launchpad/apps/openclaw.yaml"
-      - "registry/launchpad/apps/hermes.yaml"
-      - "registry/launchpad/apps/opencode.yaml"
-      - "registry/launchpad/apps/kilocode.yaml"
       - "policies/launchpad/apps/openclaw.safe.toml"
       - "policies/launchpad/apps/hermes.safe.toml"
       - "policies/launchpad/apps/opencode.safe.toml"
@@ -128,6 +124,20 @@ jobs:
         run: |
           set -euo pipefail
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute pinned upstream source tree hash
+        id: source-tree
+        working-directory: upstream
+        run: |
+          set -euo pipefail
+          source_tree_sha256="$(
+            git ls-files -z |
+              sort -z |
+              xargs -0 sha256sum |
+              sha256sum |
+              awk '{print "sha256:" $1}'
+          )"
+          echo "sha256=${source_tree_sha256}" >> "$GITHUB_OUTPUT"
 
       - name: Verify license marker
         working-directory: upstream
@@ -274,8 +284,10 @@ jobs:
           UPSTREAM_REPO: https://github.com/${{ matrix.upstream_repo }}
           UPSTREAM_REF: ${{ matrix.upstream_ref }}
           UPSTREAM_COMMIT: ${{ steps.upstream.outputs.commit }}
+          SOURCE_TREE_SHA256: ${{ steps.source-tree.outputs.sha256 }}
           LICENSE_SPDX: ${{ matrix.license_spdx }}
           IMAGE_REF: ${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}
+          SUBJECT_NAME: ${{ steps.meta.outputs.image }}
           DIGEST: ${{ steps.build.outputs.digest }}
           GRYPE_STATUS: ${{ steps.grype.outputs.status }}
         run: |
@@ -287,6 +299,11 @@ jobs:
             --arg upstream_repo "${UPSTREAM_REPO}" \
             --arg upstream_ref "${UPSTREAM_REF}" \
             --arg upstream_commit "${UPSTREAM_COMMIT}" \
+            --arg source_sha "${UPSTREAM_COMMIT}" \
+            --arg source_tree_sha256 "${SOURCE_TREE_SHA256}" \
+            --arg workflow_ref "${GITHUB_REPOSITORY}/.github/workflows/launchpad-artifacts.yml@${GITHUB_REF}" \
+            --arg subject_name "${SUBJECT_NAME}" \
+            --arg subject_digest "${DIGEST}" \
             --arg license_spdx "${LICENSE_SPDX}" \
             --arg license_ref "${UPSTREAM_REPO}/blob/${UPSTREAM_REF}/LICENSE" \
             --arg redistribution "allowed_by_${LICENSE_SPDX}_with_upstream_notice" \
@@ -306,6 +323,11 @@ jobs:
               upstream_repo: $upstream_repo,
               upstream_ref: $upstream_ref,
               upstream_commit: $upstream_commit,
+              source_sha: $source_sha,
+              source_tree_sha256: $source_tree_sha256,
+              workflow_ref: $workflow_ref,
+              subject_name: $subject_name,
+              subject_digest: $subject_digest,
               license_spdx: $license_spdx,
               license_ref: $license_ref,
               redistribution: $redistribution,
@@ -403,6 +425,19 @@ jobs:
           image="${REGISTRY}/${IMAGE_PREFIX}/egress-proxy"
           echo "image=${image}" >> "$GITHUB_OUTPUT"
           echo "tag=${image}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+      - name: Compute egress proxy source tree hash
+        id: source-tree
+        run: |
+          set -euo pipefail
+          source_tree_sha256="$(
+            cd helm
+            git ls-files -z tools/launchpad/egressproxy tools/launchpad/artifacts/egress-proxy.Dockerfile |
+              sort -z |
+              xargs -0 sha256sum |
+              sha256sum |
+              awk '{print "sha256:" $1}'
+          )"
+          echo "sha256=${source_tree_sha256}" >> "$GITHUB_OUTPUT"
       - id: build
         name: Build and push egress proxy image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -456,6 +491,11 @@ jobs:
             status=failed
           fi
           jq -n \
+            --arg source_sha "${GITHUB_SHA}" \
+            --arg source_tree_sha256 "${{ steps.source-tree.outputs.sha256 }}" \
+            --arg workflow_ref "${GITHUB_REPOSITORY}/.github/workflows/launchpad-artifacts.yml@${GITHUB_REF}" \
+            --arg subject_name "${{ steps.meta.outputs.image }}" \
+            --arg subject_digest "${{ steps.build.outputs.digest }}" \
             --arg image "${IMAGE_REF}" \
             --arg digest "${{ steps.build.outputs.digest }}" \
             --arg signature_ref "cosign://${IMAGE_REF}" \
@@ -465,6 +505,11 @@ jobs:
             --arg provenance_ref "github-actions://${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}" \
             '{
               component: "egress-proxy",
+              source_sha: $source_sha,
+              source_tree_sha256: $source_tree_sha256,
+              workflow_ref: $workflow_ref,
+              subject_name: $subject_name,
+              subject_digest: $subject_digest,
               image: $image,
               digest: $digest,
               signature_tool: "cosign",
@@ -518,16 +563,29 @@ jobs:
               manifests+=("${manifest}")
             fi
           done
+          source_tree_sha256="$(
+            find launchpad-artifacts -type f -name '*.json' -print0 |
+              sort -z |
+              xargs -0 sha256sum |
+              sha256sum |
+              awk '{print "sha256:" $1}'
+          )"
           jq -s \
             --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg github_run_id "${GITHUB_RUN_ID}" \
             --arg github_run_attempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg source_sha "${GITHUB_SHA}" \
+            --arg source_tree_sha256 "${source_tree_sha256}" \
+            --arg workflow_ref "${GITHUB_REPOSITORY}/.github/workflows/launchpad-artifacts.yml@${GITHUB_REF}" \
             --slurpfile egress_proxy "${egress_manifest}" \
             '{
               schema_version: "helm.launchpad.artifacts.v1",
               generated_at: $generated_at,
               github_run_id: $github_run_id,
               github_run_attempt: $github_run_attempt,
+              source_sha: $source_sha,
+              source_tree_sha256: $source_tree_sha256,
+              workflow_ref: $workflow_ref,
               egress_proxy: $egress_proxy[0],
               artifacts: .
             }' "${manifests[@]}" > launchpad-artifact-manifest.json
@@ -537,91 +595,11 @@ jobs:
           name: launchpad-artifact-manifest
           path: launchpad-artifact-manifest.json
 
-  pin-digests:
-    name: Re-pin launchpad image digests into chart values
-    runs-on: ubuntu-latest
-    needs: aggregate
-    # Only pin from authoritative main builds — these are the images actually
-    # published to GHCR. Satisfies the rule "never pin a digest before CI has
-    # published the rebuilt image": we pin the digest this run just pushed.
-    if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: launchpad-artifact-manifest
-          path: /tmp/launchpad
-      - name: Re-pin chart digests from the artifact manifest and open a PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          manifest=/tmp/launchpad/launchpad-artifact-manifest.json
-          values=deploy/helm-chart/values.yaml
-
-          # The aggregate manifest is the race-free source of truth: each digest
-          # comes from a single build leg's own evidence file, not from matrix
-          # job outputs (which can clobber each other across legs).
-          openclaw="$(jq -r '.artifacts[] | select(.app_id=="openclaw") | .digest' "$manifest")"
-          hermes="$(jq -r '.artifacts[] | select(.app_id=="hermes") | .digest' "$manifest")"
-          egress="$(jq -r '.egress_proxy.digest' "$manifest")"
-          for d in "$openclaw" "$hermes" "$egress"; do
-            case "$d" in
-              sha256:*) ;;
-              *) echo "::error::manifest yielded an invalid digest: '$d'"; exit 1 ;;
-            esac
-          done
-
-          # Surgical, minimal-diff rewrite: replace only the digest line that
-          # immediately follows each image's repository line. A YAML round-trip
-          # (yq -i) would reflow the whole file; awk touches just the 4 lines.
-          # egress-proxy is shared, so both sidecar copies move together — the
-          # exact two-copy sync that was missed manually in PR #275.
-          awk -v oc="$openclaw" -v he="$hermes" -v eg="$egress" '
-            /repository: ".*\/openclaw"/     { pend="oc"; print; next }
-            /repository: ".*\/hermes"/       { pend="he"; print; next }
-            /repository: ".*\/egress-proxy"/ { pend="eg"; print; next }
-            /^[[:space:]]*digest:/ && pend != "" {
-              d = (pend=="oc" ? oc : (pend=="he" ? he : eg))
-              sub(/digest:.*/, "digest: \"" d "\"")
-              pend=""
-            }
-            { print }
-          ' "$values" > "$values.tmp"
-          mv "$values.tmp" "$values"
-
-          for d in "$openclaw" "$hermes" "$egress"; do
-            grep -q "$d" "$values" || { echo "::error::digest $d missing after rewrite"; exit 1; }
-          done
-
-          if git diff --quiet -- "$values"; then
-            echo "Chart digests already current — nothing to pin."
-            exit 0
-          fi
-
-          branch="automation/pin-launchpad-digests-${GITHUB_RUN_ID}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
-          git add "$values"
-          git commit -m "ci(launchpad): re-pin launchpad image digests"
-          git push origin "$branch"
-          gh pr create \
-            --title "ci(launchpad): re-pin launchpad image digests" \
-            --body "$(printf 'Automated re-pin of launchpad image digests published by run %s.\n\n- openclaw: %s\n- hermes: %s\n- egress-proxy (both sidecars): %s\n' "${GITHUB_RUN_ID}" "$openclaw" "$hermes" "$egress")" \
-            --base main \
-            --head "$branch"
-
   live-conformance:
     name: Live BYO model-provider local-container conformance
     runs-on: ubuntu-latest
     needs: aggregate
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_live_conformance }}
+    if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.run_live_conformance)) }}
     permissions:
       contents: read
       packages: read
@@ -728,3 +706,100 @@ jobs:
         with:
           name: launchpad-promotion-manifest
           path: /tmp/launchpad-promotion/launchpad-promotion-manifest.json
+
+  promotion-pr:
+    name: Open Launchpad promotion PR
+    runs-on: ubuntu-latest
+    needs: live-conformance
+    if: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.25.10"
+          cache-dependency-path: "**/go.sum"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: launchpad-promotion-manifest
+          path: /tmp/launchpad-promotion
+      - name: Promote verified images and open a reference update PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          manifest=/tmp/launchpad-promotion/launchpad-promotion-manifest.json
+          result=/tmp/launchpad-promotion-result.json
+          go run ./core/cmd/helm-ai-kernel launch promote \
+            --manifest "${manifest}" \
+            --apps openclaw,hermes \
+            --write \
+            --sync-derived \
+            --check \
+            --json | tee "${result}"
+
+          changed_paths=(
+            registry/launchpad/apps/openclaw.yaml
+            registry/launchpad/apps/hermes.yaml
+            registry/launchpad/image-lock.json
+            deploy/helm-chart/values.yaml
+          )
+          if git diff --quiet -- "${changed_paths[@]}"; then
+            echo "Launchpad promoted refs already current — no PR needed."
+            exit 0
+          fi
+
+          manifest_hash="$(jq -r '.manifest_hash' "${result}")"
+          source_sha="$(jq -r '.source_sha // "n/a"' "${manifest}")"
+          source_tree_sha256="$(jq -r '.source_tree_sha256 // "n/a"' "${manifest}")"
+          workflow_ref="$(jq -r '.workflow_ref // "n/a"' "${manifest}")"
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          {
+            echo "| component | image | digest | cosign | sbom | provenance |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+            jq -r '.artifacts[]
+              | select(.app_id == "openclaw" or .app_id == "hermes")
+              | "| \(.app_id) | `\(.image)` | `\(.digest)` | `\(.signature_ref)` | `\(.sbom_ref)` | `\(.provenance_ref)` |"' "${manifest}"
+            jq -r '.egress_proxy
+              | "| egress-proxy | `\(.image)` | `\(.digest)` | `\(.signature_ref)` | `\(.sbom_ref)` | `\(.provenance_ref)` |"' "${manifest}"
+          } > /tmp/launchpad-digest-table.md
+
+          cat > /tmp/launchpad-promotion-pr.md <<EOF
+          Automated Launchpad promotion from a verified CI manifest.
+
+          Source SHA: \`${source_sha}\`
+          Source tree SHA256: \`${source_tree_sha256}\`
+          Workflow ref: \`${workflow_ref}\`
+          Workflow run: ${run_url}
+          Promotion manifest hash: \`${manifest_hash}\`
+
+          ## Image refs
+          EOF
+          cat /tmp/launchpad-digest-table.md >> /tmp/launchpad-promotion-pr.md
+          cat >> /tmp/launchpad-promotion-pr.md <<'EOF'
+
+          ## Validation
+          - `go run ./core/cmd/helm-ai-kernel launch promote --manifest <manifest> --apps openclaw,hermes --write --sync-derived --check --json`
+          - `make launchpad-promotion-check`
+          - `go test ./tests/launchpad/... -run TestLiveModelProviderLocalContainerConformance -count=1 -timeout 30m -v`
+
+          Promotion commits update committed AppSpec evidence plus generated refs only. They intentionally do not retrigger the producer image build workflow.
+          EOF
+
+          branch="automation/launchpad-promotion-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${branch}"
+          git add "${changed_paths[@]}"
+          git commit -m "ci(launchpad): promote signed launchpad image refs"
+          git push origin "${branch}"
+          gh pr create \
+            --title "ci(launchpad): promote signed launchpad image refs" \
+            --body-file /tmp/launchpad-promotion-pr.md \
+            --base main \
+            --head "${branch}"

--- a/Makefile
+++ b/Makefile
@@ -345,3 +345,7 @@ docs-coverage:
 
 docs-truth:
 	python3 scripts/check_documentation_truth.py
+
+.PHONY: launchpad-promotion-check
+launchpad-promotion-check:
+	cd core && go run ./cmd/helm-ai-kernel launch promote --apps openclaw,hermes --sync-derived --check

--- a/core/cmd/helm-ai-kernel/launch_cmd.go
+++ b/core/cmd/helm-ai-kernel/launch_cmd.go
@@ -984,18 +984,65 @@ func runLaunchPromote(args []string, catalog *lpregistry.Catalog, stdout, stderr
 	fs.SetOutput(stderr)
 	manifestPath := fs.String("manifest", "", "Launchpad artifact manifest JSON from CI")
 	appID := fs.String("app", "", "app id to promote")
+	appIDs := fs.String("apps", "", "comma-separated app ids to promote")
 	specPath := fs.String("spec", "", "app spec path to write when --write is set")
 	artifactVerificationRef := fs.String("artifact-verification-ref", "", "artifact verification evidence ref")
 	liveE2ERunID := fs.String("live-e2e-run-id", "", "live local-container e2e run id")
 	evidencePackRef := fs.String("evidence-pack-ref", "", "offline-verifiable EvidencePack ref")
 	teardownReceiptRef := fs.String("teardown-receipt-ref", "", "teardown receipt ref")
 	writeSpec := fs.Bool("write", false, "write promoted app spec YAML")
+	syncDerived := fs.Bool("sync-derived", false, "sync generated Launchpad image references after promotion")
+	checkOnly := fs.Bool("check", false, "fail if committed Launchpad promotion references have drift")
 	jsonOut := fs.Bool("json", false, "emit JSON")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	if *manifestPath == "" || *appID == "" {
-		fmt.Fprintln(stderr, "Usage: helm-ai-kernel launch promote --manifest <promotion-manifest.json> --app <app> [--artifact-verification-ref <ref> --live-e2e-run-id <id> --evidence-pack-ref <ref> --teardown-receipt-ref <ref>] [--write] [--json]")
+	selectedApps := parseLaunchPromoteApps(*appID, *appIDs)
+	if len(selectedApps) == 0 {
+		fmt.Fprintln(stderr, "Usage: helm-ai-kernel launch promote --manifest <promotion-manifest.json> (--app <app>|--apps <a,b>) [--artifact-verification-ref <ref> --live-e2e-run-id <id> --evidence-pack-ref <ref> --teardown-receipt-ref <ref>] [--write] [--sync-derived] [--check] [--json]")
+		return 2
+	}
+	if *specPath != "" && len(selectedApps) != 1 {
+		fmt.Fprintln(stderr, "launch promotion error: --spec can only be used with a single --app")
+		return 2
+	}
+	if *manifestPath == "" {
+		apps, err := lppromotion.AppsByID(catalog, selectedApps)
+		if err != nil {
+			fmt.Fprintf(stderr, "launch promotion check error: %v\n", err)
+			return 1
+		}
+		if *syncDerived && *writeSpec {
+			if err := lppromotion.SyncDerived(catalog.Root, apps); err != nil {
+				fmt.Fprintf(stderr, "launch promotion derived sync error: %v\n", err)
+				return 1
+			}
+		}
+		if *checkOnly {
+			drifts := lppromotion.CheckDerived(catalog.Root, apps)
+			if len(drifts) > 0 {
+				for _, drift := range drifts {
+					fmt.Fprintf(stderr, "launch promotion drift: %s\n", drift)
+				}
+				if *jsonOut {
+					_ = writeLaunchJSON(stdout, map[string]any{"ok": false, "apps": selectedApps, "drifts": drifts})
+				}
+				return 1
+			}
+			if *jsonOut {
+				return writeLaunchJSON(stdout, map[string]any{"ok": true, "apps": selectedApps})
+			}
+			fmt.Fprintf(stdout, "Launchpad promotion refs are in sync for %s.\n", strings.Join(selectedApps, ","))
+			return 0
+		}
+		if *syncDerived && *writeSpec {
+			if *jsonOut {
+				return writeLaunchJSON(stdout, map[string]any{"ok": true, "apps": selectedApps, "synced": true})
+			}
+			fmt.Fprintf(stdout, "Synced Launchpad derived refs for %s.\n", strings.Join(selectedApps, ","))
+			return 0
+		}
+		fmt.Fprintln(stderr, "launch promotion error: --manifest is required unless --check or --write --sync-derived is used")
 		return 2
 	}
 	manifest, err := lppromotion.LoadManifest(*manifestPath)
@@ -1003,50 +1050,118 @@ func runLaunchPromote(args []string, catalog *lpregistry.Catalog, stdout, stderr
 		fmt.Fprintf(stderr, "launch promotion manifest error: %v\n", err)
 		return 1
 	}
-	artifact, ok := manifest.Entry(*appID)
-	if !ok {
-		fmt.Fprintf(stderr, "launch promotion error: artifact for app %s not found\n", *appID)
-		return 1
-	}
-	app, ok := catalog.App(*appID)
-	if !ok {
-		fmt.Fprintf(stderr, "launch promotion error: app %s not found in registry\n", *appID)
-		return 1
-	}
-	refs, err := manifest.EvidenceRefsFor(artifact, lppromotion.EvidenceRefs{
-		ArtifactVerificationRef: *artifactVerificationRef,
-		LiveE2ERunID:            *liveE2ERunID,
-		EvidencePackRef:         *evidencePackRef,
-		TeardownReceiptRef:      *teardownReceiptRef,
-	})
+	manifestHash, err := manifest.Hash()
 	if err != nil {
-		fmt.Fprintf(stderr, "launch promotion denied: %v\n", err)
+		fmt.Fprintf(stderr, "launch promotion manifest hash error: %v\n", err)
 		return 1
 	}
-	promoted, err := lppromotion.Promote(app, artifact, refs)
-	if err != nil {
-		fmt.Fprintf(stderr, "launch promotion denied: %v\n", err)
-		return 1
-	}
-	if *writeSpec {
-		target := *specPath
-		if target == "" {
-			target = filepath.Join(catalog.Root, "registry", "launchpad", "apps", promoted.ID+".yaml")
+	promotedApps := make([]lpregistry.AppSpec, 0, len(selectedApps))
+	for _, selectedApp := range selectedApps {
+		artifact, ok := manifest.Entry(selectedApp)
+		if !ok {
+			fmt.Fprintf(stderr, "launch promotion error: artifact for app %s not found\n", selectedApp)
+			return 1
 		}
-		if err := lppromotion.WriteAppSpec(target, promoted); err != nil {
-			fmt.Fprintf(stderr, "launch promotion write error: %v\n", err)
+		app, ok := catalog.App(selectedApp)
+		if !ok {
+			fmt.Fprintf(stderr, "launch promotion error: app %s not found in registry\n", selectedApp)
+			return 1
+		}
+		refs, err := manifest.EvidenceRefsFor(artifact, lppromotion.EvidenceRefs{
+			ArtifactVerificationRef: *artifactVerificationRef,
+			LiveE2ERunID:            *liveE2ERunID,
+			EvidencePackRef:         *evidencePackRef,
+			TeardownReceiptRef:      *teardownReceiptRef,
+		})
+		if err != nil {
+			fmt.Fprintf(stderr, "launch promotion denied for %s: %v\n", selectedApp, err)
+			return 1
+		}
+		promoted, err := lppromotion.Promote(app, artifact, refs)
+		if err != nil {
+			fmt.Fprintf(stderr, "launch promotion denied for %s: %v\n", selectedApp, err)
+			return 1
+		}
+		if promoted.Metadata == nil {
+			promoted.Metadata = map[string]string{}
+		}
+		promoted.Metadata["promotion_manifest_hash"] = manifestHash
+		if *writeSpec {
+			target := *specPath
+			if target == "" {
+				target = filepath.Join(catalog.Root, "registry", "launchpad", "apps", promoted.ID+".yaml")
+			}
+			if err := lppromotion.WriteAppSpec(target, promoted); err != nil {
+				fmt.Fprintf(stderr, "launch promotion write error: %v\n", err)
+				return 1
+			}
+		}
+		promotedApps = append(promotedApps, promoted)
+	}
+	if *syncDerived {
+		if !*writeSpec {
+			fmt.Fprintln(stderr, "launch promotion error: --sync-derived requires --write when using a manifest")
+			return 2
+		}
+		if err := lppromotion.SyncDerived(catalog.Root, promotedApps); err != nil {
+			fmt.Fprintf(stderr, "launch promotion derived sync error: %v\n", err)
+			return 1
+		}
+	}
+	var drifts []string
+	if *checkOnly {
+		checkApps := promotedApps
+		if !*writeSpec {
+			checkApps, err = lppromotion.AppsByID(catalog, selectedApps)
+			if err != nil {
+				fmt.Fprintf(stderr, "launch promotion check error: %v\n", err)
+				return 1
+			}
+		}
+		drifts = lppromotion.CheckDerived(catalog.Root, checkApps)
+		if len(drifts) > 0 {
+			for _, drift := range drifts {
+				fmt.Fprintf(stderr, "launch promotion drift: %s\n", drift)
+			}
+			if *jsonOut {
+				_ = writeLaunchJSON(stdout, map[string]any{
+					"ok":            false,
+					"manifest_hash": manifestHash,
+					"apps":          promotedApps,
+					"drifts":        drifts,
+				})
+			}
 			return 1
 		}
 	}
 	if *jsonOut {
-		return writeLaunchJSON(stdout, promoted)
+		return writeLaunchJSON(stdout, map[string]any{
+			"ok":            len(drifts) == 0,
+			"manifest_hash": manifestHash,
+			"apps":          promotedApps,
+		})
 	}
 	if *writeSpec {
-		fmt.Fprintf(stdout, "Promoted %s to oss_supported from signed artifact manifest.\n", promoted.ID)
+		fmt.Fprintf(stdout, "Promoted %s to oss_supported from signed artifact manifest (%s).\n", strings.Join(selectedApps, ","), manifestHash)
 	} else {
-		fmt.Fprintf(stdout, "Promotion dry run for %s passed; use --write to update the app spec.\n", promoted.ID)
+		fmt.Fprintf(stdout, "Promotion dry run for %s passed; use --write to update app specs.\n", strings.Join(selectedApps, ","))
 	}
 	return 0
+}
+
+func parseLaunchPromoteApps(appID, appIDs string) []string {
+	var selected []string
+	add := func(value string) {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				selected = append(selected, part)
+			}
+		}
+	}
+	add(appID)
+	add(appIDs)
+	return selected
 }
 
 func redactLaunchLog(value string, secrets ...string) string {

--- a/core/cmd/helm-ai-kernel/launch_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/launch_cmd_test.go
@@ -87,6 +87,67 @@ func TestLaunchPromoteDryRunRequiresCompleteManifestAndRefs(t *testing.T) {
 	}
 }
 
+func TestLaunchPromoteWritesMultipleAppsAndDerivedRefs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "registry", "launchpad", "apps"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeLaunchPromoteValuesFixture(t, root)
+	manifestPath := filepath.Join(root, "manifest.json")
+	manifest := launchPromotionManifestFixture("openclaw", "hermes")
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	catalog := &lpregistry.Catalog{
+		Root: root,
+		Apps: []lpregistry.AppSpec{
+			launchPromoteCandidate("openclaw"),
+			launchPromoteCandidate("hermes"),
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runLaunchPromote([]string{
+		"--manifest", manifestPath,
+		"--apps", "openclaw,hermes",
+		"--write",
+		"--sync-derived",
+		"--check",
+		"--json",
+	}, catalog, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("runLaunchPromote code=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, path := range []string{
+		filepath.Join(root, "registry", "launchpad", "apps", "openclaw.yaml"),
+		filepath.Join(root, "registry", "launchpad", "apps", "hermes.yaml"),
+		filepath.Join(root, "registry", "launchpad", "image-lock.json"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected generated file %s: %v", path, err)
+		}
+	}
+	if !strings.Contains(stdout.String(), `"manifest_hash"`) || !strings.Contains(stdout.String(), `"ok": true`) {
+		t.Fatalf("promotion output missing manifest hash/ok: %s", stdout.String())
+	}
+	values, err := os.ReadFile(filepath.Join(root, "deploy", "helm-chart", "values.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"sha256:" + strings.Repeat("a", 64),
+		"sha256:" + strings.Repeat("c", 64),
+	} {
+		if !strings.Contains(string(values), want) {
+			t.Fatalf("values.yaml missing %s: %s", want, values)
+		}
+	}
+}
+
 func TestLaunchEvidenceExportVerifiesDirectoryAndArchive(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("HELM_LAUNCHPAD_HOME", root)
@@ -130,6 +191,132 @@ func TestLaunchEvidenceExportVerifiesDirectoryAndArchive(t *testing.T) {
 	}
 	if strings.Contains(stdout.String(), `"verified": false`) {
 		t.Fatalf("evidence export had failed verification: %s", stdout.String())
+	}
+}
+
+func launchPromotionManifestFixture(appIDs ...string) map[string]any {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	proxyDigest := "sha256:" + strings.Repeat("c", 64)
+	artifacts := make([]map[string]string, 0, len(appIDs))
+	for _, appID := range appIDs {
+		artifacts = append(artifacts, map[string]string{
+			"app_id":                    appID,
+			"app_version":               "v2026.5.12",
+			"source_sha":                strings.Repeat("b", 40),
+			"source_tree_sha256":        "sha256:" + strings.Repeat("d", 64),
+			"workflow_ref":              "Mindburn-Labs/helm-ai-kernel/.github/workflows/launchpad-artifacts.yml@refs/heads/main",
+			"subject_name":              "ghcr.io/mindburn-labs/helm-launchpad/" + appID,
+			"subject_digest":            digest,
+			"upstream_repo":             "https://github.com/" + appID + "/" + appID,
+			"upstream_ref":              "v2026.5.12",
+			"upstream_commit":           strings.Repeat("b", 40),
+			"license_spdx":              "MIT",
+			"license_ref":               "https://github.com/" + appID + "/" + appID + "/blob/v2026.5.12/LICENSE",
+			"redistribution":            "allowed_by_MIT_with_upstream_notice",
+			"image":                     "ghcr.io/mindburn-labs/helm-launchpad/" + appID + "@" + digest,
+			"digest":                    digest,
+			"signature_tool":            "cosign",
+			"signature_ref":             "cosign://ghcr.io/mindburn-labs/helm-launchpad/" + appID + "@" + digest,
+			"sbom_tool":                 "syft",
+			"sbom_ref":                  "artifact://sbom-" + appID + ".spdx.json",
+			"vulnerability_scan_tool":   "grype",
+			"vulnerability_scan_ref":    "artifact://grype-" + appID + ".json",
+			"vulnerability_scan_status": "completed",
+			"provenance_ref":            "github-actions://123/1",
+			"artifact_verification_ref": "github-actions://123/1/artifact-verification/" + appID,
+			"live_e2e_run_id":           "github-actions://123/1/live-e2e/" + appID,
+			"evidence_pack_ref":         "github-actions://123/1/evidencepack/" + appID,
+			"teardown_receipt_ref":      "github-actions://123/1/teardown/" + appID,
+		})
+	}
+	return map[string]any{
+		"schema_version":     "helm.launchpad.artifacts.v1",
+		"generated_at":       "2026-06-12T00:00:00Z",
+		"github_run_id":      "123",
+		"github_run_attempt": "1",
+		"source_sha":         strings.Repeat("e", 40),
+		"source_tree_sha256": "sha256:" + strings.Repeat("f", 64),
+		"workflow_ref":       "Mindburn-Labs/helm-ai-kernel/.github/workflows/launchpad-artifacts.yml@refs/heads/main",
+		"subject_name":       "launchpad-artifact-manifest",
+		"subject_digest":     "sha256:" + strings.Repeat("1", 64),
+		"artifacts":          artifacts,
+		"egress_proxy": map[string]string{
+			"component":                 "egress-proxy",
+			"source_sha":                strings.Repeat("e", 40),
+			"source_tree_sha256":        "sha256:" + strings.Repeat("f", 64),
+			"workflow_ref":              "Mindburn-Labs/helm-ai-kernel/.github/workflows/launchpad-artifacts.yml@refs/heads/main",
+			"subject_name":              "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy",
+			"subject_digest":            proxyDigest,
+			"image":                     "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@" + proxyDigest,
+			"digest":                    proxyDigest,
+			"signature_tool":            "cosign",
+			"signature_ref":             "cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@" + proxyDigest,
+			"sbom_tool":                 "syft",
+			"sbom_ref":                  "artifact://sbom-egress-proxy.spdx.json",
+			"vulnerability_scan_tool":   "grype",
+			"vulnerability_scan_ref":    "artifact://grype-egress-proxy.json",
+			"vulnerability_scan_status": "completed",
+			"provenance_ref":            "github-actions://123/1",
+		},
+	}
+}
+
+func launchPromoteCandidate(appID string) lpregistry.AppSpec {
+	return lpregistry.AppSpec{
+		ID:             appID,
+		Name:           appID,
+		Version:        "v0.0.0",
+		Availability:   lpregistry.AvailabilityOSSCandidate,
+		SupportLevel:   lpregistry.SupportLevelAgentLive,
+		Redistribution: "allowed_by_mit_pending_helm_signed_artifact",
+		License:        lpregistry.LicenseSpec{Status: "verified", SPDX: "MIT"},
+		Install:        lpregistry.InstallSpec{Strategy: "signed_oci"},
+		FrameworkContract: lpregistry.FrameworkContractSpec{
+			EgressProxy: lpregistry.EgressProxyContractSpec{Required: true},
+			Images: []lpregistry.FrameworkImageContractSpec{{
+				Name:    appID + "-production",
+				Image:   "ghcr.io/mindburn-labs/helm-launchpad/" + appID + "@sha256:" + strings.Repeat("0", 64),
+				Digest:  "sha256:" + strings.Repeat("0", 64),
+				Purpose: "production_proof",
+			}},
+		},
+		Conformance: lpregistry.ConformanceSpec{LicenseVerified: true, PolicyPackPresent: true},
+	}
+}
+
+func writeLaunchPromoteValuesFixture(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "deploy", "helm-chart"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "scripts", "ci"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	digest := "sha256:" + strings.Repeat("0", 64)
+	values := `launchpadApps:
+  openclaw:
+    image:
+      repository: "ghcr.io/mindburn-labs/helm-launchpad/openclaw"
+      digest: "` + digest + `"
+    egressSidecar:
+      image:
+        repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
+        digest: "` + digest + `"
+  hermes:
+    image:
+      repository: "ghcr.io/mindburn-labs/helm-launchpad/hermes"
+      digest: "` + digest + `"
+    egressSidecar:
+      image:
+        repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
+        digest: "` + digest + `"
+`
+	if err := os.WriteFile(filepath.Join(root, "deploy", "helm-chart", "values.yaml"), []byte(values), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/usr/bin/env bash\nIMAGE_LOCK=\"${ROOT}/registry/launchpad/image-lock.json\"\n"
+	if err := os.WriteFile(filepath.Join(root, "scripts", "ci", "launchpad_k8s_smoke.sh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/core/pkg/launchpad/promotion/derived.go
+++ b/core/pkg/launchpad/promotion/derived.go
@@ -266,14 +266,35 @@ func CheckSmokeScriptUsesImageLock(root string) error {
 	if !strings.Contains(text, "registry/launchpad/image-lock.json") {
 		issues = append(issues, "preload images must come from registry/launchpad/image-lock.json")
 	}
-	hardCoded := regexp.MustCompile(`ghcr\.io/mindburn-labs/helm-launchpad/[a-z0-9-]+@sha256:[0-9a-f]{64}`)
-	if hardCoded.MatchString(text) {
+	if hasHardCodedLaunchpadImageDigest(text) {
 		issues = append(issues, "hard-coded launchpad image digest found")
 	}
 	if len(issues) > 0 {
 		return fmt.Errorf("scripts/ci/launchpad_k8s_smoke.sh drift: %s", strings.Join(issues, "; "))
 	}
 	return nil
+}
+
+func hasHardCodedLaunchpadImageDigest(script string) bool {
+	const prefix = "ghcr.io/mindburn-labs/helm-launchpad/"
+	tokens := strings.FieldsFunc(script, func(r rune) bool {
+		switch r {
+		case ' ', '\t', '\r', '\n', '"', '\'', '`', '(', ')', '[', ']', '{', '}', '<', '>', ',', ';':
+			return true
+		default:
+			return false
+		}
+	})
+	for _, token := range tokens {
+		if !strings.HasPrefix(token, prefix) {
+			continue
+		}
+		_, digest, err := splitImageDigest(token)
+		if err == nil && registryDigest(digest) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateAppSpecRefs(app registry.AppSpec) []string {

--- a/core/pkg/launchpad/promotion/derived.go
+++ b/core/pkg/launchpad/promotion/derived.go
@@ -1,0 +1,477 @@
+package promotion
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/registry"
+	"gopkg.in/yaml.v3"
+)
+
+const ImageLockSchemaVersion = "helm.launchpad.image-lock.v1"
+
+type ImageLock struct {
+	SchemaVersion string           `json:"schema_version"`
+	GeneratedFrom []string         `json:"generated_from"`
+	Images        []ImageLockEntry `json:"images"`
+}
+
+type ImageLockEntry struct {
+	Name       string `json:"name"`
+	Role       string `json:"role"`
+	Image      string `json:"image"`
+	Repository string `json:"repository"`
+	Digest     string `json:"digest"`
+	Source     string `json:"source"`
+	Preload    bool   `json:"preload"`
+}
+
+func AppsByID(catalog *registry.Catalog, appIDs []string) ([]registry.AppSpec, error) {
+	apps := make([]registry.AppSpec, 0, len(appIDs))
+	seen := map[string]struct{}{}
+	for _, appID := range appIDs {
+		appID = strings.TrimSpace(appID)
+		if appID == "" {
+			continue
+		}
+		if _, ok := seen[appID]; ok {
+			return nil, fmt.Errorf("duplicate launchpad promotion app %q", appID)
+		}
+		seen[appID] = struct{}{}
+		app, ok := catalog.App(appID)
+		if !ok {
+			return nil, fmt.Errorf("app %s not found in registry", appID)
+		}
+		apps = append(apps, app)
+	}
+	if len(apps) == 0 {
+		return nil, errors.New("no launchpad promotion apps selected")
+	}
+	return apps, nil
+}
+
+func SyncDerived(root string, apps []registry.AppSpec) error {
+	if err := WriteImageLock(root, apps); err != nil {
+		return err
+	}
+	return SyncHelmValues(root, apps)
+}
+
+func CheckDerived(root string, apps []registry.AppSpec) []string {
+	var drifts []string
+	for _, app := range apps {
+		drifts = append(drifts, validateAppSpecRefs(app)...)
+	}
+	if err := CheckImageLock(root, apps); err != nil {
+		drifts = append(drifts, err.Error())
+	}
+	if err := CheckHelmValues(root, apps); err != nil {
+		drifts = append(drifts, err.Error())
+	}
+	if err := CheckSmokeScriptUsesImageLock(root); err != nil {
+		drifts = append(drifts, err.Error())
+	}
+	return drifts
+}
+
+func WriteImageLock(root string, apps []registry.AppSpec) error {
+	lock, err := BuildImageLock(root, apps)
+	if err != nil {
+		return err
+	}
+	data, err := MarshalImageLock(lock)
+	if err != nil {
+		return err
+	}
+	path := imageLockPath(root)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+func CheckImageLock(root string, apps []registry.AppSpec) error {
+	lock, err := BuildImageLock(root, apps)
+	if err != nil {
+		return err
+	}
+	want, err := MarshalImageLock(lock)
+	if err != nil {
+		return err
+	}
+	have, err := os.ReadFile(imageLockPath(root))
+	if err != nil {
+		return fmt.Errorf("registry/launchpad/image-lock.json missing or unreadable: %w", err)
+	}
+	if !bytes.Equal(bytes.TrimSpace(have), bytes.TrimSpace(want)) {
+		return fmt.Errorf("registry/launchpad/image-lock.json drift: regenerate with launch promote --sync-derived --write")
+	}
+	return nil
+}
+
+func BuildImageLock(root string, apps []registry.AppSpec) (ImageLock, error) {
+	lock := ImageLock{
+		SchemaVersion: ImageLockSchemaVersion,
+		GeneratedFrom: make([]string, 0, len(apps)),
+		Images:        make([]ImageLockEntry, 0, len(apps)+1),
+	}
+	var egress *ImageLockEntry
+	for _, app := range apps {
+		specPath := filepath.ToSlash(filepath.Join("registry", "launchpad", "apps", app.ID+".yaml"))
+		repo, digest, err := splitImageDigest(app.Install.Image)
+		if err != nil {
+			return ImageLock{}, fmt.Errorf("app %s install image: %w", app.ID, err)
+		}
+		if digest != app.Install.Digest {
+			return ImageLock{}, fmt.Errorf("app %s install image digest %s does not match install.digest %s", app.ID, digest, app.Install.Digest)
+		}
+		lock.GeneratedFrom = append(lock.GeneratedFrom, specPath)
+		lock.Images = append(lock.Images, ImageLockEntry{
+			Name:       app.ID,
+			Role:       "launchpad_app",
+			Image:      app.Install.Image,
+			Repository: repo,
+			Digest:     app.Install.Digest,
+			Source:     specPath,
+			Preload:    true,
+		})
+		if app.FrameworkContract.EgressProxy.Required {
+			proxy := app.FrameworkContract.EgressProxy
+			proxyRepo, proxyDigest, err := splitImageDigest(proxy.Image)
+			if err != nil {
+				return ImageLock{}, fmt.Errorf("app %s egress proxy image: %w", app.ID, err)
+			}
+			if proxyDigest != proxy.Digest {
+				return ImageLock{}, fmt.Errorf("app %s egress proxy image digest %s does not match egress digest %s", app.ID, proxyDigest, proxy.Digest)
+			}
+			entry := ImageLockEntry{
+				Name:       "egress-proxy",
+				Role:       "egress_proxy",
+				Image:      proxy.Image,
+				Repository: proxyRepo,
+				Digest:     proxy.Digest,
+				Source:     specPath,
+				Preload:    true,
+			}
+			if egress == nil {
+				egress = &entry
+			} else if egress.Image != entry.Image || egress.Digest != entry.Digest || egress.Repository != entry.Repository {
+				return ImageLock{}, fmt.Errorf("egress proxy drift across promoted apps: %s uses %s, earlier apps use %s", app.ID, entry.Image, egress.Image)
+			}
+		}
+	}
+	if egress != nil {
+		lock.Images = append(lock.Images, *egress)
+	}
+	return lock, nil
+}
+
+func MarshalImageLock(lock ImageLock) ([]byte, error) {
+	data, err := json.MarshalIndent(lock, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func SyncHelmValues(root string, apps []registry.AppSpec) error {
+	path := helmValuesPath(root)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	replacements, err := helmDigestReplacements(apps)
+	if err != nil {
+		return err
+	}
+	updated, err := replaceDigestLinesAfterRepository(string(data), replacements)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(updated), 0o644)
+}
+
+func CheckHelmValues(root string, apps []registry.AppSpec) error {
+	data, err := os.ReadFile(helmValuesPath(root))
+	if err != nil {
+		return fmt.Errorf("deploy/helm-chart/values.yaml missing or unreadable: %w", err)
+	}
+	type chartImage struct {
+		Repository string `yaml:"repository"`
+		Digest     string `yaml:"digest"`
+	}
+	type chartApp struct {
+		Image         chartImage `yaml:"image"`
+		EgressSidecar struct {
+			Image chartImage `yaml:"image"`
+		} `yaml:"egressSidecar"`
+	}
+	var values struct {
+		LaunchpadApps struct {
+			OpenClaw chartApp `yaml:"openclaw"`
+			Hermes   chartApp `yaml:"hermes"`
+		} `yaml:"launchpadApps"`
+	}
+	if err := yaml.Unmarshal(data, &values); err != nil {
+		return fmt.Errorf("deploy/helm-chart/values.yaml parse error: %w", err)
+	}
+	for _, app := range apps {
+		chartApp := chartApp{}
+		switch app.ID {
+		case "openclaw":
+			chartApp = values.LaunchpadApps.OpenClaw
+		case "hermes":
+			chartApp = values.LaunchpadApps.Hermes
+		default:
+			return fmt.Errorf("deploy/helm-chart/values.yaml has no Launchpad chart mapping for app %s", app.ID)
+		}
+		if chartApp.Image.Repository == "" || chartApp.Image.Digest == "" {
+			return fmt.Errorf("deploy/helm-chart/values.yaml missing launchpadApps.%s", app.ID)
+		}
+		repo, _, err := splitImageDigest(app.Install.Image)
+		if err != nil {
+			return fmt.Errorf("app %s install image: %w", app.ID, err)
+		}
+		if chartApp.Image.Repository != repo || chartApp.Image.Digest != app.Install.Digest {
+			return fmt.Errorf("helm values drift for %s image: got %s@%s want %s@%s", app.ID, chartApp.Image.Repository, chartApp.Image.Digest, repo, app.Install.Digest)
+		}
+		if app.FrameworkContract.EgressProxy.Required {
+			proxy := app.FrameworkContract.EgressProxy
+			proxyRepo, _, err := splitImageDigest(proxy.Image)
+			if err != nil {
+				return fmt.Errorf("app %s egress proxy image: %w", app.ID, err)
+			}
+			if chartApp.EgressSidecar.Image.Repository != proxyRepo || chartApp.EgressSidecar.Image.Digest != proxy.Digest {
+				return fmt.Errorf("helm values drift for %s egress sidecar: got %s@%s want %s@%s", app.ID, chartApp.EgressSidecar.Image.Repository, chartApp.EgressSidecar.Image.Digest, proxyRepo, proxy.Digest)
+			}
+		}
+	}
+	return nil
+}
+
+func CheckSmokeScriptUsesImageLock(root string) error {
+	data, err := os.ReadFile(filepath.Join(root, "scripts", "ci", "launchpad_k8s_smoke.sh"))
+	if err != nil {
+		return fmt.Errorf("scripts/ci/launchpad_k8s_smoke.sh missing or unreadable: %w", err)
+	}
+	text := string(data)
+	var issues []string
+	if !strings.Contains(text, "registry/launchpad/image-lock.json") {
+		issues = append(issues, "preload images must come from registry/launchpad/image-lock.json")
+	}
+	hardCoded := regexp.MustCompile(`ghcr\.io/mindburn-labs/helm-launchpad/[a-z0-9-]+@sha256:[0-9a-f]{64}`)
+	if hardCoded.MatchString(text) {
+		issues = append(issues, "hard-coded launchpad image digest found")
+	}
+	if len(issues) > 0 {
+		return fmt.Errorf("scripts/ci/launchpad_k8s_smoke.sh drift: %s", strings.Join(issues, "; "))
+	}
+	return nil
+}
+
+func validateAppSpecRefs(app registry.AppSpec) []string {
+	var drifts []string
+	repo, digest, err := splitImageDigest(app.Install.Image)
+	if err != nil {
+		drifts = append(drifts, fmt.Sprintf("app %s install image: %v", app.ID, err))
+	} else if digest != app.Install.Digest {
+		drifts = append(drifts, fmt.Sprintf("app %s install digest drift: image has %s, install.digest has %s", app.ID, digest, app.Install.Digest))
+	}
+	if app.SupplyChainEvidence.ArtifactDigest != "" && app.SupplyChainEvidence.ArtifactDigest != app.Install.Digest {
+		drifts = append(drifts, fmt.Sprintf("app %s supply_chain_evidence.artifact_digest drift: got %s want %s", app.ID, app.SupplyChainEvidence.ArtifactDigest, app.Install.Digest))
+	}
+	if app.SupplyChainEvidence.SignatureRef != "" && !strings.Contains(app.SupplyChainEvidence.SignatureRef, app.Install.Digest) {
+		drifts = append(drifts, fmt.Sprintf("app %s signature_ref does not bind install digest %s", app.ID, app.Install.Digest))
+	}
+	foundContractImage := false
+	for _, image := range app.FrameworkContract.Images {
+		contractRepo, contractDigest, err := splitImageDigest(image.Image)
+		if err != nil {
+			drifts = append(drifts, fmt.Sprintf("app %s framework image %s: %v", app.ID, image.Name, err))
+			continue
+		}
+		if contractRepo != repo {
+			continue
+		}
+		foundContractImage = true
+		if contractDigest != app.Install.Digest || image.Digest != app.Install.Digest {
+			drifts = append(drifts, fmt.Sprintf("app %s framework image %s digest drift: got %s/%s want %s", app.ID, image.Name, contractDigest, image.Digest, app.Install.Digest))
+		}
+	}
+	if !foundContractImage {
+		drifts = append(drifts, fmt.Sprintf("app %s framework_contract.images missing production image for %s", app.ID, repo))
+	}
+	if app.FrameworkContract.EgressProxy.Required {
+		proxy := app.FrameworkContract.EgressProxy
+		if _, proxyDigest, err := splitImageDigest(proxy.Image); err != nil {
+			drifts = append(drifts, fmt.Sprintf("app %s egress proxy image: %v", app.ID, err))
+		} else if proxyDigest != proxy.Digest {
+			drifts = append(drifts, fmt.Sprintf("app %s egress proxy digest drift: image has %s, digest has %s", app.ID, proxyDigest, proxy.Digest))
+		}
+		if proxy.SignatureRef == "" || !strings.Contains(proxy.SignatureRef, proxy.Digest) {
+			drifts = append(drifts, fmt.Sprintf("app %s egress proxy signature_ref does not bind digest %s", app.ID, proxy.Digest))
+		}
+		if proxy.SBOMRef == "" || proxy.VulnerabilityScanRef == "" {
+			drifts = append(drifts, fmt.Sprintf("app %s egress proxy missing SBOM or vulnerability scan refs", app.ID))
+		}
+	}
+	return drifts
+}
+
+func helmDigestReplacements(apps []registry.AppSpec) (map[string]string, error) {
+	replacements := map[string]string{}
+	for _, app := range apps {
+		repo, digest, err := splitImageDigest(app.Install.Image)
+		if err != nil {
+			return nil, fmt.Errorf("app %s install image: %w", app.ID, err)
+		}
+		if digest != app.Install.Digest {
+			return nil, fmt.Errorf("app %s install image digest %s does not match install.digest %s", app.ID, digest, app.Install.Digest)
+		}
+		replacements[repo] = app.Install.Digest
+		if app.FrameworkContract.EgressProxy.Required {
+			proxy := app.FrameworkContract.EgressProxy
+			proxyRepo, proxyDigest, err := splitImageDigest(proxy.Image)
+			if err != nil {
+				return nil, fmt.Errorf("app %s egress proxy image: %w", app.ID, err)
+			}
+			if proxyDigest != proxy.Digest {
+				return nil, fmt.Errorf("app %s egress proxy image digest %s does not match egress digest %s", app.ID, proxyDigest, proxy.Digest)
+			}
+			if existing, ok := replacements[proxyRepo]; ok && existing != proxy.Digest {
+				return nil, fmt.Errorf("egress proxy digest drift across promoted apps: got %s and %s", existing, proxy.Digest)
+			}
+			replacements[proxyRepo] = proxy.Digest
+		}
+	}
+	return replacements, nil
+}
+
+func replaceDigestLinesAfterRepository(content string, replacements map[string]string) (string, error) {
+	repoLine := regexp.MustCompile(`^(\s*)repository:\s*"?([^"\s]+)"?\s*$`)
+	digestLine := regexp.MustCompile(`^(\s*)digest:\s*"?sha256:[0-9a-f]{64}"?\s*$`)
+	lines := strings.SplitAfter(content, "\n")
+	var out strings.Builder
+	pendingRepo := ""
+	pendingDigest := ""
+	applied := map[string]int{}
+	for _, line := range lines {
+		body := strings.TrimSuffix(line, "\n")
+		if pendingRepo != "" && !digestLine.MatchString(body) {
+			trimmed := strings.TrimSpace(body)
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				return "", fmt.Errorf("repository %s was not followed by a digest line in Helm values", pendingRepo)
+			}
+		}
+		if match := repoLine.FindStringSubmatch(body); match != nil {
+			if digest, ok := replacements[match[2]]; ok {
+				pendingRepo = match[2]
+				pendingDigest = digest
+			}
+			out.WriteString(line)
+			continue
+		}
+		if pendingRepo != "" {
+			if match := digestLine.FindStringSubmatch(body); match != nil {
+				suffix := ""
+				if strings.HasSuffix(line, "\n") {
+					suffix = "\n"
+				}
+				out.WriteString(match[1] + `digest: "` + pendingDigest + `"` + suffix)
+				applied[pendingRepo]++
+				pendingRepo = ""
+				pendingDigest = ""
+				continue
+			}
+		}
+		out.WriteString(line)
+	}
+	if pendingRepo != "" {
+		return "", fmt.Errorf("repository %s was not followed by a digest line in Helm values", pendingRepo)
+	}
+	var missing []string
+	for repo := range replacements {
+		if applied[repo] == 0 {
+			missing = append(missing, repo)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return "", fmt.Errorf("Helm values missing digest fields for repositories: %s", strings.Join(missing, ", "))
+	}
+	return out.String(), nil
+}
+
+func syncFrameworkContractImages(images []registry.FrameworkImageContractSpec, entry ArtifactEntry) []registry.FrameworkImageContractSpec {
+	repo, _, err := splitImageDigest(entry.Image)
+	if err != nil {
+		return images
+	}
+	out := append([]registry.FrameworkImageContractSpec{}, images...)
+	matched := false
+	for i := range out {
+		imageRepo, _, err := splitImageDigest(out[i].Image)
+		if err != nil || imageRepo != repo {
+			continue
+		}
+		out[i].Image = entry.Image
+		out[i].Digest = entry.Digest
+		matched = true
+	}
+	if !matched {
+		out = append(out, registry.FrameworkImageContractSpec{
+			Name:    entry.AppID + "-production",
+			Image:   entry.Image,
+			Digest:  entry.Digest,
+			Purpose: "production_proof",
+		})
+	}
+	return out
+}
+
+func validateSubjectBinding(label, image, digest, subjectName, subjectDigest string) error {
+	if subjectName == "" && subjectDigest == "" {
+		return nil
+	}
+	repo, imageDigest, err := splitImageDigest(image)
+	if err != nil {
+		return fmt.Errorf("%s subject binding: %w", label, err)
+	}
+	if subjectName != "" && subjectName != repo {
+		return fmt.Errorf("%s subject_name %q does not match image repository %q", label, subjectName, repo)
+	}
+	if subjectDigest != "" && subjectDigest != digest {
+		return fmt.Errorf("%s subject_digest %q does not match digest %q", label, subjectDigest, digest)
+	}
+	if subjectDigest != "" && subjectDigest != imageDigest {
+		return fmt.Errorf("%s subject_digest %q does not match image digest %q", label, subjectDigest, imageDigest)
+	}
+	return nil
+}
+
+func splitImageDigest(image string) (string, string, error) {
+	parts := strings.Split(image, "@")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("expected immutable image@sha256 digest, got %q", image)
+	}
+	digest := strings.TrimSpace(parts[1])
+	if !registryDigest(digest) {
+		return "", "", fmt.Errorf("digest must be sha256:<64 lowercase hex>, got %q", digest)
+	}
+	return strings.TrimSpace(parts[0]), digest, nil
+}
+
+func imageLockPath(root string) string {
+	return filepath.Join(root, "registry", "launchpad", "image-lock.json")
+}
+
+func helmValuesPath(root string) string {
+	return filepath.Join(root, "deploy", "helm-chart", "values.yaml")
+}

--- a/core/pkg/launchpad/promotion/manifest.go
+++ b/core/pkg/launchpad/promotion/manifest.go
@@ -1,6 +1,8 @@
 package promotion
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,12 +27,23 @@ type Manifest struct {
 	GeneratedAt      string          `json:"generated_at"`
 	GitHubRunID      string          `json:"github_run_id,omitempty"`
 	GitHubRunAttempt string          `json:"github_run_attempt,omitempty"`
+	SourceSHA        string          `json:"source_sha,omitempty"`
+	SourceTreeSHA256 string          `json:"source_tree_sha256,omitempty"`
+	WorkflowRef      string          `json:"workflow_ref,omitempty"`
+	SubjectName      string          `json:"subject_name,omitempty"`
+	SubjectDigest    string          `json:"subject_digest,omitempty"`
+	ManifestHash     string          `json:"manifest_hash,omitempty"`
 	EgressProxy      *EgressProxy    `json:"egress_proxy,omitempty"`
 	Artifacts        []ArtifactEntry `json:"artifacts"`
 }
 
 type EgressProxy struct {
 	Component               string `json:"component,omitempty"`
+	SourceSHA               string `json:"source_sha,omitempty"`
+	SourceTreeSHA256        string `json:"source_tree_sha256,omitempty"`
+	WorkflowRef             string `json:"workflow_ref,omitempty"`
+	SubjectName             string `json:"subject_name,omitempty"`
+	SubjectDigest           string `json:"subject_digest,omitempty"`
 	Image                   string `json:"image"`
 	Digest                  string `json:"digest"`
 	SignatureTool           string `json:"signature_tool"`
@@ -46,6 +59,11 @@ type EgressProxy struct {
 type ArtifactEntry struct {
 	AppID                   string       `json:"app_id"`
 	AppVersion              string       `json:"app_version"`
+	SourceSHA               string       `json:"source_sha,omitempty"`
+	SourceTreeSHA256        string       `json:"source_tree_sha256,omitempty"`
+	WorkflowRef             string       `json:"workflow_ref,omitempty"`
+	SubjectName             string       `json:"subject_name,omitempty"`
+	SubjectDigest           string       `json:"subject_digest,omitempty"`
 	UpstreamRepo            string       `json:"upstream_repo"`
 	UpstreamRef             string       `json:"upstream_ref"`
 	UpstreamCommit          string       `json:"upstream_commit"`
@@ -94,6 +112,17 @@ func LoadManifest(path string) (Manifest, error) {
 	return manifest, nil
 }
 
+func (m Manifest) Hash() (string, error) {
+	clone := m
+	clone.ManifestHash = ""
+	data, err := json.Marshal(clone)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
 func (m Manifest) Entry(appID string) (ArtifactEntry, bool) {
 	for _, artifact := range m.Artifacts {
 		if artifact.AppID == appID {
@@ -125,6 +154,9 @@ func ValidateArtifact(entry ArtifactEntry) error {
 	}
 	if !strings.Contains(entry.Image, "@"+entry.Digest) {
 		return fmt.Errorf("app %s artifact manifest image must be immutable image@%s", entry.AppID, entry.Digest)
+	}
+	if err := validateSubjectBinding("app "+entry.AppID, entry.Image, entry.Digest, entry.SubjectName, entry.SubjectDigest); err != nil {
+		return err
 	}
 	if strings.ToLower(entry.SignatureTool) != "cosign" || entry.SignatureRef == "" {
 		return fmt.Errorf("app %s artifact manifest requires cosign signature evidence", entry.AppID)
@@ -161,6 +193,9 @@ func ValidateEgressProxyArtifact(proxy EgressProxy) error {
 	}
 	if !strings.Contains(proxy.Image, "@"+proxy.Digest) {
 		return fmt.Errorf("egress proxy artifact image must be immutable image@%s", proxy.Digest)
+	}
+	if err := validateSubjectBinding("egress proxy", proxy.Image, proxy.Digest, proxy.SubjectName, proxy.SubjectDigest); err != nil {
+		return err
 	}
 	if strings.ToLower(proxy.SignatureTool) != "cosign" {
 		return fmt.Errorf("egress proxy artifact requires cosign signature evidence")
@@ -222,6 +257,15 @@ func Promote(app registry.AppSpec, entry ArtifactEntry, refs EvidenceRefs) (regi
 	out := app
 	out.Version = entry.AppVersion
 	out.Availability = registry.AvailabilityOSSSupported
+	if out.SupportLevel == "" ||
+		out.SupportLevel == registry.SupportLevelVerifyOnly ||
+		out.SupportLevel == registry.SupportLevelDemo ||
+		out.SupportLevel == registry.SupportLevelBlockedRepairRequired {
+		out.SupportLevel = registry.SupportLevelOSSSupported
+		if out.FrameworkContract.EgressProxy.Required || out.ModelGateway.LogicalSecret != "" {
+			out.SupportLevel = registry.SupportLevelAgentLive
+		}
+	}
 	out.Redistribution = entry.Redistribution
 	out.Install.Strategy = "signed_oci"
 	out.Install.Image = entry.Image
@@ -261,6 +305,7 @@ func Promote(app registry.AppSpec, entry ArtifactEntry, refs EvidenceRefs) (regi
 			ReceiptRef:           receiptRef,
 		}
 	}
+	out.FrameworkContract.Images = syncFrameworkContractImages(out.FrameworkContract.Images, entry)
 	out.PromotionEvidence = registry.PromotionEvidenceSpec{
 		ArtifactVerificationRef: refs.ArtifactVerificationRef,
 		LiveE2ERunID:            refs.LiveE2ERunID,

--- a/core/pkg/launchpad/promotion/manifest_test.go
+++ b/core/pkg/launchpad/promotion/manifest_test.go
@@ -1,6 +1,9 @@
 package promotion
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -47,6 +50,32 @@ func TestManifestEntryCarriesTopLevelEgressProxyArtifact(t *testing.T) {
 	}
 }
 
+func TestManifestHashIgnoresEmbeddedManifestHash(t *testing.T) {
+	manifest := Manifest{
+		SchemaVersion:    ManifestSchemaVersion,
+		GeneratedAt:      "2026-06-12T00:00:00Z",
+		GitHubRunID:      "123",
+		GitHubRunAttempt: "1",
+		SourceSHA:        strings.Repeat("d", 40),
+		SourceTreeSHA256: "sha256:" + strings.Repeat("e", 64),
+		WorkflowRef:      "Mindburn-Labs/helm-ai-kernel/.github/workflows/launchpad-artifacts.yml@refs/heads/main",
+		Artifacts:        []ArtifactEntry{validArtifact("openclaw")},
+		EgressProxy:      ptr(validEgressProxyArtifact()),
+	}
+	hash, err := manifest.Hash()
+	if err != nil {
+		t.Fatalf("Hash: %v", err)
+	}
+	manifest.ManifestHash = hash
+	hashWithEmbeddedValue, err := manifest.Hash()
+	if err != nil {
+		t.Fatalf("Hash with embedded value: %v", err)
+	}
+	if hash != hashWithEmbeddedValue {
+		t.Fatalf("manifest hash changed after embedding hash: %s != %s", hash, hashWithEmbeddedValue)
+	}
+}
+
 func TestPromoteBindsRunBuiltEgressProxyArtifact(t *testing.T) {
 	app := candidateApp("openclaw")
 	app.FrameworkContract.EgressProxy = registry.EgressProxyContractSpec{
@@ -71,6 +100,68 @@ func TestPromoteBindsRunBuiltEgressProxyArtifact(t *testing.T) {
 	}
 	if promoted.FrameworkContract.EgressProxy.SignatureRef != proxy.SignatureRef {
 		t.Fatalf("egress proxy signature ref not bound from manifest: %#v", promoted.FrameworkContract.EgressProxy)
+	}
+}
+
+func TestSyncDerivedWritesImageLockAndHelmValues(t *testing.T) {
+	root := t.TempDir()
+	apps := []registry.AppSpec{
+		promotedAppForDerived(t, "openclaw"),
+		promotedAppForDerived(t, "hermes"),
+	}
+	writeDerivedFixture(t, root, "sha256:"+strings.Repeat("0", 64), false)
+
+	if err := SyncDerived(root, apps); err != nil {
+		t.Fatalf("SyncDerived: %v", err)
+	}
+	if drifts := CheckDerived(root, apps); len(drifts) != 0 {
+		t.Fatalf("CheckDerived drifts after sync: %v", drifts)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "registry", "launchpad", "image-lock.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lock ImageLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		t.Fatalf("image lock json: %v", err)
+	}
+	if lock.SchemaVersion != ImageLockSchemaVersion || len(lock.Images) != 3 {
+		t.Fatalf("unexpected image lock: %#v", lock)
+	}
+	values, err := os.ReadFile(filepath.Join(root, "deploy", "helm-chart", "values.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, app := range apps {
+		if !strings.Contains(string(values), app.Install.Digest) {
+			t.Fatalf("values.yaml missing digest for %s: %s", app.ID, values)
+		}
+	}
+}
+
+func TestCheckDerivedDetectsImageLockValuesAndSmokeDrift(t *testing.T) {
+	root := t.TempDir()
+	apps := []registry.AppSpec{
+		promotedAppForDerived(t, "openclaw"),
+		promotedAppForDerived(t, "hermes"),
+	}
+	writeDerivedFixture(t, root, "sha256:"+strings.Repeat("0", 64), true)
+	if err := os.MkdirAll(filepath.Join(root, "registry", "launchpad"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "registry", "launchpad", "image-lock.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	drifts := CheckDerived(root, apps)
+	if len(drifts) < 3 {
+		t.Fatalf("CheckDerived drifts = %v, want image-lock, values, and smoke drift", drifts)
+	}
+	joined := strings.Join(drifts, "\n")
+	for _, want := range []string{"image-lock.json drift", "helm values drift", "hard-coded launchpad image digest"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("CheckDerived missing %q in %v", want, drifts)
+		}
 	}
 }
 
@@ -206,6 +297,11 @@ func validArtifact(appID string) ArtifactEntry {
 	return ArtifactEntry{
 		AppID:                   appID,
 		AppVersion:              "v2026.5.12",
+		SourceSHA:               strings.Repeat("b", 40),
+		SourceTreeSHA256:        "sha256:" + strings.Repeat("d", 64),
+		WorkflowRef:             "Mindburn-Labs/helm-ai-kernel/.github/workflows/launchpad-artifacts.yml@refs/heads/main",
+		SubjectName:             "ghcr.io/mindburn-labs/helm-launchpad/" + appID,
+		SubjectDigest:           digest,
 		UpstreamRepo:            "https://github.com/openclaw/openclaw",
 		UpstreamRef:             "v2026.5.12",
 		UpstreamCommit:          strings.Repeat("b", 40),
@@ -229,6 +325,11 @@ func validEgressProxyArtifact() EgressProxy {
 	digest := "sha256:" + strings.Repeat("c", 64)
 	return EgressProxy{
 		Component:               "egress-proxy",
+		SourceSHA:               strings.Repeat("e", 40),
+		SourceTreeSHA256:        "sha256:" + strings.Repeat("f", 64),
+		WorkflowRef:             "Mindburn-Labs/helm-ai-kernel/.github/workflows/launchpad-artifacts.yml@refs/heads/main",
+		SubjectName:             "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy",
+		SubjectDigest:           digest,
 		Image:                   "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@" + digest,
 		Digest:                  digest,
 		SignatureTool:           "cosign",
@@ -240,6 +341,62 @@ func validEgressProxyArtifact() EgressProxy {
 		VulnerabilityScanStatus: "completed",
 		ProvenanceRef:           "github-actions://123/1",
 	}
+}
+
+func promotedAppForDerived(t *testing.T, appID string) registry.AppSpec {
+	t.Helper()
+	app := candidateApp(appID)
+	app.FrameworkContract.EgressProxy = registry.EgressProxyContractSpec{Required: true}
+	entry := validArtifact(appID)
+	proxy := validEgressProxyArtifact()
+	entry.EgressProxy = &proxy
+	promoted, err := Promote(app, entry, validRefsFor(appID))
+	if err != nil {
+		t.Fatalf("Promote(%s): %v", appID, err)
+	}
+	return promoted
+}
+
+func writeDerivedFixture(t *testing.T, root, digest string, hardCodedSmoke bool) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "deploy", "helm-chart"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "scripts", "ci"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	values := `launchpadApps:
+  openclaw:
+    image:
+      repository: "ghcr.io/mindburn-labs/helm-launchpad/openclaw"
+      digest: "` + digest + `"
+    egressSidecar:
+      image:
+        repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
+        digest: "` + digest + `"
+  hermes:
+    image:
+      repository: "ghcr.io/mindburn-labs/helm-launchpad/hermes"
+      digest: "` + digest + `"
+    egressSidecar:
+      image:
+        repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
+        digest: "` + digest + `"
+`
+	if err := os.WriteFile(filepath.Join(root, "deploy", "helm-chart", "values.yaml"), []byte(values), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/usr/bin/env bash\nIMAGE_LOCK=\"${ROOT}/registry/launchpad/image-lock.json\"\n"
+	if hardCodedSmoke {
+		script = "#!/usr/bin/env bash\ndocker pull ghcr.io/mindburn-labs/helm-launchpad/openclaw@" + digest + "\n"
+	}
+	if err := os.WriteFile(filepath.Join(root, "scripts", "ci", "launchpad_k8s_smoke.sh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func ptr[T any](value T) *T {
+	return &value
 }
 
 func validRefs() EvidenceRefs {

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -337,7 +337,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:22d78073a11b911f372cd27fa7886101d319b60d367441b18208f2be9d9dfb34"
+        digest: "sha256:395cd585d0e2345e649455953f0d7765b141440bfb2fc753a4ae944e2ba350f8"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:
@@ -378,7 +378,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:22d78073a11b911f372cd27fa7886101d319b60d367441b18208f2be9d9dfb34"
+        digest: "sha256:395cd585d0e2345e649455953f0d7765b141440bfb2fc753a4ae944e2ba350f8"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:

--- a/registry/launchpad/image-lock.json
+++ b/registry/launchpad/image-lock.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "helm.launchpad.image-lock.v1",
+  "generated_from": [
+    "registry/launchpad/apps/openclaw.yaml",
+    "registry/launchpad/apps/hermes.yaml"
+  ],
+  "images": [
+    {
+      "name": "openclaw",
+      "role": "launchpad_app",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995",
+      "repository": "ghcr.io/mindburn-labs/helm-launchpad/openclaw",
+      "digest": "sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995",
+      "source": "registry/launchpad/apps/openclaw.yaml",
+      "preload": true
+    },
+    {
+      "name": "hermes",
+      "role": "launchpad_app",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652",
+      "repository": "ghcr.io/mindburn-labs/helm-launchpad/hermes",
+      "digest": "sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652",
+      "source": "registry/launchpad/apps/hermes.yaml",
+      "preload": true
+    },
+    {
+      "name": "egress-proxy",
+      "role": "egress_proxy",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:395cd585d0e2345e649455953f0d7765b141440bfb2fc753a4ae944e2ba350f8",
+      "repository": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy",
+      "digest": "sha256:395cd585d0e2345e649455953f0d7765b141440bfb2fc753a4ae944e2ba350f8",
+      "source": "registry/launchpad/apps/openclaw.yaml",
+      "preload": true
+    }
+  ]
+}

--- a/scripts/ci/launchpad_k8s_smoke.sh
+++ b/scripts/ci/launchpad_k8s_smoke.sh
@@ -21,6 +21,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE_LOCK="${ROOT}/registry/launchpad/image-lock.json"
 MODE="${LAUNCHPAD_SMOKE_MODE:-positive}"
 PROFILE="${LAUNCHPAD_SMOKE_PROFILE:-launchpad-smoke}"
 NAMESPACE="${LAUNCHPAD_SMOKE_NAMESPACE:-helm-launchpad-smoke}"
@@ -85,6 +86,7 @@ require kubectl
 require helm
 require docker
 require python3
+require jq
 
 apply_ghcr_pull_secret() {
     GHCR_USERNAME="$GHCR_USERNAME" GHCR_TOKEN="$GHCR_TOKEN" \
@@ -195,10 +197,19 @@ fi
 if [ "$PRE_LOAD_LAUNCHPAD_IMAGES" = "1" ] && [ "$MODE" != "baseline" ]; then
     # Debug-only path. Private digest-pinned GHCR refs have proven unreliable
     # through `minikube image load`; the normal path below uses imagePullSecrets.
-    for img in \
-        "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995" \
-        "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652" \
-        "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:e09e0aec1e0e1f926f4cd18444e88310656b85551cbc10a6c340acb979a42e03"; do
+    if [ ! -f "$IMAGE_LOCK" ]; then
+        echo "::error::Launchpad image lock not found: $IMAGE_LOCK" >&2
+        exit 1
+    fi
+    preload_images=()
+    while IFS= read -r img; do
+        preload_images+=("$img")
+    done < <(jq -r '.images[] | select(.preload != false) | .image' "$IMAGE_LOCK")
+    if [ "${#preload_images[@]}" -eq 0 ]; then
+        echo "::error::Launchpad image lock does not contain preload images: $IMAGE_LOCK" >&2
+        exit 1
+    fi
+    for img in "${preload_images[@]}"; do
         docker pull --platform=linux/amd64 "$img"
         minikube -p "$PROFILE" image load "$img"
         if ! minikube -p "$PROFILE" image ls 2>/dev/null | grep -qF "$img"; then


### PR DESCRIPTION
## Summary
- Adds source-owned Launchpad promotion drift checks and generated `registry/launchpad/image-lock.json`.
- Extends `helm-ai-kernel launch promote` with `--apps`, `--sync-derived`, and `--check` for multi-app promotions.
- Syncs current OpenClaw/Hermes chart egress sidecar refs back to the committed AppSpec authority.
- Replaces the old chart-only digest pinning workflow with a live-conformance-gated promotion PR job.

Linear: MIN-518. Related release validation: MIN-377. Prior release authority context: MIN-413.

## Validation
- `go test ./pkg/launchpad/promotion ./cmd/helm-ai-kernel -count=1`
- `make launchpad-promotion-check`
- `bash -n scripts/ci/launchpad_k8s_smoke.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/launchpad-artifacts.yml"); YAML.load_file(".github/workflows/ci.yml")'`\n- `go test ./tests/launchpad/... -run TestLiveModelProviderLocalContainerConformance -count=1` (live env unset locally; provider-backed execution remains CI-secret gated)\n\n## Notes\n- Promotion commits update AppSpecs/generated refs and no longer retrigger the producer image build path.\n- If live conformance secrets are unavailable on main artifact builds, the promotion PR job remains blocked by the live-conformance prerequisite rather than publishing supported refs.