### PR TITLE
Fix release asset EvidencePack staging

### DIFF
--- a/core/pkg/conform/gates/g0_build_identity.go
+++ b/core/pkg/conform/gates/g0_build_identity.go
@@ -1,9 +1,13 @@
 package gates
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
 )
@@ -127,6 +131,16 @@ func (g *G0BuildIdentity) Run(ctx *conform.RunContext) *conform.GateResult {
 		result.Reasons = append(result.Reasons, conform.ReasonTrustRootsMissing)
 	}
 
+	if result.Pass && os.Getenv("HELM_RELEASE_EVIDENCE_RECEIPT") == "1" {
+		if relPath, err := writeReleaseEvidenceReceipt(ctx); err == nil {
+			result.EvidencePaths = append(result.EvidencePaths, relPath)
+			result.Metrics.Counts["release_receipts"] = 1
+		} else {
+			result.Pass = false
+			result.Reasons = append(result.Reasons, conform.ReasonReceiptChainBroken)
+		}
+	}
+
 	return result
 }
 
@@ -147,4 +161,55 @@ func copyToEvidence(src, dst string) {
 	}
 	_ = os.MkdirAll(filepath.Dir(dst), 0750)
 	_ = os.WriteFile(dst, data, 0600)
+}
+
+func writeReleaseEvidenceReceipt(ctx *conform.RunContext) (string, error) {
+	const relPath = "02_PROOFGRAPH/receipts/001_release_build_identity.json"
+	if ctx == nil {
+		return "", fmt.Errorf("missing run context")
+	}
+	issuedAt := time.Now().UTC()
+	if ctx.Clock != nil {
+		issuedAt = ctx.Clock().UTC()
+	}
+	decisionHash := releaseReceiptHash(ctx.RunID, string(ctx.Profile), ctx.ProjectRoot)
+	receipt := map[string]any{
+		"schema_version":        "helm.release_receipt.v1",
+		"receipt_id":            "release-build-identity",
+		"run_id":                ctx.RunID,
+		"seq":                   1,
+		"lamport_clock":         1,
+		"tenant_id":             "tenant:release",
+		"timestamp_virtual":     issuedAt.Format(time.RFC3339),
+		"actor":                 "release-workflow",
+		"action_type":           "policy_decision",
+		"effect_class":          "REVERSIBLE",
+		"effect_type":           "release_asset_staging",
+		"decision_id":           "decision:" + decisionHash,
+		"decision_hash":         decisionHash,
+		"intent_id":             "intent:" + ctx.RunID,
+		"parent_receipt_hashes": []string{"genesis"},
+		"status":                "allow",
+	}
+	data, err := json.MarshalIndent(receipt, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(ctx.EvidenceDir, relPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0600); err != nil {
+		return "", err
+	}
+	return relPath, nil
+}
+
+func releaseReceiptHash(parts ...string) string {
+	h := sha256.New()
+	for _, part := range parts {
+		h.Write([]byte(part))
+		h.Write([]byte{0})
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
 }

--- a/core/pkg/conform/gates/g0_build_identity_test.go
+++ b/core/pkg/conform/gates/g0_build_identity_test.go
@@ -1,6 +1,7 @@
 package gates
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,6 +42,29 @@ func TestG0_SBOMPresent(t *testing.T) {
 	require.NotEmpty(t, gate.Name())
 	result := gate.Run(ctx)
 	require.True(t, result.Pass, "all artifacts present: %v", result.Reasons)
+}
+
+func TestG0ReleaseEvidenceReceiptOptIn(t *testing.T) {
+	_, ctx := setupG0(t)
+	t.Setenv("HELM_RELEASE_EVIDENCE_RECEIPT", "1")
+
+	require.NoError(t, os.WriteFile(filepath.Join(ctx.ProjectRoot, "go.sum"), []byte("dep-lock"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(ctx.ProjectRoot, "artifacts", "build_identity.json"), []byte(`{"version":"1.0"}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(ctx.ProjectRoot, "artifacts", "sbom.json"), []byte(`{"components":[]}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(ctx.ProjectRoot, "artifacts", "provenance.json"), []byte(`{"predicate":{}}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(ctx.ProjectRoot, "artifacts", "trust_roots.json"), []byte(`{"keys":[]}`), 0600))
+
+	result := (&G0BuildIdentity{}).Run(ctx)
+	require.True(t, result.Pass, "all artifacts present: %v", result.Reasons)
+	require.Equal(t, 1, result.Metrics.Counts["release_receipts"])
+
+	receiptPath := filepath.Join(ctx.EvidenceDir, "02_PROOFGRAPH", "receipts", "001_release_build_identity.json")
+	data, err := os.ReadFile(receiptPath)
+	require.NoError(t, err)
+	var receipt map[string]any
+	require.NoError(t, json.Unmarshal(data, &receipt))
+	require.Equal(t, "policy_decision", receipt["action_type"])
+	require.NotEmpty(t, receipt["decision_hash"])
 }
 
 func TestG0_SBOMAbsent(t *testing.T) {

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -33,8 +33,9 @@ make docs-coverage docs-truth
 On tag builds, the Makefile derives `VERSION` from `GITHUB_REF_NAME` so the
 binary version, SBOM component version, OpenVEX filename, Homebrew formula, and
 release attestation all match the tag. `stage_release_assets.sh` requires the
-matching OpenVEX file and verifies `evidence-pack.tar` before it writes the
-final checksum manifest.
+matching OpenVEX file, generates a non-seeded release EvidencePack from release
+build inputs, verifies `evidence-pack.tar`, and writes the final checksum
+manifest.
 
 `verify_cosign.sh` verifies every bundle it finds. A run with zero
 `*.cosign.bundle` files proves no signature coverage; check that bundle files

--- a/scripts/release/stage_release_assets.sh
+++ b/scripts/release/stage_release_assets.sh
@@ -121,13 +121,24 @@ with tarfile.open(out, "w") as tar:
             tar.addfile(info, fh)
 PY
 
-log_step "generating L2 conformance evidence"
-if ! "$ROOT/bin/helm-ai-kernel" conform --level L2 --output "$TMP_DIR/conformance" --json > "$TMP_DIR/conformance-report.json"; then
-    echo "::error file=scripts/release/stage_release_assets.sh::conformance failed during release asset staging" >&2
-    print_conformance_failures "$TMP_DIR/conformance-report.json"
-    exit 1
+log_step "generating release conformance evidence"
+conformance_dir="$TMP_DIR/conformance"
+conformance_report="$conformance_dir/conform_report.json"
+HELM_CONFORMANCE_ARTIFACTS_DIR="$ROOT/artifacts" bash "$ROOT/scripts/release/prepare_conformance_release_inputs.sh"
+if ! HELM_RELEASE_EVIDENCE_RECEIPT=1 "$ROOT/bin/helm-ai-kernel" conform --profile SMB --gate G0 --signed --output "$conformance_dir" > "$TMP_DIR/conformance-run.log"; then
+	echo "::error file=scripts/release/stage_release_assets.sh::conformance failed during release asset staging" >&2
+	if [ -f "$conformance_report" ]; then
+		print_conformance_failures "$conformance_report"
+	else
+		cat "$TMP_DIR/conformance-run.log" >&2
+	fi
+	exit 1
 fi
-pack_root="$(find "$TMP_DIR/conformance" -mindepth 2 -maxdepth 2 -type d -name 'run-*' | sort | tail -n 1)"
+if ! bash "$ROOT/scripts/release/conformance_release_gate.sh" "$conformance_report"; then
+	echo "::error file=scripts/release/stage_release_assets.sh::release conformance gate rejected staged EvidencePack" >&2
+	exit 1
+fi
+pack_root="$(find "$conformance_dir" -mindepth 2 -maxdepth 2 -type d -name 'run-*' | sort | tail -n 1)"
 if [ -z "$pack_root" ]; then
     echo "::error file=scripts/release/stage_release_assets.sh::conformance did not produce an EvidencePack directory" >&2
     exit 1


### PR DESCRIPTION
## Summary
- stage release assets from non-seeded release conformance inputs instead of the unsigned L2 level alias
- opt G0 into writing a minimal release policy-decision receipt so the exported EvidencePack passes offline verifier lamport/decision-hash checks
- document the release asset EvidencePack path accurately

## Validation
- `GOWORK=off go test ./pkg/conform/gates`
- `git diff --check`
- `bash -n scripts/release/stage_release_assets.sh`
- `make release-assets`

Refs #276