### PR TITLE
fix(launchpad): hash upstream sources from git index

### DIFF
--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -130,10 +130,12 @@ jobs:
         working-directory: upstream
         run: |
           set -euo pipefail
+          # Hash the Git index metadata instead of filesystem paths. Some upstream
+          # repos contain gitlinks or dangling symlinks, which `sha256sum <path>`
+          # cannot read even though the committed tree is valid.
           source_tree_sha256="$(
-            git ls-files -z |
-              sort -z |
-              xargs -0 sha256sum |
+            git ls-files -s -z |
+              LC_ALL=C sort -z |
               sha256sum |
               awk '{print "sha256:" $1}'
           )"


### PR DESCRIPTION
## Summary

- Fix `launchpad-artifacts.yml` upstream source-tree hashing so valid upstream trees with gitlinks or dangling symlinks do not fail the artifact matrix.
- Hash `git ls-files -s -z` metadata instead of running `sha256sum` against each checked-out path.

## Why

The latest `launchpad-artifacts.yml` run on `main` built OpenClaw successfully, but the workflow failed in `Build and sign opencode` while computing the pinned upstream source-tree hash:

- `sha256sum: packages/console/app/public/email: Is a directory`
- `sha256sum: packages/opencode/src/provider/sdk/copilot/AGENTS.md: No such file or directory`

That prevented aggregate, live conformance, and the automated promotion PR from running. As a result, the chart still points at the stale egress-proxy digest, and the latest `helm-integration.yml` positive k8s smoke fails because the init container cannot find `iptables`.

## Validation

- Reproduced the old hash pipeline against `anomalyco/opencode@v1.15.5`: non-zero exit with the same directory/dangling-path errors.
- Verified the new `git ls-files -s -z | LC_ALL=C sort -z | sha256sum` pipeline succeeds on the same upstream checkout.
- `/usr/bin/ruby -e 'require "yaml"; YAML.load_file(".github/workflows/launchpad-artifacts.yml"); puts "yaml ok"'`
- `git diff --check`

## Follow-up after merge

- Re-run `launchpad-artifacts.yml` on `main` with live conformance enabled.
- Merge the generated Launchpad promotion PR so `registry/launchpad/apps/{openclaw,hermes}.yaml`, `registry/launchpad/image-lock.json`, and `deploy/helm-chart/values.yaml` pick up the new egress-proxy digest that includes `iptables`.
- Re-run `helm-integration.yml` positive k8s smoke on `main`.
