### PR TITLE
docs(launchpad): clarify verify-only app boundaries

### DIFF
--- a/docs/launchpad/apps/KILOCODE.md
+++ b/docs/launchpad/apps/KILOCODE.md
@@ -9,6 +9,12 @@ Kilo Code currently has `verify_only` contract evidence. The pinned image and
 `kilocode --version` healthcheck are useful smoke proof, but `--version` smoke
 checks do not count as live-agent F2 coverage.
 
+The supported claim is deliberately limited. HELM proves that the Kilo Code app
+spec, signed OCI image reference, filesystem policy, MCP quarantine settings,
+and EvidencePack export path can be validated as a Launchpad contract. It does
+not prove that a live Kilo Code coding session, tool sequence, or model-backed
+workflow has passed the full F2 runtime bar.
+
 ```mermaid
 flowchart TD
     A[Kilo Code Agent] -->|Request Tool Call| B(HELM AI Kernel)
@@ -23,6 +29,18 @@ flowchart TD
 ```bash
 helm-ai-kernel app preflight kilocode --json
 ```
+
+## Operator boundary
+Kilo Code keeps a scoped workspace and app-state mount, denied default network
+egress, schema-pinned MCP manifests, and escalation for unknown MCP tools. The
+default profile requires no provider secret, keeps `runtime_install_policy`
+forbidden, and relies on baked dependencies such as `kilocode-cli` and
+`ripgrep` instead of launch-time downloads.
+
+Do not treat this page as a live-agent success claim until teardown receipts,
+offline verification, and EvidencePack material exist for a real Kilo Code
+command path. Until that evidence is present, the correct status is signed OCI
+plus verify-only contract preflight.
 
 ## Source Truth
 - Registry source: `registry/launchpad/apps/kilocode.yaml`

--- a/docs/launchpad/apps/OPENCODE.md
+++ b/docs/launchpad/apps/OPENCODE.md
@@ -9,6 +9,13 @@ OpenCode currently has `verify_only` contract evidence. The pinned image and
 `opencode --version` healthcheck are useful smoke proof, but `--version` smoke
 checks do not count as live-agent F2 coverage.
 
+The supported claim is narrower than a full interactive agent run. HELM proves
+that the app registry entry, policy, image digest, MCP quarantine rules, and
+EvidencePack export path can be assembled and checked without runtime package
+installation. Operators should treat this as contract readiness for the
+Launchpad boundary, not as proof that arbitrary OpenCode tool use has been
+observed under live workload conditions.
+
 ```mermaid
 flowchart TD
     A[OpenCode Agent] -->|Request Tool Call| B(HELM AI Kernel)
@@ -23,6 +30,18 @@ flowchart TD
 ```bash
 helm-ai-kernel app preflight opencode --json
 ```
+
+## Operator boundary
+OpenCode runs with scoped workspace and app-state mounts, denied default network
+egress, schema-pinned MCP manifests, and unknown MCP tools escalated instead of
+silently allowed. The app has no required model secret in the default profile,
+and the registry keeps `runtime_install_policy` forbidden so the image cannot
+repair missing dependencies by downloading packages at launch time.
+
+Do not promote this page to live F2 language until a real command path has
+teardown receipts, offline verification, and EvidencePack material at the same
+bar as the live OpenClaw and Hermes launchpad flows. Until then, the correct
+operational posture is signed OCI plus verify-only preflight.
 
 ## Source Truth
 - Registry source: `registry/launchpad/apps/opencode.yaml`


### PR DESCRIPTION
## Summary
- expand OpenCode and Kilo Code public launchpad pages so docs-platform thin-page checks pass
- keep both pages explicitly verify-only and avoid live F2 promotion language
- document operator controls: scoped mounts, default-deny egress, MCP quarantine, no runtime installs

## Validation
- wc -w docs/launchpad/apps/OPENCODE.md docs/launchpad/apps/KILOCODE.md
- git diff --check

Refs Mindburn-Labs/helm-ai-kernel#276