### PR TITLE
ci(launchpad): keep multi-arch build logs active

### DIFF
--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -212,6 +212,8 @@ jobs:
       - id: build
         name: Build and push OCI image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: upstream
           file: ${{ matrix.dockerfile }}
@@ -443,6 +445,8 @@ jobs:
       - id: build
         name: Build and push egress proxy image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        env:
+          BUILDKIT_PROGRESS: plain
         with:
           context: helm
           file: helm/tools/launchpad/artifacts/egress-proxy.Dockerfile


### PR DESCRIPTION
## Summary
- force plain BuildKit progress logs for Launchpad app image builds
- apply the same setting to the egress-proxy image build
- addresses the silent OpenCode multi-arch Buildx failure observed after #332 merged

## Validation
- actionlint .github/workflows/launchpad-artifacts.yml
- git diff --check

Refs #277