### PR TITLE
fix(launchpad): mark transparent egress in local containers

### DIFF
--- a/core/pkg/launchpad/runtime/coverage_test.go
+++ b/core/pkg/launchpad/runtime/coverage_test.go
@@ -300,9 +300,14 @@ exit 0
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"--network launch-net", "-e TOKEN=secret", "-e APP_STATE_DIR=/var/lib/app/state", "-v", "app"} {
+	for _, want := range []string{"--network launch-net", "-e TOKEN=secret", "-e APP_STATE_DIR=/var/lib/app/state", "-e HELM_EGRESS_TRANSPARENT=1", "-v", "app"} {
 		if !strings.Contains(string(logData), want) {
 			t.Fatalf("docker run log missing %q: %s", want, logData)
+		}
+	}
+	for _, unwanted := range []string{"HTTP_PROXY=http://proxy:8080", "HTTPS_PROXY=http://proxy:8080"} {
+		if strings.Contains(string(logData), unwanted) {
+			t.Fatalf("transparent sidecar docker run log included %q: %s", unwanted, logData)
 		}
 	}
 

--- a/core/pkg/launchpad/runtime/local_container.go
+++ b/core/pkg/launchpad/runtime/local_container.go
@@ -162,9 +162,13 @@ func (r LocalContainerRuntime) Start(req ContainerRequest) (ContainerHandle, err
 		env[key] = value
 	}
 	if proxyHandle.ProxyURL != "" {
-		env["HTTPS_PROXY"] = proxyHandle.ProxyURL
-		env["HTTP_PROXY"] = proxyHandle.ProxyURL
-		env["NO_PROXY"] = "127.0.0.1,localhost"
+		if proxyHandle.NetworkName != "" {
+			env["HELM_EGRESS_TRANSPARENT"] = "1"
+		} else {
+			env["HTTPS_PROXY"] = proxyHandle.ProxyURL
+			env["HTTP_PROXY"] = proxyHandle.ProxyURL
+			env["NO_PROXY"] = "127.0.0.1,localhost"
+		}
 	}
 	network := sandbox.NetworkPolicy{Disabled: true, EgressAllowlist: req.NetworkAllowlist}
 	if proxyHandle.NetworkName != "" {


### PR DESCRIPTION
## Summary
- stop injecting HTTP_PROXY/HTTPS_PROXY when local-container uses the Docker sidecar egress network
- set HELM_EGRESS_TRANSPARENT=1 for transparent egress so model-gateway-check does not attempt CONNECT through the sidecar listener
- keep HTTP proxy env behavior for non-network/static egress proxies

## Validation
- /Users/ivan/.local/share/mise/installs/go/1.22.12/bin/go test ./core/pkg/launchpad/runtime
- /Users/ivan/.local/share/mise/installs/go/1.22.12/bin/go test ./tests/launchpad
- git diff --check

Context: main Launchpad Artifacts run 27431976603 built/signed OpenClaw successfully but failed live conformance with curl Proxy CONNECT aborted; evidence showed local-container used transparent sidecar image while runtime still injected proxy env.