### PR TITLE
ci(launchpad): preserve git metadata in artifact builds

### DIFF
--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -153,9 +153,6 @@ jobs:
           set -euo pipefail
           cp helm/tools/launchpad/artifacts/model-gateway-check.sh upstream/.helm-launchpad-model-gateway-check.sh
           cat > upstream/.dockerignore <<'EOF'
-          .git
-          .git/**
-          **/.git
           **/.DS_Store
           **/node_modules
           **/.cache


### PR DESCRIPTION
## Summary
- keep upstream `.git` metadata in the launchpad artifact Docker build context
- preserve the rest of the generated `.dockerignore` pruning for node_modules/cache/build output

## Why
PR #338 added a generated `.dockerignore` that excluded `.git`. The opencode and kilocode upstream build scripts call `git branch --show-current` during `bun ... build`, so the `d3dbf534` Launchpad Artifacts run failed with `fatal: not a git repository` before producing candidate image manifests.

## Validation
- `actionlint .github/workflows/launchpad-artifacts.yml`
- `git diff --check`

Refs #277