### PR TITLE
ci(launchpad): keep git metadata in app build context

### DIFF
--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -153,9 +153,6 @@ jobs:
           set -euo pipefail
           cp helm/tools/launchpad/artifacts/model-gateway-check.sh upstream/.helm-launchpad-model-gateway-check.sh
           cat > upstream/.dockerignore <<'EOF'
-          .git
-          .git/**
-          **/.git
           **/.DS_Store
           **/node_modules
           **/.cache


### PR DESCRIPTION
## Summary
- Stop excluding `.git` from the generated upstream `.dockerignore` used by Launchpad app artifact builds.
- Keep cache/dependency exclusions from PR #338 so platform-split builds still avoid generated bulk.

## Why
The main deployment run for `d3dbf534` proved Hermes and the egress proxy can publish with the split-by-platform workflow, but OpenCode and Kilo Code failed because their upstream build scripts call `git branch --show-current`:

- OpenCode: `fatal: not a git repository (or any of the parent directories): .git`
- Kilo Code: `fatal: not a git repository (or any of the parent directories): .git`

Run: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/27446335424

## Validation
- `actionlint .github/workflows/launchpad-artifacts.yml`
- `git diff --check`

## Notes
- No chart default change.
- No digest promotion in this PR.
- MIN-494 remains Merged/Verifying until the real Hermes/OpenRouter smoke burns measurable tokens.