### PR TITLE
fix(launchpad): pass app versions into artifact builds

### DIFF
--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -231,6 +231,9 @@ jobs:
           provenance: true
           sbom: true
           platforms: linux/amd64
+          build-args: |
+            OPENCODE_VERSION=${{ matrix.version }}
+            KILO_VERSION=${{ matrix.version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ matrix.upstream_repo }}
             org.opencontainers.image.revision=${{ steps.upstream.outputs.commit }}
@@ -260,6 +263,9 @@ jobs:
           provenance: true
           sbom: true
           platforms: linux/arm64
+          build-args: |
+            OPENCODE_VERSION=${{ matrix.version }}
+            KILO_VERSION=${{ matrix.version }}
           labels: |
             org.opencontainers.image.source=https://github.com/${{ matrix.upstream_repo }}
             org.opencontainers.image.revision=${{ steps.upstream.outputs.commit }}

--- a/tools/launchpad/artifacts/kilocode.Dockerfile
+++ b/tools/launchpad/artifacts/kilocode.Dockerfile
@@ -4,6 +4,9 @@
 # Build context: pinned upstream Kilo-Org/kilocode checkout.
 FROM oven/bun:1.3.13-debian@sha256:e95356cb8e1de62ad69ab3bd3584ba947013d27650a226804d2fc0af4e17dac2 AS build
 
+ARG KILO_VERSION
+ENV KILO_VERSION=${KILO_VERSION}
+
 WORKDIR /src/kilocode
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates g++ git make python3 \

--- a/tools/launchpad/artifacts/opencode.Dockerfile
+++ b/tools/launchpad/artifacts/opencode.Dockerfile
@@ -4,6 +4,9 @@
 # Build context: pinned upstream sst/opencode checkout.
 FROM oven/bun:1.3.14-debian@sha256:9dba1a1b43ce28c9d7931bfc4eb00feb63b0114720a0277a8f939ae4dfc9db6f AS build
 
+ARG OPENCODE_VERSION
+ENV OPENCODE_VERSION=${OPENCODE_VERSION}
+
 WORKDIR /src/opencode
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates g++ git make python3 \


### PR DESCRIPTION
## Summary
- pass app version build args into both amd64 and arm64 Launchpad artifact image builds
- export OPENCODE_VERSION/KILO_VERSION in HELM-owned OpenCode/Kilo Dockerfiles so upstream build scripts do not call git branch inside a .git-less Docker context

## Validation
- ruby YAML parse for .github/workflows/launchpad-artifacts.yml
- actionlint .github/workflows/launchpad-artifacts.yml
- git diff --check

Context: main Launchpad Artifacts run 27446963080 failed after the multi-arch split in opencode/kilocode amd64 Docker builds with fatal: not a git repository while upstream scripts tried git branch --show-current.