### PR TITLE
fix(launchpad): restore local-container proxy egress

### DIFF
--- a/core/pkg/launchpad/runtime/coverage_test.go
+++ b/core/pkg/launchpad/runtime/coverage_test.go
@@ -300,14 +300,14 @@ exit 0
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"--network launch-net", "-e TOKEN=secret", "-e APP_STATE_DIR=/var/lib/app/state", "-e HELM_EGRESS_TRANSPARENT=1", "-v", "app"} {
+	for _, want := range []string{"--network launch-net", "-e TOKEN=secret", "-e APP_STATE_DIR=/var/lib/app/state", "-e HTTPS_PROXY=http://proxy:8080", "-e HTTP_PROXY=http://proxy:8080", "-e NO_PROXY=127.0.0.1,localhost", "-v", "app"} {
 		if !strings.Contains(string(logData), want) {
 			t.Fatalf("docker run log missing %q: %s", want, logData)
 		}
 	}
-	for _, unwanted := range []string{"HTTP_PROXY=http://proxy:8080", "HTTPS_PROXY=http://proxy:8080"} {
+	for _, unwanted := range []string{"HELM_EGRESS_TRANSPARENT=1"} {
 		if strings.Contains(string(logData), unwanted) {
-			t.Fatalf("transparent sidecar docker run log included %q: %s", unwanted, logData)
+			t.Fatalf("local-container explicit proxy docker run log included %q: %s", unwanted, logData)
 		}
 	}
 

--- a/core/pkg/launchpad/runtime/local_container.go
+++ b/core/pkg/launchpad/runtime/local_container.go
@@ -162,13 +162,9 @@ func (r LocalContainerRuntime) Start(req ContainerRequest) (ContainerHandle, err
 		env[key] = value
 	}
 	if proxyHandle.ProxyURL != "" {
-		if proxyHandle.NetworkName != "" {
-			env["HELM_EGRESS_TRANSPARENT"] = "1"
-		} else {
-			env["HTTPS_PROXY"] = proxyHandle.ProxyURL
-			env["HTTP_PROXY"] = proxyHandle.ProxyURL
-			env["NO_PROXY"] = "127.0.0.1,localhost"
-		}
+		env["HTTPS_PROXY"] = proxyHandle.ProxyURL
+		env["HTTP_PROXY"] = proxyHandle.ProxyURL
+		env["NO_PROXY"] = "127.0.0.1,localhost"
 	}
 	network := sandbox.NetworkPolicy{Disabled: true, EgressAllowlist: req.NetworkAllowlist}
 	if proxyHandle.NetworkName != "" {

--- a/tools/launchpad/egressproxy/main.go
+++ b/tools/launchpad/egressproxy/main.go
@@ -1,14 +1,9 @@
-// helm-launchpad-egress-proxy is the launchpad egress sidecar. It runs as a
-// transparent proxy: an init-container installs an iptables REDIRECT that funnels
-// every outbound TCP connection from the workload container into this listener.
-// For each intercepted connection the proxy recovers the original destination via
-// SO_ORIGINAL_DST, best-effort reads the TLS SNI for a hostname, checks the
-// allowlist, writes a receipt (ALLOW or DENY — every attempt is recorded), and
-// only then tunnels allowed traffic to its real destination.
-//
-// This replaces the earlier HTTP CONNECT forward-proxy model, where egress was
-// honor-based (the workload had to opt in via HTTP_PROXY) and direct connections
-// silently bypassed the sidecar without leaving a receipt.
+// helm-launchpad-egress-proxy is the launchpad egress sidecar. It supports two
+// enforced modes: Kubernetes transparent egress, where an init-container installs
+// an iptables REDIRECT and the proxy recovers SO_ORIGINAL_DST, and Docker
+// local-container egress, where the workload is on an internal network and must
+// use this sidecar through HTTP CONNECT proxy env. In both modes the proxy checks
+// the allowlist, writes a receipt, and only then tunnels allowed traffic.
 package main
 
 import (
@@ -19,6 +14,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -83,6 +79,11 @@ type proxy struct {
 // destination is recovered from the kernel via SO_ORIGINAL_DST; the hostname, when
 // present, comes from the TLS ClientHello SNI without terminating TLS.
 func (p *proxy) handle(client net.Conn) {
+	br := bufio.NewReaderSize(client, 8192)
+	if isConnectRequest(client, br) {
+		p.handleCONNECT(client, br)
+		return
+	}
 	tcp, ok := client.(*net.TCPConn)
 	if !ok {
 		_ = client.Close()
@@ -98,7 +99,6 @@ func (p *proxy) handle(client net.Conn) {
 	// Buffer the client side so the peeked ClientHello bytes are preserved for
 	// forwarding. SNI is best-effort: ECH, non-TLS, or IP-literal traffic yields
 	// no hostname and we fall back to the original IP:port for the allowlist.
-	br := bufio.NewReaderSize(client, 8192)
 	host := sniHost(br)
 	destination := origDst
 	if host != "" {
@@ -124,6 +124,59 @@ func (p *proxy) handle(client net.Conn) {
 	if err != nil {
 		_ = p.writeReceipt("ESCALATE", destination, "upstream_dial_failed")
 		_ = client.Close()
+		return
+	}
+	_ = p.writeReceipt("ALLOW", destination, "connect_allowed")
+	tunnel(client, br, upstream)
+}
+
+func isConnectRequest(conn net.Conn, br *bufio.Reader) bool {
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	head, err := br.Peek(len("CONNECT "))
+	_ = conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(string(head[:len("CONNECT")]), "CONNECT") && head[len("CONNECT")] == ' '
+}
+
+func (p *proxy) handleCONNECT(client net.Conn, br *bufio.Reader) {
+	request, err := http.ReadRequest(br)
+	if err != nil {
+		_ = p.writeReceipt("ESCALATE", "", "connect_request_parse_failed")
+		_ = client.Close()
+		return
+	}
+	if request.Method != http.MethodConnect {
+		_ = p.writeReceipt("DENY", request.Host, "unsupported_proxy_method")
+		_, _ = client.Write([]byte("HTTP/1.1 405 Method Not Allowed\r\n\r\n"))
+		_ = client.Close()
+		return
+	}
+	destination := normalizeDestination(request.Host)
+	if destination == "" && request.URL != nil {
+		destination = normalizeDestination(request.URL.Host)
+	}
+	if !networkAllowed(destination, p.allowlist) {
+		_ = p.writeReceipt("DENY", destination, "destination_not_allowlisted")
+		_, _ = client.Write([]byte("HTTP/1.1 403 Forbidden\r\n\r\n"))
+		_ = client.Close()
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var d net.Dialer
+	upstream, err := d.DialContext(ctx, "tcp", destination)
+	if err != nil {
+		_ = p.writeReceipt("ESCALATE", destination, "upstream_dial_failed")
+		_, _ = client.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+		_ = client.Close()
+		return
+	}
+	if _, err := client.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n")); err != nil {
+		_ = upstream.Close()
+		_ = client.Close()
+		_ = p.writeReceipt("ESCALATE", destination, "proxy_connect_response_failed")
 		return
 	}
 	_ = p.writeReceipt("ALLOW", destination, "connect_allowed")

--- a/tools/launchpad/egressproxy/main_test.go
+++ b/tools/launchpad/egressproxy/main_test.go
@@ -3,7 +3,12 @@ package main
 import (
 	"bufio"
 	"crypto/tls"
+	"io"
 	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -56,4 +61,97 @@ func TestSNIHostReturnsEmptyOnNonTLS(t *testing.T) {
 	if host := sniHost(br); host != "" {
 		t.Fatalf("expected no SNI for non-TLS traffic, got %q", host)
 	}
+}
+
+func TestHTTPConnectAllowedTunnelsAndWritesReceipt(t *testing.T) {
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer backend.Close()
+	backendDone := make(chan error, 1)
+	go func() {
+		conn, err := backend.Accept()
+		if err != nil {
+			backendDone <- err
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, len("ping"))
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			backendDone <- err
+			return
+		}
+		if string(buf) != "ping" {
+			backendDone <- io.ErrUnexpectedEOF
+			return
+		}
+		_, err = conn.Write([]byte("pong"))
+		backendDone <- err
+	}()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	receiptDir := t.TempDir()
+	p := &proxy{launchID: "launch-1", allowlist: []string{backend.Addr().String()}, receiptDir: receiptDir}
+	go p.handle(server)
+
+	clientReader := bufio.NewReader(client)
+	_, _ = client.Write([]byte("CONNECT " + backend.Addr().String() + " HTTP/1.1\r\nHost: " + backend.Addr().String() + "\r\n\r\n"))
+	response, err := http.ReadResponse(clientReader, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+	_, _ = client.Write([]byte("ping"))
+	reply := make([]byte, len("pong"))
+	if _, err := io.ReadFull(clientReader, reply); err != nil {
+		t.Fatalf("read tunnel reply: %v", err)
+	}
+	if string(reply) != "pong" {
+		t.Fatalf("reply = %q", reply)
+	}
+	if err := <-backendDone; err != nil {
+		t.Fatalf("backend error: %v", err)
+	}
+	assertReceiptContains(t, receiptDir, "connect_allowed")
+}
+
+func TestHTTPConnectDeniedWritesReceipt(t *testing.T) {
+	client, server := net.Pipe()
+	defer client.Close()
+	receiptDir := t.TempDir()
+	p := &proxy{launchID: "launch-1", allowlist: []string{"openrouter.ai:443"}, receiptDir: receiptDir}
+	go p.handle(server)
+
+	clientReader := bufio.NewReader(client)
+	_, _ = client.Write([]byte("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n"))
+	response, err := http.ReadResponse(clientReader, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if response.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d", response.StatusCode)
+	}
+	assertReceiptContains(t, receiptDir, "destination_not_allowlisted")
+}
+
+func assertReceiptContains(t *testing.T, dir, text string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(data), text) {
+			return
+		}
+	}
+	t.Fatalf("no receipt in %s contained %q", dir, text)
 }


### PR DESCRIPTION
## Summary
- restore explicit HTTP(S)_PROXY injection for Docker local-container Launchpad egress sidecars
- teach the egress proxy to accept HTTP CONNECT while retaining transparent SO_ORIGINAL_DST mode for Kubernetes
- add CONNECT allow/deny receipt coverage and update local-container runtime expectations

## Evidence
- latest main launchpad-artifacts run 27450103912 built/signed all artifacts, including OpenClaw, but live conformance failed before promotion
- OpenClaw failure changed from Proxy CONNECT aborted to DNS resolution failure inside the internal Docker launch network, which shows the transparent-only local-container path cannot resolve provider hosts before TCP interception
- Hermes still has its separate Node.js 22/bootstrap DNS failure, so this PR targets the OpenClaw/local-container egress layer specifically

## Validation
- /Users/ivan/.local/share/mise/installs/go/1.22.12/bin/go test ./core/pkg/launchpad/runtime ./core/pkg/sandbox/docker ./tests/launchpad
- GOWORK=off /Users/ivan/.local/share/mise/installs/go/1.22.12/bin/go test ./...
- git diff --check