### PR TITLE
fix(launchpad): bake hermes node runtime

### DIFF
--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -76,6 +76,7 @@ framework_contract:
     runtime_install_policy: forbidden
     baked_dependencies:
         - python
+        - node
         - hermes-cli
         - launchpad-openrouter-check
     forbidden_runtime_install_patterns:
@@ -115,6 +116,7 @@ framework_contract:
           purpose: production_proof
           baked_dependencies:
               - python
+              - node
               - hermes-cli
         - name: hermes-eval-full
           image: ghcr.io/mindburn-labs/helm-launchpad/hermes-eval-full@sha256:b970c2308182384377670704f6769e200eef89e18cc1a1102de9cba0d2437527

--- a/tools/launchpad/artifacts/hermes.Dockerfile
+++ b/tools/launchpad/artifacts/hermes.Dockerfile
@@ -2,6 +2,8 @@
 
 # HELM-owned Hermes build recipe.
 # Build context: pinned upstream NousResearch/hermes-agent checkout.
+FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752 AS node
+
 FROM ghcr.io/astral-sh/uv:0.8.14-python3.12-bookworm@sha256:6f0e5c8496f34eba70f7f9f2e55d49e008b095d0395c16e3dda3437f95a2ec71 AS build
 
 WORKDIR /src/hermes
@@ -26,6 +28,11 @@ RUN apt-get update \
 
 COPY --from=build /src/hermes /opt/hermes
 COPY --from=build /licenses /licenses
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=node /usr/local/bin/corepack /usr/local/bin/corepack
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY .helm-launchpad-model-gateway-check.sh /usr/local/bin/helm-launchpad-model-gateway-check
 
 RUN <<'SH'


### PR DESCRIPTION
## Summary
- bake pinned Node.js 22 into the Hermes launchpad artifact image
- declare `node` as a Hermes baked dependency in the launchpad registry contract
- keep the local-container sidecar egress behavior from #345; this PR now carries only the remaining Hermes runtime bootstrap fix needed by the artifact workflow

## Evidence
- launchpad-artifacts run 27450103912 built/signed multi-arch manifests, then live conformance failed before promotion
- OpenClaw egress was fixed separately by #345 (`1b41082a`)
- Hermes still failed because it attempted to fetch Node.js 22 at runtime inside denied/receipted egress, so the image must carry Node before conformance can pass

## Validation
- `go test ./core/pkg/launchpad/... ./tests/launchpad`
- `git diff --check`
