### PR TITLE
fix(launchpad): repair local live gate egress

### DIFF
--- a/registry/launchkit/apps/openclaw/runtime.local.yaml
+++ b/registry/launchkit/apps/openclaw/runtime.local.yaml
@@ -14,7 +14,7 @@ command:
 healthcheck: helm-launchpad-openrouter-check
 mcp_registry_ref: mcp.registry.yaml
 provider_host_groups:
-  - model_gateway_byo
+  - openrouter
 egress_proxy_required: true
 timeout: 300s
 detached: true

--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -77,6 +77,7 @@ framework_contract:
     baked_dependencies:
         - python
         - node
+        - npm
         - hermes-cli
         - launchpad-openrouter-check
     forbidden_runtime_install_patterns:
@@ -117,6 +118,7 @@ framework_contract:
           baked_dependencies:
               - python
               - node
+              - npm
               - hermes-cli
         - name: hermes-eval-full
           image: ghcr.io/mindburn-labs/helm-launchpad/hermes-eval-full@sha256:b970c2308182384377670704f6769e200eef89e18cc1a1102de9cba0d2437527

--- a/registry/launchpad/apps/openclaw.yaml
+++ b/registry/launchpad/apps/openclaw.yaml
@@ -37,6 +37,8 @@ runtime:
 model_gateway:
     logical_secret: model_gateway
     provider: byo
+    provider_ids:
+        - openrouter
     mode: logical_binding_env_projection
     raw_provider_key_projected: true
 required_secrets:
@@ -94,7 +96,7 @@ framework_contract:
           purpose: app_cache_state
           required: true
     provider_host_groups:
-        - model_gateway_byo
+        - openrouter
     egress_proxy:
         required: true
         image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:395cd585d0e2345e649455953f0d7765b141440bfb2fc753a4ae944e2ba350f8

--- a/tests/launchpad/launchpad_conformance_test.go
+++ b/tests/launchpad/launchpad_conformance_test.go
@@ -73,8 +73,8 @@ func TestMissingModelSecretEscalates(t *testing.T) {
 		t.Fatalf("unexpected missing secret plan: %#v", compiled)
 	}
 	missing, ok := compiled.Nodes["missing_secret"].(string)
-	if !ok || missing != "one complete catalog-backed provider env group" {
-		t.Fatalf("missing model gateway must name catalog-backed BYO env set, got %#v", compiled.Nodes["missing_secret"])
+	if !ok || missing != "OPENROUTER_API_KEY" {
+		t.Fatalf("missing model gateway must name OpenRouter key, got %#v", compiled.Nodes["missing_secret"])
 	}
 }
 

--- a/tools/launchpad/artifacts/hermes.Dockerfile
+++ b/tools/launchpad/artifacts/hermes.Dockerfile
@@ -5,7 +5,6 @@
 FROM node:22-bookworm-slim@sha256:e21fc383b50d5347dc7a9f1cae45b8f4e2f0d39f7ade28e4eef7d2934522b752 AS node
 
 FROM ghcr.io/astral-sh/uv:0.8.14-python3.12-bookworm@sha256:6f0e5c8496f34eba70f7f9f2e55d49e008b095d0395c16e3dda3437f95a2ec71 AS build
-
 WORKDIR /src/hermes
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
@@ -29,9 +28,6 @@ RUN apt-get update \
 COPY --from=build /src/hermes /opt/hermes
 COPY --from=build /licenses /licenses
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
-COPY --from=node /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node /usr/local/bin/corepack /usr/local/bin/corepack
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY .helm-launchpad-model-gateway-check.sh /usr/local/bin/helm-launchpad-model-gateway-check
 
@@ -43,6 +39,10 @@ set -eu
 exec python /opt/hermes/cli.py "$@"
 HERMES
 ln -sf /usr/local/bin/helm-launchpad-model-gateway-check /usr/local/bin/helm-launchpad-openrouter-check
+ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+ln -sf ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+node --version | grep -Eq '^v22\.'
+npm --version >/dev/null
 chmod 0755 /usr/local/bin/hermes /usr/local/bin/helm-launchpad-model-gateway-check
 chown -R helm:helm /opt/hermes /licenses
 SH


### PR DESCRIPTION
## Summary
- route Docker sidecar local-container traffic through explicit HTTP(S)_PROXY env instead of the Kubernetes-only transparent egress marker
- bind OpenClaw live-gate provider metadata to OpenRouter so the compiled missing-secret and allowlist truth match the healthcheck/runtime path
- bake Node 22/npm into the Hermes artifact image so the live gate does not try to fetch Node at runtime behind the fail-closed egress proxy

## Validation
- `git diff --check`
- `env -u GOROOT /usr/local/go/bin/go test ./core/pkg/launchpad/runtime ./core/pkg/launchpad/plan ./core/pkg/launchpad/registry ./core/pkg/launchpad/conformance ./core/pkg/launchpad/modelproviders ./tests/launchpad`
- `bash -n scripts/ci/launchpad_k8s_smoke.sh scripts/ci/helm_chart_smoke.sh`
- `env -u GOROOT PATH="/usr/local/go/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" make launchpad-promotion-check`
- `docker build -f tools/launchpad/artifacts/hermes.Dockerfile -t helm-launchpad-hermes:offline-node-test /tmp/hermes-agent-v2026.5.16`
- `docker run --rm --entrypoint sh helm-launchpad-hermes:offline-node-test -lc 'set -eu; node --version; npm --version; command -v hermes; command -v helm-launchpad-openrouter-check; command -v helm-launchpad-model-gateway-check'`

## Notes
This follows the failed main Launchpad Artifacts run after native arm64 artifact publishing: OpenClaw attempted direct DNS instead of the sidecar proxy, and Hermes attempted to fetch Node at runtime. This PR keeps the live gate offline-safe and fail-closed.
