### PR TITLE
ci(launchpad): promote signed launchpad image refs

### DIFF
--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -309,7 +309,7 @@ launchpadApps:
     enabled: false
     image:
       repository: "ghcr.io/mindburn-labs/helm-launchpad/openclaw"
-      digest: "sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b"
+      digest: "sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d"
       pullPolicy: "IfNotPresent"
     gatewayPort: 18789
     tmpfsSize: "256Mi"
@@ -337,7 +337,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e"
+        digest: "sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:
@@ -354,7 +354,7 @@ launchpadApps:
     enabled: false
     image:
       repository: "ghcr.io/mindburn-labs/helm-launchpad/hermes"
-      digest: "sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c"
+      digest: "sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b"
       pullPolicy: "IfNotPresent"
     # job runs the proven single-query smoke path; deployment runs the
     # long-lived Hermes gateway process. Gateway mode is not live-F2-promoted
@@ -382,7 +382,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e"
+        digest: "sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:

--- a/registry/launchkit/apps/hermes/helm.app.yaml
+++ b/registry/launchkit/apps/hermes/helm.app.yaml
@@ -5,8 +5,8 @@ legacy_launchpad_ref: registry/launchpad/apps/hermes.yaml
 availability: oss_supported
 install:
   strategy: signed_oci
-  image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
-  digest: sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
+  image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+  digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
 policy: policy.default.yaml
 secrets: secrets.schema.yaml
 mcp_registry: mcp.registry.yaml

--- a/registry/launchkit/apps/openclaw/helm.app.yaml
+++ b/registry/launchkit/apps/openclaw/helm.app.yaml
@@ -5,8 +5,8 @@ legacy_launchpad_ref: registry/launchpad/apps/openclaw.yaml
 availability: oss_supported
 install:
   strategy: signed_oci
-  image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
-  digest: sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
+  image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+  digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
 policy: policy.default.yaml
 secrets: secrets.schema.yaml
 mcp_registry: mcp.registry.yaml

--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -10,8 +10,8 @@ availability: oss_supported
 support_level: agent_live
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
-    digest: sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
+    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
     source: https://github.com/NousResearch/hermes-agent
     ref: v2026.5.16
 runtime:
@@ -83,9 +83,9 @@ framework_contract:
         - openrouter
     egress_proxy:
         required: true
-        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e
-        digest: sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e
-        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e
+        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
+        digest: sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
+        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
         sbom_ref: artifact://sbom-egress-proxy.spdx.json
         vulnerability_scan_ref: artifact://grype-egress-proxy.json
         receipt_ref: receipts/launchpad-egress-proxy.json
@@ -95,14 +95,14 @@ framework_contract:
     evidence_profile: f2.contract.v1
     images:
         - name: hermes-production-minimal
-          image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
-          digest: sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
+          image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+          digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
           purpose: production_proof
           baked_dependencies:
-              - python
-              - node
-              - npm
-              - hermes-cli
+            - python
+            - node
+            - npm
+            - hermes-cli
         - name: hermes-eval-full
           image: ghcr.io/mindburn-labs/helm-launchpad/hermes-eval-full@sha256:b970c2308182384377670704f6769e200eef89e18cc1a1102de9cba0d2437527
           digest: sha256:b970c2308182384377670704f6769e200eef89e18cc1a1102de9cba0d2437527
@@ -145,18 +145,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
+    artifact_digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
     sbom_tool: syft
     sbom_ref: artifact://sbom-hermes.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-hermes.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://27452168072/1/artifact-verification/hermes
-    live_e2e_run_id: github-actions://27452168072/1/live-e2e/hermes
-    evidence_pack_ref: github-actions://27452168072/1/evidencepack/hermes
-    teardown_receipt_ref: github-actions://27452168072/1/teardown/hermes
+    artifact_verification_ref: github-actions://27452635722/1/artifact-verification/hermes
+    live_e2e_run_id: github-actions://27452635722/1/live-e2e/hermes
+    evidence_pack_ref: github-actions://27452635722/1/evidencepack/hermes
+    teardown_receipt_ref: github-actions://27452635722/1/teardown/hermes
 conformance:
     license_verified: true
     artifact_verified: true
@@ -168,12 +168,12 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://27452168072/1
+    artifact_workflow_run: github-actions://27452635722/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/hermes:v2026.5.16
     latest_release: v2026.5.16
-    promotion_manifest_hash: sha256:6a074a9c3330eef2b2a06a22c4bcc465e8846103a9eca1a74f3bcf8f78baf6d8
-    promotion_provenance_ref: github-actions://27452168072/1
+    promotion_manifest_hash: sha256:4568b71645177bdc95a831e3c09bd25fd6cc65cb80cb0254650863395b717e1e
+    promotion_provenance_ref: github-actions://27452635722/1
     release_published_at: "2026-05-16T09:59:15Z"
     upstream_commit: a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
     upstream_repo: https://github.com/NousResearch/hermes-agent

--- a/registry/launchpad/apps/openclaw.yaml
+++ b/registry/launchpad/apps/openclaw.yaml
@@ -10,8 +10,8 @@ availability: oss_supported
 support_level: agent_live
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
-    digest: sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
+    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+    digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
     source: https://github.com/openclaw/openclaw
     ref: v2026.5.12
 runtime:
@@ -89,9 +89,9 @@ framework_contract:
         - openrouter
     egress_proxy:
         required: true
-        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e
-        digest: sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e
-        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e
+        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
+        digest: sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
+        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
         sbom_ref: artifact://sbom-egress-proxy.spdx.json
         vulnerability_scan_ref: artifact://grype-egress-proxy.json
         receipt_ref: receipts/launchpad-egress-proxy.json
@@ -101,8 +101,8 @@ framework_contract:
     evidence_profile: f2.contract.v1
     images:
         - name: openclaw-production
-          image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
-          digest: sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
+          image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+          digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
           purpose: production_proof
           baked_dependencies:
             - openclaw-cli
@@ -139,18 +139,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
+    artifact_digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
     sbom_tool: syft
     sbom_ref: artifact://sbom-openclaw.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-openclaw.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://27452168072/1/artifact-verification/openclaw
-    live_e2e_run_id: github-actions://27452168072/1/live-e2e/openclaw
-    evidence_pack_ref: github-actions://27452168072/1/evidencepack/openclaw
-    teardown_receipt_ref: github-actions://27452168072/1/teardown/openclaw
+    artifact_verification_ref: github-actions://27452635722/1/artifact-verification/openclaw
+    live_e2e_run_id: github-actions://27452635722/1/live-e2e/openclaw
+    evidence_pack_ref: github-actions://27452635722/1/evidencepack/openclaw
+    teardown_receipt_ref: github-actions://27452635722/1/teardown/openclaw
 conformance:
     license_verified: true
     artifact_verified: true
@@ -162,12 +162,12 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://27452168072/1
+    artifact_workflow_run: github-actions://27452635722/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/openclaw:v2026.5.12
     latest_release: v2026.5.12
-    promotion_manifest_hash: sha256:6a074a9c3330eef2b2a06a22c4bcc465e8846103a9eca1a74f3bcf8f78baf6d8
-    promotion_provenance_ref: github-actions://27452168072/1
+    promotion_manifest_hash: sha256:4568b71645177bdc95a831e3c09bd25fd6cc65cb80cb0254650863395b717e1e
+    promotion_provenance_ref: github-actions://27452635722/1
     release_published_at: "2026-05-14T18:28:04Z"
     upstream_commit: f066dd2f31c231f38fbcaacd6f6dfce0801143b3
     upstream_repo: https://github.com/openclaw/openclaw

--- a/registry/launchpad/image-lock.json
+++ b/registry/launchpad/image-lock.json
@@ -8,27 +8,27 @@
     {
       "name": "openclaw",
       "role": "launchpad_app",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/openclaw",
-      "digest": "sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b",
+      "digest": "sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d",
       "source": "registry/launchpad/apps/openclaw.yaml",
       "preload": true
     },
     {
       "name": "hermes",
       "role": "launchpad_app",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/hermes",
-      "digest": "sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c",
+      "digest": "sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b",
       "source": "registry/launchpad/apps/hermes.yaml",
       "preload": true
     },
     {
       "name": "egress-proxy",
       "role": "egress_proxy",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy",
-      "digest": "sha256:d7b158b86bf34bfd36e13fa65f5d916de07acdf842295e653bbe8fa2721f7c9e",
+      "digest": "sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17",
       "source": "registry/launchpad/apps/openclaw.yaml",
       "preload": true
     }

--- a/registry/launchpad/mcp/hermes.default.yaml
+++ b/registry/launchpad/mcp/hermes.default.yaml
@@ -3,8 +3,8 @@ app_id: hermes
 server_id: hermes-default
 transport: stdio
 command: ["hermes", "mcp", "serve"]
-package_digest: sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
-signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:069cad233553951ff14fb1acc4adca31d19810ae1509c465a9155403cee67b0c
+package_digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
 schema_hash: sha256:2222222222222222222222222222222222222222222222222222222222222222
 tools:
   - name: model_gateway.complete

--- a/registry/launchpad/mcp/openclaw.default.yaml
+++ b/registry/launchpad/mcp/openclaw.default.yaml
@@ -3,8 +3,8 @@ app_id: openclaw
 server_id: openclaw-default
 transport: stdio
 command: ["openclaw", "mcp", "serve"]
-package_digest: sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
-signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:271ed3e7c1333f8946b3796d31220b3fcd0d6dcd2cef9b53f16bcda118dd843b
+package_digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
 schema_hash: sha256:1111111111111111111111111111111111111111111111111111111111111111
 tools:
   - name: model_gateway.complete


### PR DESCRIPTION
Automated Launchpad promotion from verified CI manifest, opened manually because GitHub Actions pushed the branch but was blocked from creating the PR (`createPullRequest` permission denied).

Source SHA: `2e614e217ea5ed1da9ecf8fa2b2517dedc94f417`
Source tree SHA256: `sha256:60602acbbedede11712bbcecb04dc0022e9e220e5ab8ff81fa9d4e425553a440`
Workflow ref: `Mindburn-Labs/helm-ai-kernel/.github/workflows/launchpad-artifacts.yml@refs/heads/main`
Workflow run: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/27452635722
Promotion manifest hash: `sha256:4568b71645177bdc95a831e3c09bd25fd6cc65cb80cb0254650863395b717e1e`

## Image refs
| component | image | digest | provenance |
| --- | --- | --- | --- |
| openclaw | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d` | `sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d` | `github-actions://27452635722/1/artifact-verification/openclaw` |
| hermes | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b` | `sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b` | `github-actions://27452635722/1/artifact-verification/hermes` |
| egress-proxy | `ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17` | `sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17` | `github-actions://27452635722/1/egress-proxy` |

## Validation
- `launchpad-artifacts.yml` run 27452635722: image builds/signing passed; live BYO model-provider local-container conformance passed in 3m44s; final workflow failed only when GitHub Actions could not create this PR.
- `go test ./core/pkg/launchpad/... ./tests/launchpad`
- `make launchpad-promotion-check`
- `git diff --check origin/main...HEAD`

This PR also syncs the OpenClaw/Hermes MCP package digests and LaunchKit mirror refs to the promoted package digests so registry validation remains internally consistent.
