### PR TITLE
fix(launchpad): keep helm test logs available

### DIFF
--- a/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
+++ b/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: test
   annotations:
     helm.sh/hook: test
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-delete-policy: before-hook-creation
     helm.ai/test-intent: "kernel health + launchpad-app Pod presence"
 spec:
   restartPolicy: Never


### PR DESCRIPTION
## Summary
- keep the Launchpad connectivity Helm test pod until the next hook creation instead of deleting it immediately on success
- prevents `helm test --logs` from failing after a successful test phase when Helm races the hook-succeeded cleanup

## Evidence
- Main post-merge Helm Integration run 27453872952: positive OpenClaw/Hermes smoke reached OpenClaw Ready, Hermes Job Complete, and Helm test Phase Succeeded, then failed on `unable to get pod logs ... pod not found`
- Local: `go test ./tests/launchpad`
- Local: `git diff --check`

## Notes
- Local Kubernetes Helm v3 is not installed in this shell; `helm` resolves to the HELM verifier, so chart render/lint is delegated to CI's pinned Helm v3 path.
