### PR TITLE
fix(launchpad): sync promotion-derived refs

### DIFF
--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -951,10 +951,15 @@ jobs:
             --sync-derived \
             --check \
             --json | tee "${result}"
+          make launchpad-promotion-check
 
           changed_paths=(
             registry/launchpad/apps/openclaw.yaml
             registry/launchpad/apps/hermes.yaml
+            registry/launchkit/apps/openclaw/helm.app.yaml
+            registry/launchkit/apps/hermes/helm.app.yaml
+            registry/launchpad/mcp/openclaw.default.yaml
+            registry/launchpad/mcp/hermes.default.yaml
             registry/launchpad/image-lock.json
             deploy/helm-chart/values.yaml
           )

--- a/core/pkg/launchpad/promotion/derived.go
+++ b/core/pkg/launchpad/promotion/derived.go
@@ -61,7 +61,13 @@ func SyncDerived(root string, apps []registry.AppSpec) error {
 	if err := WriteImageLock(root, apps); err != nil {
 		return err
 	}
-	return SyncHelmValues(root, apps)
+	if err := SyncHelmValues(root, apps); err != nil {
+		return err
+	}
+	if err := SyncLaunchKitSpecs(root, apps); err != nil {
+		return err
+	}
+	return SyncMCPManifests(root, apps)
 }
 
 func CheckDerived(root string, apps []registry.AppSpec) []string {
@@ -73,6 +79,12 @@ func CheckDerived(root string, apps []registry.AppSpec) []string {
 		drifts = append(drifts, err.Error())
 	}
 	if err := CheckHelmValues(root, apps); err != nil {
+		drifts = append(drifts, err.Error())
+	}
+	if err := CheckLaunchKitSpecs(root, apps); err != nil {
+		drifts = append(drifts, err.Error())
+	}
+	if err := CheckMCPManifests(root, apps); err != nil {
 		drifts = append(drifts, err.Error())
 	}
 	if err := CheckSmokeScriptUsesImageLock(root); err != nil {
@@ -252,6 +264,108 @@ func CheckHelmValues(root string, apps []registry.AppSpec) error {
 				return fmt.Errorf("helm values drift for %s egress sidecar: got %s@%s want %s@%s", app.ID, chartApp.EgressSidecar.Image.Repository, chartApp.EgressSidecar.Image.Digest, proxyRepo, proxy.Digest)
 			}
 		}
+	}
+	return nil
+}
+
+type derivedLaunchKitAppSpec struct {
+	ID                 string               `yaml:"id"`
+	Name               string               `yaml:"name"`
+	Version            string               `yaml:"version"`
+	LegacyLaunchpadRef string               `yaml:"legacy_launchpad_ref"`
+	Availability       string               `yaml:"availability"`
+	Install            registry.InstallSpec `yaml:"install"`
+	Policy             string               `yaml:"policy"`
+	Secrets            string               `yaml:"secrets"`
+	MCPRegistry        string               `yaml:"mcp_registry"`
+	Runtimes           map[string]string    `yaml:"runtimes"`
+	EvidenceProfile    string               `yaml:"evidence_profile"`
+}
+
+func SyncLaunchKitSpecs(root string, apps []registry.AppSpec) error {
+	if !exists(launchKitRoot(root)) {
+		return nil
+	}
+	for _, app := range apps {
+		path := launchKitAppPath(root, app.ID)
+		var spec derivedLaunchKitAppSpec
+		if err := readYAMLFile(path, &spec); err != nil {
+			return fmt.Errorf("registry/launchkit/apps/%s/helm.app.yaml missing or unreadable: %w", app.ID, err)
+		}
+		spec.Availability = string(app.Availability)
+		spec.Install = app.Install
+		if err := writeYAMLFile(path, spec); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func CheckLaunchKitSpecs(root string, apps []registry.AppSpec) error {
+	if !exists(launchKitRoot(root)) {
+		return nil
+	}
+	var drifts []string
+	for _, app := range apps {
+		path := launchKitAppPath(root, app.ID)
+		var spec derivedLaunchKitAppSpec
+		if err := readYAMLFile(path, &spec); err != nil {
+			drifts = append(drifts, fmt.Sprintf("registry/launchkit/apps/%s/helm.app.yaml missing or unreadable: %v", app.ID, err))
+			continue
+		}
+		if spec.Availability != string(app.Availability) {
+			drifts = append(drifts, fmt.Sprintf("app %s LaunchKit availability drift: got %s want %s", app.ID, spec.Availability, app.Availability))
+		}
+		if spec.Install.Strategy != app.Install.Strategy || spec.Install.Image != app.Install.Image || spec.Install.Digest != app.Install.Digest {
+			drifts = append(drifts, fmt.Sprintf("app %s LaunchKit install drift: got %s/%s/%s want %s/%s/%s", app.ID, spec.Install.Strategy, spec.Install.Image, spec.Install.Digest, app.Install.Strategy, app.Install.Image, app.Install.Digest))
+		}
+	}
+	if len(drifts) > 0 {
+		return fmt.Errorf("registry/launchkit drift: %s", strings.Join(drifts, "; "))
+	}
+	return nil
+}
+
+func SyncMCPManifests(root string, apps []registry.AppSpec) error {
+	for _, app := range apps {
+		for _, ref := range app.MCPManifests {
+			path := mcpManifestPath(root, ref)
+			var manifest registry.MCPServerManifest
+			if err := readYAMLFile(path, &manifest); err != nil {
+				return fmt.Errorf("registry/launchpad/mcp/%s.yaml missing or unreadable: %w", ref, err)
+			}
+			manifest.PackageDigest = app.Install.Digest
+			if app.SupplyChainEvidence.SignatureRef != "" {
+				manifest.SignatureRef = app.SupplyChainEvidence.SignatureRef
+			}
+			if err := writeYAMLFile(path, manifest); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func CheckMCPManifests(root string, apps []registry.AppSpec) error {
+	var drifts []string
+	for _, app := range apps {
+		for _, ref := range app.MCPManifests {
+			path := mcpManifestPath(root, ref)
+			var manifest registry.MCPServerManifest
+			if err := readYAMLFile(path, &manifest); err != nil {
+				drifts = append(drifts, fmt.Sprintf("registry/launchpad/mcp/%s.yaml missing or unreadable: %v", ref, err))
+				continue
+			}
+			if manifest.PackageDigest != app.Install.Digest {
+				drifts = append(drifts, fmt.Sprintf("app %s MCP manifest %q package_digest drift: got %s want %s", app.ID, ref, manifest.PackageDigest, app.Install.Digest))
+			}
+			if app.SupplyChainEvidence.SignatureRef != "" && manifest.SignatureRef != app.SupplyChainEvidence.SignatureRef {
+				drifts = append(drifts, fmt.Sprintf("app %s MCP manifest %q signature_ref drift: got %s want %s", app.ID, ref, manifest.SignatureRef, app.SupplyChainEvidence.SignatureRef))
+			}
+		}
+	}
+	if len(drifts) > 0 {
+		return fmt.Errorf("registry/launchpad/mcp drift: %s", strings.Join(drifts, "; "))
 	}
 	return nil
 }
@@ -495,4 +609,40 @@ func imageLockPath(root string) string {
 
 func helmValuesPath(root string) string {
 	return filepath.Join(root, "deploy", "helm-chart", "values.yaml")
+}
+
+func launchKitRoot(root string) string {
+	return filepath.Join(root, "registry", "launchkit", "apps")
+}
+
+func launchKitAppPath(root, appID string) string {
+	return filepath.Join(launchKitRoot(root), appID, "helm.app.yaml")
+}
+
+func mcpManifestPath(root, ref string) string {
+	return filepath.Join(root, "registry", "launchpad", "mcp", ref+".yaml")
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func readYAMLFile(path string, out any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("parse error: %w", err)
+	}
+	return nil
+}
+
+func writeYAMLFile(path string, value any) error {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
 }

--- a/core/pkg/launchpad/promotion/manifest_test.go
+++ b/core/pkg/launchpad/promotion/manifest_test.go
@@ -103,7 +103,7 @@ func TestPromoteBindsRunBuiltEgressProxyArtifact(t *testing.T) {
 	}
 }
 
-func TestSyncDerivedWritesImageLockAndHelmValues(t *testing.T) {
+func TestSyncDerivedWritesImageLockHelmValuesLaunchKitAndMCP(t *testing.T) {
 	root := t.TempDir()
 	apps := []registry.AppSpec{
 		promotedAppForDerived(t, "openclaw"),
@@ -136,10 +136,26 @@ func TestSyncDerivedWritesImageLockAndHelmValues(t *testing.T) {
 		if !strings.Contains(string(values), app.Install.Digest) {
 			t.Fatalf("values.yaml missing digest for %s: %s", app.ID, values)
 		}
+		launchKit, err := os.ReadFile(filepath.Join(root, "registry", "launchkit", "apps", app.ID, "helm.app.yaml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(launchKit), app.Install.Image) || !strings.Contains(string(launchKit), app.Install.Digest) {
+			t.Fatalf("LaunchKit spec missing promoted ref for %s: %s", app.ID, launchKit)
+		}
+		for _, ref := range app.MCPManifests {
+			manifest, err := os.ReadFile(filepath.Join(root, "registry", "launchpad", "mcp", ref+".yaml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(manifest), app.Install.Digest) || !strings.Contains(string(manifest), app.SupplyChainEvidence.SignatureRef) {
+				t.Fatalf("MCP manifest missing promoted ref for %s: %s", app.ID, manifest)
+			}
+		}
 	}
 }
 
-func TestCheckDerivedDetectsImageLockValuesAndSmokeDrift(t *testing.T) {
+func TestCheckDerivedDetectsImageLockValuesLaunchKitMCPAndSmokeDrift(t *testing.T) {
 	root := t.TempDir()
 	apps := []registry.AppSpec{
 		promotedAppForDerived(t, "openclaw"),
@@ -154,11 +170,11 @@ func TestCheckDerivedDetectsImageLockValuesAndSmokeDrift(t *testing.T) {
 	}
 
 	drifts := CheckDerived(root, apps)
-	if len(drifts) < 3 {
-		t.Fatalf("CheckDerived drifts = %v, want image-lock, values, and smoke drift", drifts)
+	if len(drifts) < 5 {
+		t.Fatalf("CheckDerived drifts = %v, want image-lock, values, LaunchKit, MCP, and smoke drift", drifts)
 	}
 	joined := strings.Join(drifts, "\n")
-	for _, want := range []string{"image-lock.json drift", "helm values drift", "hard-coded launchpad image digest"} {
+	for _, want := range []string{"image-lock.json drift", "helm values drift", "registry/launchkit drift", "registry/launchpad/mcp drift", "hard-coded launchpad image digest"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("CheckDerived missing %q in %v", want, drifts)
 		}
@@ -283,6 +299,7 @@ func candidateApp(id string) registry.AppSpec {
 			Strategy: "signed_oci",
 			Image:    "ghcr.io/mindburn-labs/helm-launchpad/" + id + ":candidate",
 		},
+		MCPManifests:         []string{id + ".default"},
 		EvidenceRequirements: []string{"cpi_output"},
 		Conformance: registry.ConformanceSpec{
 			LicenseVerified:   true,
@@ -365,6 +382,14 @@ func writeDerivedFixture(t *testing.T, root, digest string, hardCodedSmoke bool)
 	if err := os.MkdirAll(filepath.Join(root, "scripts", "ci"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	for _, appID := range []string{"openclaw", "hermes"} {
+		if err := os.MkdirAll(filepath.Join(root, "registry", "launchkit", "apps", appID), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(root, "registry", "launchpad", "mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	values := `launchpadApps:
   openclaw:
     image:
@@ -385,6 +410,45 @@ func writeDerivedFixture(t *testing.T, root, digest string, hardCodedSmoke bool)
 `
 	if err := os.WriteFile(filepath.Join(root, "deploy", "helm-chart", "values.yaml"), []byte(values), 0o644); err != nil {
 		t.Fatal(err)
+	}
+	for _, appID := range []string{"openclaw", "hermes"} {
+		spec := `id: ` + appID + `
+name: ` + appID + `
+version: v0.0.0
+legacy_launchpad_ref: registry/launchpad/apps/` + appID + `.yaml
+availability: oss_supported
+install:
+  strategy: signed_oci
+  image: ghcr.io/mindburn-labs/helm-launchpad/` + appID + `@` + digest + `
+  digest: ` + digest + `
+policy: policy.default.yaml
+secrets: secrets.schema.yaml
+mcp_registry: mcp.registry.yaml
+runtimes:
+  demo: runtime.demo.yaml
+  local: runtime.local.yaml
+  cloud: runtime.cloud.yaml
+evidence_profile: evidence.profile.yaml
+`
+		if err := os.WriteFile(filepath.Join(root, "registry", "launchkit", "apps", appID, "helm.app.yaml"), []byte(spec), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		mcp := `id: ` + appID + `.default
+app_id: ` + appID + `
+server_id: ` + appID + `-default
+transport: stdio
+command: ["` + appID + `", "mcp", "serve"]
+package_digest: ` + digest + `
+signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/` + appID + `@` + digest + `
+schema_hash: sha256:` + strings.Repeat("1", 64) + `
+tools:
+  - name: model_gateway.complete
+    schema_hash: sha256:` + strings.Repeat("2", 64) + `
+    effect: side_effect
+`
+		if err := os.WriteFile(filepath.Join(root, "registry", "launchpad", "mcp", appID+".default.yaml"), []byte(mcp), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	script := "#!/usr/bin/env bash\nIMAGE_LOCK=\"${ROOT}/registry/launchpad/image-lock.json\"\n"
 	if hardCodedSmoke {

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -307,7 +307,7 @@ launchpadApps:
     enabled: false
     image:
       repository: "ghcr.io/mindburn-labs/helm-launchpad/openclaw"
-      digest: "sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d"
+      digest: "sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463"
       pullPolicy: "IfNotPresent"
     gatewayPort: 18789
     tmpfsSize: "256Mi"
@@ -335,7 +335,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17"
+        digest: "sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:
@@ -380,7 +380,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17"
+        digest: "sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:

--- a/registry/launchkit/apps/hermes/helm.app.yaml
+++ b/registry/launchkit/apps/hermes/helm.app.yaml
@@ -4,14 +4,16 @@ version: v2026.5.16
 legacy_launchpad_ref: registry/launchpad/apps/hermes.yaml
 availability: oss_supported
 install:
-  strategy: signed_oci
-  image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
-  digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    strategy: signed_oci
+    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    source: https://github.com/NousResearch/hermes-agent
+    ref: v2026.5.16
 policy: policy.default.yaml
 secrets: secrets.schema.yaml
 mcp_registry: mcp.registry.yaml
 runtimes:
-  demo: runtime.demo.yaml
-  local: runtime.local.yaml
-  cloud: runtime.cloud.yaml
+    cloud: runtime.cloud.yaml
+    demo: runtime.demo.yaml
+    local: runtime.local.yaml
 evidence_profile: evidence.profile.yaml

--- a/registry/launchkit/apps/openclaw/helm.app.yaml
+++ b/registry/launchkit/apps/openclaw/helm.app.yaml
@@ -4,14 +4,16 @@ version: v2026.5.12
 legacy_launchpad_ref: registry/launchpad/apps/openclaw.yaml
 availability: oss_supported
 install:
-  strategy: signed_oci
-  image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
-  digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+    strategy: signed_oci
+    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+    digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+    source: https://github.com/openclaw/openclaw
+    ref: v2026.5.12
 policy: policy.default.yaml
 secrets: secrets.schema.yaml
 mcp_registry: mcp.registry.yaml
 runtimes:
-  demo: runtime.demo.yaml
-  local: runtime.local.yaml
-  cloud: runtime.cloud.yaml
+    cloud: runtime.cloud.yaml
+    demo: runtime.demo.yaml
+    local: runtime.local.yaml
 evidence_profile: evidence.profile.yaml

--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -83,9 +83,9 @@ framework_contract:
         - openrouter
     egress_proxy:
         required: true
-        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
-        digest: sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
-        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
+        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
+        digest: sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
+        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
         sbom_ref: artifact://sbom-egress-proxy.spdx.json
         vulnerability_scan_ref: artifact://grype-egress-proxy.json
         receipt_ref: receipts/launchpad-egress-proxy.json
@@ -153,10 +153,10 @@ supply_chain_evidence:
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-hermes.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://27452635722/1/artifact-verification/hermes
-    live_e2e_run_id: github-actions://27452635722/1/live-e2e/hermes
-    evidence_pack_ref: github-actions://27452635722/1/evidencepack/hermes
-    teardown_receipt_ref: github-actions://27452635722/1/teardown/hermes
+    artifact_verification_ref: github-actions://27453055635/1/artifact-verification/hermes
+    live_e2e_run_id: github-actions://27453055635/1/live-e2e/hermes
+    evidence_pack_ref: github-actions://27453055635/1/evidencepack/hermes
+    teardown_receipt_ref: github-actions://27453055635/1/teardown/hermes
 conformance:
     license_verified: true
     artifact_verified: true
@@ -168,12 +168,12 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://27452635722/1
+    artifact_workflow_run: github-actions://27453055635/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/hermes:v2026.5.16
     latest_release: v2026.5.16
-    promotion_manifest_hash: sha256:4568b71645177bdc95a831e3c09bd25fd6cc65cb80cb0254650863395b717e1e
-    promotion_provenance_ref: github-actions://27452635722/1
+    promotion_manifest_hash: sha256:ee6a7acb4f0963e1414973138ef02ee3a5e16ff79f501b63f3455e5bc0fadcd1
+    promotion_provenance_ref: github-actions://27453055635/1
     release_published_at: "2026-05-16T09:59:15Z"
     upstream_commit: a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
     upstream_repo: https://github.com/NousResearch/hermes-agent

--- a/registry/launchpad/apps/openclaw.yaml
+++ b/registry/launchpad/apps/openclaw.yaml
@@ -10,8 +10,8 @@ availability: oss_supported
 support_level: agent_live
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
-    digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+    digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
     source: https://github.com/openclaw/openclaw
     ref: v2026.5.12
 runtime:
@@ -89,9 +89,9 @@ framework_contract:
         - openrouter
     egress_proxy:
         required: true
-        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
-        digest: sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
-        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17
+        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
+        digest: sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
+        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
         sbom_ref: artifact://sbom-egress-proxy.spdx.json
         vulnerability_scan_ref: artifact://grype-egress-proxy.json
         receipt_ref: receipts/launchpad-egress-proxy.json
@@ -101,8 +101,8 @@ framework_contract:
     evidence_profile: f2.contract.v1
     images:
         - name: openclaw-production
-          image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
-          digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+          image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+          digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
           purpose: production_proof
           baked_dependencies:
             - openclaw-cli
@@ -139,18 +139,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+    artifact_digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
     sbom_tool: syft
     sbom_ref: artifact://sbom-openclaw.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-openclaw.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://27452635722/1/artifact-verification/openclaw
-    live_e2e_run_id: github-actions://27452635722/1/live-e2e/openclaw
-    evidence_pack_ref: github-actions://27452635722/1/evidencepack/openclaw
-    teardown_receipt_ref: github-actions://27452635722/1/teardown/openclaw
+    artifact_verification_ref: github-actions://27453055635/1/artifact-verification/openclaw
+    live_e2e_run_id: github-actions://27453055635/1/live-e2e/openclaw
+    evidence_pack_ref: github-actions://27453055635/1/evidencepack/openclaw
+    teardown_receipt_ref: github-actions://27453055635/1/teardown/openclaw
 conformance:
     license_verified: true
     artifact_verified: true
@@ -162,12 +162,12 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://27452635722/1
+    artifact_workflow_run: github-actions://27453055635/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/openclaw:v2026.5.12
     latest_release: v2026.5.12
-    promotion_manifest_hash: sha256:4568b71645177bdc95a831e3c09bd25fd6cc65cb80cb0254650863395b717e1e
-    promotion_provenance_ref: github-actions://27452635722/1
+    promotion_manifest_hash: sha256:ee6a7acb4f0963e1414973138ef02ee3a5e16ff79f501b63f3455e5bc0fadcd1
+    promotion_provenance_ref: github-actions://27453055635/1
     release_published_at: "2026-05-14T18:28:04Z"
     upstream_commit: f066dd2f31c231f38fbcaacd6f6dfce0801143b3
     upstream_repo: https://github.com/openclaw/openclaw

--- a/registry/launchpad/image-lock.json
+++ b/registry/launchpad/image-lock.json
@@ -8,9 +8,9 @@
     {
       "name": "openclaw",
       "role": "launchpad_app",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/openclaw",
-      "digest": "sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d",
+      "digest": "sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463",
       "source": "registry/launchpad/apps/openclaw.yaml",
       "preload": true
     },
@@ -26,9 +26,9 @@
     {
       "name": "egress-proxy",
       "role": "egress_proxy",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy",
-      "digest": "sha256:3dd670b2ba65ab766ec897bc649251ce54580715ff0108f9f10ff8395af73a17",
+      "digest": "sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce",
       "source": "registry/launchpad/apps/openclaw.yaml",
       "preload": true
     }

--- a/registry/launchpad/mcp/hermes.default.yaml
+++ b/registry/launchpad/mcp/hermes.default.yaml
@@ -2,17 +2,29 @@ id: hermes.default
 app_id: hermes
 server_id: hermes-default
 transport: stdio
-command: ["hermes", "mcp", "serve"]
+command:
+    - hermes
+    - mcp
+    - serve
 package_digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
 signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
 schema_hash: sha256:2222222222222222222222222222222222222222222222222222222222222222
 tools:
-  - name: model_gateway.complete
-    schema_hash: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
-    effect: side_effect
-    description: Model gateway request mediated by HELM policy and receipts.
-    labels: ["model", "egress"]
-effect_labels: ["model", "egress", "side_effect"]
-required_secrets: ["model_gateway"]
-network_grants: ["catalog:model-providers"]
-filesystem_grants: ["workspace:rw", "app_state:rw"]
+    - name: model_gateway.complete
+      schema_hash: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      effect: side_effect
+      description: Model gateway request mediated by HELM policy and receipts.
+      labels:
+        - model
+        - egress
+effect_labels:
+    - model
+    - egress
+    - side_effect
+required_secrets:
+    - model_gateway
+network_grants:
+    - catalog:model-providers
+filesystem_grants:
+    - workspace:rw
+    - app_state:rw

--- a/registry/launchpad/mcp/openclaw.default.yaml
+++ b/registry/launchpad/mcp/openclaw.default.yaml
@@ -2,17 +2,29 @@ id: openclaw.default
 app_id: openclaw
 server_id: openclaw-default
 transport: stdio
-command: ["openclaw", "mcp", "serve"]
-package_digest: sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
-signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:5a80f884f7615a232971cfebed95cbc5322452a04de4519afa12e57409f9a12d
+command:
+    - openclaw
+    - mcp
+    - serve
+package_digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
 schema_hash: sha256:1111111111111111111111111111111111111111111111111111111111111111
 tools:
-  - name: model_gateway.complete
-    schema_hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    effect: side_effect
-    description: Model gateway request mediated by HELM policy and receipts.
-    labels: ["model", "egress"]
-effect_labels: ["model", "egress", "side_effect"]
-required_secrets: ["model_gateway"]
-network_grants: ["catalog:model-providers"]
-filesystem_grants: ["workspace:rw", "app_state:rw"]
+    - name: model_gateway.complete
+      schema_hash: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      effect: side_effect
+      description: Model gateway request mediated by HELM policy and receipts.
+      labels:
+        - model
+        - egress
+effect_labels:
+    - model
+    - egress
+    - side_effect
+required_secrets:
+    - model_gateway
+network_grants:
+    - catalog:model-providers
+filesystem_grants:
+    - workspace:rw
+    - app_state:rw


### PR DESCRIPTION
## Summary
- make launch promotion `--sync-derived` update LaunchKit and MCP digest/signature refs, not only image-lock and chart values
- make the artifact workflow actually run `make launchpad-promotion-check` before committing promotion refs
- promote the verified refs from Launchpad Artifacts run 27453055635:
  - openclaw `sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463`
  - hermes `sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b`
  - egress-proxy `sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce`

## Validation
- `go test ./cmd/helm-ai-kernel ./pkg/launchpad/promotion ./pkg/launchpad/registry` from `core/`
- `go test ./tests/launchpad`
- `actionlint .github/workflows/launchpad-artifacts.yml`
- `make launchpad-promotion-check`
- `bash scripts/ci/helm_chart_smoke.sh`
- replayed `gh run download 27453055635 --name launchpad-promotion-manifest` through `go run ./core/cmd/helm-ai-kernel launch promote --manifest ... --apps openclaw,hermes --write --sync-derived --check --json`

## Notes
The current main artifact run passed build/sign/aggregate and `Live BYO model-provider local-container conformance`; it only failed because GitHub Actions is not permitted to create pull requests. This branch replaces the invalid stale automation branch output with a rebased, full-check promotion.
