### PR TITLE
fix(chart): relax launchpad node selector

### DIFF
--- a/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
@@ -33,8 +33,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.launchpadApps.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.launchpadApps.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -112,8 +114,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.launchpadApps.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.launchpadApps.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
@@ -27,8 +27,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.launchpadApps.nodeSelector }}
       nodeSelector:
-        {{- toYaml .Values.launchpadApps.nodeSelector | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
+++ b/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
@@ -16,8 +16,10 @@ spec:
   imagePullSecrets:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.launchpadApps.nodeSelector }}
   nodeSelector:
-    {{- toYaml .Values.launchpadApps.nodeSelector | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -848,7 +848,7 @@
         "nodeSelector": {
           "type": "object",
           "additionalProperties": { "type": "string" },
-          "description": "nodeSelector applied to every launchpad-app Pod. Current chart-pinned launchpad app digests are linux/amd64-only; the artifact workflow publishes multi-arch candidates, but keep `kubernetes.io/arch: amd64` until a digest re-pin lands with linux/arm64 manifests."
+          "description": "Optional nodeSelector applied to every launchpad-app Pod. Launchpad app images are published as linux/amd64 + linux/arm64 manifests; set this map explicitly only when architecture or node pool pinning is required."
         },
         "networkPolicy": {
           "type": "object",

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -286,11 +286,9 @@ openrouter:
 # docs/launchpad/K8S_SMOKE.md for the conformance map between
 # registry/launchpad/apps/{openclaw,hermes}.yaml and these templates.
 launchpadApps:
-  # Current chart-pinned launchpad app digests are linux/amd64-only. The
-  # launchpad artifact workflow now publishes multi-arch candidates, but keep
-  # this selector until a digest re-pin lands with linux/arm64 manifests.
-  nodeSelector:
-    kubernetes.io/arch: amd64
+  # Launchpad app images are published as linux/amd64 + linux/arm64 manifests.
+  # Operators who need architecture pinning can set this map explicitly.
+  nodeSelector: {}
 
   # NetworkPolicy default-deny with explicit DNS + 443 egress allowance for
   # the sidecar proxy. Enforcement requires a CNI that honors NetworkPolicy

--- a/docs/launchpad/K8S_SMOKE.md
+++ b/docs/launchpad/K8S_SMOKE.md
@@ -143,11 +143,11 @@ on the cluster — the k8s analogue of the docker sandbox-leak audit.
 
 ## Known limitations
 
-- **Image architecture pinning.** The launchpad artifact workflow now
-  publishes `linux/amd64,linux/arm64` candidates, but the chart-pinned
-  openclaw, hermes, and egress-proxy digests remain `linux/amd64` until a
-  follow-up digest re-pin lands. The chart keeps
-  `launchpadApps.nodeSelector.kubernetes.io/arch: amd64` during that gap.
+- **Optional image architecture pinning.** The default chart-pinned openclaw,
+  hermes, and egress-proxy digests are multi-arch
+  `linux/amd64,linux/arm64` manifests. The chart leaves
+  `launchpadApps.nodeSelector` empty by default; operators can set it
+  explicitly when they need architecture or node pool pinning.
 - **CNI enforcement.** The NetworkPolicy object is created
   unconditionally, but enforcement requires a CNI that honors it. The
   smoke driver opts minikube into Calico (`--cni=calico`). On the


### PR DESCRIPTION
## Summary
- default `launchpadApps.nodeSelector` to `{}` now that the promoted launchpad image refs are multi-arch
- omit launchpad app/test `nodeSelector` fields when the map is empty
- update chart schema and k8s smoke docs to describe optional operator pinning

## Validation
- `make helm-chart-smoke`
- pinned Helm render check: default openclaw+hermes deployment mode emits no `nodeSelector` / `kubernetes.io/arch`
- pinned Helm render check: explicit `launchpadApps.nodeSelector.kubernetes.io/arch=arm64` renders in openclaw, hermes, and launchpad test Pods
- `git diff --check`

Closes the remaining chart-default gap for #277 after #349 promoted the multi-arch digest refs.