### PR TITLE
ci(launchpad): promote signed launchpad image refs

### DIFF
--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -307,7 +307,7 @@ launchpadApps:
     enabled: false
     image:
       repository: "ghcr.io/mindburn-labs/helm-launchpad/openclaw"
-      digest: "sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463"
+      digest: "sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e"
       pullPolicy: "IfNotPresent"
     gatewayPort: 18789
     tmpfsSize: "256Mi"
@@ -335,7 +335,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce"
+        digest: "sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:
@@ -352,7 +352,7 @@ launchpadApps:
     enabled: false
     image:
       repository: "ghcr.io/mindburn-labs/helm-launchpad/hermes"
-      digest: "sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b"
+      digest: "sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe"
       pullPolicy: "IfNotPresent"
     # job runs the proven single-query smoke path; deployment runs the
     # long-lived Hermes gateway process. Gateway mode is not live-F2-promoted
@@ -380,7 +380,7 @@ launchpadApps:
     egressSidecar:
       image:
         repository: "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy"
-        digest: "sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce"
+        digest: "sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf"
         pullPolicy: "IfNotPresent"
       port: 8080
       allowlist:

--- a/registry/launchkit/apps/hermes/helm.app.yaml
+++ b/registry/launchkit/apps/hermes/helm.app.yaml
@@ -5,8 +5,8 @@ legacy_launchpad_ref: registry/launchpad/apps/hermes.yaml
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
-    digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
+    digest: sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
     source: https://github.com/NousResearch/hermes-agent
     ref: v2026.5.16
 policy: policy.default.yaml

--- a/registry/launchkit/apps/openclaw/helm.app.yaml
+++ b/registry/launchkit/apps/openclaw/helm.app.yaml
@@ -5,8 +5,8 @@ legacy_launchpad_ref: registry/launchpad/apps/openclaw.yaml
 availability: oss_supported
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
-    digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
+    digest: sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
     source: https://github.com/openclaw/openclaw
     ref: v2026.5.12
 policy: policy.default.yaml

--- a/registry/launchpad/apps/hermes.yaml
+++ b/registry/launchpad/apps/hermes.yaml
@@ -10,8 +10,8 @@ availability: oss_supported
 support_level: agent_live
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
-    digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
+    digest: sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
     source: https://github.com/NousResearch/hermes-agent
     ref: v2026.5.16
 runtime:
@@ -83,9 +83,9 @@ framework_contract:
         - openrouter
     egress_proxy:
         required: true
-        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
-        digest: sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
-        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
+        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf
+        digest: sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf
+        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf
         sbom_ref: artifact://sbom-egress-proxy.spdx.json
         vulnerability_scan_ref: artifact://grype-egress-proxy.json
         receipt_ref: receipts/launchpad-egress-proxy.json
@@ -95,8 +95,8 @@ framework_contract:
     evidence_profile: f2.contract.v1
     images:
         - name: hermes-production-minimal
-          image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
-          digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+          image: ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
+          digest: sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
           purpose: production_proof
           baked_dependencies:
             - python
@@ -145,18 +145,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    artifact_digest: sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
     sbom_tool: syft
     sbom_ref: artifact://sbom-hermes.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-hermes.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://27453055635/1/artifact-verification/hermes
-    live_e2e_run_id: github-actions://27453055635/1/live-e2e/hermes
-    evidence_pack_ref: github-actions://27453055635/1/evidencepack/hermes
-    teardown_receipt_ref: github-actions://27453055635/1/teardown/hermes
+    artifact_verification_ref: github-actions://27455536990/1/artifact-verification/hermes
+    live_e2e_run_id: github-actions://27455536990/1/live-e2e/hermes
+    evidence_pack_ref: github-actions://27455536990/1/evidencepack/hermes
+    teardown_receipt_ref: github-actions://27455536990/1/teardown/hermes
 conformance:
     license_verified: true
     artifact_verified: true
@@ -168,12 +168,12 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://27453055635/1
+    artifact_workflow_run: github-actions://27455536990/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/hermes:v2026.5.16
     latest_release: v2026.5.16
-    promotion_manifest_hash: sha256:ee6a7acb4f0963e1414973138ef02ee3a5e16ff79f501b63f3455e5bc0fadcd1
-    promotion_provenance_ref: github-actions://27453055635/1
+    promotion_manifest_hash: sha256:fb0f4a7a9fe839d708228df6367e8a624aff97a6e8f343168f6bf61bbface2a6
+    promotion_provenance_ref: github-actions://27455536990/1
     release_published_at: "2026-05-16T09:59:15Z"
     upstream_commit: a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
     upstream_repo: https://github.com/NousResearch/hermes-agent

--- a/registry/launchpad/apps/openclaw.yaml
+++ b/registry/launchpad/apps/openclaw.yaml
@@ -10,8 +10,8 @@ availability: oss_supported
 support_level: agent_live
 install:
     strategy: signed_oci
-    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
-    digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+    image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
+    digest: sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
     source: https://github.com/openclaw/openclaw
     ref: v2026.5.12
 runtime:
@@ -89,9 +89,9 @@ framework_contract:
         - openrouter
     egress_proxy:
         required: true
-        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
-        digest: sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
-        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce
+        image: ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf
+        digest: sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf
+        signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf
         sbom_ref: artifact://sbom-egress-proxy.spdx.json
         vulnerability_scan_ref: artifact://grype-egress-proxy.json
         receipt_ref: receipts/launchpad-egress-proxy.json
@@ -101,8 +101,8 @@ framework_contract:
     evidence_profile: f2.contract.v1
     images:
         - name: openclaw-production
-          image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
-          digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+          image: ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
+          digest: sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
           purpose: production_proof
           baked_dependencies:
             - openclaw-cli
@@ -139,18 +139,18 @@ evidence_requirements:
     - syft_sbom
     - grype_vulnerability_scan
 supply_chain_evidence:
-    artifact_digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+    artifact_digest: sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
     signature_tool: cosign
-    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+    signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
     sbom_tool: syft
     sbom_ref: artifact://sbom-openclaw.spdx.json
     vulnerability_scan_tool: grype
     vulnerability_scan_ref: artifact://grype-openclaw.json
 promotion_evidence:
-    artifact_verification_ref: github-actions://27453055635/1/artifact-verification/openclaw
-    live_e2e_run_id: github-actions://27453055635/1/live-e2e/openclaw
-    evidence_pack_ref: github-actions://27453055635/1/evidencepack/openclaw
-    teardown_receipt_ref: github-actions://27453055635/1/teardown/openclaw
+    artifact_verification_ref: github-actions://27455536990/1/artifact-verification/openclaw
+    live_e2e_run_id: github-actions://27455536990/1/live-e2e/openclaw
+    evidence_pack_ref: github-actions://27455536990/1/evidencepack/openclaw
+    teardown_receipt_ref: github-actions://27455536990/1/teardown/openclaw
 conformance:
     license_verified: true
     artifact_verified: true
@@ -162,12 +162,12 @@ conformance:
     receipt_verified: true
     evidence_pack_verified: true
 metadata:
-    artifact_workflow_run: github-actions://27453055635/1
+    artifact_workflow_run: github-actions://27455536990/1
     helm_oci_status: promoted_from_signed_ci_artifact_manifest
     helm_oci_target: ghcr.io/mindburn-labs/helm-launchpad/openclaw:v2026.5.12
     latest_release: v2026.5.12
-    promotion_manifest_hash: sha256:ee6a7acb4f0963e1414973138ef02ee3a5e16ff79f501b63f3455e5bc0fadcd1
-    promotion_provenance_ref: github-actions://27453055635/1
+    promotion_manifest_hash: sha256:fb0f4a7a9fe839d708228df6367e8a624aff97a6e8f343168f6bf61bbface2a6
+    promotion_provenance_ref: github-actions://27455536990/1
     release_published_at: "2026-05-14T18:28:04Z"
     upstream_commit: f066dd2f31c231f38fbcaacd6f6dfce0801143b3
     upstream_repo: https://github.com/openclaw/openclaw

--- a/registry/launchpad/image-lock.json
+++ b/registry/launchpad/image-lock.json
@@ -8,27 +8,27 @@
     {
       "name": "openclaw",
       "role": "launchpad_app",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/openclaw",
-      "digest": "sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463",
+      "digest": "sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e",
       "source": "registry/launchpad/apps/openclaw.yaml",
       "preload": true
     },
     {
       "name": "hermes",
       "role": "launchpad_app",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/hermes",
-      "digest": "sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b",
+      "digest": "sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe",
       "source": "registry/launchpad/apps/hermes.yaml",
       "preload": true
     },
     {
       "name": "egress-proxy",
       "role": "egress_proxy",
-      "image": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce",
+      "image": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy@sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf",
       "repository": "ghcr.io/mindburn-labs/helm-launchpad/egress-proxy",
-      "digest": "sha256:d17fb073ae30948703e6f9be836fd6f06a3c7a17ee42b4f62579b019ab7724ce",
+      "digest": "sha256:83c77bd60f74f94b00b8315bbfcb71435b7314d8cf0b0093de17339231706caf",
       "source": "registry/launchpad/apps/openclaw.yaml",
       "preload": true
     }

--- a/registry/launchpad/mcp/hermes.default.yaml
+++ b/registry/launchpad/mcp/hermes.default.yaml
@@ -6,8 +6,8 @@ command:
     - hermes
     - mcp
     - serve
-package_digest: sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
-signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:2f0ed099d76b454857a4909da3c38f93b4958a819159ec069b7a3ec88113d07b
+package_digest: sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
+signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:6d106d351db159fd4ae5788a68bc383115472eb1d00c05afc1fae1f011e2b3fe
 schema_hash: sha256:2222222222222222222222222222222222222222222222222222222222222222
 tools:
     - name: model_gateway.complete

--- a/registry/launchpad/mcp/openclaw.default.yaml
+++ b/registry/launchpad/mcp/openclaw.default.yaml
@@ -6,8 +6,8 @@ command:
     - openclaw
     - mcp
     - serve
-package_digest: sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
-signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:9c96ac049c9da8058e1493bea61cb21dac3cac64d3db03c469ca95a09827a463
+package_digest: sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
+signature_ref: cosign://ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:12fd0c07be068dbf32159583160aa066152d53efa2b617351ba2cf5083f5b62e
 schema_hash: sha256:1111111111111111111111111111111111111111111111111111111111111111
 tools:
     - name: model_gateway.complete


### PR DESCRIPTION
## Summary
- Promote signed Launchpad image references from main artifact run 27455536990.
- Update app specs, image lock, chart defaults, LaunchKit specs, and MCP manifests together.
- Preserve digest-pinned launchpad app references.

## Evidence
- Source run: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/27455536990
- Run head: f0d7e041317e1e8bc858e6667214af254d5bf43f
- Run status: all build/sign/aggregate/live BYO local-container conformance jobs passed; workflow failed only because GitHub Actions could not create this PR.
- Promotion check in the failed job passed: `Launchpad promotion refs are in sync for openclaw,hermes.`

## Local validation
- `git diff --check origin/main...HEAD`
- `env -u GOROOT PATH="/usr/local/go/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" make launchpad-promotion-check`
- `bash scripts/ci/helm_chart_smoke.sh`

## MIN-494 status
This does not close MIN-494. The real Hermes/OpenRouter token-burning smoke still needs to run with token-meter telemetry and produce `ft_tokens_total`.
