### PR TITLE
chore: refresh Launchpad model provider catalog

### DIFF
--- a/core/pkg/launchpad/modelproviders/source_fingerprints.json
+++ b/core/pkg/launchpad/modelproviders/source_fingerprints.json
@@ -26,8 +26,8 @@
       "final_url": "https://help.aliyun.com/zh/model-studio/compatibility-of-openai-with-dashscope",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:57785666c3c81d5ab031eb7e27c9c81240424fbc7ef4cf2533144d2bf5a43a30",
-      "content_length": 237455
+      "content_sha256": "sha256:05150139b9680e1f042d9a20fbe0128136f4afb8d1c807540472b0a899315b5f",
+      "content_length": 195811
     },
     {
       "provider_id": "amazon-bedrock",
@@ -62,8 +62,8 @@
       "final_url": "https://platform.claude.com/docs/en/api/messages",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:e3c04e0f78068ccd6a9f78f714e782318b177e248cae52eaa8c385ae0a8e6a52",
-      "content_length": 579580
+      "content_sha256": "sha256:10c054ef4912aaaefdf0387ebc62bdc8d91c34ebce801ffccb3576f94a2edd06",
+      "content_length": 622270
     },
     {
       "provider_id": "azure-ai-foundry",
@@ -71,7 +71,7 @@
       "final_url": "https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:15dbddfbc2d3d6854eee875c420a261b8338cf4b87c2d7de3d99f975352b44c0",
+      "content_sha256": "sha256:fb9f6ec8dbb3554e7ed2172b9af1fde6f5b161cff4329a40bcd0761fba520ea1",
       "content_length": 73758
     },
     {
@@ -80,7 +80,7 @@
       "final_url": "https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/endpoints",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:15dbddfbc2d3d6854eee875c420a261b8338cf4b87c2d7de3d99f975352b44c0",
+      "content_sha256": "sha256:fb9f6ec8dbb3554e7ed2172b9af1fde6f5b161cff4329a40bcd0761fba520ea1",
       "content_length": 73758
     },
     {
@@ -89,7 +89,7 @@
       "final_url": "https://learn.microsoft.com/en-us/azure/foundry/openai/supported-languages",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:4215945212f475bfd5f6bb80b99bd8733a06dfa02828e3dfad2ce94ba078b9a7",
+      "content_sha256": "sha256:f75a386d882c2a6fc81c7575709b705f89aa13cbbf8a7d9f24d9ff1f0dc9f6c4",
       "content_length": 115126
     },
     {
@@ -98,7 +98,7 @@
       "final_url": "https://learn.microsoft.com/en-us/azure/foundry/openai/whisper-quickstart",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:c187fbf5a4279d87bd4e7184319c7717b6c0a28c49608d9b3f6fe58057ccf76d",
+      "content_sha256": "sha256:9428f13545143aa440fa575f01bd1483b19944e9cf7313340b760eec64c446cb",
       "content_length": 113165
     },
     {
@@ -107,7 +107,7 @@
       "final_url": "https://platform.baichuan-ai.com/docs/api",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:a606907325a7f828202bc3758126b6481a317cdbdaf09eb2de1b6804c3509014",
+      "content_sha256": "sha256:1c579c5024cb8647571420b45f58248037d9c0446b0bb4561763e6d54b8c098d",
       "content_length": 76687
     },
     {
@@ -116,8 +116,8 @@
       "final_url": "https://cloud.baidu.com/doc/qianfan/index.html",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:68abd7faa998cad2951538d0ca7a7d3094a718aac16675cd979313dd5eca0eb0",
-      "content_length": 380578
+      "content_sha256": "sha256:36130ba6f38e7428aba449cac9fe0f2f332aa986546bf2a6d46c76e2362cc4e2",
+      "content_length": 386242
     },
     {
       "provider_id": "cerebras",
@@ -125,8 +125,8 @@
       "final_url": "https://inference-docs.cerebras.ai/api-reference/chat-completions",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:391f709bc47364d25b1ec21cbe634c7e586270be406dcb5cec71fd4edf7c6da5",
-      "content_length": 969187
+      "content_sha256": "sha256:f393a40cedf08080d24211dc619cbe11aa24fabedbc650d306316bd2b30243c1",
+      "content_length": 971356
     },
     {
       "provider_id": "cloudflare-ai-gateway",
@@ -134,8 +134,8 @@
       "final_url": "https://developers.cloudflare.com/ai-gateway/usage/chat-completion",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:8956303ef5720a7cc00dcd7e52b6129ec9cb2d4757f505050a55d395a62ca04d",
-      "content_length": 500590
+      "content_sha256": "sha256:9b083addda104854538006cc4889cf5b94c58aa301ba27cdab22fc8212a5b2f3",
+      "content_length": 501129
     },
     {
       "provider_id": "cloudflare-ai-gateway",
@@ -143,8 +143,8 @@
       "final_url": "https://developers.cloudflare.com/ai-gateway/usage/rest-api",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:83cd31ac9343d2ab6fc30bac1b525717d71efa77249d46e77c2e751089ab9a72",
-      "content_length": 201315
+      "content_sha256": "sha256:221a5d04eec1732748406c387d863e5c67db87ec18a89c2b189695617636b38f",
+      "content_length": 201821
     },
     {
       "provider_id": "cohere",
@@ -152,8 +152,8 @@
       "final_url": "https://docs.cohere.com/reference/chat",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:6441aa12df0388c79533ea061f2737bc19bc99c50980ace1f296fe885a3142f9",
-      "content_length": 4248987
+      "content_sha256": "sha256:96c903a2d8b6fbab996236e50752e60cf6177745f6ceca0fe96336e88de43b8f",
+      "content_length": 4151604
     },
     {
       "provider_id": "deepinfra",
@@ -161,8 +161,8 @@
       "final_url": "https://docs.deepinfra.com",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:a1e8e708e11a32dff0c661e3ec93d8bff356de7530987a248990fa263dfa82e5",
-      "content_length": 350904
+      "content_sha256": "sha256:ef4a878abf880cd27bc2ae89710a19882e7b33683413e12f6fe2ba33bfd336f9",
+      "content_length": 353233
     },
     {
       "provider_id": "deepinfra",
@@ -170,8 +170,8 @@
       "final_url": "https://docs.deepinfra.com/api-reference/introduction",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:e75e1710b002e367b4508677ce1dc69857b0d6f9b35c36207609c6544ed7675b",
-      "content_length": 391220
+      "content_sha256": "sha256:186428b21b1a6a120b2d32a9426a1cec033d3a14e4eae66081748ec1a258983b",
+      "content_length": 393549
     },
     {
       "provider_id": "deepinfra",
@@ -179,8 +179,8 @@
       "final_url": "https://docs.deepinfra.com/chat/overview",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:20e7b05b88ad45038838d8349101c57c5785c2fc985cc7e31ce56693ec29485a",
-      "content_length": 617340
+      "content_sha256": "sha256:82f8b5cf6627ea1af203ae2e6a055b913a090b388d785af6ea2a059406f2ee60",
+      "content_length": 619669
     },
     {
       "provider_id": "deepseek",
@@ -197,8 +197,8 @@
       "final_url": "https://docs.fireworks.ai/api-reference/post-chatcompletions",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:783b57ac69907354ab44caf59cc1c52fb2d13dde2e80dfc7c9cddd6e83b752fd",
-      "content_length": 871778
+      "content_sha256": "sha256:8d170c9d9cccc5f6bc56cd870bcc09f5191112d1be4218a613066749c200ff15",
+      "content_length": 874412
     },
     {
       "provider_id": "github-models",
@@ -206,8 +206,8 @@
       "final_url": "https://docs.github.com/en/github-models/about-github-models",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:7f74a756fa486e8d33db2fc9826170e8c47cae31306d8b320a29748fdd808b60",
-      "content_length": 81067
+      "content_sha256": "sha256:4047c7f441e9e15964c153c1332ee7d0406b7ad947edb7b439f5197b3bcd9f2b",
+      "content_length": 81060
     },
     {
       "provider_id": "github-models",
@@ -215,8 +215,8 @@
       "final_url": "https://docs.github.com/en/rest/models/catalog",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:a8d30a43dcb4887681e1a7f0eb7f935da6df0c9e4a9695a7a210f7b04d637174",
-      "content_length": 259732
+      "content_sha256": "sha256:43c16e8bd4289b3707ec6b907c8262e9362bee6421d4dbe1d93f789a8469e214",
+      "content_length": 259725
     },
     {
       "provider_id": "github-models",
@@ -224,8 +224,8 @@
       "final_url": "https://docs.github.com/en/rest/models/inference",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:c4525b2eb6dc0867a1a084eec40dcbf2130396d9b610cba0f6793c2bb28a5332",
-      "content_length": 321136
+      "content_sha256": "sha256:37de68e768a7c4c06a70c841e8e0a08b8563f3db9db889c1c8a0dbec4d7326ad",
+      "content_length": 321129
     },
     {
       "provider_id": "google-gemini",
@@ -233,8 +233,8 @@
       "final_url": "https://ai.google.dev/api/generate-content",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:29c7b74433f3504bfc7e9124ea8672ac9220a2a50d68f92a53e0925bf96e7b46",
-      "content_length": 1004389
+      "content_sha256": "sha256:9d6b52dcd21da27f17586826ee1b85afc95239927f14f150b41734fe27dbf76f",
+      "content_length": 1004429
     },
     {
       "provider_id": "google-vertex-ai",
@@ -242,8 +242,8 @@
       "final_url": "https://docs.cloud.google.com/gemini-enterprise-agent-platform/resources/locations",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:669907e2c1aa2d50ddd063ef17599372c687996fd3af1bf5675593d83a526c41",
-      "content_length": 960434
+      "content_sha256": "sha256:0615631b5423981ebda705b76b7e5cfbee6d59091fd9fb76f1d7005707cd3c9a",
+      "content_length": 960359
     },
     {
       "provider_id": "google-vertex-ai",
@@ -251,8 +251,8 @@
       "final_url": "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/migrate/openai/auth-and-credentials",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:4fc83829190ef1399fe6bb6295e95c3b7f27751b4e2a5bd4796f21fcd275edf1",
-      "content_length": 372354
+      "content_sha256": "sha256:2f14b00907fcaebc01eea40efe6bac8b2248333e187fd05088be9e22eb4b3056",
+      "content_length": 372397
     },
     {
       "provider_id": "google-vertex-ai",
@@ -260,8 +260,8 @@
       "final_url": "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/start/openai",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:cb8e1601726259e62220db145018a422c9942c9baadc8552018c6eb78de245ab",
-      "content_length": 403140
+      "content_sha256": "sha256:ee0ba69777cb5877bd1ff2a73d6cf424c1625b155b698e80333bfa59f2db8673",
+      "content_length": 403187
     },
     {
       "provider_id": "groq",
@@ -269,8 +269,8 @@
       "final_url": "https://console.groq.com/docs/api-reference",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:a4afb7d3627e940939de372372cc7d90af54e99f9a60dce87b724a97cb0a32d3",
-      "content_length": 1525980
+      "content_sha256": "sha256:d21c38c474c3540de3fbaa14dd03669d211737bd573fcd47bce5bc994fb93535",
+      "content_length": 1525766
     },
     {
       "provider_id": "hugging-face",
@@ -278,8 +278,8 @@
       "final_url": "https://huggingface.co/docs/inference-providers/index",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:75598b7133112c5c0df737850f7d7752dbe7bb2cdbe5ca1564798dfb79446d15",
-      "content_length": 193423
+      "content_sha256": "sha256:89994aa2ef0fca22a275852eaeb8563ca69f39d2c2e15309e9d89edcec9928e0",
+      "content_length": 193407
     },
     {
       "provider_id": "hugging-face",
@@ -287,8 +287,8 @@
       "final_url": "https://huggingface.co/docs/inference-providers/en/index",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:b042b0613b98611ec8170a4c57541bb13abe0d9e28a4ba582d0cc6be9498634b",
-      "content_length": 193789
+      "content_sha256": "sha256:6cd657b729670fc60860ed2f03935b110e44e280d88a9f571ff8b9734fe803f6",
+      "content_length": 193773
     },
     {
       "provider_id": "hugging-face",
@@ -296,8 +296,8 @@
       "final_url": "https://huggingface.co/docs/inference-providers/providers/hf-inference",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:6b9b8fb44655f2aa012b4901ed0c83b87a07e01d126598253cec6e1a5666d27b",
-      "content_length": 277563
+      "content_sha256": "sha256:43fe8e1f8504bebd3ba496abc2c4dd216311dd4424d9ced8a2e59c52633c518b",
+      "content_length": 277566
     },
     {
       "provider_id": "ibm-watsonx",
@@ -305,8 +305,8 @@
       "final_url": "https://cloud.ibm.com/apidocs/watsonx-ai",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:ef8838b23e26786022241dcb9a60d1af047f1659b4ffb32668bebfcf1aa7ba99",
-      "content_length": 4732954
+      "content_sha256": "sha256:e81795a3d18f93d277f7d209c0fcd008bfabcdff5cb26d8bbf150f14580bf428",
+      "content_length": 4732966
     },
     {
       "provider_id": "iflytek-spark",
@@ -314,8 +314,8 @@
       "final_url": "https://www.xfyun.cn/doc/spark/CodingPlan.html",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:cd0a479654287deca172139e9d87b1062f4803aa6d689726f02e90cb20c63c77",
-      "content_length": 107644
+      "content_sha256": "sha256:7aeeef170d50d3747f44d0b5bd4f95e1e4229739759151e9bfe0ef7094dba5e6",
+      "content_length": 107610
     },
     {
       "provider_id": "iflytek-spark",
@@ -323,7 +323,7 @@
       "final_url": "https://www.xfyun.cn/doc/spark/HTTP%E8%B0%83%E7%94%A8%E6%96%87%E6%A1%A3.html",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:b2c37964b849a2f0a62b707ff092cdf141dcf1bd0c9501fe54631ebebabba322",
+      "content_sha256": "sha256:38e34efcdaccef44de8543d7a681ebabfb38c486d108aa4c4f4860c42cc565d4",
       "content_length": 129559
     },
     {
@@ -341,8 +341,8 @@
       "final_url": "https://docs.ionos.com/cloud/ai/ai-model-hub/how-tos/tool-integration",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:9854bccd665044cb3d011ed610d71241147233dc63868a3970a590c48b17a860",
-      "content_length": 905946
+      "content_sha256": "sha256:9ae5318e6c903153e206a0cf9eecb311fd5d22e7111a60a919ab56fbaa4e9d27",
+      "content_length": 909097
     },
     {
       "provider_id": "minimax",
@@ -350,8 +350,8 @@
       "final_url": "https://platform.minimax.io/docs/api-reference/api-overview",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:62a89ceb5d643eddf24cb504f87eb56939e0e8a45a89706f6227f2381b12a40f",
-      "content_length": 540306
+      "content_sha256": "sha256:c3bc2604e9e0f1141af248b481fe380bac33eceeb01d1f1ed1a4ffcd19cd1cbf",
+      "content_length": 542331
     },
     {
       "provider_id": "minimax",
@@ -359,8 +359,8 @@
       "final_url": "https://platform.minimaxi.com/docs/api-reference/api-overview",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:a1defff8cbcb93cfeb6c150953d77b280c7cd03909a793de0bb5d5ae1d75a418",
-      "content_length": 589403
+      "content_sha256": "sha256:fb5cfd1ddef3b0873dad92fa6da71a1aadb7673465493391c6d182263e1f5726",
+      "content_length": 591457
     },
     {
       "provider_id": "mistral",
@@ -368,8 +368,8 @@
       "final_url": "https://docs.mistral.ai/api",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:cdef38dd37eb5145b908f71910108f1280cddc783d7caf80c3541b705a1de97d",
-      "content_length": 1678894
+      "content_sha256": "sha256:841435b565d5c0abb0f018d97e5904129e87ce0c5d66dac2e8853cb49fb2f65c",
+      "content_length": 1679752
     },
     {
       "provider_id": "modelscope",
@@ -377,7 +377,7 @@
       "final_url": "https://modelscope.cn/docs/model-service/API-Inference",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:33009879e155ae869da128ee6919d5a9f52684a33611c481039570e7210c3960",
+      "content_sha256": "sha256:27edb17885f4d000422370511506bbd7aa63004db765648502e334734a9c8e44",
       "content_length": 3247
     },
     {
@@ -386,7 +386,7 @@
       "final_url": "https://modelscope.cn/docs/model-service/deployment/swingdeploy-openai-api-compatible",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:07483f201cee44e6b76690f79af9e408de05fb8b710518ed0b65b2e822ebd7b0",
+      "content_sha256": "sha256:e0f7c3cdfbf3eb8e15e5488990fb2e9d0034292d2ce276b09cac53ede50cb481",
       "content_length": 3344
     },
     {
@@ -395,8 +395,8 @@
       "final_url": "https://platform.kimi.ai/docs/overview",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:d1e76234a38b6f4036d40dc3e74768a48ec5a94db5865a5ccdefd4fb22594d53",
-      "content_length": 245588
+      "content_sha256": "sha256:26fe5f54ed6ea1163c4149ccf27f6cdf64113b805a1d0e5ff1b66989692c3b96",
+      "content_length": 251097
     },
     {
       "provider_id": "nebius",
@@ -413,8 +413,8 @@
       "final_url": "https://docs.tokenfactory.nebius.com/quickstart",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:ac8b57e6e57af14b9804e524f08e0b0e10d695db1ae0845b6377c292bd4b1ecd",
-      "content_length": 400043
+      "content_sha256": "sha256:8cb642bf6f680ce653a24cb915f679241d146f2b0cf1f618ac1c488ba222e0f1",
+      "content_length": 402216
     },
     {
       "provider_id": "nebius",
@@ -422,8 +422,8 @@
       "final_url": "https://docs.tokenfactory.nebius.com/api-reference/introduction",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:91d7548b93dc791d0143168bec09084c73fde684217eac4a6005a5fe4ecb64c2",
-      "content_length": 370854
+      "content_sha256": "sha256:170fd6786898a5c14a2ea994db56e6f5f1fa88148bea1be59d9b761994933187",
+      "content_length": 373027
     },
     {
       "provider_id": "nvidia-nim",
@@ -431,8 +431,8 @@
       "final_url": "https://docs.api.nvidia.com/nim/reference/llm-apis",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:7b0b34cb32a7b3b1384f08570b6ed675cabbf82eae63d707ad196dc024b5b413",
-      "content_length": 1369264
+      "content_sha256": "sha256:254c806dd367561343c1a907a6baa02a4cbe9afab77a480a28fa258fff9f94dd",
+      "content_length": 1376343
     },
     {
       "provider_id": "openai",
@@ -440,8 +440,8 @@
       "final_url": "https://developers.openai.com/api/reference/overview",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:c76dc5b63ca93456821e9d100671517bbedd29fb9598432cb4477d1b4e265b89",
-      "content_length": 466297
+      "content_sha256": "sha256:b57b1e471218e796963531b44786739cb0061e9bdff3a0873ee84da8c7874fba",
+      "content_length": 387176
     },
     {
       "provider_id": "openrouter",
@@ -449,8 +449,8 @@
       "final_url": "https://openrouter.ai/docs/api/reference/overview",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:1c126f87d111c9bde6e40b7286b9c53cd951e1502b708615de01433c89190941",
-      "content_length": 769345
+      "content_sha256": "sha256:acfc67ee2dbb6ef6d8ab03fc04d44473807fb6a5822495ac93000b2c95f94056",
+      "content_length": 753118
     },
     {
       "provider_id": "ovhcloud-ai-endpoints",
@@ -458,8 +458,8 @@
       "final_url": "https://docs.ovhcloud.com/en/guides/public-cloud/ai-machine-learning/ai-endpoints-responses-api",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:0a3ce6f17df4802359fcae8a1d96c5ef5af60c29bc7f4817fc91dfbf062518fe",
-      "content_length": 1381631
+      "content_sha256": "sha256:ccd0793bbc3d9d2d1d99814899bbadd57e212e32ecf3c5c83c71f4d148a31941",
+      "content_length": 1383408
     },
     {
       "provider_id": "ovhcloud-ai-endpoints",
@@ -467,8 +467,8 @@
       "final_url": "https://docs.ovhcloud.com/en",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:3783d9d48eab6596131b0a095ba593cf4713b151298229f78a5c5672fa182895",
-      "content_length": 1137990
+      "content_sha256": "sha256:7a934b01a6ecfd9f49fd82642551e03142bf2277e74ded4f6f5f1f9131030544",
+      "content_length": 1138867
     },
     {
       "provider_id": "perplexity",
@@ -476,8 +476,8 @@
       "final_url": "https://docs.perplexity.ai/api-reference/sonar-post",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:2b9908edf5f34c1330ed58f7cae43f88b8a139fbc939cfdbdd84b3a7a06b654d",
-      "content_length": 690222
+      "content_sha256": "sha256:dac57b3c3f082052fb90bb51dd4ee2db8e8d1f8b9cdef0cff839ccfb9d693302",
+      "content_length": 692994
     },
     {
       "provider_id": "replicate",
@@ -512,8 +512,8 @@
       "final_url": "https://docs.sambanova.ai/docs/en/features/openai-compatibility",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:e98fcdda62592843eef571d27e7603d029d58ce60f50e6ab9abf48b537b427d8",
-      "content_length": 597881
+      "content_sha256": "sha256:20a999fb6341ed743c6af9455e575d8dde20ae4773cc77c923a5b8c6b54bf157",
+      "content_length": 599888
     },
     {
       "provider_id": "sambanova",
@@ -521,8 +521,8 @@
       "final_url": "https://docs.sambanova.ai/docs/en/get-started/api-keys-urls",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:a11709523f250896e137353752e04b2e5fd7b60e6ae86c2bceb4a7003e89b79c",
-      "content_length": 492560
+      "content_sha256": "sha256:359031f97f8d8a17409a1b90e6f40933c3b0d22f5dffc98ba4303b0daec686e2",
+      "content_length": 494567
     },
     {
       "provider_id": "scaleway-generative-apis",
@@ -530,7 +530,7 @@
       "final_url": "https://www.scaleway.com/en/developers/api/generative-apis",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:08ceb59806bb33b8786cfc83ed3b1302deceb82d12034758fe5c89c4b70af3b6",
+      "content_sha256": "sha256:98bde45da82b3e171aed555c001375f455548f9e8b3b2d2da6dc74cdd8349c77",
       "content_length": 212250
     },
     {
@@ -539,8 +539,8 @@
       "final_url": "https://www.scaleway.com/en/docs/generative-apis/api-cli/using-generative-apis",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:510a460b771583e48cdddfbcf3b4db5ea92a89e2f05ee593ab3db478a9f47d71",
-      "content_length": 869197
+      "content_sha256": "sha256:aa8a37422695888ca8847b584a50b3de413a99a978c09b22baee30939631b1d0",
+      "content_length": 869189
     },
     {
       "provider_id": "scaleway-generative-apis",
@@ -548,8 +548,8 @@
       "final_url": "https://www.scaleway.com/en/docs/generative-apis/quickstart",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:f42d37be5630aadbe6eb48ecdaad19509845573fa5fa53c695857b2888526a19",
-      "content_length": 892819
+      "content_sha256": "sha256:442fccbcd9b10bb66b8936a370cce5f81913b51b388af39973a5e5c1dfeaf960",
+      "content_length": 893837
     },
     {
       "provider_id": "siliconflow",
@@ -566,13 +566,17 @@
       "final_url": "https://docs.siliconflow.com/en/api-reference/chat-completions/chat-completions",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:ba3e722ab068d780169f699f3d62c344610b72164dc2574271ecea50d5f71a24",
-      "content_length": 455529
+      "content_sha256": "sha256:4f73664808c51df663b52972d3bb6a8b2c1acfab12f26199f67f28f4bc507991",
+      "content_length": 459118
     },
     {
       "provider_id": "stepfun",
       "source_url": "https://platform.stepfun.ai/docs/en/guide/openai",
-      "reachable": false
+      "final_url": "https://platform.stepfun.ai/docs/en/guides/developer/openai",
+      "http_status": 200,
+      "content_type": "text/html",
+      "content_sha256": "sha256:bc1f6c42d862df0b310c4e33472216e2427556cef190e1c1f1f5bf4eb8f42906",
+      "content_length": 506169
     },
     {
       "provider_id": "stepfun",
@@ -580,8 +584,8 @@
       "final_url": "https://platform.stepfun.ai/docs/en/step-plan/quick-start",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:6fa3008ce93e26cd989546eb2e9381a791072777b3298ca6040ed026a56bfcf2",
-      "content_length": 405991
+      "content_sha256": "sha256:08714813aa9f8aca589082bf6e2bf3a1614e19f34e5ecedefb0768bcf51dc895",
+      "content_length": 408100
     },
     {
       "provider_id": "tencent-hunyuan",
@@ -589,8 +593,8 @@
       "final_url": "https://cloud.tencent.com/document/product/1729",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:d6f87bd6594ffc70489e61188915fc782e7606af36c676a626e7ff0c804990a3",
-      "content_length": 31384
+      "content_sha256": "sha256:5facb60ddb92de618cf09f71826787f6fa2aa7a81966516418dcd957af2e8b7d",
+      "content_length": 31468
     },
     {
       "provider_id": "together-ai",
@@ -598,8 +602,8 @@
       "final_url": "https://docs.together.ai/reference/chat-completions",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:92386f67709e6e102fbcbf3f1ff286848bfd9092311de3bc409de88d617587c9",
-      "content_length": 620043
+      "content_sha256": "sha256:637892c75ca2a9885326192bc232be293f0c75526af3555c063ca290179fb180",
+      "content_length": 623625
     },
     {
       "provider_id": "vercel-ai-gateway",
@@ -607,8 +611,8 @@
       "final_url": "https://vercel.com/docs/ai-gateway",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:56a8d29ee41ca776398a1c1b3af0367225f96d3894b4eabac5c80b34c145b909",
-      "content_length": 794761
+      "content_sha256": "sha256:cf9bcdc895cf7720bdff379e46633ac3c9edd8c55ded9d8ffd7459df8f0cf74c",
+      "content_length": 785571
     },
     {
       "provider_id": "vercel-ai-gateway",
@@ -616,8 +620,8 @@
       "final_url": "https://vercel.com/docs/ai-gateway/sdks-and-apis/openai-chat-completions",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:07a663c6cd519069899ebdd3cbbc9b8db2148e128cd1b2c84c57f49db7f9aaf6",
-      "content_length": 944715
+      "content_sha256": "sha256:3763b33b014ef61055bbb98553eacb56988ec3a7362e5de6dcc023f98bfadc39",
+      "content_length": 935549
     },
     {
       "provider_id": "vercel-ai-gateway",
@@ -625,8 +629,8 @@
       "final_url": "https://vercel.com/docs/ai-gateway/sdks-and-apis",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:c778660d38d9f7649a40f6edf4236b93c9f5cdbe58712c12cb75829bc97ceaf6",
-      "content_length": 855911
+      "content_sha256": "sha256:99c491c4e737a128ab62c450b37336a922926b541264a82cd544fab9f40e936d",
+      "content_length": 846885
     },
     {
       "provider_id": "volcengine-ark",
@@ -634,8 +638,8 @@
       "final_url": "https://www.volcengine.com/docs/82379",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:9a4abe2ae404de5a5fe40df929f2d4c900d9b6368de0b4375c72d52deb4f4b7d",
-      "content_length": 684455
+      "content_sha256": "sha256:32c3893d80582d5f1037b4aa993ab6982fb76f5dc15feaf225e258d1cc6f299c",
+      "content_length": 686234
     },
     {
       "provider_id": "xai",
@@ -643,8 +647,8 @@
       "final_url": "https://docs.x.ai/developers/rest-api-reference/inference/chat",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:f88a629131fb3916b9079721c411af50e93948795666e203465c489fb17f9535",
-      "content_length": 995921
+      "content_sha256": "sha256:0743502a377ff09338cb7d4f0e5337538fc8c0ea70b0e1a4c4823a32631d6435",
+      "content_length": 995983
     },
     {
       "provider_id": "zhipu-bigmodel",
@@ -652,8 +656,8 @@
       "final_url": "https://docs.bigmodel.cn/cn/guide/start/introduction",
       "http_status": 200,
       "content_type": "text/html",
-      "content_sha256": "sha256:f410b927941af5eda997e9f70a37ba4f3b43286b5d99c9ceb81b799ce3500acf",
-      "content_length": 359323
+      "content_sha256": "sha256:474291a62dd1b23479721abd8c5e8e49725b668834f9d4e01ed303eb506d66d4",
+      "content_length": 354912
     }
   ]
 }


### PR DESCRIPTION
## Summary
- refresh Launchpad model provider source fingerprints from the scheduled catalog updater
- preserves the generated branch that GitHub Actions already pushed in run 27458625543

## Evidence
- Source run: Launchpad Model Provider Catalog 27458625543
- The workflow failed only when trying to create this PR with the GitHub Actions token: `createPullRequest` is not permitted
