### PR TITLE
fix(ci): keep launchpad promotion branch push green

### DIFF
--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -1013,8 +1013,12 @@ jobs:
           git add "${changed_paths[@]}"
           git commit -m "ci(launchpad): promote signed launchpad image refs"
           git push origin "${branch}"
-          gh pr create \
+          if gh pr create \
             --title "ci(launchpad): promote signed launchpad image refs" \
             --body-file /tmp/launchpad-promotion-pr.md \
             --base main \
-            --head "${branch}"
+            --head "${branch}"; then
+            exit 0
+          fi
+
+          echo "::warning::Launchpad promotion branch was pushed as ${branch}, but this workflow token could not create a PR. Open the PR manually from the pushed branch."


### PR DESCRIPTION
## Summary
- Keep Launchpad artifact promotion branch creation green when the workflow token cannot create PRs.
- Preserve the pushed automation branch and emit a GitHub Actions warning with manual PR instructions.

## Root cause
Launchpad Artifacts run https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/27464618490 built, signed, aggregated, and live-conformance-verified the artifacts successfully, then failed only at gh pr create with: GraphQL: GitHub Actions is not permitted to create or approve pull requests.

## Validation
- YAML parsed successfully with system Ruby.
- Python assertion verified the non-fatal gh pr create wrapper and warning text.
- git diff --check.

Manual promotion PR from the already-pushed branch: https://github.com/Mindburn-Labs/helm-ai-kernel/pull/357