### PR TITLE
fix(ci): authenticate setup-protoc release lookups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           java-version: "21"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ github.token }}
       - name: Run Make-first PR quality profile
         run: make quality-pr
 
@@ -85,6 +87,8 @@ jobs:
           go-version: "1.25.10"
           cache-dependency-path: "**/go.sum"
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          repo-token: ${{ github.token }}
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           version: "34.1"
+          repo-token: ${{ github.token }}
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Pass github.token to all arduino/setup-protoc calls in CI and release validation.
- This avoids unauthenticated GitHub API release lookup rate limits, which caused the #359 kernel job to fail before kernel tests started.

## Evidence
- Failed job: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/27467246389/job/81191651000
- setup-protoc action metadata exposes repo-token: GitHub repo token to use to avoid rate limiter.

## Validation
- YAML parsed successfully for ci.yml and release.yml.
- Python assertion verified every setup-protoc use in those files has repo-token.
- git diff --check.