### PR TITLE
ci: run OpenRouter probe before live smoke

### DIFF
--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -142,7 +142,7 @@ jobs:
             --run "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --case helm-integration-openrouter-probe \
             --out token-evidence \
-            --min-total 1 \
+            --min-total 1
           bash scripts/ci/launchpad_k8s_smoke.sh --mode positive
 
       - name: Upload OpenRouter token evidence


### PR DESCRIPTION
## Summary
- fix Helm Integration live-positive shell sequencing so the OpenRouter token probe is its own command
- keep the launchpad smoke as the next command after token evidence is written

## Validation
- /usr/bin/ruby YAML parse for .github/workflows/helm-integration.yml
- git diff --check

## Notes
- Fixes the failed main Helm Integration run on d6f6983e where bash scripts/ci/launchpad_k8s_smoke.sh was parsed as an extra openrouter_token_meter.py argument.