### PR TITLE
fix(ci): separate OpenRouter proof from smoke command

### DIFF
--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -142,7 +142,7 @@ jobs:
             --run "${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             --case helm-integration-openrouter-probe \
             --out token-evidence \
-            --min-total 1 \
+            --min-total 1
           bash scripts/ci/launchpad_k8s_smoke.sh --mode positive
 
       - name: Upload OpenRouter token evidence


### PR DESCRIPTION
## Summary
- Fix the Helm Integration positive smoke shell block so the OpenRouter token probe and launchpad smoke script run as separate commands.
- Preserve #361's token-proof gate while unblocking main smoke.

## Validation
- /usr/bin/ruby -e 'require "yaml"; YAML.load_file(".github/workflows/helm-integration.yml")'
- /usr/bin/python3 -m unittest scripts/ci/test_openrouter_token_meter.py
- command-separation assertion for --min-total and launchpad_k8s_smoke.sh
- git diff --check