### PR TITLE
launchpad: require runtime telemetry evidence

### DIFF
--- a/core/pkg/launchpad/session/executor.go
+++ b/core/pkg/launchpad/session/executor.go
@@ -339,6 +339,7 @@ func (e Executor) ExecuteLaunch(compiled plan.LaunchPlan, opts ExecuteOptions) (
 	runtimeEnvironment := map[string]any{"state": "RUNNING", "container_id": runtimeResult.ContainerID}
 	addRuntimeStartEvidence(runtimeEnvironment, runtimeResult)
 	addJSON(artifacts, "runtime_environment.json", runtimeEnvironment)
+	addRuntimeTelemetryEvidence(artifacts, compiled, run, runtimeResult, "running")
 	return e.persist(run, artifacts)
 }
 
@@ -789,6 +790,49 @@ func addRuntimeStartEvidence(dst map[string]any, result RuntimeStartResult) {
 		dst["egress_network_name"] = result.EgressNetworkName
 	}
 	dst["token_broker_enabled"] = result.TokenBrokerEnabled
+}
+
+func addRuntimeTelemetryEvidence(dst map[string][]byte, compiled plan.LaunchPlan, run LaunchRun, result RuntimeStartResult, status string) {
+	telemetry := map[string]any{
+		"schema_version":             "helm.launchpad.runtime_telemetry.v1",
+		"source":                     "launchpad-session-executor",
+		"generated_at":               time.Now().UTC().Format(time.RFC3339),
+		"launch_id":                  run.LaunchID,
+		"app_id":                     run.AppID,
+		"app_version":                run.AppVersion,
+		"substrate_id":               run.SubstrateID,
+		"principal":                  run.Principal,
+		"plan_hash":                  run.PlanHash,
+		"artifact_digest":            run.ArtifactDigest,
+		"kernel_verdict":             run.KernelVerdict,
+		"state":                      string(run.State),
+		"status":                     status,
+		"runtime":                    result.Runtime,
+		"container_observed":         result.ContainerID != "",
+		"egress_receipt_ref_present": result.EgressReceiptRef != "",
+		"egress_proxy_present":       result.EgressProxyID != "" || result.EgressProxyName != "" || result.EgressProxyImage != "",
+		"isolation_mode":             result.IsolationMode,
+		"isolation_hardened":         result.IsolationHardened,
+		"runtime_class":              result.RuntimeClass,
+		"payload_inspection":         result.PayloadInspection,
+		"network_proof":              result.NetworkProof,
+		"token_broker_enabled":       result.TokenBrokerEnabled,
+		"healthcheck_count":          len(compiled.Healthchecks),
+		"network_allowlist_count":    len(compiled.NetworkAllowlist),
+		"model_gateway_provider":     compiled.ModelGatewayProvider,
+		"model_gateway_mode":         compiled.ModelGatewayMode,
+	}
+	addOptionalCIField(telemetry, "github_run_id", "GITHUB_RUN_ID")
+	addOptionalCIField(telemetry, "github_run_attempt", "GITHUB_RUN_ATTEMPT")
+	addOptionalCIField(telemetry, "github_sha", "GITHUB_SHA")
+	addOptionalCIField(telemetry, "github_workflow", "GITHUB_WORKFLOW")
+	addJSON(dst, "03_TELEMETRY/runtime.json", telemetry)
+}
+
+func addOptionalCIField(dst map[string]any, key, envName string) {
+	if value := strings.TrimSpace(os.Getenv(envName)); value != "" {
+		dst[key] = value
+	}
 }
 
 func appendUnique(values []string, next string) []string {

--- a/core/pkg/launchpad/session/executor_test.go
+++ b/core/pkg/launchpad/session/executor_test.go
@@ -275,6 +275,47 @@ func TestExecutorRunsNetworkedLaunchWithEgressReceipt(t *testing.T) {
 	}
 }
 
+func TestExecutorWritesRuntimeTelemetryEvidence(t *testing.T) {
+	store := NewStore(t.TempDir())
+	t.Setenv("GITHUB_RUN_ID", "12345")
+	t.Setenv("GITHUB_RUN_ATTEMPT", "2")
+	t.Setenv("GITHUB_SHA", "0123456789abcdef0123456789abcdef01234567")
+
+	run, err := NewExecutor(store).ExecuteLaunch(allowPlan(), ExecuteOptions{
+		Reason:            "test",
+		RuntimeStarter:    &fakeNetworkStarter{},
+		HealthcheckRunner: &fakeHealthcheck{},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteLaunch: %v", err)
+	}
+	if len(run.EvidencePackRefs) == 0 {
+		t.Fatalf("evidence pack missing: %#v", run)
+	}
+
+	var telemetry map[string]any
+	readJSON(t, filepath.Join(run.EvidencePackRefs[0], "03_TELEMETRY/runtime.json"), &telemetry)
+	for key, want := range map[string]string{
+		"schema_version":     "helm.launchpad.runtime_telemetry.v1",
+		"launch_id":          "launch-allow",
+		"app_id":             "openclaw",
+		"state":              "RUNNING",
+		"kernel_verdict":     "ALLOW",
+		"runtime":            "local-container",
+		"github_run_id":      "12345",
+		"github_run_attempt": "2",
+		"github_sha":         "0123456789abcdef0123456789abcdef01234567",
+	} {
+		if telemetry[key] != want {
+			t.Fatalf("runtime telemetry %s = %#v, want %q in %#v", key, telemetry[key], want, telemetry)
+		}
+	}
+	if telemetry["egress_receipt_ref_present"] != true {
+		t.Fatalf("runtime telemetry missing egress receipt marker: %#v", telemetry)
+	}
+	assertTarContains(t, run.EvidencePackRefs[len(run.EvidencePackRefs)-1], "03_TELEMETRY/runtime.json")
+}
+
 func TestExecutorBundlesEgressProxyReceiptOnRuntimeFailure(t *testing.T) {
 	receiptPath := filepath.Join(t.TempDir(), "egress-receipt.json")
 	if err := os.WriteFile(receiptPath, []byte(`{"receipt_id":"receipt:egress","subject":{"proxy_image":"proxy@sha256:abc"}}`+"\n"), 0o600); err != nil {

--- a/tests/launchpad/live_conformance_test.go
+++ b/tests/launchpad/live_conformance_test.go
@@ -239,12 +239,37 @@ func verifyLiveEvidenceRefs(t *testing.T, appID string, refs []string) {
 	if !report.Verified {
 		t.Fatalf("%s EvidencePack directory did not verify: %s", appID, report.Summary)
 	}
+	verifyLiveRuntimeTelemetry(t, appID, dirRef)
 	root := repoRoot(t)
 	cmd := exec.Command("go", "run", "./core/cmd/helm-ai-kernel", "verify", "--bundle", archiveRef, "--json")
 	cmd.Dir = root
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("%s EvidencePack tar did not verify offline: %v\n%s", appID, err, string(out))
+	}
+}
+
+func verifyLiveRuntimeTelemetry(t *testing.T, appID, dirRef string) {
+	t.Helper()
+	path := filepath.Join(dirRef, "03_TELEMETRY", "runtime.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("%s EvidencePack missing runtime telemetry proof %s: %v", appID, path, err)
+	}
+	var telemetry map[string]any
+	if err := json.Unmarshal(data, &telemetry); err != nil {
+		t.Fatalf("%s runtime telemetry proof is not JSON: %v", appID, err)
+	}
+	for _, key := range []string{"schema_version", "launch_id", "app_id", "state", "runtime", "kernel_verdict"} {
+		if strings.TrimSpace(fmt.Sprint(telemetry[key])) == "" {
+			t.Fatalf("%s runtime telemetry proof missing %s: %#v", appID, key, telemetry)
+		}
+	}
+	if telemetry["app_id"] != appID {
+		t.Fatalf("%s runtime telemetry app_id = %#v, want %q", appID, telemetry["app_id"], appID)
+	}
+	if telemetry["state"] != "RUNNING" && telemetry["state"] != "DELETED" {
+		t.Fatalf("%s runtime telemetry state = %#v, want RUNNING or DELETED", appID, telemetry["state"])
 	}
 }
 


### PR DESCRIPTION
## Summary
- add runtime telemetry evidence to Launchpad EvidencePacks at 03_TELEMETRY/runtime.json
- require live conformance to prove runtime telemetry evidence is present, non-empty, run-labeled, and tied to the launched app
- cover EvidencePack telemetry generation in session executor tests

## Validation
- env -u GOROOT /opt/homebrew/bin/go test ./core/pkg/launchpad/session
- env -u GOROOT /opt/homebrew/bin/go test ./tests/launchpad/...
- git diff --check

## Notes
The local shell had GOROOT pointing at a stale mise Go 1.22.12 install, so validation explicitly unset GOROOT while using Homebrew Go.