### PR TITLE
fix(release): scope pre-release version status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -847,8 +847,11 @@ jobs:
             --expected-version "$VERSION" \
             --write-status dist/version-status/version-status.json \
             published \
-            --skip github-release \
-            --skip homebrew-tap
+            --only ghcr-image \
+            --only ghcr-chart \
+            --only npm-sdk \
+            --only pypi-sdk \
+            --only crates-sdk
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: version-status

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -322,11 +322,50 @@ PUBLISHED_CHECKS = {
 }
 
 
-def check_published(contract: dict[str, Any], version: str, skip: set[str]) -> list[SurfaceResult]:
+def check_published(contract: dict[str, Any], version: str, skip: set[str], only: set[str] | None = None) -> list[SurfaceResult]:
     results: list[SurfaceResult] = []
-    for surface in contract.get("published_surfaces", []):
+    surfaces = list(contract.get("published_surfaces", []))
+    known_ids = {surface["id"] for surface in surfaces}
+    if only is not None:
+        unknown_only = sorted(only - known_ids)
+        if unknown_only:
+            results.append(
+                SurfaceResult(
+                    "published-surface-selection",
+                    "fail",
+                    "known published surface id",
+                    unknown_only,
+                    detail=f"unknown --only surface id(s): {', '.join(unknown_only)}",
+                    blocking=True,
+                )
+            )
+
+    for surface in surfaces:
+        if only is not None and surface["id"] not in only:
+            results.append(
+                SurfaceResult(
+                    surface["id"],
+                    "skipped",
+                    version,
+                    None,
+                    url=fmt(surface.get("human_url") or surface.get("url", ""), version),
+                    detail="not selected by caller",
+                    blocking=False,
+                )
+            )
+            continue
         if surface["id"] in skip:
-            results.append(SurfaceResult(surface["id"], "skipped", version, None, url=fmt(surface.get("human_url") or surface.get("url", ""), version), detail="skipped by caller", blocking=False))
+            results.append(
+                SurfaceResult(
+                    surface["id"],
+                    "skipped",
+                    version,
+                    None,
+                    url=fmt(surface.get("human_url") or surface.get("url", ""), version),
+                    detail="skipped by caller",
+                    blocking=False,
+                )
+            )
             continue
         checker = PUBLISHED_CHECKS.get(surface["kind"])
         if checker is None:
@@ -392,6 +431,7 @@ def parse_args() -> argparse.Namespace:
     local.add_argument("--tag", help="tag ref to compare, for example v1.2.3")
     published = sub.add_parser("published", help="check public registry surfaces")
     published.add_argument("--skip", action="append", default=[], help="published surface id to skip; can be passed more than once")
+    published.add_argument("--only", action="append", default=[], help="published surface id to check; when passed, all other published surfaces are skipped")
     published.add_argument("--surface-timeout", type=float, default=REQUEST_TIMEOUT_SECONDS, help="timeout in seconds for each public surface request")
     return parser.parse_args()
 
@@ -411,7 +451,7 @@ def main() -> int:
         results = source_results
     elif args.mode == "published":
         source_results = check_local(contract, version, None)
-        registry_results = check_published(contract, version, set(args.skip))
+        registry_results = check_published(contract, version, set(args.skip), set(args.only) if args.only else None)
         results = source_results + registry_results
     else:
         raise AssertionError(args.mode)

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -42,6 +42,60 @@ class VersionDriftMonitorTests(unittest.TestCase):
         }
         self.assertFalse(unsupported)
 
+    def test_published_only_skips_unselected_surfaces(self) -> None:
+        contract = {
+            "published_surfaces": [
+                {"id": "selected", "kind": "example", "url": "https://example.test/selected"},
+                {"id": "unselected", "kind": "example", "url": "https://example.test/unselected"},
+            ]
+        }
+        original = drift.PUBLISHED_CHECKS.copy()
+        drift.PUBLISHED_CHECKS["example"] = lambda surface, version: drift.SurfaceResult(
+            surface["id"],
+            "pass",
+            version,
+            version,
+            url=surface["url"],
+        )
+        try:
+            results = drift.check_published(contract, "0.5.12", set(), {"selected"})
+        finally:
+            drift.PUBLISHED_CHECKS.clear()
+            drift.PUBLISHED_CHECKS.update(original)
+
+        by_id = {result.id: result for result in results}
+        self.assertEqual(by_id["selected"].status, "pass")
+        self.assertEqual(by_id["unselected"].status, "skipped")
+        self.assertFalse(by_id["unselected"].blocking)
+        self.assertEqual(by_id["unselected"].detail, "not selected by caller")
+
+    def test_published_only_rejects_unknown_surfaces(self) -> None:
+        contract = {
+            "published_surfaces": [
+                {"id": "selected", "kind": "example", "url": "https://example.test/selected"},
+            ]
+        }
+        original = drift.PUBLISHED_CHECKS.copy()
+        drift.PUBLISHED_CHECKS["example"] = lambda surface, version: drift.SurfaceResult(
+            surface["id"],
+            "pass",
+            version,
+            version,
+            url=surface["url"],
+        )
+        try:
+            results = drift.check_published(contract, "0.5.12", set(), {"typo"})
+        finally:
+            drift.PUBLISHED_CHECKS.clear()
+            drift.PUBLISHED_CHECKS.update(original)
+
+        selection = results[0]
+        self.assertEqual(selection.id, "published-surface-selection")
+        self.assertEqual(selection.status, "fail")
+        self.assertTrue(selection.blocking)
+        self.assertEqual(selection.actual, ["typo"])
+        self.assertIn("unknown --only", selection.detail or "")
+
     def test_published_error_preserves_advisory_status(self) -> None:
         surface = {
             "id": "pkg-go-dev-sdk",


### PR DESCRIPTION
## Summary

- add `published --only` support to `scripts/release/check_version_drift.py`
- use an explicit allow-list for the pre-GitHub-Release `version-status` gate
- keep asynchronous/post-release surfaces out of the pre-release gate so GitHub Release creation is not blocked by ArtifactHub/Maven/docs/Homebrew propagation order

## Validation

- `/usr/bin/python3 scripts/release/check_version_drift_test.py`
- `GITHUB_TOKEN="$(gh auth token)" /usr/bin/python3 scripts/release/check_version_drift.py --expected-version 0.5.12 --write-status /tmp/version-status-pre-release.json published --only ghcr-image --only ghcr-chart --only npm-sdk --only pypi-sdk --only crates-sdk`
- `git diff --check`

## Release Recovery Note

This fixes the workflow logic for subsequent tag runs. The existing `v0.5.12` tag is not rewritten; its release recovery should proceed from the already-published artifacts and the still-running tag workflow evidence.