### PR TITLE
fix(quickstart): harden local onboarding runtime

### DIFF
--- a/core/cmd/helm-ai-kernel/local_first_run_routes.go
+++ b/core/cmd/helm-ai-kernel/local_first_run_routes.go
@@ -72,7 +72,7 @@ func (q *quickstartRuntime) exchange(token string) (map[string]any, int, string)
 	}
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if time.Now().UTC().After(q.ExpiresAt) {
+	if q.expired(time.Now()) {
 		return nil, http.StatusUnauthorized, "local quickstart token expired"
 	}
 	if q.used {
@@ -94,6 +94,13 @@ func (q *quickstartRuntime) sessionDocument() map[string]any {
 		"expires_at":    q.ExpiresAt.Format(time.RFC3339),
 		"entitlements":  []string{"OSS_CORE"},
 	}
+}
+
+func (q *quickstartRuntime) expired(now time.Time) bool {
+	if q == nil {
+		return true
+	}
+	return !now.UTC().Before(q.ExpiresAt)
 }
 
 func RegisterLocalFirstRunRoutes(mux *http.ServeMux, svc *Services, opts serverOptions) {
@@ -142,14 +149,14 @@ func RegisterLocalFirstRunRoutes(mux *http.ServeMux, svc *Services, opts serverO
 		_ = json.NewEncoder(w).Encode(doc)
 	})
 
-	mux.HandleFunc("/api/v1/onboarding/state", protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/onboarding/state", protectQuickstartOnboarding(opts.Quickstart, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			api.WriteMethodNotAllowed(w)
 			return
 		}
 		writeOnboardingState(w, r, svc, opts, nil)
 	}))
-	mux.HandleFunc("/api/v1/onboarding/run-step", protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/onboarding/run-step", protectQuickstartOnboarding(opts.Quickstart, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			api.WriteMethodNotAllowed(w)
 			return
@@ -173,7 +180,7 @@ func RegisterLocalFirstRunRoutes(mux *http.ServeMux, svc *Services, opts serverO
 		}
 		writeOnboardingState(w, r, svc, opts, map[string]string{step.ID: receiptRef})
 	}))
-	mux.HandleFunc("/api/v1/onboarding/export", protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/onboarding/export", protectQuickstartOnboarding(opts.Quickstart, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			api.WriteMethodNotAllowed(w)
 			return
@@ -186,6 +193,16 @@ func RegisterLocalFirstRunRoutes(mux *http.ServeMux, svc *Services, opts serverO
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(export)
 	}))
+}
+
+func protectQuickstartOnboarding(runtime *quickstartRuntime, handler http.HandlerFunc) http.HandlerFunc {
+	return protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		if runtime.expired(time.Now()) {
+			api.WriteUnauthorized(w, "Local quickstart session expired")
+			return
+		}
+		handler(w, r)
+	})
 }
 
 func RegisterLocalConsoleAssetRoutes(mux *http.ServeMux, opts serverOptions, bindAddr string, port int) {

--- a/core/cmd/helm-ai-kernel/local_first_run_routes.go
+++ b/core/cmd/helm-ai-kernel/local_first_run_routes.go
@@ -149,14 +149,14 @@ func RegisterLocalFirstRunRoutes(mux *http.ServeMux, svc *Services, opts serverO
 		_ = json.NewEncoder(w).Encode(doc)
 	})
 
-	mux.HandleFunc("/api/v1/onboarding/state", protectQuickstartOnboarding(opts.Quickstart, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/onboarding/state", protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			api.WriteMethodNotAllowed(w)
 			return
 		}
 		writeOnboardingState(w, r, svc, opts, nil)
 	}))
-	mux.HandleFunc("/api/v1/onboarding/run-step", protectQuickstartOnboarding(opts.Quickstart, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/onboarding/run-step", protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			api.WriteMethodNotAllowed(w)
 			return
@@ -180,7 +180,7 @@ func RegisterLocalFirstRunRoutes(mux *http.ServeMux, svc *Services, opts serverO
 		}
 		writeOnboardingState(w, r, svc, opts, map[string]string{step.ID: receiptRef})
 	}))
-	mux.HandleFunc("/api/v1/onboarding/export", protectQuickstartOnboarding(opts.Quickstart, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/onboarding/export", protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			api.WriteMethodNotAllowed(w)
 			return
@@ -193,16 +193,6 @@ func RegisterLocalFirstRunRoutes(mux *http.ServeMux, svc *Services, opts serverO
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(export)
 	}))
-}
-
-func protectQuickstartOnboarding(runtime *quickstartRuntime, handler http.HandlerFunc) http.HandlerFunc {
-	return protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
-		if runtime.expired(time.Now()) {
-			api.WriteUnauthorized(w, "Local quickstart session expired")
-			return
-		}
-		handler(w, r)
-	})
 }
 
 func RegisterLocalConsoleAssetRoutes(mux *http.ServeMux, opts serverOptions, bindAddr string, port int) {

--- a/core/cmd/helm-ai-kernel/onboard_cmd.go
+++ b/core/cmd/helm-ai-kernel/onboard_cmd.go
@@ -69,7 +69,7 @@ func runOnboardCmd(args []string, stdout, stderr io.Writer) int {
 
 	// Step 3: Generate Ed25519 trust root
 	fmt.Fprintf(stdout, "%s[3/5]%s Generating trust root...    ", ColorBold, ColorReset)
-	signer, err := loadOrGenerateSigner()
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
 	if err != nil {
 		fmt.Fprintf(stderr, "\n❌ Failed: %v\n", err)
 		return 2

--- a/core/cmd/helm-ai-kernel/onboard_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/onboard_cmd_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOnboardUsesCustomDataDirForTrustRoot(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	dataDir := filepath.Join(cwd, "custom-data")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runOnboardCmd([]string{"--data-dir", dataDir, "--yes"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("onboard code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	pubKey, err := os.ReadFile(filepath.Join(dataDir, "root.pub"))
+	if err != nil {
+		t.Fatalf("custom data dir root.pub missing: %v", err)
+	}
+	config, err := os.ReadFile(filepath.Join(cwd, "helm.yaml"))
+	if err != nil {
+		t.Fatalf("helm.yaml missing: %v", err)
+	}
+	if !strings.Contains(string(config), `data_dir: "`+dataDir+`"`) {
+		t.Fatalf("helm.yaml did not reference custom data dir: %s", string(config))
+	}
+	if !strings.Contains(string(config), `root_public_key: "`+strings.TrimSpace(string(pubKey))+`"`) {
+		t.Fatalf("helm.yaml trust root did not match custom data dir public key")
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "data", "root.key")); !os.IsNotExist(err) {
+		t.Fatalf("onboard wrote root.key outside custom data dir: %v", err)
+	}
+}

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -57,15 +57,7 @@ func runQuickstartCmd(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	if os.Getenv(helmauth.AdminAPIKeyEnv) == "" {
-		_ = os.Setenv(helmauth.AdminAPIKeyEnv, prepared.Runtime.SessionToken)
-	}
-	if os.Getenv(runtimeTenantIDEnv) == "" {
-		_ = os.Setenv(runtimeTenantIDEnv, prepared.Runtime.TenantID)
-	}
-	if os.Getenv(runtimePrincipalIDEnv) == "" {
-		_ = os.Setenv(runtimePrincipalIDEnv, prepared.Runtime.PrincipalID)
-	}
+	installQuickstartRuntimeEnv(prepared.Runtime)
 
 	runServerWithOptions(serverOptions{
 		Mode:              "quickstart",
@@ -94,6 +86,15 @@ func runQuickstartCmd(args []string, stdout, stderr io.Writer) int {
 		Stderr: stderr,
 	})
 	return 0
+}
+
+func installQuickstartRuntimeEnv(runtime *quickstartRuntime) {
+	if runtime == nil {
+		return
+	}
+	_ = os.Setenv(helmauth.AdminAPIKeyEnv, runtime.SessionToken)
+	_ = os.Setenv(runtimeTenantIDEnv, runtime.TenantID)
+	_ = os.Setenv(runtimePrincipalIDEnv, runtime.PrincipalID)
 }
 
 func parseQuickstartArgs(args []string, stderr io.Writer) (quickstartOptions, int) {

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -95,6 +95,7 @@ func installQuickstartRuntimeEnv(runtime *quickstartRuntime) {
 	_ = os.Setenv(helmauth.AdminAPIKeyEnv, runtime.SessionToken)
 	_ = os.Setenv(runtimeTenantIDEnv, runtime.TenantID)
 	_ = os.Setenv(runtimePrincipalIDEnv, runtime.PrincipalID)
+	_ = os.Setenv(quickstartExpiresAtEnv, runtime.ExpiresAt.Format(time.RFC3339Nano))
 }
 
 func parseQuickstartArgs(args []string, stderr io.Writer) (quickstartOptions, int) {

--- a/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
+++ b/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
@@ -150,6 +150,9 @@ func TestQuickstartInstallsGeneratedRuntimeEnv(t *testing.T) {
 	if got := os.Getenv(runtimePrincipalIDEnv); got != runtime.PrincipalID {
 		t.Fatalf("principal env = %q, want %q", got, runtime.PrincipalID)
 	}
+	if got := os.Getenv(quickstartExpiresAtEnv); got != runtime.ExpiresAt.Format(time.RFC3339Nano) {
+		t.Fatalf("quickstart expiry env = %q, want %q", got, runtime.ExpiresAt.Format(time.RFC3339Nano))
+	}
 }
 
 func TestQuickstartLocalSessionExchangeRejectsNonLoopback(t *testing.T) {
@@ -176,6 +179,7 @@ func TestQuickstartOnboardingRejectsExpiredSession(t *testing.T) {
 	t.Setenv("HELM_ADMIN_API_KEY", runtime.SessionToken)
 	t.Setenv(runtimeTenantIDEnv, runtime.TenantID)
 	t.Setenv(runtimePrincipalIDEnv, runtime.PrincipalID)
+	t.Setenv(quickstartExpiresAtEnv, runtime.ExpiresAt.Format(time.RFC3339Nano))
 
 	mux := http.NewServeMux()
 	RegisterLocalFirstRunRoutes(mux, &Services{}, serverOptions{Quickstart: runtime})

--- a/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
+++ b/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
@@ -133,6 +133,25 @@ func TestQuickstartLocalSessionExchangeLoopbackOneTimeAndExpiry(t *testing.T) {
 	}
 }
 
+func TestQuickstartInstallsGeneratedRuntimeEnv(t *testing.T) {
+	runtime := quickstartRouteRuntime()
+	t.Setenv("HELM_ADMIN_API_KEY", "external-admin-key")
+	t.Setenv(runtimeTenantIDEnv, "external-tenant")
+	t.Setenv(runtimePrincipalIDEnv, "external-principal")
+
+	installQuickstartRuntimeEnv(runtime)
+
+	if got := os.Getenv("HELM_ADMIN_API_KEY"); got != runtime.SessionToken {
+		t.Fatalf("admin api key = %q, want generated session token", got)
+	}
+	if got := os.Getenv(runtimeTenantIDEnv); got != runtime.TenantID {
+		t.Fatalf("tenant env = %q, want %q", got, runtime.TenantID)
+	}
+	if got := os.Getenv(runtimePrincipalIDEnv); got != runtime.PrincipalID {
+		t.Fatalf("principal env = %q, want %q", got, runtime.PrincipalID)
+	}
+}
+
 func TestQuickstartLocalSessionExchangeRejectsNonLoopback(t *testing.T) {
 	runtime := &quickstartRuntime{
 		BootstrapToken: "bootstrap-token",
@@ -148,6 +167,25 @@ func TestQuickstartLocalSessionExchangeRejectsNonLoopback(t *testing.T) {
 	rec := postLocalExchange(t, mux, "bootstrap-token", "192.0.2.10:49152")
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("non-loopback status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestQuickstartOnboardingRejectsExpiredSession(t *testing.T) {
+	runtime := quickstartRouteRuntime()
+	runtime.ExpiresAt = time.Now().UTC().Add(-time.Minute)
+	t.Setenv("HELM_ADMIN_API_KEY", runtime.SessionToken)
+	t.Setenv(runtimeTenantIDEnv, runtime.TenantID)
+	t.Setenv(runtimePrincipalIDEnv, runtime.PrincipalID)
+
+	mux := http.NewServeMux()
+	RegisterLocalFirstRunRoutes(mux, &Services{}, serverOptions{Quickstart: runtime})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/onboarding/state", nil)
+	authorizeQuickstartRequest(req, runtime)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expired onboarding session status=%d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/route_auth.go
+++ b/core/cmd/helm-ai-kernel/route_auth.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/api"
 	helmauth "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/auth"
@@ -15,6 +16,7 @@ const (
 	principalHeader        = "X-Helm-Principal-ID"
 	runtimeTenantIDEnv     = "HELM_RUNTIME_TENANT_ID"
 	runtimePrincipalIDEnv  = "HELM_RUNTIME_PRINCIPAL_ID"
+	quickstartExpiresAtEnv = "HELM_QUICKSTART_SESSION_EXPIRES_AT"
 	defaultRuntimeTenantID = "default"
 	serviceAPIKeyEnv       = "HELM_SERVICE_API_KEY"
 	servicePrincipalID     = "service-internal"
@@ -43,6 +45,10 @@ func requireRuntimeAdmin(handler http.HandlerFunc) http.HandlerFunc {
 			api.WriteUnauthorized(w, detail)
 			return
 		}
+		if expired, configured := quickstartSessionExpired(time.Now()); configured && expired {
+			api.WriteUnauthorized(w, "Local quickstart session expired")
+			return
+		}
 		handler(w, r.WithContext(helmauth.WithPrincipal(r.Context(), principal)))
 	}
 }
@@ -53,6 +59,10 @@ func requireRuntimeTenant(handler http.HandlerFunc) http.HandlerFunc {
 		adminPrincipal, detail, ok := helmauth.AdminPrincipalFromRequest(r, adminKey)
 		if !ok {
 			api.WriteUnauthorized(w, detail)
+			return
+		}
+		if expired, configured := quickstartSessionExpired(time.Now()); configured && expired {
+			api.WriteUnauthorized(w, "Local quickstart session expired")
 			return
 		}
 
@@ -102,6 +112,18 @@ func configuredRuntimePrincipalID(adminPrincipal helmauth.Principal) string {
 		return principalID
 	}
 	return strings.TrimSpace(adminPrincipal.GetID())
+}
+
+func quickstartSessionExpired(now time.Time) (bool, bool) {
+	raw := strings.TrimSpace(os.Getenv(quickstartExpiresAtEnv))
+	if raw == "" {
+		return false, false
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return true, true
+	}
+	return !now.UTC().Before(expiresAt.UTC()), true
 }
 
 func requireRuntimeService(handler http.HandlerFunc) http.HandlerFunc {

--- a/core/cmd/helm-ai-kernel/route_auth_test.go
+++ b/core/cmd/helm-ai-kernel/route_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	helmauth "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/auth"
 )
@@ -54,6 +55,65 @@ func TestTenantScopedRuntimeAuthBindsConfiguredTenantAndPrincipal(t *testing.T) 
 
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("tenant-scoped route with tenant status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantScopedRuntimeAuthRejectsExpiredQuickstartSession(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", "quickstart-session")
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+	t.Setenv(quickstartExpiresAtEnv, time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano))
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("tenant-scoped handler should not run after quickstart session expiry")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evaluate", nil)
+	req.Header.Set("Authorization", "Bearer quickstart-session")
+	req.Header.Set(tenantHeader, "tenant-a")
+	req.Header.Set(principalHeader, "principal-a")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("tenant-scoped route with expired quickstart session status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAdminRuntimeAuthRejectsExpiredQuickstartSession(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", "quickstart-session")
+	t.Setenv(quickstartExpiresAtEnv, time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano))
+	handler := protectRuntimeHandler(RouteAuthAdmin, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("admin handler should not run after quickstart session expiry")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/console/diagnostics", nil)
+	req.Header.Set("Authorization", "Bearer quickstart-session")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("admin route with expired quickstart session status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantScopedRuntimeAuthAllowsUnexpiredQuickstartSession(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", "quickstart-session")
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+	t.Setenv(quickstartExpiresAtEnv, time.Now().UTC().Add(time.Minute).Format(time.RFC3339Nano))
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evaluate", nil)
+	req.Header.Set("Authorization", "Bearer quickstart-session")
+	req.Header.Set(tenantHeader, "tenant-a")
+	req.Header.Set(principalHeader, "principal-a")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("tenant-scoped route with unexpired quickstart session status = %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/scripts/sdk/gen.sh
+++ b/scripts/sdk/gen.sh
@@ -189,6 +189,11 @@ classmethod_validators = {
     "EntitlementDecision": {"user_state_validate_enum"},
     "EnvExposurePolicy": {"mode_validate_enum"},
     "EvidenceEnvelopeExportRequest": {"envelope_validate_enum"},
+    "LocalConsoleRuntimeConfig": {"profile_validate_enum", "entitlements_validate_enum"},
+    "LocalSessionExchangeResponse": {"entitlements_validate_enum"},
+    "OnboardingRunStepRequest": {"step_id_validate_enum"},
+    "OnboardingState": {"mode_validate_enum", "entitlements_validate_enum"},
+    "OnboardingStep": {"id_validate_enum", "status_validate_enum", "verdict_validate_enum"},
 }
 lines = s.splitlines()
 out = []

--- a/sdk/python/helm_sdk/types_gen.py
+++ b/sdk/python/helm_sdk/types_gen.py
@@ -11011,6 +11011,7 @@ class LocalConsoleRuntimeConfig(BaseModel):
     __properties: ClassVar[List[str]] = ["api_base_url", "local_mode", "start_onboarding", "tenant_id", "principal_id", "profile", "entitlements"]
 
     @field_validator('profile')
+    @classmethod
     def profile_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['claude', 'codex', 'mcp', 'openai-compatible']):
@@ -11018,6 +11019,7 @@ class LocalConsoleRuntimeConfig(BaseModel):
         return value
 
     @field_validator('entitlements')
+    @classmethod
     def entitlements_validate_enum(cls, value):
         """Validates the enum"""
         for i in value:
@@ -11193,6 +11195,7 @@ class LocalSessionExchangeResponse(BaseModel):
     __properties: ClassVar[List[str]] = ["session_token", "tenant_id", "principal_id", "principal", "expires_at", "entitlements"]
 
     @field_validator('entitlements')
+    @classmethod
     def entitlements_validate_enum(cls, value):
         """Validates the enum"""
         for i in value:
@@ -13519,6 +13522,7 @@ class OnboardingRunStepRequest(BaseModel):
     __properties: ClassVar[List[str]] = ["step_id"]
 
     @field_validator('step_id')
+    @classmethod
     def step_id_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['health', 'policy', 'allow', 'deny', 'mcp', 'verify']):
@@ -13609,6 +13613,7 @@ class OnboardingState(BaseModel):
     __properties: ClassVar[List[str]] = ["mode", "entitlements", "profile", "policy_path", "evidence_pack_ref", "steps"]
 
     @field_validator('mode')
+    @classmethod
     def mode_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['self-hosted-oss']):
@@ -13616,6 +13621,7 @@ class OnboardingState(BaseModel):
         return value
 
     @field_validator('entitlements')
+    @classmethod
     def entitlements_validate_enum(cls, value):
         """Validates the enum"""
         for i in value:
@@ -13720,6 +13726,7 @@ class OnboardingStep(BaseModel):
     __properties: ClassVar[List[str]] = ["id", "title", "description", "status", "verdict", "reason_code", "receipt_ref"]
 
     @field_validator('id')
+    @classmethod
     def id_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['health', 'policy', 'allow', 'deny', 'mcp', 'verify']):
@@ -13727,6 +13734,7 @@ class OnboardingStep(BaseModel):
         return value
 
     @field_validator('status')
+    @classmethod
     def status_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['pending', 'pass']):
@@ -13734,6 +13742,7 @@ class OnboardingStep(BaseModel):
         return value
 
     @field_validator('verdict')
+    @classmethod
     def verdict_validate_enum(cls, value):
         """Validates the enum"""
         if value not in set(['ALLOW', 'DENY', 'ESCALATE']):


### PR DESCRIPTION
## Summary
- follow-up to #368 for the resolved quickstart review threads
- bind quickstart runtime env to the generated local session values
- enforce quickstart session expiry on onboarding APIs
- keep onboard --data-dir trust root in the same data directory
- add @classmethod decorators for generated onboarding Python validators and update the SDK generator allowlist

## Validation
- GOROOT= /opt/homebrew/bin/go test ./core/cmd/helm-ai-kernel
- GOROOT= /opt/homebrew/bin/go vet ./core/cmd/helm-ai-kernel
- PYTHON_BIN=/Users/ivan/.local/share/mise/installs/python/3.12.11/bin/python3 PATH=/Users/ivan/.local/share/mise/installs/python/3.12.11/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin GOROOT= make test-sdk-py

## Note
- make sdk-openapi-check was not used as a gate for this narrow follow-up because it rewrote the TypeScript aggregate with thousands of unrelated generated-format/import-order changes in this local shell before failing the drift check.
