### PR TITLE
fix(release): compile pinned SLSA generator

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -43,3 +43,4 @@ jobs:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true
       upload-tag-name: ${{ github.event.release.tag_name || inputs.tag || '' }}
+      compile-generator: true


### PR DESCRIPTION
## Summary
- keep the SLSA v2.1.0 reusable workflow pinned by commit SHA
- set `compile-generator: true` so the generator binary is built from that pinned source
- fixes the workflow_dispatch path for `v0.5.12` provenance publication after #369

## Evidence
- Failed run: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/27481468720
- Failure mode: `slsa-generator-generic-linux-amd64: No such file or directory`
- Root cause: SLSA v2.1.0 only downloads the prebuilt generator binary when the reusable workflow ref is a tag; this repo pins by SHA, so the generator must be compiled.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
