### PR TITLE
fix(release): compile pinned SLSA generator

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -41,5 +41,6 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hashes }}"
+      compile-generator: true
       upload-assets: true
       upload-tag-name: ${{ github.event.release.tag_name || inputs.tag || '' }}


### PR DESCRIPTION
## Summary
- keep the SLSA v2.1.0 reusable workflow pinned by commit SHA
- set `compile-generator: true` so the generator is built from the pinned source instead of trying to download a release binary for the SHA

## Evidence
- Post-merge run for #369 failed in SLSA L3 Provenance run `27481468720`.
- The generator step tried to execute `/home/runner/work/helm-ai-kernel/helm-ai-kernel/slsa-generator-generic-linux-amd64` and failed with `No such file or directory`.
- Upstream v2.1.0 workflow comments state that `compile-generator: false` downloads the builder binary from the release at the detected ref, which must be a tag reference. Our workflow pins the reusable workflow by commit SHA.

## Validation
- `python3` YAML parse of `.github/workflows/slsa-provenance.yml`
- `git diff --check`
