### PR TITLE
fix(onboard): honor --data-dir when materializing the trust root

### DIFF
--- a/core/cmd/helm-ai-kernel/onboard_cmd.go
+++ b/core/cmd/helm-ai-kernel/onboard_cmd.go
@@ -69,7 +69,7 @@ func runOnboardCmd(args []string, stdout, stderr io.Writer) int {
 
 	// Step 3: Generate Ed25519 trust root
 	fmt.Fprintf(stdout, "%s[3/5]%s Generating trust root...    ", ColorBold, ColorReset)
-	signer, err := loadOrGenerateSigner()
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
 	if err != nil {
 		fmt.Fprintf(stderr, "\n❌ Failed: %v\n", err)
 		return 2

--- a/core/cmd/helm-ai-kernel/onboard_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/onboard_cmd_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestOnboardTrustRootMatchesCustomDataDir verifies that `helm onboard --data-dir <dir>`
+// advertises a root_public_key in helm.yaml that matches the signer materialized under
+// that same data dir, rather than the default "data/" directory. Regression test for the
+// onboard trust-root mismatch where step 3 used loadOrGenerateSigner() (hard-coded "data")
+// instead of loadOrGenerateSignerWithDataDir(dataDir).
+func TestOnboardTrustRootMatchesCustomDataDir(t *testing.T) {
+	workDir := chdirTempDir(t)
+	dataDir := filepath.Join(workDir, "custom-data")
+
+	var stdout, stderr bytes.Buffer
+	if code := runOnboardCmd([]string{"--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("onboard exited %d\nstdout=%s\nstderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	// The trust root must be persisted under the custom data dir, never the default "data/".
+	if _, err := os.Stat(filepath.Join(dataDir, "root.key")); err != nil {
+		t.Fatalf("root.key not written under custom data dir %q: %v", dataDir, err)
+	}
+	if _, err := os.Stat(filepath.Join("data", "root.key")); err == nil {
+		t.Fatal("onboard wrote a root key under the default data/ dir; --data-dir was ignored for the signer")
+	}
+
+	configBytes, err := os.ReadFile("helm.yaml")
+	if err != nil {
+		t.Fatalf("read helm.yaml: %v", err)
+	}
+	configKey := rootPublicKeyFromConfig(t, string(configBytes))
+
+	// Loading from the same data dir loads the persisted key (no regeneration), so its
+	// public key must equal what onboard advertised in helm.yaml.
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+	if err != nil {
+		t.Fatalf("load signer from custom data dir: %v", err)
+	}
+	wantKey := hex.EncodeToString(signer.PublicKeyBytes())
+	if configKey != wantKey {
+		t.Fatalf("root_public_key mismatch:\n  helm.yaml:        %s\n  %s signer: %s", configKey, dataDir, wantKey)
+	}
+}
+
+func rootPublicKeyFromConfig(t *testing.T, config string) string {
+	t.Helper()
+	const marker = "root_public_key:"
+	for _, line := range strings.Split(config, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, marker) {
+			continue
+		}
+		value := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, marker)), `"`)
+		if value == "" {
+			t.Fatalf("empty root_public_key in helm.yaml:\n%s", config)
+		}
+		return value
+	}
+	t.Fatalf("root_public_key not found in helm.yaml:\n%s", config)
+	return ""
+}


### PR DESCRIPTION
## Summary

`helm-ai-kernel onboard --data-dir <dir>` advertised a `root_public_key` in `helm.yaml` that did **not** match the signer a later server would actually use.

`runOnboardCmd` step 3 called `loadOrGenerateSigner()` — a zero-arg wrapper hard-coded to the default `data/` directory — while step 2 (SQLite store) and step 4 (`helm.yaml` `data_dir:`) already honored `--data-dir`. So with a non-default `--data-dir`:

- `root_public_key` written to `helm.yaml` came from `./data/`'s signer, but
- a server booted from that config loads/generates its signer under `<dataDir>`,

leaving the config's advertised trust root mismatched against the runtime signer (a silent integrity gap, not a crash).

## Fix

One line in `core/cmd/helm-ai-kernel/onboard_cmd.go` step 3:

```go
signer, err := loadOrGenerateSignerWithDataDir(dataDir)  // was: loadOrGenerateSigner()
```

This matches the helper the quickstart path already uses (`quickstart_cmd.go` → `prepareQuickstart`).

## Test

New `core/cmd/helm-ai-kernel/onboard_cmd_test.go` runs onboard with a custom `--data-dir` and asserts:
1. `helm.yaml`'s `root_public_key` equals the pubkey of the signer **loaded** (not regenerated) from that same data dir, and
2. no `root.key` leaks into the default `./data/`.

Verified non-vacuous: reverting the fix makes the test fail; with the fix it passes.

## Verification

- `MISE_TRUSTED_CONFIG_PATHS="$PWD" go test ./core/cmd/helm-ai-kernel` → `ok`
- `go vet ./core/cmd/helm-ai-kernel` → exit 0

## Context

Onboard-only latent bug, flagged as a **Codex P2 on merged PR #368** (OSS quickstart) and confirmed during review. Separate from the quickstart feature that shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)