### PR TITLE
docs(launchpad): deepen Hermes and Kilo Code app truth

### DIFF
--- a/docs/launchpad/apps/HERMES.md
+++ b/docs/launchpad/apps/HERMES.md
@@ -1,8 +1,19 @@
 ---
+title: Hermes on HELM
 last_reviewed: "2026-06-11"
 ---
 
 # Hermes on HELM
+
+## Audience
+Operators and security reviewers who want to run the upstream Hermes agent
+(`NousResearch/hermes-agent`, MIT-licensed) behind the HELM AI Kernel
+fail-closed execution boundary.
+
+## Outcome
+After this page you know which registry, policy, launch command, and runbook
+own the Hermes sandbox behavior, how to launch the signed OCI artifact, and
+which EvidencePack artifacts must exist before the live-agent proof is accepted.
 
 ## What this proves
 Hermes runs through HELM’s fail-closed execution boundary. The launch is driven by a registry-pinned app definition and a safe default-deny policy: HELM installs Hermes into a sandboxed local container, gates every tool call through the kernel verdict path, and emits a signed receipt for each lifecycle step, from install and healthcheck to teardown. The run ends with an exported EvidencePack that anyone can verify offline, so "it ran safely" is a checkable claim rather than an assertion.
@@ -30,7 +41,17 @@ helm-ai-kernel launch hermes local-container --headless --output json
 ## Source Truth
 - Registry source: `registry/launchpad/apps/hermes.yaml`
 - Policy source: `policies/launchpad/apps/hermes.safe.toml`
+- Launch commands: `core/cmd/helm-ai-kernel/up_cmd.go`, `core/cmd/helm-ai-kernel/launch_cmd.go`
 - Production runbook: `docs/launchpad/HERMES_PRODUCTION_RUNBOOK.md`
+- Validation: `python3 scripts/check_documentation_coverage.py` and `python3 scripts/check_documentation_truth.py`
+
+## Troubleshooting
+| Symptom | First check |
+| --- | --- |
+| Launch fails before install | Verify the signed OCI image digest pinned in `registry/launchpad/apps/hermes.yaml`. |
+| Healthcheck times out | Confirm the `model_gateway` secret is bound; the healthcheck sends one OpenRouter query through the launch-scoped egress proxy. |
+| Hermes cannot write config or cache files | `HOME` is redirected to the writable app-state mount at `/var/lib/hermes`; check the filesystem policy mounts and state directory. |
+| An MCP tool is refused | Unknown MCP servers are quarantined and unknown MCP tools return `ESCALATE`; add a pinned schema before broadening access. |
 
 ## Production claim boundary
 Hermes production proof uses explicit `--live` mode with OpenRouter-only model

--- a/docs/launchpad/apps/KILOCODE.md
+++ b/docs/launchpad/apps/KILOCODE.md
@@ -1,8 +1,18 @@
 ---
+title: Kilo Code on HELM
 last_reviewed: "2026-06-11"
 ---
 
 # Kilo Code on HELM
+
+## Audience
+Operators and security reviewers validating the upstream Kilo Code agent
+(`Kilo-Org/kilocode`, MIT-licensed) as a HELM Launchpad app contract.
+
+## Outcome
+After this page you can verify the Kilo Code signed OCI artifact contract,
+understand why its current support level is `verify_only`, and identify the
+evidence that is still missing before HELM can claim live-agent F2 coverage.
 
 ## What this proves
 Kilo Code currently has `verify_only` contract evidence. The pinned image and
@@ -45,6 +55,16 @@ plus verify-only contract preflight.
 ## Source Truth
 - Registry source: `registry/launchpad/apps/kilocode.yaml`
 - Policy source: `policies/launchpad/apps/kilocode.safe.toml`
+- Launch command owner: `core/cmd/helm-ai-kernel/launch_cmd.go`
+- Validation: `python3 scripts/check_documentation_coverage.py` and `python3 scripts/check_documentation_truth.py`
+
+## Troubleshooting
+| Symptom | First check |
+| --- | --- |
+| Contract preflight fails | Verify the signed OCI image digest and `framework_contract` fields in `registry/launchpad/apps/kilocode.yaml`. |
+| Healthcheck fails | The current healthcheck is `kilocode --version`; confirm the baked `kilocode-cli` dependency resolves inside the image. |
+| An MCP tool is refused | Unknown MCP servers are quarantined and unknown MCP tools return `ESCALATE`; pin the tool schema in `kilocode.default` before authorizing it. |
+| A live-agent claim is requested | Hold the claim until a real Kilo Code command path emits teardown receipts, offline verification, and EvidencePack material. |
 
 ## Evidence requirements
 - cpi_output


### PR DESCRIPTION
## Summary

- Adds operator/security-reviewer audience and outcome sections for Hermes and Kilo Code Launchpad docs.
- Expands source-truth links to the owning registry, policy, command, and validation scripts.
- Adds troubleshooting tables while preserving current claim boundaries: Hermes remains `agent_live`; Kilo Code remains `verify_only` and explicitly not live-agent F2 evidence.

## Validation

- `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH make docs-coverage docs-truth`
- `git diff --check`

Note: plain `make docs-coverage docs-truth` in this temporary worktree was blocked by mise refusing to trust the new worktree's `mise.toml`. The file only pins Go 1.25.10, and the docs targets only invoke Python, so the validation command above uses Homebrew Python ahead of the mise shim without changing gate logic.
