### PR TITLE
feat(kernel): certification evidence gate, verifier telemetry, demo mcp, receipt comparison (MIN-719/568/609/570)

### DIFF
--- a/core/cmd/helm-ai-kernel/contract_routes.go
+++ b/core/cmd/helm-ai-kernel/contract_routes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	evidencepkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
 	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+	helmotel "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/otel"
 	runtimesandbox "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtime/sandbox"
 )
 
@@ -1626,7 +1627,14 @@ func verifyEvidenceRequest(r *http.Request) map[string]any {
 		}
 		receipts = append(receipts, &receipt)
 	}
-	return verificationResult(verifyReceiptBundle(parsed, receipts), receipts)
+	errs := verifyReceiptBundle(parsed, receipts)
+	recordVerification(r.Context(), helmotel.VerificationEvent{
+		EnvelopeID:  parsed.Manifest.SessionID,
+		Verified:    len(errs) == 0,
+		CheckCount:  len(receipts),
+		EvidenceRef: parsed.Manifest.SessionID,
+	})
+	return verificationResult(errs, receipts)
 }
 
 func readEvidenceBundleRequest(r *http.Request) ([]byte, error) {

--- a/core/cmd/helm-ai-kernel/demo_cmd.go
+++ b/core/cmd/helm-ai-kernel/demo_cmd.go
@@ -22,11 +22,12 @@ import (
 //	2 = config error
 func runDemoCmd(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "Usage: helm-ai-kernel demo <organization|research-lab> [flags]")
+		fmt.Fprintln(stderr, "Usage: helm-ai-kernel demo <organization|research-lab|mcp> [flags]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Subcommands:")
 		fmt.Fprintln(stderr, "  organization  Run the canonical starter organization demo")
 		fmt.Fprintln(stderr, "  research-lab  Run a research-lab reference scenario")
+		fmt.Fprintln(stderr, "  mcp           Run the MCP governance proof scenarios")
 		return 2
 	}
 
@@ -35,12 +36,15 @@ func runDemoCmd(args []string, stdout, stderr io.Writer) int {
 		return runDemoScenario("organization", args[1:], stdout, stderr)
 	case "research-lab":
 		return runDemoScenario("research-lab", args[1:], stdout, stderr)
+	case "mcp":
+		return runMCPProof(args[1:], stdout, stderr)
 	case "--help", "-h":
-		fmt.Fprintln(stdout, "Usage: helm-ai-kernel demo <organization|research-lab> [flags]")
+		fmt.Fprintln(stdout, "Usage: helm-ai-kernel demo <organization|research-lab|mcp> [flags]")
 		fmt.Fprintln(stdout, "")
 		fmt.Fprintln(stdout, "Subcommands:")
 		fmt.Fprintln(stdout, "  organization  Run the canonical starter organization demo")
 		fmt.Fprintln(stdout, "  research-lab  Run a research-lab reference scenario")
+		fmt.Fprintln(stdout, "  mcp           Run the MCP governance proof scenarios")
 		return 0
 	default:
 		fmt.Fprintf(stderr, "Unknown demo subcommand: %s\n", args[0])

--- a/core/cmd/helm-ai-kernel/demo_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/demo_cmd_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestDemoMCPAlias verifies that `demo mcp` routes to runMCPProof and produces a
+// verified MCP governance proof.
+func TestDemoMCPAlias(t *testing.T) {
+	out := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	code := runDemoCmd([]string{
+		"mcp",
+		"--out", out,
+		"--run-id", "demo-mcp-test",
+		"--at", "2026-01-01T00:00:00Z",
+		"--json",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("demo mcp failed with code %d: stderr=%s", code, stderr.String())
+	}
+
+	var summary mcpProofSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("demo mcp output is not valid summary JSON: %v\noutput: %s", err, stdout.String())
+	}
+	if summary.SchemaVersion != "helm.mcp.proof/v1" {
+		t.Errorf("unexpected schema version %q", summary.SchemaVersion)
+	}
+	if !summary.OfflineVerified {
+		t.Errorf("MCP proof EvidencePack should verify offline")
+	}
+	if len(summary.Scenarios) == 0 {
+		t.Errorf("MCP proof should run at least one scenario")
+	}
+}
+
+// TestDemoUnknownSubcommand verifies unknown subcommands are still rejected and
+// the usage text advertises the mcp alias.
+func TestDemoUnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runDemoCmd([]string{"bogus"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("unknown subcommand should exit 2, got %d", code)
+	}
+
+	stderr.Reset()
+	if code := runDemoCmd(nil, &stdout, &stderr); code != 2 {
+		t.Fatalf("missing subcommand should exit 2, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "mcp") {
+		t.Errorf("usage should advertise the mcp subcommand, got: %s", stderr.String())
+	}
+}

--- a/core/cmd/helm-ai-kernel/verification_telemetry.go
+++ b/core/cmd/helm-ai-kernel/verification_telemetry.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+
+	helmmetrics "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/metrics"
+	helmotel "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/otel"
+)
+
+// verificationMetrics is the process-wide collector for the north-star
+// adoption metric: EvidencePack verifications run against this binary, whether
+// over the HTTP verify endpoint or the `verify` CLI command.
+var verificationMetrics = helmmetrics.NewGovernanceMetrics()
+
+// verificationTracer emits verifier spans. A NoopTracer is the safe default
+// when no OTLP endpoint is configured; spans are still constructed so the code
+// path is exercised identically with or without an exporter.
+var verificationTracer = helmotel.NoopTracer()
+
+// recordVerification reports one EvidencePack verification run to both the
+// Prometheus-compatible counter and the OTel verifier span.
+func recordVerification(ctx context.Context, event helmotel.VerificationEvent) {
+	verificationMetrics.RecordVerification()
+	verificationTracer.TraceVerification(ctx, event)
+}

--- a/core/cmd/helm-ai-kernel/verify_cmd.go
+++ b/core/cmd/helm-ai-kernel/verify_cmd.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
 	evidencepkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
+	helmotel "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/otel"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/verifier"
 )
 
@@ -239,6 +241,13 @@ func runVerifyCmd(args []string, stdout, stderr io.Writer) int {
 	}
 
 	finalizeVerifyReport(report)
+
+	recordVerification(context.Background(), helmotel.VerificationEvent{
+		EnvelopeID:  report.EnvelopeID,
+		Verified:    report.Verified,
+		CheckCount:  len(report.Checks),
+		EvidenceRef: bundle,
+	})
 
 	// Write auditor JSON report to file if requested
 	if jsonOutFile != "" {

--- a/core/pkg/otel/governance_tracer.go
+++ b/core/pkg/otel/governance_tracer.go
@@ -62,6 +62,13 @@ const (
 	AttrA2AOriginAgent       = "helm.a2a.origin_agent"
 	AttrA2ATargetAgent       = "helm.a2a.target_agent"
 	AttrA2ANegotiationResult = "helm.a2a.negotiation_result"
+
+	// Verifier attributes
+	AttrVerifierEnvelopeID  = "helm.verifier.envelope_id"
+	AttrVerifierVerified    = "helm.verifier.verified"
+	AttrVerifierCheckCount  = "helm.verifier.check_count"
+	AttrVerifierReceiptRef  = "helm.verifier.receipt_ref"
+	AttrVerifierEvidenceRef = "helm.verifier.evidence_ref"
 )
 
 // Config holds configuration for the governance telemetry exporter.
@@ -79,10 +86,11 @@ type GovernanceTracer struct {
 	meterProvider  *sdkmetric.MeterProvider
 
 	// Metrics
-	decisionCounter metric.Int64Counter
-	denialCounter   metric.Int64Counter
-	budgetGauge     metric.Float64Gauge
-	latencyHist     metric.Float64Histogram
+	decisionCounter     metric.Int64Counter
+	denialCounter       metric.Int64Counter
+	verificationCounter metric.Int64Counter
+	budgetGauge         metric.Float64Gauge
+	latencyHist         metric.Float64Histogram
 }
 
 // NewGovernanceTracer creates a new governance telemetry exporter.
@@ -137,6 +145,9 @@ func NewGovernanceTracer(cfg Config) (*GovernanceTracer, error) {
 	)
 	gt.denialCounter, _ = gt.meter.Int64Counter("helm.denials.total",
 		metric.WithDescription("Total governance denials"),
+	)
+	gt.verificationCounter, _ = gt.meter.Int64Counter("helm.verifications.total",
+		metric.WithDescription("Total EvidencePack verification runs"),
 	)
 	gt.budgetGauge, _ = gt.meter.Float64Gauge("helm.budget.utilization",
 		metric.WithDescription("Budget utilization ratio"),
@@ -463,6 +474,47 @@ func (gt *GovernanceTracer) TraceDenial(ctx context.Context, d DenialEvent) {
 	))
 }
 
+// VerificationEvent represents one EvidencePack verification run to trace.
+//
+// Verifications by parties other than the operator are the north-star adoption
+// signal (the category is won when receipts are verified by auditors, customers,
+// and counterparties — not just produced). This span lets OTel backends count
+// and inspect verifications alongside the decisions/denials they attest to.
+type VerificationEvent struct {
+	EnvelopeID  string
+	Verified    bool
+	CheckCount  int
+	ReceiptRef  string
+	EvidenceRef string
+}
+
+// TraceVerification records an EvidencePack verification run as an OTel span and
+// metric. The span name is "helm.verifier.verification".
+func (gt *GovernanceTracer) TraceVerification(ctx context.Context, e VerificationEvent) {
+	attrs := []attribute.KeyValue{
+		attribute.Bool(AttrVerifierVerified, e.Verified),
+		attribute.Int64(AttrVerifierCheckCount, int64(e.CheckCount)),
+	}
+	if e.EnvelopeID != "" {
+		attrs = append(attrs, attribute.String(AttrVerifierEnvelopeID, e.EnvelopeID))
+	}
+	if e.ReceiptRef != "" {
+		attrs = append(attrs, attribute.String(AttrVerifierReceiptRef, e.ReceiptRef))
+	}
+	if e.EvidenceRef != "" {
+		attrs = append(attrs, attribute.String(AttrVerifierEvidenceRef, e.EvidenceRef))
+	}
+
+	_, span := gt.tracer.Start(ctx, "helm.verifier.verification",
+		trace.WithAttributes(attrs...),
+	)
+	span.End()
+
+	gt.verificationCounter.Add(ctx, 1, metric.WithAttributes(
+		attribute.Bool(AttrVerifierVerified, e.Verified),
+	))
+}
+
 // InjectTraceparent writes the active span context from ctx into the outgoing
 // HTTP headers as a W3C traceparent. Use this before forwarding a request to
 // an upstream model provider so the downstream span tree links back to the
@@ -498,15 +550,17 @@ func NoopTracer() *GovernanceTracer {
 	meter := sdkmetric.NewMeterProvider().Meter("helm.governance.noop")
 	counter, _ := meter.Int64Counter("helm.decisions.total")
 	denials, _ := meter.Int64Counter("helm.denials.total")
+	verifications, _ := meter.Int64Counter("helm.verifications.total")
 	gauge, _ := meter.Float64Gauge("helm.budget.utilization")
 	hist, _ := meter.Float64Histogram("helm.decision.latency")
 	return &GovernanceTracer{
-		tracer:          otel.Tracer("helm.governance.noop"),
-		meter:           meter,
-		decisionCounter: counter,
-		denialCounter:   denials,
-		budgetGauge:     gauge,
-		latencyHist:     hist,
+		tracer:              otel.Tracer("helm.governance.noop"),
+		meter:               meter,
+		decisionCounter:     counter,
+		denialCounter:       denials,
+		verificationCounter: verifications,
+		budgetGauge:         gauge,
+		latencyHist:         hist,
 	}
 }
 

--- a/core/pkg/trust/certification.go
+++ b/core/pkg/trust/certification.go
@@ -60,11 +60,23 @@ func (g *CertificationGate) SetRequirement(context string, level CertificationLe
 }
 
 // RecordCertification records a pack's certification level.
-func (g *CertificationGate) RecordCertification(record *CertificationRecord) {
+//
+// VERIFIED and higher certifications must carry signed test-suite evidence: a
+// non-zero TestsTotal where every test passed. A record that claims VERIFIED or
+// PRODUCTION without a clean, non-empty test run is rejected and not stored, so
+// CheckInstall can never grant an install on an unsubstantiated certification.
+func (g *CertificationGate) RecordCertification(record *CertificationRecord) error {
+	if certOrder[record.Level] >= certOrder[CertVerified] {
+		if record.TestsTotal == 0 || record.TestsPassed != record.TestsTotal {
+			return fmt.Errorf("certification %s for %s@%s requires a complete test suite: %d/%d tests passed",
+				record.Level, record.PackName, record.PackVersion, record.TestsPassed, record.TestsTotal)
+		}
+	}
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	key := record.PackName + "@" + record.PackVersion
 	g.records[key] = record
+	return nil
 }
 
 // CheckInstall verifies a pack meets the certification requirement for a context.

--- a/core/pkg/trust/certification_test.go
+++ b/core/pkg/trust/certification_test.go
@@ -8,10 +8,12 @@ import (
 func TestCertificationGatePass(t *testing.T) {
 	g := NewCertificationGate()
 	g.SetRequirement("production", CertProduction)
-	g.RecordCertification(&CertificationRecord{
+	if err := g.RecordCertification(&CertificationRecord{
 		PackName: "deploy-factory", PackVersion: "1.0", Level: CertProduction,
 		CertifiedBy: "qa", CertifiedAt: time.Now(), TestsPassed: 100, TestsTotal: 100,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	err := g.CheckInstall("deploy-factory", "1.0", "production")
 	if err != nil {
@@ -22,9 +24,11 @@ func TestCertificationGatePass(t *testing.T) {
 func TestCertificationGateFail(t *testing.T) {
 	g := NewCertificationGate()
 	g.SetRequirement("production", CertProduction)
-	g.RecordCertification(&CertificationRecord{
+	if err := g.RecordCertification(&CertificationRecord{
 		PackName: "test-pack", PackVersion: "1.0", Level: CertBasic,
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	err := g.CheckInstall("test-pack", "1.0", "production")
 	if err == nil {
@@ -42,7 +46,12 @@ func TestCertificationGateNoCert(t *testing.T) {
 
 func TestCertificationGetRecord(t *testing.T) {
 	g := NewCertificationGate()
-	g.RecordCertification(&CertificationRecord{PackName: "p", PackVersion: "1.0", Level: CertVerified})
+	if err := g.RecordCertification(&CertificationRecord{
+		PackName: "p", PackVersion: "1.0", Level: CertVerified,
+		TestsPassed: 12, TestsTotal: 12,
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	r, err := g.GetCertification("p", "1.0")
 	if err != nil {
@@ -51,4 +60,37 @@ func TestCertificationGetRecord(t *testing.T) {
 	if r.Level != CertVerified {
 		t.Fatalf("expected VERIFIED, got %s", r.Level)
 	}
+}
+
+func TestCertificationRequiresTestEvidence(t *testing.T) {
+	g := NewCertificationGate()
+
+	t.Run("production_without_tests_rejected", func(t *testing.T) {
+		if err := g.RecordCertification(&CertificationRecord{
+			PackName: "no-tests", PackVersion: "1.0", Level: CertProduction,
+			TestsTotal: 0,
+		}); err == nil {
+			t.Fatal("PRODUCTION with TestsTotal==0 must error")
+		}
+		if _, err := g.GetCertification("no-tests", "1.0"); err == nil {
+			t.Fatal("rejected certification must not be stored")
+		}
+	})
+
+	t.Run("verified_with_failures_rejected", func(t *testing.T) {
+		if err := g.RecordCertification(&CertificationRecord{
+			PackName: "failing", PackVersion: "1.0", Level: CertVerified,
+			TestsPassed: 9, TestsTotal: 10,
+		}); err == nil {
+			t.Fatal("VERIFIED with failing tests must error")
+		}
+	})
+
+	t.Run("basic_without_tests_allowed", func(t *testing.T) {
+		if err := g.RecordCertification(&CertificationRecord{
+			PackName: "basic", PackVersion: "1.0", Level: CertBasic,
+		}); err != nil {
+			t.Fatalf("BASIC does not require test evidence: %v", err)
+		}
+	})
 }

--- a/core/pkg/trust/trust_regression_test.go
+++ b/core/pkg/trust/trust_regression_test.go
@@ -845,14 +845,18 @@ func TestClosing_CertificationLevel_Values(t *testing.T) {
 func TestClosing_CertificationGate_CheckInstall(t *testing.T) {
 	gate := NewCertificationGate()
 	gate.SetRequirement("production", CertProduction)
-	gate.RecordCertification(&CertificationRecord{PackName: "pack1", PackVersion: "1.0", Level: CertBasic})
+	if err := gate.RecordCertification(&CertificationRecord{PackName: "pack1", PackVersion: "1.0", Level: CertBasic}); err != nil {
+		t.Fatal(err)
+	}
 	t.Run("basic_fails_production", func(t *testing.T) {
 		err := gate.CheckInstall("pack1", "1.0", "production")
 		if err == nil {
 			t.Fatal("basic cert should fail production requirement")
 		}
 	})
-	gate.RecordCertification(&CertificationRecord{PackName: "pack2", PackVersion: "1.0", Level: CertProduction})
+	if err := gate.RecordCertification(&CertificationRecord{PackName: "pack2", PackVersion: "1.0", Level: CertProduction, TestsPassed: 50, TestsTotal: 50}); err != nil {
+		t.Fatal(err)
+	}
 	t.Run("production_passes", func(t *testing.T) {
 		err := gate.CheckInstall("pack2", "1.0", "production")
 		if err != nil {
@@ -866,7 +870,9 @@ func TestClosing_CertificationGate_CheckInstall(t *testing.T) {
 		}
 	})
 	t.Run("default_requires_basic", func(t *testing.T) {
-		gate.RecordCertification(&CertificationRecord{PackName: "pack3", PackVersion: "1.0", Level: CertNone})
+		if err := gate.RecordCertification(&CertificationRecord{PackName: "pack3", PackVersion: "1.0", Level: CertNone}); err != nil {
+			t.Fatal(err)
+		}
 		err := gate.CheckInstall("pack3", "1.0", "unset-context")
 		if err == nil {
 			t.Fatal("NONE should fail default BASIC requirement")
@@ -876,7 +882,9 @@ func TestClosing_CertificationGate_CheckInstall(t *testing.T) {
 
 func TestClosing_CertificationGate_GetCertification(t *testing.T) {
 	gate := NewCertificationGate()
-	gate.RecordCertification(&CertificationRecord{PackName: "p1", PackVersion: "2.0", Level: CertVerified})
+	if err := gate.RecordCertification(&CertificationRecord{PackName: "p1", PackVersion: "2.0", Level: CertVerified, TestsPassed: 7, TestsTotal: 7}); err != nil {
+		t.Fatal(err)
+	}
 	t.Run("found", func(t *testing.T) {
 		r, err := gate.GetCertification("p1", "2.0")
 		if err != nil {

--- a/docs/receipt-comparison-aar-acta.md
+++ b/docs/receipt-comparison-aar-acta.md
@@ -1,0 +1,84 @@
+---
+title: Receipt Comparison — AAR/Pipelock vs IETF ACTA vs HELM
+last_reviewed: 2026-06-14
+---
+
+# Receipt Comparison — AAR/Pipelock vs IETF ACTA vs HELM Receipt v1.0
+
+## Audience
+
+Maintainers and reviewers positioning the HELM receipt against two adjacent
+signed-receipt designs: the **AAR / Pipelock** agent-action receipt model, and the
+IETF Internet-Draft **draft-farley-acta-signed-receipts-01** ("Agent Compliance
+& Transparency Architecture" signed receipts). The goal is to know, primitive by
+primitive, where HELM already matches or exceeds these designs, what it would
+cost to interoperate, and exactly how far we are allowed to phrase each claim
+without overclaiming.
+
+## Source truth
+
+- **HELM receipt format**: `protocols/specs/rfc/receipt-format-v1.md` (v1.0.0,
+  Final). Every HELM cell below is bound to a section of that spec — no HELM
+  capability is asserted here that the spec does not normatively define. Golden
+  vectors live in `tests/conformance/` and `core/pkg/contracts/testdata/`.
+- **AAR / Pipelock** and **IETF ACTA** columns describe those external designs
+  at the level needed for the comparison. They are *their* claims, not HELM
+  measurements, and are not reproduced from a HELM-controlled artifact. Treat
+  them as "best current understanding of the external spec," to be re-checked
+  against the upstream document before any external publication.
+
+> [!IMPORTANT]
+> This document is internal positioning, not a marketing artifact. The
+> "wording guardrail" column is normative for any external copy: do not phrase a
+> HELM claim more strongly than the guardrail permits.
+
+## Why this matters
+
+Signed agent-action receipts are converging into a category. AAR/Pipelock and
+the ACTA draft both stake out "cryptographically signed, verifiable record of
+what an agent was permitted to do." HELM's receipt predates neither claim of
+superiority nor a finished interop story — so this page records, honestly, where
+the HELM v1.0 wire format stands and what the bridge would cost.
+
+## Primitive-by-primitive comparison
+
+| Primitive | HELM: matches / exceeds / gap | Interop cost | Wording guardrail (no overclaim) |
+| --- | --- | --- | --- |
+| **Canonical serialization** | **Matches.** HELM mandates RFC 8785 JCS for content addressing (spec §4.1). AAR/Pipelock and ACTA both rely on a deterministic canonical form before signing. | Low if the peer uses JCS; medium if the peer uses a different canonicalization (e.g. JWS/JCS-of-JWS, or protobuf-canonical) — a transcoder must re-canonicalize without changing semantics. | Say "uses RFC 8785 JCS, the same canonicalization discipline as peer designs." Do **not** say "byte-compatible with ACTA/AAR" — that is unverified. |
+| **Content-addressed ID** | **Matches/exceeds.** `receipt_id = SHA-256(canonical_json(receipt_without_id))` (spec §2.1, §4.2). Self-certifying ID is at least as strong as a peer that signs an externally-assigned UUID. | Low. A peer expecting a UUID can carry `receipt_id` as an opaque string; a peer expecting content addressing can recompute it. | "Content-addressed via SHA-256 over canonical JSON." Avoid "more secure than X" — it is a different ID model, not a measured improvement. |
+| **Signature scheme** | **Matches.** Ed25519 over `receipt_id`, with `signer_key_id` referencing a published trust root (spec §2.3). | Low–medium. If a peer mandates JWS/COSE envelopes or a different curve (ECDSA P-256), a wrapping/translation layer is required; the signed preimage differs. | "Ed25519-signed, offline-verifiable." Do **not** claim JWS/COSE compatibility — HELM signs a bare preimage, not a JOSE/COSE structure. |
+| **Verdict semantics** | **Exceeds (richer).** Three-valued `ALLOW \| DENY \| ESCALATE` (spec §2.2), where ESCALATE encodes human-in-the-loop. A binary allow/deny peer cannot represent ESCALATE losslessly. | Medium. Mapping ESCALATE onto a binary peer loses information; the safe mapping is ESCALATE → deny-pending, never ESCALATE → allow. | "Three-valued verdict including an explicit escalate/HITL state." Do **not** say peers "lack" HITL — they may model it elsewhere; say HELM carries it *in the receipt*. |
+| **Reason codes** | **Exceeds.** Normative reason-code registry of 20 codes across Policy/PDP/Resource/Schema/Temporal/Security/Tenancy/Jurisdiction (spec §2.5), required on DENY/ESCALATE. | Medium. Peers with a free-text or smaller enum need a mapping table; unmapped codes should pass through as an opaque string, not be dropped. | "Carries a normative reason-code registry." Do **not** claim the registry is an industry standard — it is HELM-defined. |
+| **Causal ordering** | **Exceeds.** Monotonic `lamport` clock, strictly increasing per kernel instance (spec §2.4), plus ProofGraph hash-chained DAG (spec §3). Tamper-evident ordering, not just per-record signatures. | Medium–high. A peer with only per-record signatures (no chain) cannot consume the ordering guarantee; bridging preserves signatures but drops chain semantics unless the peer adopts the ProofGraph node reference. | "Lamport-ordered and hash-chained into a ProofGraph DAG." Do **not** imply peers are "unordered" without checking — say HELM's ordering is *in-band and verifiable offline*. |
+| **Proof-graph binding** | **Exceeds / potential gap for peers.** Each receipt MUST map 1:1 to a ProofGraph node via `proofgraph_node` (spec §3, §5 step 5). This is a HELM-specific structure. | High to fully interoperate. A peer without a ProofGraph can ignore `proofgraph_node` (still verifies the receipt), but cannot reproduce the DAG-level tamper evidence. | "Binds each receipt to a tamper-evident ProofGraph node." Do **not** claim peers can verify the DAG — they verify the *receipt*; DAG verification needs the HELM ProofGraph. |
+| **Counterfactual / observe-only receipts** | **Exceeds (distinctive).** `enforcement = enforced \| counterfactual`, with counterfactual receipts binding `observe_grant_id` + sealed boundary record, carrying `would_have_verdict`, and signed over an enforcement-prefixed preimage so they can never be replayed as enforced (spec §2.6). | High. Most peers have no notion of a no-authority "would-have" receipt; a bridge MUST NOT present a counterfactual receipt to a peer that would read it as enforced. Default-safe mapping: drop or clearly relabel. | "Distinguishes enforced vs counterfactual receipts cryptographically." This is a genuine differentiator — but phrase it as "we found no equivalent in the reviewed peer specs," not "no other receipt format has this." |
+| **Offline verification** | **Matches.** Verifiable with only JCS + SHA-256 + Ed25519, by parties who do not trust the producer (spec §Implementation Independence, §5). | Low. This is the shared premise of all three designs; interop here is about key distribution, not format. | "Offline-verifiable by untrusting third parties using open primitives." Safe to state plainly — it is normative in the spec. |
+| **Payload binding** | **Matches.** `payload_hash` = SHA-256 of the execution payload (spec §2). Receipt commits to the effect without embedding it. | Low. A peer carrying an inline payload vs a hash needs a content-resolution step, but the commitment model is standard. | "Commits to the execution payload by hash." Do **not** claim the payload itself is portable — only its hash is in the receipt. |
+| **Fail-closed semantics** | **Matches.** No valid receipt ⇒ no effect execution (spec §6). | N/A (deployment property, not wire-format). Does not affect on-the-wire interop. | "Fail-closed: no receipt, no execution." Spec-backed; safe to state. Keep it a property of the *kernel*, not of the receipt bytes. |
+
+## Net read
+
+- **No on-the-wire format gap that blocks interop.** HELM's primitives are the
+  shared category primitives (JCS, SHA-256, Ed25519, content addressing,
+  offline verification). The real interop cost is in translation layers
+  (signature envelope shape, verdict/reason mapping), not in missing
+  capabilities.
+- **HELM's distinctive surface is structural, not cryptographic:** ProofGraph
+  binding and counterfactual receipts. These are where HELM exceeds the reviewed
+  peer designs — and also where a naive bridge can silently drop guarantees, so
+  they need the strictest wording guardrails.
+
+## Honest gaps / follow-ups
+
+1. **External specs not pinned in-repo.** The AAR/Pipelock and ACTA columns are
+   based on the external designs as understood at review time, not on a vendored
+   copy of `draft-farley-acta-signed-receipts-01` or an AAR/Pipelock spec
+   artifact. Before any external publication, re-verify each peer cell against
+   the upstream document and pin the exact draft revision.
+2. **No conformance bridge exists yet.** There is no HELM↔ACTA or HELM↔AAR
+   transcoder or golden cross-vector in this repo. Until one lands under
+   `tests/conformance/`, do not claim "interoperates with" — claim only
+   "shares the underlying primitives with."
+3. **Counterfactual uniqueness is scoped to the reviewed specs.** The claim that
+   no peer has an enforced/counterfactual distinction is bounded by what was
+   reviewed here; it is not a survey of the whole field.


### PR DESCRIPTION
Closes MIN-719, MIN-568, MIN-609, MIN-570.

- **MIN-719**: RecordCertification now returns error and refuses to store VERIFIED/PRODUCTION certs lacking a complete passing test suite (TestsTotal>0 && TestsPassed==TestsTotal). +regression test.
- **MIN-568**: TraceVerification (helm.verifier.* span + helm.verifications.total counter) wired into HTTP verifyEvidenceRequest and the verify CLI.
- **MIN-609**: demo mcp subcommand delegates to runMCPProof.
- **MIN-570**: docs/receipt-comparison-aar-acta.md (AAR/Pipelock vs IETF ACTA draft vs HELM receipt-format-v1) — external columns marked unverified.

Gate: go build/vet/test (trust, otel, cmd) + make verify-fixtures all green.

---
Agent-authored (Claude Code) under the HELM Linear sweep; local gates green. Requires review + CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)