### PR TITLE
feat(kernel): anchor receipt issuance in transparency log, fail-closed (MIN-720)

### DIFF
--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -32,6 +32,7 @@ import (
 	dockersandbox "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/sandbox/docker"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store/ledger"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/translog"
 
 	_ "github.com/lib/pq" // Postgres Driver
 )
@@ -343,6 +344,22 @@ func runServerWithOptions(opts serverOptions) {
 		services.PolicyReconciler = policyReconciler
 		services.PolicySnapshotStore = policyStore
 		services.PolicyScope = policyScope
+
+		// Receipt transparency log: anchor every issued receipt hash. Sharing
+		// the signer's public key as the log identity matches `helm-ai-kernel
+		// log` (see translog_cmd.go). Fail-closed by default; degrade only when
+		// HELM_TRANSPARENCY_DEGRADE is explicitly set.
+		transpLog, transpErr := translog.Open(filepath.Join(dataDir, "translog"))
+		if transpErr != nil {
+			if envBool("HELM_PRODUCTION") {
+				log.Fatalf("Failed to open receipt transparency log: %v", transpErr)
+			}
+			log.Printf("[helm] receipt transparency log disabled (dev): %v", transpErr)
+		} else {
+			services.TranspLog = transpLog
+			services.TranspLogID = translog.LogIDFromPublicKey(signer.PublicKeyBytes())
+			services.TranspLogDegrade = envBool("HELM_TRANSPARENCY_DEGRADE")
+		}
 		extraRoutes = func(mux *http.ServeMux) {
 			RegisterSubsystemRoutes(mux, services)
 			RegisterConsoleRoutes(mux, services, opts)

--- a/core/cmd/helm-ai-kernel/receipt_routes.go
+++ b/core/cmd/helm-ai-kernel/receipt_routes.go
@@ -263,10 +263,63 @@ func persistDecisionReceipt(ctx context.Context, svc *Services, decision *contra
 		if err := svc.ReceiptSigner.SignReceipt(receipt); err != nil {
 			return nil, fmt.Errorf("sign receipt %s: %w", receiptID, err)
 		}
+		// Anchor the signed receipt hash in the transparency log before it is
+		// persisted. Fail-closed: an append failure aborts the builder, which
+		// rolls back AppendCausal so no receipt is stored. Degrade mode is the
+		// only escape and must be explicitly enabled in config.
+		if err := anchorReceiptTransparency(svc, receipt); err != nil {
+			return nil, err
+		}
 		return receipt, nil
 	})
 	if err != nil {
 		return fmt.Errorf("store receipt %s: %w", receiptID, err)
+	}
+	return nil
+}
+
+// TransparencyAppender is the subset of the receipt transparency log needed at
+// issuance time: append a receipt-hash leaf and report its assigned index.
+type TransparencyAppender interface {
+	Append(leafInput []byte) (uint64, error)
+}
+
+// anchorReceiptTransparency appends the signed receipt's content hash to the
+// transparency log and records the resulting leaf on the receipt. It is
+// fail-closed by default: if the log is configured but the append fails,
+// issuance is aborted. When svc.TranspLogDegrade is set, an append failure
+// instead records a deferred anchor so the receipt can be backfilled later.
+// A nil log leaves the receipt unanchored (no transparency configured).
+func anchorReceiptTransparency(svc *Services, receipt *contracts.Receipt) error {
+	if svc == nil || svc.TranspLog == nil {
+		return nil
+	}
+	leafHashHex, err := contracts.ReceiptChainHash(receipt)
+	if err != nil {
+		return fmt.Errorf("transparency leaf hash for %s: %w", receipt.ReceiptID, err)
+	}
+	leafInput, err := hex.DecodeString(leafHashHex)
+	if err != nil {
+		return fmt.Errorf("decode transparency leaf hash for %s: %w", receipt.ReceiptID, err)
+	}
+	index, appendErr := svc.TranspLog.Append(leafInput)
+	if appendErr != nil {
+		if !svc.TranspLogDegrade {
+			return fmt.Errorf("transparency log append for %s: %w", receipt.ReceiptID, appendErr)
+		}
+		receipt.LogID = svc.TranspLogID
+		receipt.Transparency = &contracts.TransparencyAnchor{
+			Backend:  "translog",
+			LogID:    svc.TranspLogID,
+			Deferred: true,
+		}
+		return nil
+	}
+	receipt.LogID = svc.TranspLogID
+	receipt.LeafIndex = index
+	receipt.Transparency = &contracts.TransparencyAnchor{
+		Backend: "translog",
+		LogID:   svc.TranspLogID,
 	}
 	return nil
 }

--- a/core/cmd/helm-ai-kernel/receipt_routes_test.go
+++ b/core/cmd/helm-ai-kernel/receipt_routes_test.go
@@ -159,6 +159,108 @@ func TestPersistDecisionReceiptLinksToCanonicalPreviousReceiptHash(t *testing.T)
 	}
 }
 
+type fakeTransparencyLog struct {
+	appended  [][]byte
+	appendErr error
+	nextIndex uint64
+}
+
+func (l *fakeTransparencyLog) Append(leafInput []byte) (uint64, error) {
+	if l.appendErr != nil {
+		return 0, l.appendErr
+	}
+	l.appended = append(l.appended, append([]byte(nil), leafInput...))
+	idx := l.nextIndex
+	l.nextIndex++
+	return idx, nil
+}
+
+func newTransparencyDecision() *contracts.DecisionRecord {
+	return &contracts.DecisionRecord{
+		ID:                 "dec-tl",
+		Action:             "EXECUTE_TOOL",
+		Verdict:            string(contracts.VerdictAllow),
+		PolicyDecisionHash: "sha256:pdp",
+		Timestamp:          time.Unix(1700000000, 0).UTC(),
+	}
+}
+
+func TestPersistDecisionReceiptAnchorsTransparencyLeaf(t *testing.T) {
+	signer, err := helmcrypto.NewEd25519Signer("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcptStore := &captureReceiptStore{}
+	tl := &fakeTransparencyLog{nextIndex: 5}
+	svc := &Services{ReceiptStore: rcptStore, ReceiptSigner: signer, TranspLog: tl, TranspLogID: "log-abc"}
+
+	if err := persistDecisionReceipt(context.Background(), svc, newTransparencyDecision(), "agent.test", []byte("EXECUTE_TOOL:tool"), map[string]any{"source": "test"}); err != nil {
+		t.Fatalf("persist receipt: %v", err)
+	}
+	if rcptStore.stored == nil {
+		t.Fatal("receipt was not stored")
+	}
+	if len(tl.appended) != 1 {
+		t.Fatalf("expected exactly one transparency append, got %d", len(tl.appended))
+	}
+	if rcptStore.stored.LogID != "log-abc" {
+		t.Fatalf("receipt log_id = %q, want log-abc", rcptStore.stored.LogID)
+	}
+	if rcptStore.stored.LeafIndex != 5 {
+		t.Fatalf("receipt leaf_index = %d, want 5", rcptStore.stored.LeafIndex)
+	}
+	if rcptStore.stored.Transparency == nil || rcptStore.stored.Transparency.Deferred {
+		t.Fatalf("expected non-deferred transparency anchor, got %+v", rcptStore.stored.Transparency)
+	}
+}
+
+func TestPersistDecisionReceiptBlocksWhenTransparencyAppendFailsFailClosed(t *testing.T) {
+	signer, err := helmcrypto.NewEd25519Signer("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcptStore := &captureReceiptStore{}
+	appendErr := errors.New("transparency log unavailable")
+	// Default posture: TranspLogDegrade is false (fail-closed).
+	svc := &Services{ReceiptStore: rcptStore, ReceiptSigner: signer, TranspLog: &fakeTransparencyLog{appendErr: appendErr}, TranspLogID: "log-abc"}
+
+	err = persistDecisionReceipt(context.Background(), svc, newTransparencyDecision(), "agent.test", []byte("EXECUTE_TOOL:tool"), map[string]any{"source": "test"})
+	if !errors.Is(err, appendErr) {
+		t.Fatalf("expected transparency append error to block issuance, got %v", err)
+	}
+	if rcptStore.stored != nil {
+		t.Fatalf("fail-closed issuance must not store a receipt, got %+v", rcptStore.stored)
+	}
+}
+
+func TestPersistDecisionReceiptDegradesWhenExplicitlyAllowed(t *testing.T) {
+	signer, err := helmcrypto.NewEd25519Signer("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcptStore := &captureReceiptStore{}
+	svc := &Services{
+		ReceiptStore:     rcptStore,
+		ReceiptSigner:    signer,
+		TranspLog:        &fakeTransparencyLog{appendErr: errors.New("transparency log unavailable")},
+		TranspLogID:      "log-abc",
+		TranspLogDegrade: true,
+	}
+
+	if err := persistDecisionReceipt(context.Background(), svc, newTransparencyDecision(), "agent.test", []byte("EXECUTE_TOOL:tool"), map[string]any{"source": "test"}); err != nil {
+		t.Fatalf("degrade mode must not block issuance: %v", err)
+	}
+	if rcptStore.stored == nil {
+		t.Fatal("degrade mode should still store the receipt")
+	}
+	if rcptStore.stored.Transparency == nil || !rcptStore.stored.Transparency.Deferred {
+		t.Fatalf("expected deferred transparency anchor under degrade, got %+v", rcptStore.stored.Transparency)
+	}
+	if rcptStore.stored.LeafIndex != 0 {
+		t.Fatalf("deferred anchor must not claim a leaf index, got %d", rcptStore.stored.LeafIndex)
+	}
+}
+
 func TestPersistDecisionReceiptReturnsStoreError(t *testing.T) {
 	signer, err := helmcrypto.NewEd25519Signer("test")
 	if err != nil {

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -70,6 +70,16 @@ type Services struct {
 	ReceiptStore  store.ReceiptStore
 	ReceiptSigner helmcrypto.Signer
 
+	// --- Receipt Transparency Log (RFC 6962) ---
+	// TranspLog anchors every issued receipt hash in an append-only Merkle
+	// log. TranspLogID is the log identity (hex SHA-256 of the kernel public
+	// key). TranspLogDegrade, when true, downgrades a transparency append
+	// failure from fail-closed (issuance blocked) to a deferred anchor; the
+	// production default is false (fail-closed).
+	TranspLog        TransparencyAppender
+	TranspLogID      string
+	TranspLogDegrade bool
+
 	// --- Cross-cutting ---
 	KernelRT *kernelruntime.Server
 

--- a/core/pkg/contracts/receipt.go
+++ b/core/pkg/contracts/receipt.go
@@ -84,6 +84,14 @@ type Receipt struct {
 	EmergencyScopeHash           string `json:"emergency_scope_hash,omitempty"`
 	SafeDepState                 string `json:"safe_dep_state,omitempty"`
 	SafeDepReasonCode            string `json:"safe_dep_reason_code,omitempty"`
+
+	// Receipt Transparency Log (RFC 6962) anchoring. Populated when the
+	// receipt hash is appended to the append-only transparency log during
+	// issuance. LogID and LeafIndex identify the leaf; Transparency carries
+	// the log backend identity for verifiers.
+	Transparency *TransparencyAnchor `json:"transparency,omitempty"`
+	LogID        string              `json:"log_id,omitempty"`
+	LeafIndex    uint64              `json:"leaf_index,omitempty"`
 }
 
 type Projection struct {

--- a/core/pkg/evidencepack/builder.go
+++ b/core/pkg/evidencepack/builder.go
@@ -168,6 +168,23 @@ func (b *Builder) AddReplayManifest(name string, manifest interface{}) error {
 	return nil
 }
 
+// AddTransparencySTH captures a signed tree head (RFC 6962 checkpoint) of the
+// receipt transparency log at pack-build time. Embedding the STH lets a
+// verifier prove every receipt in the pack was anchored under a log root the
+// kernel signed at export time, without trusting the exporter. The sth value
+// is any JSON-serializable signed tree head (e.g. translog.SignedTreeHead).
+func (b *Builder) AddTransparencySTH(name string, sth interface{}) error {
+	data, err := json.MarshalIndent(sth, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal transparency sth %s: %w", name, err)
+	}
+	b.entries["transparency/"+name+".json"] = entryData{
+		content:     data,
+		contentType: "application/json",
+	}
+	return nil
+}
+
 func safeEvidenceName(value string) string {
 	value = strings.TrimSpace(value)
 	value = strings.Trim(value, "/")

--- a/core/pkg/evidencepack/builder_test.go
+++ b/core/pkg/evidencepack/builder_test.go
@@ -146,6 +146,40 @@ func TestAddReplayManifest(t *testing.T) {
 	}
 }
 
+func TestAddTransparencySTH(t *testing.T) {
+	b := newTestBuilder()
+	sth := map[string]any{
+		"tree_size": 42,
+		"root_hash": "abc123",
+		"log_id":    "log-1",
+		"signature": "sig-1",
+	}
+	if err := b.AddTransparencySTH("checkpoint", sth); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, content, err := b.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := content["transparency/checkpoint.json"]; !ok {
+		t.Fatal("expected transparency/checkpoint.json in content map")
+	}
+
+	found := false
+	for _, e := range manifest.Entries {
+		if e.Path == "transparency/checkpoint.json" {
+			found = true
+			if e.ContentHash == "" {
+				t.Fatal("expected non-empty hash for transparency entry")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected transparency/checkpoint.json in manifest entries")
+	}
+}
+
 func TestAllNewEntryTypes_InSinglePack(t *testing.T) {
 	b := newTestBuilder()
 

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-14T02:09:40Z
-# Commit: 3a4896b9cd201862be729cae305839882c5b73f1
+# Generated: 2026-06-14T03:17:56Z
+# Commit: 9601bc52982467aed69ee8cb7fb71682920589bc
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md
@@ -204,7 +204,7 @@ c9aefcaefb9565ba86fdf087f6d05c6c6c49873172a5ba720ff6dccbce0b7f47  core/pkg/contr
 0ffa51fc3b14fe46dddd1610386859d7196c03d7f0e0b17986e8724731cb8506  core/pkg/contracts/posture_budget_corridor_test.go
 72cbfdedd6cd7d9a859bdf9cf227fbda0262748c73c3c0570bb500beb43d9d12  core/pkg/contracts/proofs.go
 9a102cb08f0bc539c18ca998d3a3fd54ba3cde0a4114731f136be6ef1f25aa55  core/pkg/contracts/proposals.go
-a3799381a176b814101bd51818daf971a28f8709c188aa87b8293081c76f985f  core/pkg/contracts/receipt.go
+72d9e3269a98849270c5f5afdb0bb8d07238e67a8f571fe81500b7785ff95736  core/pkg/contracts/receipt.go
 15026d4ed482963f29113ffdb0252ee6fb7b8192e93a0af0767f1270ae2f7f8c  core/pkg/contracts/receipt_fuzz_test.go
 3fa9fa9aa737572cf7213e619c3571dc2c9a1b00b147f08c5e3e6a0b7c077503  core/pkg/contracts/receipt_hash.go
 13cd995836c12a34fccd699fed492b360b4f82c1c10a9f4ae458b65d7faa9dad  core/pkg/contracts/receipt_hash_parity_test.go
@@ -309,8 +309,8 @@ b747620621ea158e1bb12b77c15c265f8701aa9a33cb608c9ad1026dc218845d  core/pkg/crypt
 0686f9c57e9ddbb46d7a4e85d60eff54e38d53d422c022e7e6f7389f319b1871  core/pkg/crypto/zk/safety_checker_test.go
 8739c7e4d2df1d7752b28e89d5b590705959f9be623a783182720d86db6bdb4a  core/pkg/evidencepack/README.md
 3d6a8c4c2a29d59f9d37df6ca68c90c5afe8d0525aa36530fdb2ad5dd01b76d8  core/pkg/evidencepack/archive.go
-4a7951a170e8bea3bdc1090bb0edeeb6da5ddae5a7e85b99f3166173517b35aa  core/pkg/evidencepack/builder.go
-4833006a321a206e7fbf1417ccff655ff556f4bc92a6df64d38123d3971ef2b4  core/pkg/evidencepack/builder_test.go
+0916a3df70d15dd977beb773d1035e97995f8069382e36b77522c6cbc24e575a  core/pkg/evidencepack/builder.go
+314a0568858a1744478f437ec9b22f072c0d2e5d028e5a8b4acaab0bbd5174aa  core/pkg/evidencepack/builder_test.go
 3cd6a38836549c616bed8ec4ed4b80703d0a7ab1380aab8f29c3c9b47a197e63  core/pkg/evidencepack/chaos_test.go
 3a8fc2a7e02a595353921b68baefe4f444644ba991bb380f8063be40749dbb63  core/pkg/evidencepack/evidencepack_behavior_coverage_test.go
 b0282931372d24fc5a0d12acab58ab374e6d6cf3a43130b7fc7f445811697a26  core/pkg/evidencepack/evidencepack_contracts_test.go


### PR DESCRIPTION
Closes MIN-720. Builds on the MIN-513 transparency log.

- Receipt struct gains TransparencyAnchor/LogID/LeafIndex (omitempty; signature canonicalization unchanged).
- persistDecisionReceipt anchors the signed receipt hash via translog inside the AppendCausal builder tx — **fail-closed** (append error rolls back, nothing stored). Degrade only if HELM_TRANSPARENCY_DEGRADE is set.
- evidencepack Builder.AddTransparencySTH captures an STH at pack-build.
- Regenerated tools/boundary/protected.manifest (contracts+evidencepack drifted).

Caveat: STH capture is wired as a Builder method; calling it from the export command is a follow-up. Gate: go build/vet/test + make verify-fixtures green, incl. fail-closed block test.

---
Agent-authored (Claude Code) under the HELM Linear sweep; local gates green. Requires review + CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)