### PR TITLE
MIN-739 Block stale Go SDK publication drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The complete diagram doctrine lives in
 | Surface | Current install or status |
 | --- | --- |
 | CLI | GitHub Release binaries; the latest release attaches a `helm-ai-kernel.rb` formula asset. Verify the public tap before relying on `brew install mindburnlabs/tap/helm-ai-kernel` for the latest version |
-| Go SDK | `go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@main`; tagged module versions are tracked as an OSS-readiness follow-up |
+| Go SDK | `go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.14` |
 | Python SDK | `pip install helm-sdk` |
 | TypeScript SDK | `npm install @mindburn/helm-ai-kernel` |
 | Rust SDK | `cargo add helm-sdk` |

--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -248,7 +248,7 @@ Run online verification only after offline verification passes:
 | Python | `pip install helm-sdk` | `make test-sdk-py` |
 | TypeScript / JavaScript | `npm install @mindburn/helm-ai-kernel` | `make test-sdk-ts` |
 | Rust | `cargo add helm-sdk` | `make test-sdk-rust` |
-| Go | source/module path `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go`; pin `@main` or a commit until tagged module releases are aligned | `cd sdk/go && go test ./...` |
+| Go | `go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.14`; the Go module is released by the subdirectory tag `sdk/go/v0.5.14` | `cd sdk/go && go test ./...` |
 | Java | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.14` | `make test-sdk-java` |
 
 Use [SDK Index](sdks/00_INDEX.md) before publishing SDK install instructions.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -71,7 +71,7 @@ The repository retains packaging metadata for the kernel binaries, container ima
 | Python SDK | `helm-sdk` |
 | Rust SDK | `helm-sdk` |
 | Java SDK | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.14` |
-| Go SDK | `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@main`; pin `@main` or a commit until tagged module releases are aligned |
+| Go SDK | `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.14`; publish with the subdirectory tag `sdk/go/v0.5.14` |
 
 ## Release Inputs
 

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -71,7 +71,7 @@ distribution promises.
 | Python SDK | Package name `helm-sdk`; source manifest follows the repository `VERSION` (`0.5.14` for this release). Verify `version-status.json` or `make version-drift-published` before publishing pinned install claims. | `sdk/python/helm_sdk/client.py` | `make test-sdk-py` |
 | TypeScript | Package name `@mindburn/helm-ai-kernel`; source manifest follows the repository `VERSION` (`0.5.14` for this release). Verify `version-status.json` or `make version-drift-published` before publishing pinned install claims. | `sdk/ts/src/client.ts` | `make test-sdk-ts` |
 | JavaScript | Uses `@mindburn/helm-ai-kernel` or raw HTTP/fetch | `sdk/ts/src/client.ts`, `examples/js_openai_baseurl/` | `make test-sdk-ts` |
-| Go SDK | Source/module path only; pin `@main` or a commit until tagged SDK modules are aligned | `sdk/go/client/client.go` | `cd sdk/go && go test ./...` |
+| Go SDK | Module path `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.14`; released by the subdirectory tag `sdk/go/v0.5.14` | `sdk/go/client/client.go` | `cd sdk/go && go test ./...` |
 | Rust SDK | Package name `helm-sdk`; source manifest follows the repository `VERSION` (`0.5.14` for this release). Verify `version-status.json` or `make version-drift-published` before publishing pinned install claims. | `sdk/rust/src/client.rs` | `make test-sdk-rust` |
 | Java SDK | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.14`; verified by remote Maven resolution and repo1 artifacts. | `sdk/java/pom.xml` | `make test-sdk-java` |
 
@@ -113,7 +113,7 @@ Use the OpenAI-compatible proxy instead of the SDK when an existing OpenAI-style
 ## Go
 
 ```bash
-go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@main
+go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.14
 cd sdk/go
 go test ./...
 ```

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -194,6 +194,13 @@
       "replacement": "io.github.mindburnlabs:helm-sdk:{version}"
     },
     {
+      "id": "publishing-doc-go-module",
+      "path": "docs/PUBLISHING.md",
+      "kind": "regex",
+      "pattern": "github\\.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "replacement": "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}"
+    },
+    {
       "id": "verification-doc-current-release",
       "path": "docs/VERIFICATION.md",
       "kind": "regex",
@@ -292,6 +299,13 @@
       "replacement": "io.github.mindburnlabs:helm-sdk:{version}"
     },
     {
+      "id": "readme-current-go-module",
+      "path": "README.md",
+      "kind": "regex",
+      "pattern": "github\\.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "replacement": "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}"
+    },
+    {
       "id": "developer-journey-current-release-target",
       "path": "docs/DEVELOPER_JOURNEY.md",
       "kind": "regex",
@@ -327,11 +341,25 @@
       "replacement": "io.github.mindburnlabs:helm-sdk:{version}"
     },
     {
+      "id": "developer-journey-go-module",
+      "path": "docs/DEVELOPER_JOURNEY.md",
+      "kind": "regex",
+      "pattern": "github\\.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "replacement": "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}"
+    },
+    {
       "id": "sdk-index-java-coordinate",
       "path": "docs/sdks/00_INDEX.md",
       "kind": "regex",
       "pattern": "io\\.github\\.mindburnlabs:helm-sdk:(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
       "replacement": "io.github.mindburnlabs:helm-sdk:{version}"
+    },
+    {
+      "id": "sdk-index-go-module",
+      "path": "docs/sdks/00_INDEX.md",
+      "kind": "regex",
+      "pattern": "github\\.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "replacement": "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}"
     },
     {
       "id": "sdk-index-source-version-claims",
@@ -533,6 +561,13 @@
       "blocking": false
     },
     {
+      "id": "sdk-go-readme-module-version",
+      "path": "sdk/go/README.md",
+      "kind": "regex",
+      "pattern": "github\\.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "replacement": "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}"
+    },
+    {
       "id": "sdk-java-src-main-java-labs-mindburn-helm-typesgen-java-generated-openapi",
       "path": "sdk/java/src/main/java/labs/mindburn/helm/TypesGen.java",
       "kind": "regex",
@@ -632,11 +667,18 @@
       "human_url": "https://github.com/Mindburn-Labs/homebrew-tap/blob/main/Formula/helm-ai-kernel.rb"
     },
     {
+      "id": "go-proxy-sdk",
+      "kind": "go_proxy_module",
+      "url": "https://proxy.golang.org/github.com/!mindburn-!labs/helm-ai-kernel/sdk/go/@v/v{version}.info",
+      "human_url": "https://pkg.go.dev/github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}",
+      "origin_subdir": "sdk/go",
+      "origin_ref": "refs/tags/sdk/go/v{version}"
+    },
+    {
       "id": "pkg-go-dev-sdk",
       "kind": "pkg_go_dev",
       "url": "https://pkg.go.dev/github.com/Mindburn-Labs/helm-ai-kernel/sdk/go?tab=versions",
-      "human_url": "https://pkg.go.dev/github.com/Mindburn-Labs/helm-ai-kernel/sdk/go",
-      "blocking": false
+      "human_url": "https://pkg.go.dev/github.com/Mindburn-Labs/helm-ai-kernel/sdk/go"
     },
     {
       "id": "docs-site-developer-journey",
@@ -644,10 +686,15 @@
       "url": "https://helm.docs.mindburn.org/helm-ai-kernel/developer-journey",
       "human_url": "https://helm.docs.mindburn.org/helm-ai-kernel/developer-journey",
       "contains": [
-        "io.github.mindburnlabs:helm-sdk:{version}"
+        "io.github.mindburnlabs:helm-sdk:{version}",
+        "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}",
+        "sdk/go/v{version}"
       ],
       "rejects": [
-        "io.github.mindburnlabs:helm-sdk:0.5.2"
+        "io.github.mindburnlabs:helm-sdk:0.5.2",
+        "sdk/go@main",
+        "pin <code>@main</code>",
+        "until tagged module releases are aligned"
       ]
     },
     {
@@ -657,11 +704,16 @@
       "human_url": "https://helm.docs.mindburn.org/helm-ai-kernel/sdks",
       "contains": [
         "io.github.mindburnlabs:helm-sdk:{version}",
+        "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}",
+        "sdk/go/v{version}",
         "version-status.json"
       ],
       "rejects": [
         "source manifest currently declares",
-        "io.github.mindburnlabs:helm-sdk:0.5.2"
+        "io.github.mindburnlabs:helm-sdk:0.5.2",
+        "sdk/go@main",
+        "pin <code>@main</code>",
+        "until tagged SDK modules are aligned"
       ]
     },
     {

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -298,12 +298,36 @@ def check_http_contains(surface: dict[str, Any], version: str) -> SurfaceResult:
     return SurfaceResult(surface["id"], "pass" if not missing and not rejected else "fail", expected, actual, url=fmt(surface.get("human_url", url), version), blocking=is_blocking(surface))
 
 
+def check_go_proxy_module(surface: dict[str, Any], version: str) -> SurfaceResult:
+    url = fmt(surface["url"], version)
+    payload = request_json(url)
+    origin = payload.get("Origin") or {}
+    expected = {
+        "version": f"v{version}",
+        "origin_subdir": surface.get("origin_subdir"),
+        "origin_ref": fmt(surface.get("origin_ref", "refs/tags/sdk/go/v{version}"), version),
+    }
+    actual = {
+        "version": payload.get("Version"),
+        "origin_subdir": origin.get("Subdir"),
+        "origin_ref": origin.get("Ref"),
+    }
+    return SurfaceResult(
+        surface["id"],
+        "pass" if actual == expected else "fail",
+        expected,
+        actual,
+        url=fmt(surface.get("human_url", url), version),
+        blocking=is_blocking(surface),
+    )
+
+
 def check_pkg_go_dev(surface: dict[str, Any], version: str) -> SurfaceResult:
     url = fmt(surface["url"], version)
     text = request_text(url)
     versions = unique(re.findall(r"\bv[0-9]+\.[0-9]+\.[0-9]+\b", text))
     expected = f"v{version}"
-    detail = None if expected in versions else "pkg.go.dev has not indexed the aligned SDK module tag yet"
+    detail = None if expected in versions else "pkg.go.dev has not indexed the required SDK module tag yet"
     return SurfaceResult(surface["id"], "pass" if expected in versions else "fail", expected, versions, url=fmt(surface.get("human_url", url), version), detail=detail, blocking=is_blocking(surface))
 
 
@@ -318,6 +342,7 @@ PUBLISHED_CHECKS = {
     "ghcr_tags": check_ghcr_tags,
     "http_exists": check_http_exists,
     "http_contains": check_http_contains,
+    "go_proxy_module": check_go_proxy_module,
     "pkg_go_dev": check_pkg_go_dev,
 }
 

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -22,6 +22,7 @@ class VersionDriftMonitorTests(unittest.TestCase):
             "pypi-sdk",
             "crates-sdk",
             "maven-sdk",
+            "go-proxy-sdk",
             "pkg-go-dev-sdk",
             "docs-site-developer-journey",
             "docs-site-sdk-index",
@@ -30,8 +31,12 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertFalse(required - ids)
 
         kinds = {surface["id"]: surface["kind"] for surface in contract["published_surfaces"]}
+        blocking = {surface["id"]: drift.is_blocking(surface) for surface in contract["published_surfaces"]}
+        self.assertEqual(kinds["go-proxy-sdk"], "go_proxy_module")
         self.assertEqual(kinds["pkg-go-dev-sdk"], "pkg_go_dev")
         self.assertEqual(kinds["docs-site-sdk-index"], "http_contains")
+        self.assertTrue(blocking["go-proxy-sdk"])
+        self.assertTrue(blocking["pkg-go-dev-sdk"])
 
     def test_all_published_surface_kinds_are_supported(self) -> None:
         contract = drift.load_contract(drift.DEFAULT_CONTRACT)
@@ -98,8 +103,8 @@ class VersionDriftMonitorTests(unittest.TestCase):
 
     def test_published_error_preserves_advisory_status(self) -> None:
         surface = {
-            "id": "pkg-go-dev-sdk",
-            "url": "https://pkg.go.dev/example",
+            "id": "optional-docs-cache",
+            "url": "https://example.test/cache",
             "blocking": False,
         }
         result = drift.published_error(surface, "0.5.10", TimeoutError("timed out"))
@@ -121,8 +126,8 @@ class VersionDriftMonitorTests(unittest.TestCase):
         )
         advisory = drift.published_error(
             {
-                "id": "pkg-go-dev-sdk",
-                "url": "https://pkg.go.dev/example",
+                "id": "optional-docs-cache",
+                "url": "https://example.test/cache",
                 "blocking": False,
             },
             "0.5.10",
@@ -135,12 +140,37 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertEqual(payload["registry_versions"][0]["status"], "fail")
         self.assertTrue(payload["registry_versions"][0]["blocking"])
         self.assertIn("TimeoutError", payload["registry_versions"][0]["detail"])
-        self.assertEqual(payload["registry_versions"][1]["id"], "pkg-go-dev-sdk")
+        self.assertEqual(payload["registry_versions"][1]["id"], "optional-docs-cache")
         self.assertFalse(payload["registry_versions"][1]["blocking"])
 
         advisory_only = drift.status_payload("published", "0.5.10", [advisory], [], [advisory])
         self.assertEqual(advisory_only["status"], "pass")
         self.assertEqual(advisory_only["registry_versions"][0]["status"], "fail")
+
+    def test_go_proxy_module_validates_subdirectory_tag(self) -> None:
+        original = drift.request_json
+        drift.request_json = lambda _url: {
+            "Version": "v0.5.14",
+            "Origin": {
+                "Subdir": "sdk/go",
+                "Ref": "refs/tags/sdk/go/v0.5.14",
+            },
+        }
+        try:
+            surface = {
+                "id": "go-proxy-sdk",
+                "kind": "go_proxy_module",
+                "url": "https://proxy.golang.org/github.com/!mindburn-!labs/helm-ai-kernel/sdk/go/@v/v{version}.info",
+                "origin_subdir": "sdk/go",
+                "origin_ref": "refs/tags/sdk/go/v{version}",
+            }
+            result = drift.check_go_proxy_module(surface, "0.5.14")
+        finally:
+            drift.request_json = original
+
+        self.assertEqual(result.status, "pass")
+        self.assertTrue(result.blocking)
+        self.assertEqual(result.actual["origin_ref"], "refs/tags/sdk/go/v0.5.14")
 
     def test_http_contains_reports_missing_tokens(self) -> None:
         original = drift.request_text

--- a/scripts/release/distribute.sh
+++ b/scripts/release/distribute.sh
@@ -21,8 +21,33 @@ echo "Distributing HELM $VERSION across all ecosystems..."
 
 # 1. Go (via Git Tags)
 echo "🐹 Tagging Go SDK..."
-git tag -f "sdk/go/v$VERSION"
-git push -f origin "sdk/go/v$VERSION"
+GO_TAG="sdk/go/v$VERSION"
+GO_TAG_TARGET="$(git rev-parse HEAD^{commit})"
+if git rev-parse -q --verify "refs/tags/$GO_TAG" >/dev/null; then
+    EXISTING_GO_TAG_TARGET="$(git rev-parse "$GO_TAG^{commit}")"
+    if [ "$EXISTING_GO_TAG_TARGET" != "$GO_TAG_TARGET" ]; then
+        echo "❌ Go SDK tag $GO_TAG points at $EXISTING_GO_TAG_TARGET, expected $GO_TAG_TARGET."
+        echo "   Refusing to move an existing release tag."
+        exit 1
+    fi
+else
+    git tag -a "$GO_TAG" -m "Release Go SDK v$VERSION"
+fi
+
+REMOTE_GO_TAG_TARGET="$(git ls-remote --tags origin "refs/tags/$GO_TAG^{}" | awk '{print $1}')"
+if [ -z "$REMOTE_GO_TAG_TARGET" ]; then
+    REMOTE_GO_TAG_TARGET="$(git ls-remote --tags origin "refs/tags/$GO_TAG" | awk '{print $1}')"
+fi
+if [ -n "$REMOTE_GO_TAG_TARGET" ]; then
+    if [ "$REMOTE_GO_TAG_TARGET" != "$GO_TAG_TARGET" ]; then
+        echo "❌ Remote Go SDK tag $GO_TAG points at $REMOTE_GO_TAG_TARGET, expected $GO_TAG_TARGET."
+        echo "   Refusing to overwrite an existing release tag."
+        exit 1
+    fi
+    echo "ℹ️  Go SDK tag $GO_TAG already exists on origin."
+else
+    git push origin "refs/tags/$GO_TAG"
+fi
 echo "✅ Go SDK tagged (v$VERSION)."
 
 # 2. Rust (Crates.io)

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -5,12 +5,11 @@ Typed Go client for the HELM kernel HTTP API.
 ## Install
 
 ```bash
-go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@main
+go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.14
 ```
 
 Version truth is the repository `VERSION` file (`0.5.14` for this release).
-Go consumers should pin by commit or `@main` until SDK module release tags are
-realigned with the repository release version.
+Tagged Go module releases use the subdirectory tag form `sdk/go/v0.5.14`.
 
 ## Local Test
 


### PR DESCRIPTION
## Summary
- add a blocking Go proxy module surface for `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v<version>`
- make `pkg-go-dev-sdk` blocking instead of advisory
- replace stale Go `@main` install guidance with `@v0.5.14` and subdirectory tag truth
- refuse force-moving Go SDK release tags in `scripts/release/distribute.sh`
- extend public docs-site checks so stale Go `@main` copy fails after this lands

## Validation
- `python3 -m json.tool release/version-surfaces.yaml`
- `PYTHONPATH=scripts/release python3 -m unittest scripts.release.check_version_drift_test`
- `python3 scripts/release/check_version_drift.py --expected-version 0.5.14 local`
- `python3 scripts/release/check_version_drift.py --expected-version 0.5.14 published --only go-proxy-sdk`
- `python3 scripts/release/check_version_drift.py --expected-version 0.5.14 published --only pkg-go-dev-sdk`
- `bash -n scripts/release/distribute.sh`
- `env GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org GONOPROXY= GONOSUMDB= GONOPRIVATE= go list -m -json github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.14`
- `make docs-truth`

## Notes
The live docs site currently still has stale Go `@main` copy; the new `docs-site-developer-journey` and `docs-site-sdk-index` checks correctly fail until this source docs update is deployed.

Linear: MIN-739