### PR TITLE
fix(demo): emit a canonical sealed EvidencePack so verify passes out of the box (MIN-738)

### DIFF
--- a/core/cmd/helm-ai-kernel/demo_cmd.go
+++ b/core/cmd/helm-ai-kernel/demo_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -9,8 +10,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
+	evidencepkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidencepack"
 )
 
 // runDemoCmd implements `helm-ai-kernel demo` — run governed demonstrations.
@@ -54,18 +60,19 @@ func runDemoCmd(args []string, stdout, stderr io.Writer) int {
 
 // demoReceipt represents a receipt emitted during the demo.
 type demoReceipt struct {
-	ReceiptID  string            `json:"receipt_id"`
-	Timestamp  string            `json:"timestamp"`
-	Principal  string            `json:"principal"`
-	Action     string            `json:"action"`
-	Tool       string            `json:"tool,omitempty"`
-	Verdict    string            `json:"verdict"`
-	ReasonCode string            `json:"reason_code"`
-	Hash       string            `json:"hash"`
-	Lamport    uint64            `json:"lamport_clock"`
-	PrevHash   string            `json:"prev_hash"`
-	Mode       string            `json:"mode,omitempty"`
-	Metadata   map[string]string `json:"metadata,omitempty"`
+	ReceiptID    string            `json:"receipt_id"`
+	Timestamp    string            `json:"timestamp"`
+	Principal    string            `json:"principal"`
+	Action       string            `json:"action"`
+	Tool         string            `json:"tool,omitempty"`
+	Verdict      string            `json:"verdict"`
+	ReasonCode   string            `json:"reason_code"`
+	Hash         string            `json:"hash"`
+	DecisionHash string            `json:"decision_hash"`
+	Lamport      uint64            `json:"lamport_clock"`
+	PrevHash     string            `json:"prev_hash"`
+	Mode         string            `json:"mode,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
 }
 
 type demoActor struct {
@@ -262,17 +269,18 @@ func runDemoScenario(kind string, args []string, stdout, stderr io.Writer) int {
 		principalID := strings.ReplaceAll(strings.ToLower(principal), " ", "_")
 
 		r := demoReceipt{
-			ReceiptID:  fmt.Sprintf("rcpt-%s-%d", hash[:8], lamport),
-			Timestamp:  ts,
-			Principal:  principal,
-			Action:     action,
-			Tool:       tool,
-			Verdict:    verdict,
-			ReasonCode: reason,
-			Hash:       hash,
-			Lamport:    lamport,
-			PrevHash:   prevHash,
-			Mode:       mode,
+			ReceiptID:    fmt.Sprintf("rcpt-%s-%d", hash[:8], lamport),
+			Timestamp:    ts,
+			Principal:    principal,
+			Action:       action,
+			Tool:         tool,
+			Verdict:      verdict,
+			ReasonCode:   reason,
+			Hash:         hash,
+			DecisionHash: hash,
+			Lamport:      lamport,
+			PrevHash:     prevHash,
+			Mode:         mode,
 			Metadata: map[string]string{
 				"organization_id": cfg.organizationID,
 				"scope_id":        cfg.scopeID,
@@ -404,47 +412,17 @@ func runDemoScenario(kind string, args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "\n%s━━━ All Phases Complete ━━━%s\n\n", ColorBold+ColorCyan, ColorReset)
 
 	fmt.Fprintf(stdout, "%sExporting EvidencePack...%s\n", ColorBold, ColorReset)
-	if err := os.MkdirAll(outDir, 0750); err != nil {
-		fmt.Fprintf(stderr, "Error creating evidence dir: %v\n", err)
-		return 2
-	}
-
-	for i, r := range receipts {
-		data, _ := json.MarshalIndent(r, "", "  ")
-		fname := fmt.Sprintf("%03d_%s.json", i+1, r.ReceiptID)
-		if err := os.WriteFile(filepath.Join(outDir, fname), data, 0644); err != nil {
-			fmt.Fprintf(stderr, "Error writing receipt: %v\n", err)
-			return 2
-		}
-	}
-
-	manifest := map[string]any{
-		"session_id":       "demo-starter-" + time.Now().UTC().Format("20060102-150405"),
-		"template":         template,
-		"provider":         provider,
-		"scenario":         cfg.key,
-		"organization_id":  cfg.organizationID,
-		"scope_id":         cfg.scopeID,
-		"execution_mode":   mode,
-		"receipts":         len(receipts),
-		"exported_at":      time.Now().UTC().Format(time.RFC3339),
-		"final_hash":       prevHash,
-		"lamport":          lamport,
-		"features":         []string{"skill_lifecycle", "maintenance_loop", "approval_gate", "sandbox_exec", "deny_path", "organization_scoping"},
-		"authority_scope":  map[string]any{"organization_id": cfg.organizationID, "scope_id": cfg.scopeID},
-		"principal_fields": []string{"principal_id", "organization_id", "scope_id"},
-	}
-	manifestData, _ := json.MarshalIndent(manifest, "", "  ")
-	if err := os.WriteFile(filepath.Join(outDir, "manifest.json"), manifestData, 0644); err != nil {
-		fmt.Fprintf(stderr, "Error writing manifest: %v\n", err)
+	if err := writeVerifiableEvidencePack(outDir, cfg, receipts, template, provider, mode, prevHash, lamport); err != nil {
+		fmt.Fprintf(stderr, "Error sealing EvidencePack: %v\n", err)
 		return 2
 	}
 
 	fmt.Fprintf(stdout, "  📦 %d receipts → %s/\n", len(receipts), outDir)
+	fmt.Fprintf(stdout, "  🔏 Sealed (dev-local) → %s/%s\n", outDir, evidencepkg.EvidencePackSealPath)
 	if err := generateProofReportJSON(receipts, outDir, template, provider); err != nil {
 		fmt.Fprintf(stderr, "Warning: could not generate JSON report: %v\n", err)
 	} else {
-		fmt.Fprintf(stdout, "  📊 Run Report → %s/run-report.json\n", outDir)
+		fmt.Fprintf(stdout, "  📊 Run Report → %s/%s\n", outDir, demoRunReportRelPath)
 	}
 
 	fmt.Fprintf(stdout, "\n%sVerifying EvidencePack...%s\n", ColorBold, ColorReset)
@@ -471,14 +449,13 @@ func runDemoScenario(kind string, args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "\n%s🎉 Demo complete.%s Evidence at %s/\n", ColorBold+ColorGreen, ColorReset, outDir)
 	fmt.Fprintf(stdout, "%s   Bound scope:%s org=%s scope=%s mode=%s\n", ColorGray, ColorReset, cfg.organizationID, cfg.scopeID, mode)
 
-	reportPath := filepath.Join(outDir, "run-report.json")
+	reportPath := filepath.Join(outDir, demoRunReportRelPath)
 	fmt.Fprintf(stdout, "\n%s╔════════════════════════════════════════════════════════════╗%s\n", ColorBold+ColorCyan, ColorReset)
 	fmt.Fprintf(stdout, "%s║  HELM Demo Complete                                        ║%s\n", ColorBold+ColorCyan, ColorReset)
 	fmt.Fprintf(stdout, "%s╠════════════════════════════════════════════════════════════╣%s\n", ColorCyan, ColorReset)
 	fmt.Fprintf(stdout, "%s║%s  📊 Report:   %s%-43s%s %s║%s\n", ColorCyan, ColorReset, ColorBold, reportPath, ColorReset, ColorCyan, ColorReset)
 	fmt.Fprintf(stdout, "%s║%s  📦 Evidence: %s%-43s%s %s║%s\n", ColorCyan, ColorReset, ColorBold, outDir+"/", ColorReset, ColorCyan, ColorReset)
-	fmt.Fprintf(stdout, "%s║%s  🔍 Verify:   %s%-43s%s %s║%s\n", ColorCyan, ColorReset, ColorGray, "helm-ai-kernel export --evidence "+outDir+" --out e.tar", ColorReset, ColorCyan, ColorReset)
-	fmt.Fprintf(stdout, "%s║%s              %s%-43s%s %s║%s\n", ColorCyan, ColorReset, ColorGray, "helm-ai-kernel verify e.tar", ColorReset, ColorCyan, ColorReset)
+	fmt.Fprintf(stdout, "%s║%s  🔍 Verify:   %s%-43s%s %s║%s\n", ColorCyan, ColorReset, ColorGray, "helm-ai-kernel verify "+outDir, ColorReset, ColorCyan, ColorReset)
 	fmt.Fprintf(stdout, "%s║%s  🔄 Switch:   %s%-43s%s %s║%s\n", ColorCyan, ColorReset, ColorGray, "helm-ai-kernel demo organization --provider opensandbox", ColorReset, ColorCyan, ColorReset)
 	fmt.Fprintf(stdout, "%s╚════════════════════════════════════════════════════════════╝%s\n\n", ColorCyan, ColorReset)
 
@@ -492,6 +469,185 @@ func runDemoScenario(kind string, args []string, stdout, stderr io.Writer) int {
 // through the canonical organization scenario.
 func runDemoCompany(args []string, stdout, stderr io.Writer) int {
 	return runDemoScenario("organization", args, stdout, stderr)
+}
+
+// writeVerifiableEvidencePack emits a canonical, dev-local-sealed EvidencePack
+// under outDir so that `helm-ai-kernel verify <outDir>` accepts it out of the
+// box (MIN-738). The pack follows the §3.1 directory layout, carries receipts
+// under 02_PROOFGRAPH/receipts/, derives a canonical manifest via the evidence
+// pack Builder, and is sealed in place under the dev-local trust profile. The
+// dev-local signer key is auto-provisioned in the HELM data dir on first use,
+// so no env var or HELM_SIGNING_KEY_HEX is required. Fail-closed: any error
+// here aborts the demo before a success/verify instruction is printed.
+func writeVerifiableEvidencePack(outDir string, cfg demoScenarioConfig, receipts []demoReceipt, template, provider, mode, finalHash string, lamport uint64) error {
+	if len(receipts) == 0 {
+		return fmt.Errorf("no receipts to seal")
+	}
+	if err := conform.CreateEvidencePackDirs(outDir); err != nil {
+		return err
+	}
+
+	// Canonical manifest via the evidence pack Builder (JCS + Merkle root).
+	packID := "demo-" + cfg.key
+	builder := evidencepack.NewBuilder(packID, cfg.organizationID, cfg.scopeID, demoPolicyID)
+	for i, r := range receipts {
+		if err := builder.AddReceipt(fmt.Sprintf("%03d_%s", i+1, r.ReceiptID), r); err != nil {
+			return err
+		}
+	}
+	manifest, _, err := builder.Build()
+	if err != nil {
+		return err
+	}
+	manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "04_EXPORTS", "evidence_manifest.json"), append(manifestJSON, '\n'), 0o600); err != nil {
+		return err
+	}
+
+	// Receipts in canonical proofgraph layout (Lamport-ordered).
+	receiptsDir := filepath.Join(outDir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		return err
+	}
+	for i, r := range receipts {
+		data, err := json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			return err
+		}
+		fname := fmt.Sprintf("%03d_%s.json", i+1, r.ReceiptID)
+		if err := os.WriteFile(filepath.Join(receiptsDir, fname), append(data, '\n'), 0o600); err != nil {
+			return err
+		}
+	}
+
+	// Proof graph summary (deterministic — no wall clock in the chain).
+	proofGraph := map[string]any{
+		"version":         "1.0.0",
+		"pack_id":         packID,
+		"scenario":        cfg.key,
+		"organization_id": cfg.organizationID,
+		"scope_id":        cfg.scopeID,
+		"execution_mode":  mode,
+		"receipt_count":   len(receipts),
+		"lamport_final":   lamport,
+		"root_hash":       finalHash,
+		"topo_order_rule": "lamport_monotonic",
+		"manifest_hash":   manifest.ManifestHash,
+		"entries_root":    manifest.EntriesMerkleRoot,
+	}
+	proofGraphJSON, err := json.MarshalIndent(proofGraph, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "02_PROOFGRAPH", "proofgraph.json"), append(proofGraphJSON, '\n'), 0o600); err != nil {
+		return err
+	}
+
+	// 01_SCORE.json (+ sha256 sidecar) — required by the canonical layout.
+	score := map[string]any{
+		"pass":            true,
+		"run_id":          packID,
+		"scope":           "demo",
+		"template":        template,
+		"provider":        provider,
+		"execution_mode":  mode,
+		"receipt_count":   len(receipts),
+		"deny_path":       "fail-closed",
+		"organization_id": cfg.organizationID,
+		"scope_id":        cfg.scopeID,
+	}
+	scoreJSON, err := json.MarshalIndent(score, "", "  ")
+	if err != nil {
+		return err
+	}
+	scoreJSON = append(scoreJSON, '\n')
+	if err := os.WriteFile(filepath.Join(outDir, "01_SCORE.json"), scoreJSON, 0o600); err != nil {
+		return err
+	}
+	scoreSum := sha256.Sum256(scoreJSON)
+	if err := os.WriteFile(filepath.Join(outDir, "01_SCORE.json.sha256"), []byte(hex.EncodeToString(scoreSum[:])+"\n"), 0o600); err != nil {
+		return err
+	}
+
+	// 00_INDEX.json over every pack file (excluding the index itself and the
+	// seal, which is written after the index is hashed).
+	if err := writeDemoEvidenceIndex(outDir, packID); err != nil {
+		return err
+	}
+
+	// Seal in place with the dev-local profile. The file-dev signer
+	// auto-generates its Ed25519 key under the data dir if absent.
+	if _, err := evidencepkg.SealEvidencePack(context.Background(), outDir, evidencepkg.SealEvidencePackOptions{
+		PackID:  packID,
+		Profile: evidencepkg.EvidenceTrustProfileDevLocal,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeDemoEvidenceIndex walks the pack directory and writes 00_INDEX.json,
+// mirroring the conform engine's index format. Entries are sorted by path for
+// deterministic output.
+func writeDemoEvidenceIndex(outDir, runID string) error {
+	type indexEntry struct {
+		Path        string `json:"path"`
+		SHA256      string `json:"sha256"`
+		SizeBytes   int64  `json:"size_bytes"`
+		ContentType string `json:"content_type"`
+	}
+	var entries []indexEntry
+	err := filepath.Walk(outDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(outDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "00_INDEX.json" || rel == evidencepkg.EvidencePackSealPath {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(data)
+		ct := "application/json"
+		if !strings.HasSuffix(rel, ".json") {
+			ct = "text/plain"
+		}
+		entries = append(entries, indexEntry{
+			Path:        rel,
+			SHA256:      hex.EncodeToString(sum[:]),
+			SizeBytes:   info.Size(),
+			ContentType: ct,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	index := map[string]any{
+		"run_id":          runID,
+		"profile":         string(conform.ProfileCore),
+		"created_at":      time.Now().UTC(),
+		"topo_order_rule": "lamport_monotonic",
+		"entries":         entries,
+	}
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outDir, "00_INDEX.json"), append(data, '\n'), 0o600)
 }
 
 func init() {

--- a/core/cmd/helm-ai-kernel/demo_hardening_test.go
+++ b/core/cmd/helm-ai-kernel/demo_hardening_test.go
@@ -91,7 +91,7 @@ func TestDemoProofReportGenerated(t *testing.T) {
 	}
 
 	htmlPath := filepath.Join(dir, "data", "evidence", "run-report."+"html")
-	jsonPath := filepath.Join(dir, "data", "evidence", "run-report.json")
+	jsonPath := filepath.Join(dir, "data", "evidence", "12_REPORTS", "run-report.json")
 
 	if _, err := os.Stat(htmlPath); !os.IsNotExist(err) {
 		t.Error("HTML report should not be generated")
@@ -253,21 +253,17 @@ func TestNoWallClockInHashPreimage(t *testing.T) {
 	}
 }
 
-// readDemoReceipts reads receipt JSON files from directory in sorted order.
+// readDemoReceipts reads receipt JSON files from the canonical
+// 02_PROOFGRAPH/receipts/ layout in sorted order.
 func readDemoReceipts(t *testing.T, dir string) []demoReceipt {
 	t.Helper()
-	files, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	files, err := filepath.Glob(filepath.Join(dir, "02_PROOFGRAPH", "receipts", "*.json"))
 	if err != nil {
 		t.Fatalf("glob error: %v", err)
 	}
 
 	var receipts []demoReceipt
 	for _, f := range files {
-		base := filepath.Base(f)
-		// Skip manifest and report files
-		if base == "manifest.json" || strings.HasPrefix(base, "run-report") {
-			continue
-		}
 		data, err := os.ReadFile(f)
 		if err != nil {
 			t.Fatalf("read %s: %v", f, err)

--- a/core/cmd/helm-ai-kernel/demo_verifiable_pack_test.go
+++ b/core/cmd/helm-ai-kernel/demo_verifiable_pack_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/verifier"
+)
+
+// TestDemoPackVerifiesOffline is the permanent guard against MIN-738: a fresh
+// `demo organization` run must produce a canonical, sealed EvidencePack that
+// the offline verifier accepts out of the box (dev-local trust, no env vars).
+func TestDemoPackVerifiesOffline(t *testing.T) {
+	dir := chdirTempDir(t)
+
+	var out bytes.Buffer
+	if code := runDemoCompany([]string{"--template", "starter", "--provider", "mock"}, &out, &out); code != 0 {
+		t.Fatalf("demo failed with code %d: %s", code, out.String())
+	}
+
+	packDir := filepath.Join(dir, "data", "evidence")
+	report, err := verifier.VerifyBundle(packDir)
+	if err != nil {
+		t.Fatalf("VerifyBundle returned error: %v", err)
+	}
+
+	if !report.Verified {
+		for _, c := range report.Checks {
+			if !c.Pass {
+				t.Logf("FAILED check %s: %s", c.Name, c.Reason)
+			}
+		}
+		t.Fatalf("demo pack did not verify: %s", report.Summary)
+	}
+	if report.SealState != "valid" {
+		t.Errorf("seal state = %q, want valid", report.SealState)
+	}
+	if report.SignatureValidCount < 1 {
+		t.Errorf("signature_valid_count = %d, want >= 1", report.SignatureValidCount)
+	}
+}
+
+// TestResearchLabPackVerifiesOffline mirrors TestDemoPackVerifiesOffline for
+// the research-lab scenario, which prints the same Verify instruction.
+func TestResearchLabPackVerifiesOffline(t *testing.T) {
+	dir := chdirTempDir(t)
+
+	var out bytes.Buffer
+	if code := runDemoScenario("research-lab", []string{"--template", "starter", "--provider", "mock"}, &out, &out); code != 0 {
+		t.Fatalf("research-lab demo failed with code %d: %s", code, out.String())
+	}
+
+	packDir := filepath.Join(dir, "data", "evidence")
+	report, err := verifier.VerifyBundle(packDir)
+	if err != nil {
+		t.Fatalf("VerifyBundle returned error: %v", err)
+	}
+	if !report.Verified {
+		for _, c := range report.Checks {
+			if !c.Pass {
+				t.Logf("FAILED check %s: %s", c.Name, c.Reason)
+			}
+		}
+		t.Fatalf("research-lab pack did not verify: %s", report.Summary)
+	}
+	if report.SealState != "valid" {
+		t.Errorf("seal state = %q, want valid", report.SealState)
+	}
+}

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -16,6 +16,9 @@ func chdirTempDir(t *testing.T) string {
 		t.Fatal(err)
 	}
 	dir := t.TempDir()
+	// Isolate HELM data dir so dev-local evidence sealing (auto-generated
+	// signing keys, trust config) never touches the real ~/.helm.
+	t.Setenv("HELM_DATA_DIR", t.TempDir())
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}

--- a/core/cmd/helm-ai-kernel/proof_report.go
+++ b/core/cmd/helm-ai-kernel/proof_report.go
@@ -110,8 +110,16 @@ func verifyChain(receipts []demoReceipt) (chainOK, lamportMonotonic, denyPresent
 	return
 }
 
+// demoRunReportRelPath is the in-pack location of the human-readable run
+// report. It lives under the canonical 12_REPORTS/ subdir so it does not trip
+// the conform top-level structure check during `helm-ai-kernel verify <dir>`.
+const demoRunReportRelPath = "12_REPORTS/run-report.json"
+
 func generateProofReportJSON(receipts []demoReceipt, outDir, template, provider string) error {
-	reportPath := filepath.Join(outDir, "run-report.json")
+	reportPath := filepath.Join(outDir, demoRunReportRelPath)
+	if err := os.MkdirAll(filepath.Dir(reportPath), 0o750); err != nil {
+		return err
+	}
 
 	if len(receipts) == 0 {
 		return fmt.Errorf("no receipts to report")


### PR DESCRIPTION
## Problem (MIN-738)

The launch's "killer demo" — clone, run the demo, verify your own receipt **offline** — was broken on a clean install. `helm-ai-kernel demo organization` wrote **loose** receipt JSON files plus a hand-rolled `manifest.json`; `export` faithfully copied that incomplete structure; and `verify` correctly rejected it (no canonical layout, no `02_PROOFGRAPH/`, no native seal). The demo even printed a `Verify:` instruction that could never succeed.

## Fix

`demo` now builds a canonical §3.1 EvidencePack via the **existing** `evidencepack.Builder` and seals it in place with the **existing** `SealEvidencePack` under the `dev-local` trust profile:

- `00_INDEX.json` (hashes every file except the index + seal), `01_SCORE.json` (+ `.sha256`), `02_PROOFGRAPH/receipts/` (Lamport-ordered), `02_PROOFGRAPH/proofgraph.json`, canonical manifest in `04_EXPORTS/`, run report relocated to `12_REPORTS/`.
- Sealed via the `file-dev` signer, which **auto-provisions** its Ed25519 key in the data dir — so the loop works with **no env vars and no `HELM_SIGNING_KEY_HEX`**.
- Printed instruction is now `helm-ai-kernel verify <outDir>`.

No new crypto, no `conform` reimplementation, no verifier changes — this is wiring the demo to machinery the kernel already ships.

### Fail-closed
`writeVerifiableEvidencePack` returns an error on every path; the caller aborts the demo (exit 2) **before** any success/Verify output. An unverifiable pack is never presented as verifiable.

## Proof (end-to-end, clean data dir, zero env)

```
demo organization        -> exit 0; pack has 00_INDEX.json + 02_PROOFGRAPH/ + 07_ATTESTATIONS/evidence_pack.sig
verify data/evidence     -> envelope demo-organization · seal valid · sig 1/1 · trust dev-local · VERIFIED (exit 0)
export + verify e.tar    -> VERIFIED (exit 0)
tamper 1 byte in receipt -> FAILED · index_integrity: indexed hash mismatch (exit 1)   <- seal is load-bearing
```

## Tests
- New regression guards: `TestDemoPackVerifiesOffline`, `TestResearchLabPackVerifiesOffline` (run the real demo into a temp dir, assert `verifier.VerifyBundle` → seal valid, sig ≥ 1).
- `go test ./cmd/helm-ai-kernel/... ./pkg/evidencepack/... ./pkg/verifier/...` → green
- `make verify-fixtures` → green (golden packs unaffected)
- `make lint` → clean

Rebased on current `main` (post-#380); `demo mcp` (added by #380) uses a separate `runMCPProof` path and already produces a verified pack — unaffected.

Implemented under the `kernel-guardian` mandate; root-caused, reviewed, and proven end-to-end by the lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)