### PR TITLE
fix(kernel): persist receipt transparency anchor fields (migration + store) (MIN-720 follow-up)

### DIFF
--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -32,6 +32,7 @@ import (
 	dockersandbox "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/sandbox/docker"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store/ledger"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/translog"
 
 	_ "github.com/lib/pq" // Postgres Driver
 )
@@ -343,6 +344,22 @@ func runServerWithOptions(opts serverOptions) {
 		services.PolicyReconciler = policyReconciler
 		services.PolicySnapshotStore = policyStore
 		services.PolicyScope = policyScope
+
+		// Receipt transparency log: anchor every issued receipt hash. Sharing
+		// the signer's public key as the log identity matches `helm-ai-kernel
+		// log` (see translog_cmd.go). Fail-closed by default; degrade only when
+		// HELM_TRANSPARENCY_DEGRADE is explicitly set.
+		transpLog, transpErr := translog.Open(filepath.Join(dataDir, "translog"))
+		if transpErr != nil {
+			if envBool("HELM_PRODUCTION") {
+				log.Fatalf("Failed to open receipt transparency log: %v", transpErr)
+			}
+			log.Printf("[helm] receipt transparency log disabled (dev): %v", transpErr)
+		} else {
+			services.TranspLog = transpLog
+			services.TranspLogID = translog.LogIDFromPublicKey(signer.PublicKeyBytes())
+			services.TranspLogDegrade = envBool("HELM_TRANSPARENCY_DEGRADE")
+		}
 		extraRoutes = func(mux *http.ServeMux) {
 			RegisterSubsystemRoutes(mux, services)
 			RegisterConsoleRoutes(mux, services, opts)

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -345,10 +345,12 @@ func runServerWithOptions(opts serverOptions) {
 		services.PolicySnapshotStore = policyStore
 		services.PolicyScope = policyScope
 
-		// Receipt transparency log: anchor every issued receipt hash. Sharing
-		// the signer's public key as the log identity matches `helm-ai-kernel
-		// log` (see translog_cmd.go). Fail-closed by default; degrade only when
-		// HELM_TRANSPARENCY_DEGRADE is explicitly set.
+		// Receipt transparency log: anchor decision-record receipt hashes at
+		// issuance (see persistDecisionReceipt -> anchorReceiptTransparency). The
+		// anchor (LogID/LeafIndex/Transparency) is persisted with the receipt.
+		// Sharing the signer's public key as the log identity matches
+		// `helm-ai-kernel log` (see translog_cmd.go). Fail-closed by default;
+		// degrade only when HELM_TRANSPARENCY_DEGRADE is explicitly set.
 		transpLog, transpErr := translog.Open(filepath.Join(dataDir, "translog"))
 		if transpErr != nil {
 			if envBool("HELM_PRODUCTION") {

--- a/core/cmd/helm-ai-kernel/receipt_routes.go
+++ b/core/cmd/helm-ai-kernel/receipt_routes.go
@@ -263,10 +263,63 @@ func persistDecisionReceipt(ctx context.Context, svc *Services, decision *contra
 		if err := svc.ReceiptSigner.SignReceipt(receipt); err != nil {
 			return nil, fmt.Errorf("sign receipt %s: %w", receiptID, err)
 		}
+		// Anchor the signed receipt hash in the transparency log before it is
+		// persisted. Fail-closed: an append failure aborts the builder, which
+		// rolls back AppendCausal so no receipt is stored. Degrade mode is the
+		// only escape and must be explicitly enabled in config.
+		if err := anchorReceiptTransparency(svc, receipt); err != nil {
+			return nil, err
+		}
 		return receipt, nil
 	})
 	if err != nil {
 		return fmt.Errorf("store receipt %s: %w", receiptID, err)
+	}
+	return nil
+}
+
+// TransparencyAppender is the subset of the receipt transparency log needed at
+// issuance time: append a receipt-hash leaf and report its assigned index.
+type TransparencyAppender interface {
+	Append(leafInput []byte) (uint64, error)
+}
+
+// anchorReceiptTransparency appends the signed receipt's content hash to the
+// transparency log and records the resulting leaf on the receipt. It is
+// fail-closed by default: if the log is configured but the append fails,
+// issuance is aborted. When svc.TranspLogDegrade is set, an append failure
+// instead records a deferred anchor so the receipt can be backfilled later.
+// A nil log leaves the receipt unanchored (no transparency configured).
+func anchorReceiptTransparency(svc *Services, receipt *contracts.Receipt) error {
+	if svc == nil || svc.TranspLog == nil {
+		return nil
+	}
+	leafHashHex, err := contracts.ReceiptChainHash(receipt)
+	if err != nil {
+		return fmt.Errorf("transparency leaf hash for %s: %w", receipt.ReceiptID, err)
+	}
+	leafInput, err := hex.DecodeString(leafHashHex)
+	if err != nil {
+		return fmt.Errorf("decode transparency leaf hash for %s: %w", receipt.ReceiptID, err)
+	}
+	index, appendErr := svc.TranspLog.Append(leafInput)
+	if appendErr != nil {
+		if !svc.TranspLogDegrade {
+			return fmt.Errorf("transparency log append for %s: %w", receipt.ReceiptID, appendErr)
+		}
+		receipt.LogID = svc.TranspLogID
+		receipt.Transparency = &contracts.TransparencyAnchor{
+			Backend:  "translog",
+			LogID:    svc.TranspLogID,
+			Deferred: true,
+		}
+		return nil
+	}
+	receipt.LogID = svc.TranspLogID
+	receipt.LeafIndex = index
+	receipt.Transparency = &contracts.TransparencyAnchor{
+		Backend: "translog",
+		LogID:   svc.TranspLogID,
 	}
 	return nil
 }

--- a/core/cmd/helm-ai-kernel/receipt_routes_test.go
+++ b/core/cmd/helm-ai-kernel/receipt_routes_test.go
@@ -159,6 +159,108 @@ func TestPersistDecisionReceiptLinksToCanonicalPreviousReceiptHash(t *testing.T)
 	}
 }
 
+type fakeTransparencyLog struct {
+	appended  [][]byte
+	appendErr error
+	nextIndex uint64
+}
+
+func (l *fakeTransparencyLog) Append(leafInput []byte) (uint64, error) {
+	if l.appendErr != nil {
+		return 0, l.appendErr
+	}
+	l.appended = append(l.appended, append([]byte(nil), leafInput...))
+	idx := l.nextIndex
+	l.nextIndex++
+	return idx, nil
+}
+
+func newTransparencyDecision() *contracts.DecisionRecord {
+	return &contracts.DecisionRecord{
+		ID:                 "dec-tl",
+		Action:             "EXECUTE_TOOL",
+		Verdict:            string(contracts.VerdictAllow),
+		PolicyDecisionHash: "sha256:pdp",
+		Timestamp:          time.Unix(1700000000, 0).UTC(),
+	}
+}
+
+func TestPersistDecisionReceiptAnchorsTransparencyLeaf(t *testing.T) {
+	signer, err := helmcrypto.NewEd25519Signer("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcptStore := &captureReceiptStore{}
+	tl := &fakeTransparencyLog{nextIndex: 5}
+	svc := &Services{ReceiptStore: rcptStore, ReceiptSigner: signer, TranspLog: tl, TranspLogID: "log-abc"}
+
+	if err := persistDecisionReceipt(context.Background(), svc, newTransparencyDecision(), "agent.test", []byte("EXECUTE_TOOL:tool"), map[string]any{"source": "test"}); err != nil {
+		t.Fatalf("persist receipt: %v", err)
+	}
+	if rcptStore.stored == nil {
+		t.Fatal("receipt was not stored")
+	}
+	if len(tl.appended) != 1 {
+		t.Fatalf("expected exactly one transparency append, got %d", len(tl.appended))
+	}
+	if rcptStore.stored.LogID != "log-abc" {
+		t.Fatalf("receipt log_id = %q, want log-abc", rcptStore.stored.LogID)
+	}
+	if rcptStore.stored.LeafIndex != 5 {
+		t.Fatalf("receipt leaf_index = %d, want 5", rcptStore.stored.LeafIndex)
+	}
+	if rcptStore.stored.Transparency == nil || rcptStore.stored.Transparency.Deferred {
+		t.Fatalf("expected non-deferred transparency anchor, got %+v", rcptStore.stored.Transparency)
+	}
+}
+
+func TestPersistDecisionReceiptBlocksWhenTransparencyAppendFailsFailClosed(t *testing.T) {
+	signer, err := helmcrypto.NewEd25519Signer("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcptStore := &captureReceiptStore{}
+	appendErr := errors.New("transparency log unavailable")
+	// Default posture: TranspLogDegrade is false (fail-closed).
+	svc := &Services{ReceiptStore: rcptStore, ReceiptSigner: signer, TranspLog: &fakeTransparencyLog{appendErr: appendErr}, TranspLogID: "log-abc"}
+
+	err = persistDecisionReceipt(context.Background(), svc, newTransparencyDecision(), "agent.test", []byte("EXECUTE_TOOL:tool"), map[string]any{"source": "test"})
+	if !errors.Is(err, appendErr) {
+		t.Fatalf("expected transparency append error to block issuance, got %v", err)
+	}
+	if rcptStore.stored != nil {
+		t.Fatalf("fail-closed issuance must not store a receipt, got %+v", rcptStore.stored)
+	}
+}
+
+func TestPersistDecisionReceiptDegradesWhenExplicitlyAllowed(t *testing.T) {
+	signer, err := helmcrypto.NewEd25519Signer("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rcptStore := &captureReceiptStore{}
+	svc := &Services{
+		ReceiptStore:     rcptStore,
+		ReceiptSigner:    signer,
+		TranspLog:        &fakeTransparencyLog{appendErr: errors.New("transparency log unavailable")},
+		TranspLogID:      "log-abc",
+		TranspLogDegrade: true,
+	}
+
+	if err := persistDecisionReceipt(context.Background(), svc, newTransparencyDecision(), "agent.test", []byte("EXECUTE_TOOL:tool"), map[string]any{"source": "test"}); err != nil {
+		t.Fatalf("degrade mode must not block issuance: %v", err)
+	}
+	if rcptStore.stored == nil {
+		t.Fatal("degrade mode should still store the receipt")
+	}
+	if rcptStore.stored.Transparency == nil || !rcptStore.stored.Transparency.Deferred {
+		t.Fatalf("expected deferred transparency anchor under degrade, got %+v", rcptStore.stored.Transparency)
+	}
+	if rcptStore.stored.LeafIndex != 0 {
+		t.Fatalf("deferred anchor must not claim a leaf index, got %d", rcptStore.stored.LeafIndex)
+	}
+}
+
 func TestPersistDecisionReceiptReturnsStoreError(t *testing.T) {
 	signer, err := helmcrypto.NewEd25519Signer("test")
 	if err != nil {

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -70,6 +70,16 @@ type Services struct {
 	ReceiptStore  store.ReceiptStore
 	ReceiptSigner helmcrypto.Signer
 
+	// --- Receipt Transparency Log (RFC 6962) ---
+	// TranspLog anchors every issued receipt hash in an append-only Merkle
+	// log. TranspLogID is the log identity (hex SHA-256 of the kernel public
+	// key). TranspLogDegrade, when true, downgrades a transparency append
+	// failure from fail-closed (issuance blocked) to a deferred anchor; the
+	// production default is false (fail-closed).
+	TranspLog        TransparencyAppender
+	TranspLogID      string
+	TranspLogDegrade bool
+
 	// --- Cross-cutting ---
 	KernelRT *kernelruntime.Server
 

--- a/core/pkg/contracts/receipt.go
+++ b/core/pkg/contracts/receipt.go
@@ -84,6 +84,14 @@ type Receipt struct {
 	EmergencyScopeHash           string `json:"emergency_scope_hash,omitempty"`
 	SafeDepState                 string `json:"safe_dep_state,omitempty"`
 	SafeDepReasonCode            string `json:"safe_dep_reason_code,omitempty"`
+
+	// Receipt Transparency Log (RFC 6962) anchoring. Populated when the
+	// receipt hash is appended to the append-only transparency log during
+	// issuance. LogID and LeafIndex identify the leaf; Transparency carries
+	// the log backend identity for verifiers.
+	Transparency *TransparencyAnchor `json:"transparency,omitempty"`
+	LogID        string              `json:"log_id,omitempty"`
+	LeafIndex    uint64              `json:"leaf_index,omitempty"`
 }
 
 type Projection struct {

--- a/core/pkg/contracts/receipt_hash.go
+++ b/core/pkg/contracts/receipt_hash.go
@@ -9,11 +9,23 @@ import (
 // ReceiptChainHash returns the canonical SHA-256 digest used for receipt
 // causal links. It hashes the persisted receipt envelope, including its
 // signature, so any mutation to the previous receipt breaks the next link.
+//
+// Transparency-log anchoring metadata (Transparency, LogID, LeafIndex) is
+// excluded from the digest. Those fields are assigned AFTER the leaf hash is
+// computed (see anchorReceiptTransparency), and the assigned leaf hash IS this
+// chain hash; if anchoring metadata entered the digest, the persisted receipt's
+// recomputed chain hash would no longer match the leaf that was anchored, and
+// the prev_hash of the next causal receipt would shift depending on whether the
+// previous receipt was anchored. Excluding them keeps the chain hash stable.
 func ReceiptChainHash(receipt *Receipt) (string, error) {
 	if receipt == nil {
 		return "", fmt.Errorf("receipt is nil")
 	}
-	hash, err := canonicalize.CanonicalHash(receipt)
+	chained := *receipt
+	chained.Transparency = nil
+	chained.LogID = ""
+	chained.LeafIndex = 0
+	hash, err := canonicalize.CanonicalHash(&chained)
 	if err != nil {
 		return "", fmt.Errorf("canonical receipt hash: %w", err)
 	}

--- a/core/pkg/evidencepack/builder.go
+++ b/core/pkg/evidencepack/builder.go
@@ -168,6 +168,23 @@ func (b *Builder) AddReplayManifest(name string, manifest interface{}) error {
 	return nil
 }
 
+// AddTransparencySTH captures a signed tree head (RFC 6962 checkpoint) of the
+// receipt transparency log at pack-build time. Embedding the STH lets a
+// verifier prove every receipt in the pack was anchored under a log root the
+// kernel signed at export time, without trusting the exporter. The sth value
+// is any JSON-serializable signed tree head (e.g. translog.SignedTreeHead).
+func (b *Builder) AddTransparencySTH(name string, sth interface{}) error {
+	data, err := json.MarshalIndent(sth, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal transparency sth %s: %w", name, err)
+	}
+	b.entries["transparency/"+name+".json"] = entryData{
+		content:     data,
+		contentType: "application/json",
+	}
+	return nil
+}
+
 func safeEvidenceName(value string) string {
 	value = strings.TrimSpace(value)
 	value = strings.Trim(value, "/")

--- a/core/pkg/evidencepack/builder_test.go
+++ b/core/pkg/evidencepack/builder_test.go
@@ -146,6 +146,40 @@ func TestAddReplayManifest(t *testing.T) {
 	}
 }
 
+func TestAddTransparencySTH(t *testing.T) {
+	b := newTestBuilder()
+	sth := map[string]any{
+		"tree_size": 42,
+		"root_hash": "abc123",
+		"log_id":    "log-1",
+		"signature": "sig-1",
+	}
+	if err := b.AddTransparencySTH("checkpoint", sth); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, content, err := b.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := content["transparency/checkpoint.json"]; !ok {
+		t.Fatal("expected transparency/checkpoint.json in content map")
+	}
+
+	found := false
+	for _, e := range manifest.Entries {
+		if e.Path == "transparency/checkpoint.json" {
+			found = true
+			if e.ContentHash == "" {
+				t.Fatal("expected non-empty hash for transparency entry")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected transparency/checkpoint.json in manifest entries")
+	}
+}
+
 func TestAllNewEntryTypes_InSinglePack(t *testing.T) {
 	b := newTestBuilder()
 

--- a/core/pkg/store/migrations/002_add_receipt_transparency.sql
+++ b/core/pkg/store/migrations/002_add_receipt_transparency.sql
@@ -1,0 +1,9 @@
+-- MIN-720: persist Receipt Transparency Log (RFC 6962) anchoring metadata.
+-- anchorReceiptTransparency records the leaf identity on the receipt at
+-- issuance; without these columns the LogID/LeafIndex/Transparency fields were
+-- silently dropped and the HELM_TRANSPARENCY_DEGRADE "backfill later" deferral
+-- promise was unbacked.
+
+ALTER TABLE receipts ADD COLUMN IF NOT EXISTS log_id TEXT DEFAULT '';
+ALTER TABLE receipts ADD COLUMN IF NOT EXISTS leaf_index BIGINT DEFAULT 0;
+ALTER TABLE receipts ADD COLUMN IF NOT EXISTS transparency JSONB;

--- a/core/pkg/store/receipt_store.go
+++ b/core/pkg/store/receipt_store.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 )
 
@@ -55,7 +56,10 @@ func (s *PostgresReceiptStore) Init(ctx context.Context) error {
 			lamport_clock BIGINT,
 			output_hash TEXT DEFAULT '',
 			args_hash TEXT DEFAULT '',
-			blob_hash TEXT DEFAULT ''
+			blob_hash TEXT DEFAULT '',
+			log_id TEXT DEFAULT '',
+			leaf_index BIGINT DEFAULT 0,
+			transparency JSONB
 		);
 		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS effect_id TEXT;
 		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS external_reference_id TEXT;
@@ -65,6 +69,9 @@ func (s *PostgresReceiptStore) Init(ctx context.Context) error {
 		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS output_hash TEXT DEFAULT '';
 		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS args_hash TEXT DEFAULT '';
 		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS blob_hash TEXT DEFAULT '';
+		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS log_id TEXT DEFAULT '';
+		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS leaf_index BIGINT DEFAULT 0;
+		ALTER TABLE receipts ADD COLUMN IF NOT EXISTS transparency JSONB;
 		CREATE INDEX IF NOT EXISTS idx_receipts_executor_id ON receipts(executor_id);
 		CREATE INDEX IF NOT EXISTS idx_receipts_decision_id ON receipts(decision_id);
 		CREATE INDEX IF NOT EXISTS idx_receipts_executor_lamport ON receipts(executor_id, lamport_clock);
@@ -78,7 +85,7 @@ func (s *PostgresReceiptStore) Init(ctx context.Context) error {
 }
 
 // receiptColumns is the canonical column list for receipt queries.
-const receiptColumns = `receipt_id, decision_id, COALESCE(effect_id, execution_intent_id, '') AS effect_id, COALESCE(external_reference_id, '') AS external_reference_id, status, blob_hash, output_hash, timestamp, COALESCE(executor_id, '') AS executor_id, metadata, signature, merkle_root, COALESCE(prev_hash, '') AS prev_hash, COALESCE(lamport_clock, 0) AS lamport_clock, args_hash`
+const receiptColumns = `receipt_id, decision_id, COALESCE(effect_id, execution_intent_id, '') AS effect_id, COALESCE(external_reference_id, '') AS external_reference_id, status, blob_hash, output_hash, timestamp, COALESCE(executor_id, '') AS executor_id, metadata, signature, merkle_root, COALESCE(prev_hash, '') AS prev_hash, COALESCE(lamport_clock, 0) AS lamport_clock, args_hash, COALESCE(log_id, '') AS log_id, COALESCE(leaf_index, 0) AS leaf_index, transparency`
 
 func (s *PostgresReceiptStore) Get(ctx context.Context, decisionID string) (*contracts.Receipt, error) {
 	query := `SELECT ` + receiptColumns + ` FROM receipts WHERE decision_id = $1`
@@ -166,10 +173,11 @@ func scanReceipt(s scanner) (*contracts.Receipt, error) {
 	var metadata []byte
 	var signature sql.NullString
 	var merkleRoot sql.NullString
+	var transparency []byte
 	err := s.Scan(
 		&r.ReceiptID, &r.DecisionID, &r.EffectID, &r.ExternalReferenceID, &r.Status,
 		&r.BlobHash, &r.OutputHash, &r.Timestamp, &r.ExecutorID, &metadata, &signature,
-		&merkleRoot, &r.PrevHash, &r.LamportClock, &r.ArgsHash,
+		&merkleRoot, &r.PrevHash, &r.LamportClock, &r.ArgsHash, &r.LogID, &r.LeafIndex, &transparency,
 	)
 	if err != nil {
 		return nil, err
@@ -179,9 +187,49 @@ func scanReceipt(s scanner) (*contracts.Receipt, error) {
 			return nil, fmt.Errorf("decode receipt metadata: %w", err)
 		}
 	}
+	if err := decodeTransparencyAnchor(transparency, &r); err != nil {
+		return nil, err
+	}
 	r.Signature = signature.String
 	r.MerkleRoot = merkleRoot.String
 	return &r, nil
+}
+
+// decodeTransparencyAnchor deserializes the persisted transparency anchor JSON
+// onto the receipt. An absent/null column leaves Transparency nil.
+func decodeTransparencyAnchor(raw []byte, r *contracts.Receipt) error {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var anchor contracts.TransparencyAnchor
+	if err := json.Unmarshal(raw, &anchor); err != nil {
+		return fmt.Errorf("decode receipt transparency: %w", err)
+	}
+	r.Transparency = &anchor
+	return nil
+}
+
+// encodeTransparencyAnchor serializes the receipt's transparency anchor as
+// canonical JSON for persistence. A nil anchor yields a nil byte slice so the
+// column is stored as SQL NULL.
+func encodeTransparencyAnchor(r *contracts.Receipt) ([]byte, error) {
+	if r.Transparency == nil {
+		return nil, nil
+	}
+	encoded, err := canonicalize.JCS(r.Transparency)
+	if err != nil {
+		return nil, fmt.Errorf("marshal receipt transparency: %w", err)
+	}
+	return encoded, nil
+}
+
+// nullableJSON maps an empty JSON payload to a nil driver value so the column
+// is persisted as SQL NULL rather than an empty/invalid JSON string.
+func nullableJSON(raw []byte) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	return string(raw)
 }
 
 func (s *PostgresReceiptStore) queryOne(ctx context.Context, query string, arg any) (*contracts.Receipt, error) {
@@ -208,13 +256,18 @@ func insertPostgresReceipt(ctx context.Context, execer sqlExecer, r *contracts.R
 	query := `
 		INSERT INTO receipts (
 			receipt_id, decision_id, effect_id, external_reference_id, status, result, timestamp, executor_id,
-			metadata, signature, merkle_root, prev_hash, lamport_clock, output_hash, args_hash, blob_hash
+			metadata, signature, merkle_root, prev_hash, lamport_clock, output_hash, args_hash, blob_hash,
+			log_id, leaf_index, transparency
 		)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12, $13, $14, $15, $16)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19::jsonb)
 	`
 	metaJSON, err := json.Marshal(r.Metadata)
 	if err != nil {
 		return fmt.Errorf("marshal receipt metadata: %w", err)
+	}
+	transparencyJSON, err := encodeTransparencyAnchor(r)
+	if err != nil {
+		return err
 	}
 	_, err = execer.ExecContext(ctx, query,
 		r.ReceiptID,
@@ -233,6 +286,9 @@ func insertPostgresReceipt(ctx context.Context, execer sqlExecer, r *contracts.R
 		r.OutputHash,
 		r.ArgsHash,
 		r.BlobHash,
+		r.LogID,
+		r.LeafIndex,
+		nullableJSON(transparencyJSON),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to insert receipt: %w", err)

--- a/core/pkg/store/receipt_store_sqlite.go
+++ b/core/pkg/store/receipt_store_sqlite.go
@@ -56,12 +56,24 @@ func (s *SQLiteReceiptStore) migrate() error {
 		merkle_root TEXT,
 		prev_hash TEXT NOT NULL DEFAULT '',
 		lamport_clock INTEGER NOT NULL DEFAULT 0,
-		args_hash TEXT NOT NULL DEFAULT ''
+		args_hash TEXT NOT NULL DEFAULT '',
+		log_id TEXT NOT NULL DEFAULT '',
+		leaf_index INTEGER NOT NULL DEFAULT 0,
+		transparency TEXT
 	);`
 	if _, err := s.db.ExecContext(context.Background(), query); err != nil {
 		return err
 	}
 	if err := s.ensureColumn("args_hash", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	if err := s.ensureColumn("log_id", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	if err := s.ensureColumn("leaf_index", "INTEGER NOT NULL DEFAULT 0"); err != nil {
+		return err
+	}
+	if err := s.ensureColumn("transparency", "TEXT"); err != nil {
 		return err
 	}
 	indexes := []string{
@@ -113,7 +125,7 @@ func (s *SQLiteReceiptStore) ensureColumn(name, definition string) error {
 
 func (s *SQLiteReceiptStore) Get(ctx context.Context, decisionID string) (*contracts.Receipt, error) {
 	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash
+        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
         FROM receipts
         WHERE decision_id = ?
     `
@@ -122,7 +134,7 @@ func (s *SQLiteReceiptStore) Get(ctx context.Context, decisionID string) (*contr
 
 func (s *SQLiteReceiptStore) GetByReceiptID(ctx context.Context, receiptID string) (*contracts.Receipt, error) {
 	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash
+        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
         FROM receipts
         WHERE receipt_id = ?
     `
@@ -131,7 +143,7 @@ func (s *SQLiteReceiptStore) GetByReceiptID(ctx context.Context, receiptID strin
 
 func (s *SQLiteReceiptStore) List(ctx context.Context, limit int) ([]*contracts.Receipt, error) {
 	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash
+        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
         FROM receipts
         ORDER BY timestamp DESC
         LIMIT ?
@@ -158,7 +170,7 @@ func (s *SQLiteReceiptStore) List(ctx context.Context, limit int) ([]*contracts.
 
 func (s *SQLiteReceiptStore) ListByAgent(ctx context.Context, agentID string, since uint64, limit int) ([]*contracts.Receipt, error) {
 	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash
+        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
         FROM receipts
         WHERE executor_id = ? AND lamport_clock > ?
         ORDER BY lamport_clock ASC, timestamp ASC
@@ -186,7 +198,7 @@ func (s *SQLiteReceiptStore) ListByAgent(ctx context.Context, agentID string, si
 
 func (s *SQLiteReceiptStore) ListSince(ctx context.Context, since uint64, limit int) ([]*contracts.Receipt, error) {
 	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash
+        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
         FROM receipts
         WHERE lamport_clock > ?
         ORDER BY lamport_clock ASC, timestamp ASC
@@ -220,17 +232,21 @@ func (s *SQLiteReceiptStore) Store(ctx context.Context, r *contracts.Receipt) er
 
 func insertSQLiteReceipt(ctx context.Context, execer sqlExecer, r *contracts.Receipt) error {
 	query := `INSERT INTO receipts (
-		receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	metaJSON, err := json.Marshal(r.Metadata)
 	if err != nil {
 		return fmt.Errorf("marshal receipt metadata: %w", err)
 	}
+	transparencyJSON, err := encodeTransparencyAnchor(r)
+	if err != nil {
+		return err
+	}
 	timestamp := r.Timestamp.UTC().Format(time.RFC3339Nano)
 
 	_, err = execer.ExecContext(ctx, query,
-		r.ReceiptID, r.DecisionID, r.EffectID, r.ExternalReferenceID, r.Status, r.BlobHash, r.OutputHash, timestamp, r.ExecutorID, string(metaJSON), r.Signature, r.MerkleRoot, r.PrevHash, r.LamportClock, r.ArgsHash,
+		r.ReceiptID, r.DecisionID, r.EffectID, r.ExternalReferenceID, r.Status, r.BlobHash, r.OutputHash, timestamp, r.ExecutorID, string(metaJSON), r.Signature, r.MerkleRoot, r.PrevHash, r.LamportClock, r.ArgsHash, r.LogID, r.LeafIndex, nullableJSON(transparencyJSON),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to insert receipt: %w", err)
@@ -289,7 +305,7 @@ func (s *SQLiteReceiptStore) GetLastForSession(ctx context.Context, sessionID st
 
 func queryLastSQLiteReceipt(ctx context.Context, queryer sqlQueryer, sessionID string) (*contracts.Receipt, error) {
 	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash
+        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
         FROM receipts
         WHERE executor_id = ?
         ORDER BY lamport_clock DESC
@@ -308,30 +324,33 @@ func queryLastSQLiteReceipt(ctx context.Context, queryer sqlQueryer, sessionID s
 func (s *SQLiteReceiptStore) queryOne(ctx context.Context, query string, arg any) (*contracts.Receipt, error) {
 	row := s.db.QueryRowContext(ctx, query, arg)
 	var (
-		receiptID  string
-		decisionID string
-		effectID   string
-		externalID sql.NullString
-		status     string
-		blobHash   string
-		outputHash string
-		timestamp  string
-		executorID sql.NullString
-		metaJSON   sql.NullString
-		signature  sql.NullString
-		merkleRoot sql.NullString
-		prevHash   sql.NullString
-		lamport    uint64
-		argsHash   sql.NullString
+		receiptID    string
+		decisionID   string
+		effectID     string
+		externalID   sql.NullString
+		status       string
+		blobHash     string
+		outputHash   string
+		timestamp    string
+		executorID   sql.NullString
+		metaJSON     sql.NullString
+		signature    sql.NullString
+		merkleRoot   sql.NullString
+		prevHash     sql.NullString
+		lamport      uint64
+		argsHash     sql.NullString
+		logID        sql.NullString
+		leafIndex    uint64
+		transparency sql.NullString
 	)
-	err := row.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash)
+	err := row.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash, &logID, &leafIndex, &transparency)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("receipt not found")
 		}
 		return nil, err
 	}
-	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash)
+	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash, logID, leafIndex, transparency)
 }
 
 type sqliteScanner interface {
@@ -340,29 +359,32 @@ type sqliteScanner interface {
 
 func scanSQLiteReceipt(scanner sqliteScanner) (*contracts.Receipt, error) {
 	var (
-		receiptID  string
-		decisionID string
-		effectID   string
-		externalID sql.NullString
-		status     string
-		blobHash   string
-		outputHash string
-		timestamp  string
-		executorID sql.NullString
-		metaJSON   sql.NullString
-		signature  sql.NullString
-		merkleRoot sql.NullString
-		prevHash   sql.NullString
-		lamport    uint64
-		argsHash   sql.NullString
+		receiptID    string
+		decisionID   string
+		effectID     string
+		externalID   sql.NullString
+		status       string
+		blobHash     string
+		outputHash   string
+		timestamp    string
+		executorID   sql.NullString
+		metaJSON     sql.NullString
+		signature    sql.NullString
+		merkleRoot   sql.NullString
+		prevHash     sql.NullString
+		lamport      uint64
+		argsHash     sql.NullString
+		logID        sql.NullString
+		leafIndex    uint64
+		transparency sql.NullString
 	)
-	if err := scanner.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash); err != nil {
+	if err := scanner.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash, &logID, &leafIndex, &transparency); err != nil {
 		return nil, err
 	}
-	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash)
+	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash, logID, leafIndex, transparency)
 }
 
-func receiptFromSQLiteFields(receiptID, decisionID, effectID string, externalID sql.NullString, status, blobHash, outputHash, timestamp string, executorID, metaJSON, signature, merkleRoot, prevHash sql.NullString, lamport uint64, argsHash sql.NullString) (*contracts.Receipt, error) {
+func receiptFromSQLiteFields(receiptID, decisionID, effectID string, externalID sql.NullString, status, blobHash, outputHash, timestamp string, executorID, metaJSON, signature, merkleRoot, prevHash sql.NullString, lamport uint64, argsHash sql.NullString, logID sql.NullString, leafIndex uint64, transparency sql.NullString) (*contracts.Receipt, error) {
 	parsedTime := parseTime(timestamp)
 
 	var meta map[string]any
@@ -372,7 +394,7 @@ func receiptFromSQLiteFields(receiptID, decisionID, effectID string, externalID 
 		}
 	}
 
-	return &contracts.Receipt{
+	receipt := &contracts.Receipt{
 		ReceiptID:           receiptID,
 		DecisionID:          decisionID,
 		ExternalReferenceID: externalID.String,
@@ -388,7 +410,15 @@ func receiptFromSQLiteFields(receiptID, decisionID, effectID string, externalID 
 		PrevHash:            prevHash.String,
 		LamportClock:        lamport,
 		ArgsHash:            argsHash.String,
-	}, nil
+		LogID:               logID.String,
+		LeafIndex:           leafIndex,
+	}
+	if transparency.Valid {
+		if err := decodeTransparencyAnchor([]byte(transparency.String), receipt); err != nil {
+			return nil, err
+		}
+	}
+	return receipt, nil
 }
 
 func scanReceiptRow(rows *sql.Rows) (*contracts.Receipt, error) {

--- a/core/pkg/store/receipt_transparency_test.go
+++ b/core/pkg/store/receipt_transparency_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// TestSQLiteReceiptPersistsTransparencyAnchor proves the MIN-720 persistence
+// gap is closed: LogID, LeafIndex, and the Transparency anchor survive a
+// store/reload round-trip. Before the fix these fields were silently dropped.
+func TestSQLiteReceiptPersistsTransparencyAnchor(t *testing.T) {
+	store, cleanup := newTestSQLiteStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	r := &contracts.Receipt{
+		ReceiptID:    "rcpt-anchored",
+		DecisionID:   "dec-anchored",
+		EffectID:     "e",
+		Status:       "ALLOW",
+		Timestamp:    time.Now().UTC(),
+		ExecutorID:   "agent.exec",
+		LamportClock: 1,
+		LogID:        "logid-abc123",
+		LeafIndex:    42,
+		Transparency: &contracts.TransparencyAnchor{
+			Backend: "translog",
+			LogID:   "logid-abc123",
+		},
+	}
+	if err := store.Store(ctx, r); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	got, err := store.GetByReceiptID(ctx, "rcpt-anchored")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.LogID != "logid-abc123" {
+		t.Fatalf("LogID not persisted: got %q", got.LogID)
+	}
+	if got.LeafIndex != 42 {
+		t.Fatalf("LeafIndex not persisted: got %d", got.LeafIndex)
+	}
+	if got.Transparency == nil {
+		t.Fatal("Transparency anchor not persisted (nil)")
+	}
+	if got.Transparency.Backend != "translog" || got.Transparency.LogID != "logid-abc123" {
+		t.Fatalf("Transparency anchor mismatch: %+v", got.Transparency)
+	}
+	if got.Transparency.Deferred {
+		t.Fatalf("anchored receipt should not be deferred: %+v", got.Transparency)
+	}
+}
+
+// TestSQLiteReceiptPersistsDeferredAnchor proves the degrade-mode promise is
+// backed: a receipt whose anchor is Deferred=true persists that marker so it
+// can be backfilled later. Before the fix the "backfill later" deferral was
+// dropped on write.
+func TestSQLiteReceiptPersistsDeferredAnchor(t *testing.T) {
+	store, cleanup := newTestSQLiteStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	deferredUntil := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	r := &contracts.Receipt{
+		ReceiptID:    "rcpt-deferred",
+		DecisionID:   "dec-deferred",
+		EffectID:     "e",
+		Status:       "ALLOW",
+		Timestamp:    time.Now().UTC(),
+		ExecutorID:   "agent.exec",
+		LamportClock: 1,
+		LogID:        "logid-degrade",
+		Transparency: &contracts.TransparencyAnchor{
+			Backend:       "translog",
+			LogID:         "logid-degrade",
+			Deferred:      true,
+			DeferredUntil: deferredUntil,
+		},
+	}
+	if err := store.Store(ctx, r); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+
+	got, err := store.GetByReceiptID(ctx, "rcpt-deferred")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Transparency == nil {
+		t.Fatal("deferred Transparency anchor not persisted (nil)")
+	}
+	if !got.Transparency.Deferred {
+		t.Fatalf("Deferred marker not persisted: %+v", got.Transparency)
+	}
+	if !got.Transparency.DeferredUntil.Equal(deferredUntil) {
+		t.Fatalf("DeferredUntil not persisted: got %v want %v", got.Transparency.DeferredUntil, deferredUntil)
+	}
+
+	// A receipt with no anchor at all must still round-trip with a nil anchor.
+	plain := &contracts.Receipt{
+		ReceiptID:  "rcpt-plain",
+		DecisionID: "dec-plain",
+		Status:     "ALLOW",
+		Timestamp:  time.Now().UTC(),
+	}
+	if err := store.Store(ctx, plain); err != nil {
+		t.Fatalf("store plain: %v", err)
+	}
+	gotPlain, err := store.GetByReceiptID(ctx, "rcpt-plain")
+	if err != nil {
+		t.Fatalf("get plain: %v", err)
+	}
+	if gotPlain.Transparency != nil || gotPlain.LogID != "" || gotPlain.LeafIndex != 0 {
+		t.Fatalf("unanchored receipt should round-trip empty, got %+v", gotPlain)
+	}
+}
+
+// TestTransparencyAnchorFieldsDoNotEnterChainHash guards the canonicalization
+// invariant from anchorReceiptTransparency: the transparency anchor is recorded
+// AFTER ReceiptChainHash is computed, and the anchor fields must not alter the
+// canonical chain hash. If they did, the leaf hash used to anchor the receipt
+// would no longer match the persisted receipt's own chain hash and the
+// prev_hash of the next causal receipt would shift, breaking verification.
+func TestTransparencyAnchorFieldsDoNotEnterChainHash(t *testing.T) {
+	base := &contracts.Receipt{
+		ReceiptID:    "rcpt-hash",
+		DecisionID:   "dec-hash",
+		EffectID:     "e",
+		Status:       "ALLOW",
+		Timestamp:    time.Unix(1700000000, 0).UTC(),
+		ExecutorID:   "agent.exec",
+		LamportClock: 1,
+		ArgsHash:     "args",
+	}
+	before, err := contracts.ReceiptChainHash(base)
+	if err != nil {
+		t.Fatalf("hash before: %v", err)
+	}
+
+	base.LogID = "logid-abc123"
+	base.LeafIndex = 7
+	base.Transparency = &contracts.TransparencyAnchor{Backend: "translog", LogID: "logid-abc123"}
+
+	after, err := contracts.ReceiptChainHash(base)
+	if err != nil {
+		t.Fatalf("hash after: %v", err)
+	}
+	if before != after {
+		t.Fatalf("transparency anchor fields changed chain hash: before=%s after=%s", before, after)
+	}
+}

--- a/core/pkg/store/store_sql_coverage_test.go
+++ b/core/pkg/store/store_sql_coverage_test.go
@@ -247,7 +247,7 @@ func TestCoveragePostgresReceiptStoreQueries(t *testing.T) {
 		t.Fatal("expected init error")
 	}
 
-	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(16)...).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(19)...).WillReturnResult(sqlmock.NewResult(1, 1))
 	if err := store.Store(ctx, receipt); err != nil {
 		t.Fatalf("Store: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestCoveragePostgresReceiptStoreQueries(t *testing.T) {
 
 	mock.ExpectQuery("FROM receipts ORDER BY timestamp DESC").WithArgs(2).
 		WillReturnRows(storePostgresReceiptRows(receipt, []byte(`null`)).
-			AddRow("receipt-2", "decision-2", "effect", "", "OK", "blob", "output", now.Add(time.Second), "agent-2", []byte(`{"x":1}`), nil, nil, "", int64(8), "args"))
+			AddRow("receipt-2", "decision-2", "effect", "", "OK", "blob", "output", now.Add(time.Second), "agent-2", []byte(`{"x":1}`), nil, nil, "", int64(8), "args", "", int64(0), nil))
 	list, err := store.List(ctx, 2)
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -292,7 +292,7 @@ func TestCoveragePostgresReceiptStoreQueries(t *testing.T) {
 	}
 	mock.ExpectQuery("FROM receipts ORDER BY timestamp DESC").
 		WillReturnRows(sqlmock.NewRows(storePostgresReceiptColumns()).
-			AddRow("receipt-bad", "decision-bad", "effect", "", "OK", "blob", "output", "not-time", "agent", []byte(`null`), nil, nil, "", int64(1), "args"))
+			AddRow("receipt-bad", "decision-bad", "effect", "", "OK", "blob", "output", "not-time", "agent", []byte(`null`), nil, nil, "", int64(1), "args", "", int64(0), nil))
 	if _, err := store.List(ctx, 1); err == nil {
 		t.Fatal("expected list scan error")
 	}
@@ -395,6 +395,9 @@ func TestCoverageSQLiteReceiptMigrationAndParsingBranches(t *testing.T) {
 		sql.NullString{String: "prev", Valid: true},
 		9,
 		sql.NullString{String: "args", Valid: true},
+		sql.NullString{String: "logid", Valid: true},
+		11,
+		sql.NullString{String: `{"backend":"translog","deferred":true}`, Valid: true},
 	)
 	if err != nil {
 		t.Fatalf("receiptFromSQLiteFields: %v", err)
@@ -402,7 +405,10 @@ func TestCoverageSQLiteReceiptMigrationAndParsingBranches(t *testing.T) {
 	if receipt.Metadata["a"].(float64) != 1 || receipt.ExternalReferenceID != "external" || receipt.ArgsHash != "args" {
 		t.Fatalf("unexpected SQLite receipt: %+v", receipt)
 	}
-	if _, err := receiptFromSQLiteFields("r", "d", "e", sql.NullString{}, "OK", "", "", "", sql.NullString{}, sql.NullString{String: `{`, Valid: true}, sql.NullString{}, sql.NullString{}, sql.NullString{}, 0, sql.NullString{}); err == nil {
+	if receipt.LogID != "logid" || receipt.LeafIndex != 11 || receipt.Transparency == nil || !receipt.Transparency.Deferred {
+		t.Fatalf("transparency fields not decoded: %+v", receipt)
+	}
+	if _, err := receiptFromSQLiteFields("r", "d", "e", sql.NullString{}, "OK", "", "", "", sql.NullString{}, sql.NullString{String: `{`, Valid: true}, sql.NullString{}, sql.NullString{}, sql.NullString{}, 0, sql.NullString{}, sql.NullString{}, 0, sql.NullString{}); err == nil {
 		t.Fatal("expected SQLite metadata decode error")
 	}
 
@@ -470,7 +476,7 @@ func TestCoveragePostgresReceiptStoreAppendCausal(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("SELECT pg_advisory_xact_lock").WithArgs("agent").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery("FROM receipts WHERE executor_id").WithArgs("agent").WillReturnRows(sqlmock.NewRows(storePostgresReceiptColumns()))
-	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(16)...).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(19)...).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 	if err := store.AppendCausal(ctx, "agent", func(previous *contracts.Receipt, lamport uint64, prevHash string) (*contracts.Receipt, error) {
 		if previous != nil || lamport != 1 || prevHash != "" {
@@ -485,7 +491,7 @@ func TestCoveragePostgresReceiptStoreAppendCausal(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("SELECT pg_advisory_xact_lock").WithArgs("agent").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery("FROM receipts WHERE executor_id").WithArgs("agent").WillReturnRows(storePostgresReceiptRows(previous, nil))
-	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(16)...).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(19)...).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 	if err := store.AppendCausal(ctx, "agent", func(previous *contracts.Receipt, lamport uint64, prevHash string) (*contracts.Receipt, error) {
 		if previous == nil || previous.ReceiptID != "receipt-prev" || lamport != 4 || prevHash == "" {
@@ -537,7 +543,7 @@ func TestCoveragePostgresReceiptStoreAppendCausal(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("SELECT pg_advisory_xact_lock").WithArgs("agent").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectQuery("FROM receipts WHERE executor_id").WithArgs("agent").WillReturnRows(sqlmock.NewRows(storePostgresReceiptColumns()))
-	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(16)...).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("INSERT INTO receipts").WithArgs(storeAnySQLArgs(19)...).WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
 	if err := store.AppendCausal(ctx, "agent", func(*contracts.Receipt, uint64, string) (*contracts.Receipt, error) {
 		return storeCoverageReceipt("receipt-commit-fail", "decision-commit-fail", "agent", 1, now), nil
@@ -657,6 +663,9 @@ func storePostgresReceiptColumns() []string {
 		"prev_hash",
 		"lamport_clock",
 		"args_hash",
+		"log_id",
+		"leaf_index",
+		"transparency",
 	}
 }
 
@@ -681,5 +690,19 @@ func storePostgresReceiptRows(receipt *contracts.Receipt, metadata []byte) *sqlm
 			receipt.PrevHash,
 			int64(receipt.LamportClock),
 			receipt.ArgsHash,
+			receipt.LogID,
+			int64(receipt.LeafIndex),
+			storePostgresTransparencyValue(receipt),
 		)
+}
+
+func storePostgresTransparencyValue(receipt *contracts.Receipt) any {
+	if receipt.Transparency == nil {
+		return nil
+	}
+	encoded, err := encodeTransparencyAnchor(receipt)
+	if err != nil {
+		return nil
+	}
+	return encoded
 }

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-14T02:09:40Z
-# Commit: 3a4896b9cd201862be729cae305839882c5b73f1
+# Generated: 2026-06-14T03:17:56Z
+# Commit: 9601bc52982467aed69ee8cb7fb71682920589bc
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md
@@ -204,7 +204,7 @@ c9aefcaefb9565ba86fdf087f6d05c6c6c49873172a5ba720ff6dccbce0b7f47  core/pkg/contr
 0ffa51fc3b14fe46dddd1610386859d7196c03d7f0e0b17986e8724731cb8506  core/pkg/contracts/posture_budget_corridor_test.go
 72cbfdedd6cd7d9a859bdf9cf227fbda0262748c73c3c0570bb500beb43d9d12  core/pkg/contracts/proofs.go
 9a102cb08f0bc539c18ca998d3a3fd54ba3cde0a4114731f136be6ef1f25aa55  core/pkg/contracts/proposals.go
-a3799381a176b814101bd51818daf971a28f8709c188aa87b8293081c76f985f  core/pkg/contracts/receipt.go
+72d9e3269a98849270c5f5afdb0bb8d07238e67a8f571fe81500b7785ff95736  core/pkg/contracts/receipt.go
 15026d4ed482963f29113ffdb0252ee6fb7b8192e93a0af0767f1270ae2f7f8c  core/pkg/contracts/receipt_fuzz_test.go
 3fa9fa9aa737572cf7213e619c3571dc2c9a1b00b147f08c5e3e6a0b7c077503  core/pkg/contracts/receipt_hash.go
 13cd995836c12a34fccd699fed492b360b4f82c1c10a9f4ae458b65d7faa9dad  core/pkg/contracts/receipt_hash_parity_test.go
@@ -309,8 +309,8 @@ b747620621ea158e1bb12b77c15c265f8701aa9a33cb608c9ad1026dc218845d  core/pkg/crypt
 0686f9c57e9ddbb46d7a4e85d60eff54e38d53d422c022e7e6f7389f319b1871  core/pkg/crypto/zk/safety_checker_test.go
 8739c7e4d2df1d7752b28e89d5b590705959f9be623a783182720d86db6bdb4a  core/pkg/evidencepack/README.md
 3d6a8c4c2a29d59f9d37df6ca68c90c5afe8d0525aa36530fdb2ad5dd01b76d8  core/pkg/evidencepack/archive.go
-4a7951a170e8bea3bdc1090bb0edeeb6da5ddae5a7e85b99f3166173517b35aa  core/pkg/evidencepack/builder.go
-4833006a321a206e7fbf1417ccff655ff556f4bc92a6df64d38123d3971ef2b4  core/pkg/evidencepack/builder_test.go
+0916a3df70d15dd977beb773d1035e97995f8069382e36b77522c6cbc24e575a  core/pkg/evidencepack/builder.go
+314a0568858a1744478f437ec9b22f072c0d2e5d028e5a8b4acaab0bbd5174aa  core/pkg/evidencepack/builder_test.go
 3cd6a38836549c616bed8ec4ed4b80703d0a7ab1380aab8f29c3c9b47a197e63  core/pkg/evidencepack/chaos_test.go
 3a8fc2a7e02a595353921b68baefe4f444644ba991bb380f8063be40749dbb63  core/pkg/evidencepack/evidencepack_behavior_coverage_test.go
 b0282931372d24fc5a0d12acab58ab374e6d6cf3a43130b7fc7f445811697a26  core/pkg/evidencepack/evidencepack_contracts_test.go


### PR DESCRIPTION
Remediates MEDIUM persistence gap in merged MIN-720: Transparency/LogID/LeafIndex were set in memory but never persisted (no columns/migration), so anchoring metadata + degrade backfill marker were silently dropped. Adds migration + store insert/scan for both Postgres & SQLite; **excludes the new fields from ReceiptChainHash** so the causal chain + golden fixtures are byte-identical (verify-fixtures green). main.go comment scoped to decision-record receipts. go build/vet/test + make verify-fixtures green.

---
Review-remediation follow-up (Claude Code). Local gates green; fixes a bug confirmed by adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)