### PR TITLE
feat(receipts): external decision-receipt compatibility foundation + Receipt Spec v1.0

### DIFF
--- a/core/pkg/contracts/external_decision_receipt.go
+++ b/core/pkg/contracts/external_decision_receipt.go
@@ -1,0 +1,89 @@
+package contracts
+
+import "time"
+
+const (
+	// ExternalDecisionReceiptVersion is the schema version for a single
+	// normalized external decision receipt imported into HELM.
+	ExternalDecisionReceiptVersion = "external_decision_receipt.v1"
+	// ExternalDecisionReceiptBundleVersion is the on-disk chain envelope version.
+	ExternalDecisionReceiptBundleVersion = "external_decision_receipt_bundle.v1"
+)
+
+// ExternalReceiptKind is the top-level taxonomy discriminator for any receipt
+// HELM is asked to reason about. It deliberately separates HELM-native receipts
+// (which carry a fail-closed policy verdict bound to an effect permit) from
+// external receipts (which, at best, carry a decision-level claim).
+type ExternalReceiptKind string
+
+const (
+	// KindHELMNative is reserved for receipts that bind a HELM policy verdict to
+	// an effect permit + policy hash. No external-format adapter may emit it.
+	KindHELMNative ExternalReceiptKind = "helm_native_receipt"
+	// KindExternalDecision is a third-party decision receipt (e.g. AAR, ACTA):
+	// decision-level proof only, not execution proof.
+	KindExternalDecision ExternalReceiptKind = "external_decision_receipt"
+	// KindExternalScan is a third-party scan/proxy receipt (e.g. Pipelock egress).
+	KindExternalScan ExternalReceiptKind = "external_scan_receipt"
+)
+
+// ExternalReceiptClassification is the trust level the verifier assigns to an
+// external receipt. It is never promoted to HELM-native authority: an external
+// decision receipt lacks a verdict-bound effect permit, so the strongest level
+// it can reach is crypto_conformant (cryptographically sound, decision-level).
+type ExternalReceiptClassification string
+
+const (
+	// ClassCryptoConformant: signature verified against an externally trusted key
+	// and (if a chain is present) the chain links. Decision-level proof.
+	ClassCryptoConformant ExternalReceiptClassification = "crypto_conformant"
+	// ClassCryptoCompatibleNonConformant: cryptographically well-formed and the
+	// signature verifies, but only against a key disclosed inside the bundle
+	// (self-consistency, not authenticity) or a HELM binding is absent.
+	ClassCryptoCompatibleNonConformant ExternalReceiptClassification = "crypto_compatible_non_conformant"
+	// ClassUnverified: no trusted key, invalid signature, or hash mismatch.
+	ClassUnverified ExternalReceiptClassification = "unverified"
+)
+
+// ExternalDecisionReceipt is the HELM-internal normalized representation that
+// every external decision-receipt format (AAR, ACTA, Pipelock, …) maps into via
+// its FormatAdapter. The Classification, ReceiptHash, OriginalDigest and
+// Limitations fields are assigned by HELM during verification/import and are
+// excluded from the bytes the producer signed.
+type ExternalDecisionReceipt struct {
+	SchemaVersion  string                        `json:"schema_version"`
+	Kind           ExternalReceiptKind           `json:"kind"`
+	FormatID       string                        `json:"format_id"`
+	FormatVersion  string                        `json:"format_version,omitempty"`
+	Classification ExternalReceiptClassification `json:"classification,omitempty"`
+
+	ReceiptID       string `json:"receipt_id"`
+	PrevReceiptHash string `json:"prev_receipt_hash,omitempty"`
+	ReceiptHash     string `json:"receipt_hash,omitempty"` // "sha256:" + hex over canonical signed bytes
+
+	Action       string    `json:"action,omitempty"`
+	Verdict      string    `json:"verdict,omitempty"`
+	Subject      string    `json:"subject,omitempty"`
+	ArgsHash     string    `json:"args_hash,omitempty"`
+	DecisionTime time.Time `json:"decision_time,omitempty"`
+
+	SignatureAlgorithm string `json:"signature_algorithm,omitempty"` // "Ed25519"
+	Signature          string `json:"signature,omitempty"`           // hex or base64
+	SigningKeyID       string `json:"signing_key_id,omitempty"`
+
+	SourceVendor   string            `json:"source_vendor,omitempty"`
+	Limitations    []string          `json:"limitations,omitempty"`
+	OriginalDigest string            `json:"original_digest,omitempty"` // sha256 of verbatim source bytes
+	Metadata       map[string]string `json:"metadata,omitempty"`
+}
+
+// ExternalDecisionReceiptBundle is the on-disk envelope for one or more external
+// decision receipts. PublicKeys are local-only and never fetched over the
+// network during verification (same invariant as ExternalVerifierKey).
+type ExternalDecisionReceiptBundle struct {
+	SchemaVersion string                    `json:"schema_version"`
+	FormatID      string                    `json:"format_id,omitempty"`
+	SourceVendor  string                    `json:"source_vendor,omitempty"`
+	PublicKeys    []ExternalVerifierKey     `json:"public_keys,omitempty"`
+	Receipts      []ExternalDecisionReceipt `json:"receipts"`
+}

--- a/core/pkg/verifier/decisionreceipt/decisionreceipt.go
+++ b/core/pkg/verifier/decisionreceipt/decisionreceipt.go
@@ -1,6 +1,8 @@
-// Package decisionreceipt verifies external decision receipts (e.g. AAR, ACTA,
-// Pipelock) against HELM's neutral classification ladder and normalizes them
-// into contracts.ExternalDecisionReceipt for import into EvidencePacks.
+// Package decisionreceipt verifies external decision receipts against HELM's
+// neutral classification ladder and normalizes them into
+// contracts.ExternalDecisionReceipt for import into EvidencePacks. Target formats
+// (AAR, ACTA, Pipelock) plug in as FormatAdapters; this release ships the
+// helm_external.v1 reference adapter only.
 //
 // HELM verifies external receipts; it does NOT promote them to HELM-native
 // authority. The strongest level an external decision receipt can reach is
@@ -127,16 +129,23 @@ func VerifyReceipt(a FormatAdapter, r contracts.ExternalDecisionReceipt, bundleK
 	var checks []DecisionCheck
 	id := r.ReceiptID
 
-	computed, err := ComputeReceiptHash(a, r)
+	data, err := a.CanonicalSignedBytes(r)
 	if err != nil {
 		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: false, Reason: "canonicalization failed: " + err.Error()})
 		return contracts.ClassUnverified, checks
 	}
-	if r.ReceiptHash != "" && r.ReceiptHash != computed {
+	computed := "sha256:" + canonicalize.HashBytes(data)
+	switch {
+	case r.ReceiptHash == "":
+		// No producer-supplied hash; the signature below is the authoritative
+		// check. Record this honestly rather than implying a stored hash matched.
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: true, Detail: "no stored receipt_hash (computed " + computed + ")"})
+	case r.ReceiptHash != computed:
 		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: false, Reason: fmt.Sprintf("receipt_hash=%q computed=%q", r.ReceiptHash, computed)})
 		return contracts.ClassUnverified, checks
+	default:
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: true, Detail: computed})
 	}
-	checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: true, Detail: computed})
 
 	if strings.TrimSpace(r.Signature) == "" {
 		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: false, Reason: "missing signature"})
@@ -162,7 +171,6 @@ func VerifyReceipt(a FormatAdapter, r contracts.ExternalDecisionReceipt, bundleK
 		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: false, Reason: "invalid signature encoding: " + err.Error()})
 		return contracts.ClassUnverified, checks
 	}
-	data, _ := a.CanonicalSignedBytes(r) // err handled above
 	if !ed25519.Verify(pub, data, sig) {
 		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: false, Reason: "Ed25519 signature mismatch"})
 		return contracts.ClassUnverified, checks
@@ -226,7 +234,9 @@ func (r *Registry) VerifyBundle(raw []byte, formatID, trustedKeyHex string) (Dec
 		weakest = weaker(weakest, class)
 
 		if i > 0 {
-			if receipts[i].PrevReceiptHash != prevHash {
+			// prevHash == "" means the previous receipt was skipped/uncomputable
+			// (e.g. it forged a helm_native kind); the chain is broken there.
+			if prevHash == "" || receipts[i].PrevReceiptHash != prevHash {
 				report.Verified = false
 				weakest = contracts.ClassUnverified
 				report.Checks = append(report.Checks, DecisionCheck{Name: "decision:" + receipts[i].ReceiptID + ":chain", Pass: false, Reason: fmt.Sprintf("prev_receipt_hash=%q expected %q", receipts[i].PrevReceiptHash, prevHash)})
@@ -290,7 +300,12 @@ func decodeSignature(value string) ([]byte, error) {
 	if decoded, err := hex.DecodeString(value); err == nil {
 		return decoded, nil
 	}
-	return base64.StdEncoding.DecodeString(value)
+	for _, enc := range []*base64.Encoding{base64.StdEncoding, base64.URLEncoding, base64.RawStdEncoding, base64.RawURLEncoding} {
+		if decoded, err := enc.DecodeString(value); err == nil {
+			return decoded, nil
+		}
+	}
+	return nil, fmt.Errorf("signature is neither valid hex nor base64")
 }
 
 func decodePublicKey(keyHex string) (ed25519.PublicKey, error) {

--- a/core/pkg/verifier/decisionreceipt/decisionreceipt.go
+++ b/core/pkg/verifier/decisionreceipt/decisionreceipt.go
@@ -1,0 +1,305 @@
+// Package decisionreceipt verifies external decision receipts (e.g. AAR, ACTA,
+// Pipelock) against HELM's neutral classification ladder and normalizes them
+// into contracts.ExternalDecisionReceipt for import into EvidencePacks.
+//
+// HELM verifies external receipts; it does NOT promote them to HELM-native
+// authority. The strongest level an external decision receipt can reach is
+// crypto_conformant (decision-level proof). Execution proof requires a HELM
+// verdict-bound effect permit, which these formats do not carry.
+package decisionreceipt
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// FormatAdapter is implemented once per external decision-receipt format. It
+// owns detection, parsing, and — most importantly — reproducing the exact bytes
+// the producer signed (CanonicalSignedBytes), so HELM verifies the signature
+// without re-canonicalizing differently from the producer.
+type FormatAdapter interface {
+	FormatID() string
+	Kind() contracts.ExternalReceiptKind
+	// Detect cheaply reports whether raw bytes plausibly match this format.
+	Detect(raw []byte) bool
+	// Parse decodes vendor bytes into one or more normalized receipts. It must
+	// set Kind and FormatID and must not verify signatures.
+	Parse(raw []byte) ([]contracts.ExternalDecisionReceipt, error)
+	// CanonicalSignedBytes returns the exact bytes that were signed for r.
+	CanonicalSignedBytes(r contracts.ExternalDecisionReceipt) ([]byte, error)
+}
+
+// Registry maps format IDs to adapters.
+type Registry struct {
+	mu       sync.RWMutex
+	adapters map[string]FormatAdapter
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry { return &Registry{adapters: map[string]FormatAdapter{}} }
+
+var defaultRegistry = NewRegistry()
+
+// Register adds an adapter to the default registry. It panics if the adapter
+// declares the reserved helm_native kind (no external adapter may claim
+// HELM-native authority).
+func Register(a FormatAdapter) { defaultRegistry.Register(a) }
+
+// Default returns the process-wide registry that built-in adapters register into.
+func Default() *Registry { return defaultRegistry }
+
+// Register adds an adapter. It panics on a reserved helm_native kind.
+func (r *Registry) Register(a FormatAdapter) {
+	if a.Kind() == contracts.KindHELMNative {
+		panic(fmt.Sprintf("decisionreceipt: adapter %q may not declare helm_native kind", a.FormatID()))
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.adapters[a.FormatID()] = a
+}
+
+// Get returns the adapter registered for formatID.
+func (r *Registry) Get(formatID string) (FormatAdapter, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.adapters[formatID]
+	return a, ok
+}
+
+// DetectAdapter returns the first adapter (in deterministic id order) whose
+// Detect matches raw.
+func (r *Registry) DetectAdapter(raw []byte) (FormatAdapter, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]string, 0, len(r.adapters))
+	for id := range r.adapters {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		if r.adapters[id].Detect(raw) {
+			return r.adapters[id], true
+		}
+	}
+	return nil, false
+}
+
+// DecisionCheck is a single named verification result.
+type DecisionCheck struct {
+	Name   string `json:"name"`
+	Pass   bool   `json:"pass"`
+	Detail string `json:"detail,omitempty"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// DecisionReport is the aggregate verification outcome for an input.
+type DecisionReport struct {
+	Verified       bool                                    `json:"verified"`
+	FormatID       string                                  `json:"format_id"`
+	Kind           contracts.ExternalReceiptKind           `json:"kind"`
+	Classification contracts.ExternalReceiptClassification `json:"classification"`
+	ReceiptCount   int                                     `json:"receipt_count"`
+	Checks         []DecisionCheck                         `json:"checks"`
+	Receipts       []contracts.ExternalDecisionReceipt     `json:"receipts,omitempty"`
+}
+
+// ComputeReceiptHash returns "sha256:" + hex over the adapter's canonical signed
+// bytes for r.
+func ComputeReceiptHash(a FormatAdapter, r contracts.ExternalDecisionReceipt) (string, error) {
+	data, err := a.CanonicalSignedBytes(r)
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + canonicalize.HashBytes(data), nil
+}
+
+// VerifyReceipt verifies one receipt and returns its classification + checks.
+func VerifyReceipt(a FormatAdapter, r contracts.ExternalDecisionReceipt, bundleKeys []contracts.ExternalVerifierKey, trustedKeyHex string) (contracts.ExternalReceiptClassification, []DecisionCheck) {
+	var checks []DecisionCheck
+	id := r.ReceiptID
+
+	computed, err := ComputeReceiptHash(a, r)
+	if err != nil {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: false, Reason: "canonicalization failed: " + err.Error()})
+		return contracts.ClassUnverified, checks
+	}
+	if r.ReceiptHash != "" && r.ReceiptHash != computed {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: false, Reason: fmt.Sprintf("receipt_hash=%q computed=%q", r.ReceiptHash, computed)})
+		return contracts.ClassUnverified, checks
+	}
+	checks = append(checks, DecisionCheck{Name: "decision:" + id + ":hash", Pass: true, Detail: computed})
+
+	if strings.TrimSpace(r.Signature) == "" {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: false, Reason: "missing signature"})
+		return contracts.ClassUnverified, checks
+	}
+	if alg := strings.TrimSpace(r.SignatureAlgorithm); alg != "" && !strings.EqualFold(alg, "Ed25519") {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: false, Reason: "unsupported signature_algorithm=" + alg})
+		return contracts.ClassUnverified, checks
+	}
+
+	pub, trusted, keyErr := resolveKey(r, bundleKeys, trustedKeyHex)
+	if keyErr != nil {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":key", Pass: false, Reason: keyErr.Error()})
+		return contracts.ClassUnverified, checks
+	}
+	if pub == nil {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":key", Pass: false, Reason: "no trusted or disclosed public key for signature"})
+		return contracts.ClassUnverified, checks
+	}
+
+	sig, err := decodeSignature(r.Signature)
+	if err != nil {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: false, Reason: "invalid signature encoding: " + err.Error()})
+		return contracts.ClassUnverified, checks
+	}
+	data, _ := a.CanonicalSignedBytes(r) // err handled above
+	if !ed25519.Verify(pub, data, sig) {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: false, Reason: "Ed25519 signature mismatch"})
+		return contracts.ClassUnverified, checks
+	}
+	checks = append(checks, DecisionCheck{Name: "decision:" + id + ":signature", Pass: true, Detail: "Ed25519 verified"})
+
+	if trusted {
+		checks = append(checks, DecisionCheck{Name: "decision:" + id + ":classification", Pass: true, Detail: string(contracts.ClassCryptoConformant)})
+		return contracts.ClassCryptoConformant, checks
+	}
+	checks = append(checks, DecisionCheck{Name: "decision:" + id + ":classification", Pass: true, Detail: string(contracts.ClassCryptoCompatibleNonConformant) + " (verified against bundle-disclosed key only; decision-level proof, not execution proof)"})
+	return contracts.ClassCryptoCompatibleNonConformant, checks
+}
+
+// VerifyBundle parses raw using the registry (explicit formatID or auto-detect),
+// verifies every receipt, links the chain, and returns an aggregate report whose
+// Classification is the weakest of any receipt.
+func (r *Registry) VerifyBundle(raw []byte, formatID, trustedKeyHex string) (DecisionReport, error) {
+	var adapter FormatAdapter
+	var ok bool
+	if formatID != "" {
+		if adapter, ok = r.Get(formatID); !ok {
+			return DecisionReport{}, fmt.Errorf("unknown format_id %q", formatID)
+		}
+	} else if adapter, ok = r.DetectAdapter(raw); !ok {
+		return DecisionReport{}, fmt.Errorf("no registered adapter matched the input")
+	}
+	if adapter.Kind() == contracts.KindHELMNative {
+		return DecisionReport{}, fmt.Errorf("adapter %q must not declare helm_native kind", adapter.FormatID())
+	}
+
+	receipts, err := adapter.Parse(raw)
+	if err != nil {
+		return DecisionReport{}, fmt.Errorf("parse: %w", err)
+	}
+	report := DecisionReport{FormatID: adapter.FormatID(), Kind: adapter.Kind(), ReceiptCount: len(receipts), Verified: true, Classification: contracts.ClassCryptoConformant}
+	if len(receipts) == 0 {
+		report.Verified = false
+		report.Classification = contracts.ClassUnverified
+		report.Checks = append(report.Checks, DecisionCheck{Name: "decision:bundle", Pass: false, Reason: "no receipts in input"})
+		return report, nil
+	}
+
+	bundleKeys := extractBundleKeys(raw)
+	weakest := contracts.ClassCryptoConformant
+	var prevHash string
+	for i := range receipts {
+		if receipts[i].Kind == contracts.KindHELMNative {
+			report.Verified = false
+			report.Checks = append(report.Checks, DecisionCheck{Name: "decision:" + receipts[i].ReceiptID + ":kind", Pass: false, Reason: "external receipt must not claim helm_native kind"})
+			weakest = contracts.ClassUnverified
+			prevHash = ""
+			continue
+		}
+		class, checks := VerifyReceipt(adapter, receipts[i], bundleKeys, trustedKeyHex)
+		report.Checks = append(report.Checks, checks...)
+		receipts[i].Classification = class
+		if class == contracts.ClassUnverified {
+			report.Verified = false
+		}
+		weakest = weaker(weakest, class)
+
+		if i > 0 {
+			if receipts[i].PrevReceiptHash != prevHash {
+				report.Verified = false
+				weakest = contracts.ClassUnverified
+				report.Checks = append(report.Checks, DecisionCheck{Name: "decision:" + receipts[i].ReceiptID + ":chain", Pass: false, Reason: fmt.Sprintf("prev_receipt_hash=%q expected %q", receipts[i].PrevReceiptHash, prevHash)})
+			} else {
+				report.Checks = append(report.Checks, DecisionCheck{Name: "decision:" + receipts[i].ReceiptID + ":chain", Pass: true})
+			}
+		}
+		if h, herr := ComputeReceiptHash(adapter, receipts[i]); herr == nil {
+			prevHash = h
+		} else {
+			prevHash = ""
+		}
+	}
+	report.Classification = weakest
+	report.Receipts = receipts
+	return report, nil
+}
+
+func weaker(a, b contracts.ExternalReceiptClassification) contracts.ExternalReceiptClassification {
+	rank := map[contracts.ExternalReceiptClassification]int{
+		contracts.ClassUnverified:                    0,
+		contracts.ClassCryptoCompatibleNonConformant: 1,
+		contracts.ClassCryptoConformant:              2,
+	}
+	if rank[b] < rank[a] {
+		return b
+	}
+	return a
+}
+
+func resolveKey(r contracts.ExternalDecisionReceipt, bundleKeys []contracts.ExternalVerifierKey, trustedKeyHex string) (ed25519.PublicKey, bool, error) {
+	if strings.TrimSpace(trustedKeyHex) != "" {
+		pub, err := decodePublicKey(trustedKeyHex)
+		if err != nil {
+			return nil, false, err
+		}
+		return pub, true, nil
+	}
+	for _, k := range bundleKeys {
+		if r.SigningKeyID == "" || k.KeyID == r.SigningKeyID {
+			if pub, err := decodePublicKey(k.PublicKeyHex); err == nil {
+				return pub, false, nil
+			}
+		}
+	}
+	return nil, false, nil
+}
+
+// extractBundleKeys best-effort recovers public keys disclosed in a bundle
+// envelope. Disclosed keys prove self-consistency only, never authenticity.
+func extractBundleKeys(raw []byte) []contracts.ExternalVerifierKey {
+	var bundle contracts.ExternalDecisionReceiptBundle
+	if err := json.Unmarshal(raw, &bundle); err == nil && len(bundle.PublicKeys) > 0 {
+		return bundle.PublicKeys
+	}
+	return nil
+}
+
+func decodeSignature(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	if decoded, err := hex.DecodeString(value); err == nil {
+		return decoded, nil
+	}
+	return base64.StdEncoding.DecodeString(value)
+}
+
+func decodePublicKey(keyHex string) (ed25519.PublicKey, error) {
+	pub, err := hex.DecodeString(strings.TrimPrefix(strings.TrimSpace(keyHex), "ed25519:"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid public key hex: %w", err)
+	}
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid Ed25519 public key size: %d", len(pub))
+	}
+	return ed25519.PublicKey(pub), nil
+}

--- a/core/pkg/verifier/decisionreceipt/decisionreceipt_test.go
+++ b/core/pkg/verifier/decisionreceipt/decisionreceipt_test.go
@@ -1,0 +1,184 @@
+package decisionreceipt
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func newKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	return pub, priv
+}
+
+func sampleReceipt() contracts.ExternalDecisionReceipt {
+	return contracts.ExternalDecisionReceipt{
+		ReceiptID:    "edr_1",
+		Action:       "github.create_issue",
+		Verdict:      "allow",
+		Subject:      "did:helm:agent:demo",
+		SourceVendor: "example-vendor",
+		SigningKeyID: "key-1",
+	}
+}
+
+func adapter(t *testing.T) FormatAdapter {
+	t.Helper()
+	a, ok := Default().Get(HelmExternalFormatID)
+	if !ok {
+		t.Fatal("helm_external adapter not registered")
+	}
+	return a
+}
+
+func TestHelmExternalRoundTripTrustedKey(t *testing.T) {
+	pub, priv := newKeypair(t)
+	signed, err := SignHelmExternal(sampleReceipt(), priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	class, checks := VerifyReceipt(adapter(t), signed, nil, hex.EncodeToString(pub))
+	if class != contracts.ClassCryptoConformant {
+		t.Fatalf("class=%s, want crypto_conformant; checks=%+v", class, checks)
+	}
+}
+
+func TestHelmExternalBundleKeyOnlyIsNonConformant(t *testing.T) {
+	pub, priv := newKeypair(t)
+	signed, _ := SignHelmExternal(sampleReceipt(), priv)
+	bundleKeys := []contracts.ExternalVerifierKey{{KeyID: "key-1", Algorithm: "Ed25519", PublicKeyHex: hex.EncodeToString(pub)}}
+	class, checks := VerifyReceipt(adapter(t), signed, bundleKeys, "")
+	if class != contracts.ClassCryptoCompatibleNonConformant {
+		t.Fatalf("class=%s, want crypto_compatible_non_conformant; checks=%+v", class, checks)
+	}
+}
+
+func TestTamperedSignatureUnverified(t *testing.T) {
+	pub, priv := newKeypair(t)
+	signed, _ := SignHelmExternal(sampleReceipt(), priv)
+	b := []byte(signed.Signature)
+	if b[0] == 'a' {
+		b[0] = 'b'
+	} else {
+		b[0] = 'a'
+	}
+	signed.Signature = string(b)
+	if class, _ := VerifyReceipt(adapter(t), signed, nil, hex.EncodeToString(pub)); class != contracts.ClassUnverified {
+		t.Fatalf("class=%s, want unverified", class)
+	}
+}
+
+func TestTamperedBodyUnverified(t *testing.T) {
+	pub, priv := newKeypair(t)
+	signed, _ := SignHelmExternal(sampleReceipt(), priv)
+	signed.Action = "github.delete_repo" // mutate after signing
+	if class, _ := VerifyReceipt(adapter(t), signed, nil, hex.EncodeToString(pub)); class != contracts.ClassUnverified {
+		t.Fatalf("class=%s, want unverified after body tamper", class)
+	}
+}
+
+func TestWrongKeyUnverified(t *testing.T) {
+	_, priv := newKeypair(t)
+	otherPub, _ := newKeypair(t)
+	signed, _ := SignHelmExternal(sampleReceipt(), priv)
+	if class, _ := VerifyReceipt(adapter(t), signed, nil, hex.EncodeToString(otherPub)); class != contracts.ClassUnverified {
+		t.Fatalf("class=%s, want unverified with wrong key", class)
+	}
+}
+
+func TestNoKeyUnverified(t *testing.T) {
+	_, priv := newKeypair(t)
+	signed, _ := SignHelmExternal(sampleReceipt(), priv)
+	if class, _ := VerifyReceipt(adapter(t), signed, nil, ""); class != contracts.ClassUnverified {
+		t.Fatalf("class=%s, want unverified with no key", class)
+	}
+}
+
+func TestVerifyBundleAutoDetectAndChain(t *testing.T) {
+	pub, priv := newKeypair(t)
+	r1, _ := SignHelmExternal(sampleReceipt(), priv)
+	r2base := sampleReceipt()
+	r2base.ReceiptID = "edr_2"
+	r2base.PrevReceiptHash = r1.ReceiptHash
+	r2, _ := SignHelmExternal(r2base, priv)
+
+	bundle := contracts.ExternalDecisionReceiptBundle{
+		SchemaVersion: contracts.ExternalDecisionReceiptBundleVersion,
+		FormatID:      HelmExternalFormatID,
+		Receipts:      []contracts.ExternalDecisionReceipt{r1, r2},
+	}
+	raw, _ := json.Marshal(bundle)
+
+	rep, err := Default().VerifyBundle(raw, "", hex.EncodeToString(pub))
+	if err != nil {
+		t.Fatalf("verify bundle: %v", err)
+	}
+	if !rep.Verified || rep.Classification != contracts.ClassCryptoConformant {
+		t.Fatalf("verified=%v class=%s; checks=%+v", rep.Verified, rep.Classification, rep.Checks)
+	}
+	if rep.ReceiptCount != 2 {
+		t.Fatalf("receipt count=%d", rep.ReceiptCount)
+	}
+}
+
+func TestVerifyBundleBrokenChainUnverified(t *testing.T) {
+	pub, priv := newKeypair(t)
+	r1, _ := SignHelmExternal(sampleReceipt(), priv)
+	r2base := sampleReceipt()
+	r2base.ReceiptID = "edr_2"
+	r2base.PrevReceiptHash = "sha256:wrong"
+	r2, _ := SignHelmExternal(r2base, priv)
+	bundle := contracts.ExternalDecisionReceiptBundle{FormatID: HelmExternalFormatID, Receipts: []contracts.ExternalDecisionReceipt{r1, r2}}
+	raw, _ := json.Marshal(bundle)
+	rep, _ := Default().VerifyBundle(raw, HelmExternalFormatID, hex.EncodeToString(pub))
+	if rep.Verified {
+		t.Fatal("expected broken chain to fail verification")
+	}
+}
+
+type nativeClaimAdapter struct{}
+
+func (nativeClaimAdapter) FormatID() string                                          { return "evil.v1" }
+func (nativeClaimAdapter) Kind() contracts.ExternalReceiptKind                       { return contracts.KindHELMNative }
+func (nativeClaimAdapter) Detect([]byte) bool                                        { return false }
+func (nativeClaimAdapter) Parse([]byte) ([]contracts.ExternalDecisionReceipt, error) { return nil, nil }
+func (nativeClaimAdapter) CanonicalSignedBytes(contracts.ExternalDecisionReceipt) ([]byte, error) {
+	return nil, nil
+}
+
+func TestRegisterRejectsHelmNativeAdapter(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("registering a helm_native adapter must panic")
+		}
+	}()
+	NewRegistry().Register(nativeClaimAdapter{})
+}
+
+func TestHelmExternalNormalizesAwayNativeClaim(t *testing.T) {
+	pub, priv := newKeypair(t)
+	signed, _ := SignHelmExternal(sampleReceipt(), priv)
+	rawSigned, _ := json.Marshal(signed)
+	var m map[string]any
+	if err := json.Unmarshal(rawSigned, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	m["kind"] = string(contracts.KindHELMNative) // forge a native claim
+	raw, _ := json.Marshal(m)
+
+	rep, err := Default().VerifyBundle(raw, HelmExternalFormatID, hex.EncodeToString(pub))
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if rep.Kind == contracts.KindHELMNative {
+		t.Fatal("must never report helm_native kind for an external receipt")
+	}
+}

--- a/core/pkg/verifier/decisionreceipt/helm_external.go
+++ b/core/pkg/verifier/decisionreceipt/helm_external.go
@@ -1,0 +1,84 @@
+package decisionreceipt
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// HelmExternalFormatID is HELM's own self-describing external decision-receipt
+// format. It exercises the full verify+classify pipeline end-to-end and is the
+// import target that vendor adapters (AAR, ACTA, …) normalize into.
+const HelmExternalFormatID = "helm_external.v1"
+
+func init() { Register(helmExternalAdapter{}) }
+
+type helmExternalAdapter struct{}
+
+func (helmExternalAdapter) FormatID() string                    { return HelmExternalFormatID }
+func (helmExternalAdapter) Kind() contracts.ExternalReceiptKind { return contracts.KindExternalDecision }
+
+func (helmExternalAdapter) Detect(raw []byte) bool {
+	return strings.Contains(string(raw), HelmExternalFormatID)
+}
+
+func (helmExternalAdapter) Parse(raw []byte) ([]contracts.ExternalDecisionReceipt, error) {
+	var bundle contracts.ExternalDecisionReceiptBundle
+	if err := json.Unmarshal(raw, &bundle); err == nil && len(bundle.Receipts) > 0 {
+		out := bundle.Receipts
+		for i := range out {
+			normalizeHelmExternal(&out[i])
+		}
+		return out, nil
+	}
+	var single contracts.ExternalDecisionReceipt
+	if err := json.Unmarshal(raw, &single); err != nil {
+		return nil, err
+	}
+	normalizeHelmExternal(&single)
+	return []contracts.ExternalDecisionReceipt{single}, nil
+}
+
+func normalizeHelmExternal(r *contracts.ExternalDecisionReceipt) {
+	if r.SchemaVersion == "" {
+		r.SchemaVersion = contracts.ExternalDecisionReceiptVersion
+	}
+	r.Kind = contracts.KindExternalDecision
+	if r.FormatID == "" {
+		r.FormatID = HelmExternalFormatID
+	}
+}
+
+// CanonicalSignedBytes is JCS over the receipt with every HELM-assigned and
+// signature field cleared, so the bytes are identical at signing and
+// verification time.
+func (helmExternalAdapter) CanonicalSignedBytes(r contracts.ExternalDecisionReceipt) ([]byte, error) {
+	c := r
+	c.Signature = ""
+	c.ReceiptHash = ""
+	c.Classification = ""
+	c.OriginalDigest = ""
+	c.Limitations = nil
+	return canonicalize.JCS(c)
+}
+
+// SignHelmExternal signs r under helm_external.v1, setting ReceiptHash and
+// Signature. Exposed for producers and test fixtures.
+func SignHelmExternal(r contracts.ExternalDecisionReceipt, priv ed25519.PrivateKey) (contracts.ExternalDecisionReceipt, error) {
+	a := helmExternalAdapter{}
+	normalizeHelmExternal(&r)
+	if r.SignatureAlgorithm == "" {
+		r.SignatureAlgorithm = "Ed25519"
+	}
+	data, err := a.CanonicalSignedBytes(r)
+	if err != nil {
+		return r, err
+	}
+	r.ReceiptHash = "sha256:" + canonicalize.HashBytes(data)
+	r.Signature = hex.EncodeToString(ed25519.Sign(priv, data))
+	return r, nil
+}

--- a/core/pkg/verifier/decisionreceipt/helm_external.go
+++ b/core/pkg/verifier/decisionreceipt/helm_external.go
@@ -19,8 +19,10 @@ func init() { Register(helmExternalAdapter{}) }
 
 type helmExternalAdapter struct{}
 
-func (helmExternalAdapter) FormatID() string                    { return HelmExternalFormatID }
-func (helmExternalAdapter) Kind() contracts.ExternalReceiptKind { return contracts.KindExternalDecision }
+func (helmExternalAdapter) FormatID() string { return HelmExternalFormatID }
+func (helmExternalAdapter) Kind() contracts.ExternalReceiptKind {
+	return contracts.KindExternalDecision
+}
 
 func (helmExternalAdapter) Detect(raw []byte) bool {
 	return strings.Contains(string(raw), HelmExternalFormatID)

--- a/core/pkg/verifier/decisionreceipt/helm_external.go
+++ b/core/pkg/verifier/decisionreceipt/helm_external.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
-	"strings"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
@@ -25,7 +24,24 @@ func (helmExternalAdapter) Kind() contracts.ExternalReceiptKind {
 }
 
 func (helmExternalAdapter) Detect(raw []byte) bool {
-	return strings.Contains(string(raw), HelmExternalFormatID)
+	var probe struct {
+		FormatID string `json:"format_id"`
+		Receipts []struct {
+			FormatID string `json:"format_id"`
+		} `json:"receipts"`
+	}
+	if json.Unmarshal(raw, &probe) != nil {
+		return false
+	}
+	if probe.FormatID == HelmExternalFormatID {
+		return true
+	}
+	for _, r := range probe.Receipts {
+		if r.FormatID == HelmExternalFormatID {
+			return true
+		}
+	}
+	return false
 }
 
 func (helmExternalAdapter) Parse(raw []byte) ([]contracts.ExternalDecisionReceipt, error) {

--- a/protocols/specs/receipts/HELM_RECEIPT_SPEC_v1.0.md
+++ b/protocols/specs/receipts/HELM_RECEIPT_SPEC_v1.0.md
@@ -11,9 +11,12 @@ HELM does **not** claim to have "the only" or "the first" receipts.
 
 What HELM does claim, and this spec makes precise:
 
-> **HELM verifies AAR, ACTA, and HELM receipts. HELM-native receipts add a
-> verdict-bound effect permit and a compliance-mapped EvidencePack for *admissible
-> execution proof*. External decision receipts are *decision-level proof* only.**
+> **HELM is built to verify AAR, ACTA, and HELM receipts through pluggable format
+> adapters. This release ships the verify+classify engine and the `helm_external.v1`
+> reference adapter; the AAR/ACTA/Pipelock adapters are pending vendor test vectors
+> (§6) and are not yet claimed as supported. HELM-native receipts add a verdict-bound
+> effect permit and a compliance-mapped EvidencePack for *admissible execution
+> proof*; external decision receipts are *decision-level proof* only.**
 
 The defensible position is neutrality + binding: HELM is a verifier neutral enough
 that an auditor, insurer, or counterparty can check a receipt **without trusting the

--- a/protocols/specs/receipts/HELM_RECEIPT_SPEC_v1.0.md
+++ b/protocols/specs/receipts/HELM_RECEIPT_SPEC_v1.0.md
@@ -1,0 +1,96 @@
+# HELM Receipt Spec v1.0 (draft)
+
+Status: **draft** · Scope: external decision-receipt interoperability + classification.
+
+## 0. Why this exists
+
+Signed, offline-verifiable agent-action receipts are no longer a unique idea — AAR
+(Pipelock), the IETF `draft-farley-acta-signed-receipts` (ACTA), Signet, and others
+already use the same primitives HELM uses (Ed25519 + RFC 8785 JCS + SHA-256). So
+HELM does **not** claim to have "the only" or "the first" receipts.
+
+What HELM does claim, and this spec makes precise:
+
+> **HELM verifies AAR, ACTA, and HELM receipts. HELM-native receipts add a
+> verdict-bound effect permit and a compliance-mapped EvidencePack for *admissible
+> execution proof*. External decision receipts are *decision-level proof* only.**
+
+The defensible position is neutrality + binding: HELM is a verifier neutral enough
+that an auditor, insurer, or counterparty can check a receipt **without trusting the
+producing vendor**, and HELM-native receipts bind a fail-closed policy *verdict* to
+the *effect* that was permitted.
+
+## 1. Taxonomy (`kind`)
+
+Every receipt HELM reasons about carries a top-level `kind` discriminator:
+
+| `kind` | Meaning | Proof level |
+| --- | --- | --- |
+| `helm_native_receipt` | Binds a HELM policy verdict → effect permit → signed receipt → EvidencePack. | **Execution proof** |
+| `external_decision_receipt` | Third-party decision receipt (AAR, ACTA). | Decision-level proof |
+| `external_scan_receipt` | Third-party scan/proxy receipt (e.g. Pipelock egress). | Observation-level proof |
+
+**Hard rule:** no external-format adapter may emit `helm_native_receipt`. This is
+enforced in code (`decisionreceipt.Registry.Register` panics on a `helm_native`
+adapter; `VerifyBundle` rejects any external receipt that claims the native kind).
+
+## 2. Classification ladder
+
+Verifying an external receipt assigns a `classification`, never HELM-native authority:
+
+| `classification` | Condition |
+| --- | --- |
+| `crypto_conformant` | Signature verifies against an **externally trusted** key; chain (if any) links; content hash matches. Decision-level proof. |
+| `crypto_compatible_non_conformant` | Cryptographically well-formed and the signature verifies, but only against a key **disclosed inside the bundle** (self-consistency, not authenticity), or a HELM binding is absent. |
+| `unverified` | No trusted key, invalid signature, or content-hash mismatch. |
+
+A bundle's classification is the **weakest** of its receipts. A receipt verified
+only against a bundle-disclosed key is capped at `crypto_compatible_non_conformant`
+— it is never silently treated as execution proof.
+
+## 3. Canonicalization contract
+
+- Canonical bytes = **RFC 8785 (JCS)** over the receipt with the HELM-assigned and
+  signature fields cleared: `signature`, `receipt_hash`, `classification`,
+  `original_digest`, `limitations`.
+- `receipt_hash` = `"sha256:" + hex(SHA-256(canonical bytes))`.
+- `signature` = Ed25519 over the **same** canonical bytes; encoded hex or base64.
+- Chain linkage: `prev_receipt_hash` of receipt *n* equals `receipt_hash` of *n-1*.
+
+> **Adapter rule (the #1 correctness risk):** a format adapter's
+> `CanonicalSignedBytes` must reproduce the **producer's** signing input, not HELM's
+> JCS, when they differ. An adapter must not be shipped as "supported" until it is
+> locked against **vendor-emitted** test vectors. (See §6.)
+
+## 4. Normalized schema
+
+The HELM-internal normalized representation every adapter maps into is
+`contracts.ExternalDecisionReceipt` (JSON Schema:
+`protocols/json-schemas/receipts/external_decision_receipt.v1.schema.json`, to be
+added alongside the AAR/ACTA adapters). Bundle envelope:
+`ExternalDecisionReceiptBundle` (`public_keys` are local-only and never fetched over
+the network during verification).
+
+## 5. Reference implementation
+
+- Library: `core/pkg/verifier/decisionreceipt` — pluggable `FormatAdapter` registry +
+  signature/classification verify engine, reusing `canonicalize.JCS` and Ed25519.
+- Built-in adapter: `helm_external.v1` — HELM's self-describing external decision
+  format, fully tested end-to-end (round-trip, classification ladder, tamper, chain,
+  native-claim guard). It is the import target vendor adapters normalize into.
+
+## 6. Roadmap (honest)
+
+| Item | Status |
+| --- | --- |
+| Taxonomy + classification + verify engine + `helm_external.v1` | **this spec / shipped in code** |
+| `aar.v1` adapter | pending upstream AAR test vectors |
+| `acta.v1` adapter | pending IETF `draft-farley-acta-signed-receipts` test vectors + a filed position |
+| `pipelock.v1` (scan) adapter | pending sample receipts |
+| JSON Schemas under `protocols/json-schemas/receipts/` | with each adapter |
+| `helm-ai-kernel verify aar\|acta\|pipelock` CLI + import→EvidencePack | follow-on |
+| Hosted verifier (CLI-parity, offline) | follow-on |
+
+No adapter is advertised as "supported" before it verifies real vendor receipts
+against committed vectors. Until then the classification ladder makes the
+uncertainty explicit rather than overclaiming.


### PR DESCRIPTION
## Block 1 — Receipt Compatibility Layer (foundation)

> ⚠️ **Develop-only / merge gated behind Phase 0** per the Evidence Exchange program plan. Open for review; do not merge to a release line until the Phase-0 integrity close lands.

The product wedge: HELM as the **neutral verifier** of agent-action receipts. The receipt wedge is now contested (AAR/Pipelock, IETF ACTA, Signet all use Ed25519+JCS+SHA-256), so this lands the *verify + classify* scaffolding and the published spec — and deliberately **kills the "only/first receipt" claim**.

### What's here
- **`contracts.ExternalDecisionReceipt`** + bundle envelope + taxonomy (`kind`) and a **classification ladder** (`crypto_conformant` → `crypto_compatible_non_conformant` → `unverified`). Reuses `ExternalVerifierKey`.
- **`core/pkg/verifier/decisionreceipt`** — pluggable `FormatAdapter` registry, signature + chain + classification verify engine (reuses `canonicalize.JCS` + Ed25519), and a built-in self-describing adapter **`helm_external.v1`** that exercises the full pipeline.
- **Hard integrity guards:** no external adapter may claim `helm_native` authority (`Register` panics; `VerifyBundle` rejects forged native kind); a bundle-disclosed key caps at `crypto_compatible_non_conformant` — never silently execution proof.
- **Receipt Spec v1.0 (draft)** — `protocols/specs/receipts/HELM_RECEIPT_SPEC_v1.0.md`. Framing: *"HELM verifies AAR, ACTA, and HELM receipts. HELM-native receipts add verdict-bound effect permits + EvidencePacks for admissible execution proof."*

### Honesty boundary (important)
AAR / ACTA / Pipelock adapters are **not claimed as supported** in this PR. Per spec §6 they land only once locked against **vendor-emitted test vectors** — shipping a verifier we can't prove against real receipts would recreate the exact overclaim Phase 0 is purging. The classification ladder makes the uncertainty explicit instead.

### Verification
- `GOWORK=off go build ./pkg/contracts/... ./pkg/verifier/decisionreceipt/...` — clean.
- `GOWORK=off go test ./pkg/verifier/decisionreceipt/...` — `ok` (round-trip, classification ladder, tampered sig/body, wrong/no key, chain linkage, native-claim guard).

### Follow-ons
`aar.v1`/`acta.v1`/`pipelock.v1` adapters + JSON Schemas; `verify aar|acta|pipelock` CLI + import→EvidencePack; main-verifier wiring; hosted CLI-parity verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)