### PR TITLE
feat(receipts): import external receipt → HELM EvidencePack (verify → re-anchor)

### DIFF
--- a/core/cmd/helm-ai-kernel/import_cmd.go
+++ b/core/cmd/helm-ai-kernel/import_cmd.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/verifier/decisionreceipt"
+)
+
+func init() {
+	Register(Subcommand{
+		Name:  "import",
+		Usage: "Import an external receipt into a HELM EvidencePack (receipt <file> --out <dir> [--format <id>] [--public-key <hex>] [--json])",
+		RunFn: runImportCmd,
+	})
+}
+
+func runImportCmd(args []string, stdout, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "receipt" {
+		return runImportReceiptCmd(args[1:], stdout, stderr)
+	}
+	fmt.Fprintln(stderr, "Usage: helm-ai-kernel import receipt <file> --out <dir> [--format <id>] [--public-key <hex>] [--json]")
+	return 2
+}
+
+// runImportReceiptCmd verifies an external decision receipt and re-anchors it as
+// a content-addressed HELM EvidencePack written to --out.
+func runImportReceiptCmd(args []string, stdout, stderr io.Writer) int {
+	cmd := flag.NewFlagSet("import receipt", flag.ContinueOnError)
+	cmd.SetOutput(stderr)
+	var (
+		file       string
+		out        string
+		format     string
+		publicKey  string
+		jsonOutput bool
+	)
+	cmd.StringVar(&file, "file", "", "Path to the receipt/bundle JSON (or pass as a positional argument)")
+	cmd.StringVar(&out, "out", "", "Output directory for the EvidencePack (required)")
+	cmd.StringVar(&format, "format", "", "Format id (e.g. helm_external.v1); empty = auto-detect")
+	cmd.StringVar(&publicKey, "public-key", "", "Trusted Ed25519 public key hex")
+	cmd.BoolVar(&jsonOutput, "json", false, "Output the import result as JSON")
+	if err := cmd.Parse(reorderFlagsFirst(args, map[string]bool{"file": true, "out": true, "format": true, "public-key": true})); err != nil {
+		return 2
+	}
+	if file == "" && cmd.NArg() > 0 {
+		file = cmd.Arg(0)
+	}
+	if file == "" || out == "" {
+		fmt.Fprintln(stderr, "Error: a receipt file (positional or --file) and --out <dir> are required")
+		return 2
+	}
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: read %s: %v\n", file, err)
+		return 2
+	}
+
+	result, err := decisionreceipt.ImportReceipt(raw, decisionreceipt.ImportOptions{
+		FormatID:     format,
+		PublicKeyHex: publicKey,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 2
+	}
+	if err := writeEvidencePack(out, result.ContentMap); err != nil {
+		fmt.Fprintf(stderr, "Error: write evidence pack: %v\n", err)
+		return 2
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(result); err != nil {
+			fmt.Fprintf(stderr, "Error: encode result: %v\n", err)
+			return 2
+		}
+	} else {
+		fmt.Fprintf(stdout, "Imported %s  classification=%s\n", result.Report.FormatID, result.Report.Classification)
+		fmt.Fprintf(stdout, "EvidencePack: %s\n", out)
+		fmt.Fprintf(stdout, "  manifest_hash: %s\n", result.ManifestHash)
+		fmt.Fprintf(stdout, "  entries (%d):\n", len(result.Entries))
+		for _, e := range result.Entries {
+			fmt.Fprintf(stdout, "    %s\n", e)
+		}
+		if !result.Report.Verified {
+			fmt.Fprintln(stdout, "  note: receipt is UNVERIFIED — imported as honestly-labeled evidence only")
+		}
+	}
+
+	if !result.Report.Verified {
+		return 1
+	}
+	return 0
+}
+
+// writeEvidencePack writes a built EvidencePack content map to outDir, creating
+// subdirectories as needed.
+func writeEvidencePack(outDir string, contentMap map[string][]byte) error {
+	paths := make([]string, 0, len(contentMap))
+	for p := range contentMap {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		full := filepath.Join(outDir, p)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(full, contentMap[p], 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/core/cmd/helm-ai-kernel/import_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/import_cmd_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/verifier/decisionreceipt"
+)
+
+func TestImportReceiptCLIWritesPack(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	signed, err := decisionreceipt.SignHelmExternal(contracts.ExternalDecisionReceipt{
+		ReceiptID: "edr-cli-imp", Action: "github.create_issue", Verdict: "allow", SourceVendor: "v",
+	}, priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	in := writeReceiptFile(t, signed) // helper defined in verify_decision_receipt_cmd_test.go
+	out := filepath.Join(t.TempDir(), "pack")
+
+	var so, se bytes.Buffer
+	code := runImportReceiptCmd([]string{in, "--out", out, "--public-key", hex.EncodeToString(pub)}, &so, &se)
+	if code != 0 {
+		t.Fatalf("exit=%d, want 0; stderr=%s", code, se.String())
+	}
+	for _, p := range []string{"manifest.json", "compatibility/import_manifest.json", "host_evidence/helm_external.v1/source.json"} {
+		if _, err := os.Stat(filepath.Join(out, p)); err != nil {
+			t.Fatalf("missing pack file %s: %v", p, err)
+		}
+	}
+	if !bytes.Contains(so.Bytes(), []byte("manifest_hash")) {
+		t.Fatalf("expected manifest_hash in output: %s", so.String())
+	}
+}
+
+func TestImportReceiptCLIRequiresOut(t *testing.T) {
+	var so, se bytes.Buffer
+	code := runImportReceiptCmd([]string{"/tmp/whatever.json"}, &so, &se)
+	if code != 2 {
+		t.Fatalf("exit=%d, want 2 (missing --out)", code)
+	}
+}

--- a/core/cmd/helm-ai-kernel/verify_decision_receipt_cmd.go
+++ b/core/cmd/helm-ai-kernel/verify_decision_receipt_cmd.go
@@ -32,7 +32,7 @@ func runVerifyDecisionReceiptCmd(args []string, stdout, stderr io.Writer) int {
 	cmd.StringVar(&format, "format", "", "Format id (e.g. helm_external.v1); empty = auto-detect")
 	cmd.StringVar(&publicKey, "public-key", "", "Trusted Ed25519 public key hex. Without it, a bundle-disclosed key caps the result at crypto_compatible_non_conformant")
 	cmd.BoolVar(&jsonOutput, "json", false, "Output the DecisionReport as JSON")
-	if err := cmd.Parse(reorderFlagsFirst(args)); err != nil {
+	if err := cmd.Parse(reorderFlagsFirst(args, map[string]bool{"file": true, "format": true, "public-key": true})); err != nil {
 		return 2
 	}
 	if file == "" && cmd.NArg() > 0 {
@@ -91,8 +91,7 @@ func runVerifyDecisionReceiptCmd(args []string, stdout, stderr io.Writer) int {
 // args so `decision-receipt <file> --public-key <hex>` parses the same as
 // `decision-receipt --public-key <hex> <file>` (Go's flag package stops at the
 // first positional otherwise).
-func reorderFlagsFirst(args []string) []string {
-	valueFlags := map[string]bool{"file": true, "format": true, "public-key": true}
+func reorderFlagsFirst(args []string, valueFlags map[string]bool) []string {
 	var flags, positionals []string
 	for i := 0; i < len(args); i++ {
 		a := args[i]

--- a/core/pkg/verifier/decisionreceipt/importer.go
+++ b/core/pkg/verifier/decisionreceipt/importer.go
@@ -1,0 +1,127 @@
+package decisionreceipt
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidencepack"
+)
+
+// ImportOptions controls how an external receipt is imported into an EvidencePack.
+type ImportOptions struct {
+	FormatID     string    // "" = auto-detect
+	PublicKeyHex string    // trusted key; empty caps classification at crypto_compatible_non_conformant
+	PackID       string    // EvidencePack id; defaulted from format + receipt id if empty
+	Now          time.Time // pack timestamp; left at the builder default if zero
+}
+
+// ImportResult is the outcome of importing an external receipt.
+type ImportResult struct {
+	Report       DecisionReport         `json:"report"`
+	PackID       string                 `json:"pack_id"`
+	ManifestHash string                 `json:"manifest_hash"`
+	MerkleRoot   string                 `json:"entries_merkle_root,omitempty"`
+	Entries      []string               `json:"entries"`
+	Manifest     *evidencepack.Manifest `json:"-"`
+	ContentMap   map[string][]byte      `json:"-"`
+}
+
+// ImportReceipt verifies an external decision receipt (or bundle) and re-anchors
+// it as a content-addressed, tamper-evident HELM EvidencePack. The pack records
+// the verbatim source, the normalized receipts (carrying their classification),
+// and a compatibility manifest stating the classification + limitations — so the
+// import is never mistaken for HELM-native execution proof.
+//
+// A receipt that fails verification is still imported (with classification
+// "unverified" and report.Verified=false): re-anchoring an unverifiable claim is
+// legitimate, honestly-labeled evidence.
+func ImportReceipt(raw []byte, opts ImportOptions) (*ImportResult, error) {
+	report, err := Default().VerifyBundle(raw, opts.FormatID, opts.PublicKeyHex)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceVendor := ""
+	if len(report.Receipts) > 0 {
+		sourceVendor = report.Receipts[0].SourceVendor
+	}
+	packID := opts.PackID
+	if packID == "" {
+		packID = "external-receipt:" + report.FormatID
+		if len(report.Receipts) > 0 {
+			packID += ":" + report.Receipts[0].ReceiptID
+		}
+	}
+	actorDID := "external:unknown"
+	if sourceVendor != "" {
+		actorDID = "external:" + sourceVendor
+	}
+
+	b := evidencepack.NewBuilder(packID, actorDID, "", "")
+	if !opts.Now.IsZero() {
+		b = b.WithCreatedAt(opts.Now)
+	}
+
+	if err := b.AddHostEvidence(report.FormatID, "source.json", raw); err != nil {
+		return nil, fmt.Errorf("add source: %w", err)
+	}
+	for i := range report.Receipts {
+		name := "external_" + sanitizeName(report.Receipts[i].ReceiptID)
+		if name == "external_" {
+			name = fmt.Sprintf("external_%d", i)
+		}
+		if err := b.AddReceipt(name, report.Receipts[i]); err != nil {
+			return nil, fmt.Errorf("add receipt: %w", err)
+		}
+	}
+
+	compat := map[string]any{
+		"kind":           report.Kind,
+		"format_id":      report.FormatID,
+		"classification": report.Classification,
+		"verified":       report.Verified,
+		"limitations":    []string{"external decision receipt; decision-level proof only — not a HELM verdict-bound execution proof"},
+		"checks":         report.Checks,
+	}
+	compatJSON, err := json.MarshalIndent(compat, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("marshal compatibility manifest: %w", err)
+	}
+	b.AddRawEntry("compatibility/import_manifest.json", "application/json", compatJSON)
+
+	manifest, contentMap, err := b.Build()
+	if err != nil {
+		return nil, fmt.Errorf("build evidence pack: %w", err)
+	}
+	entries := make([]string, 0, len(contentMap))
+	for p := range contentMap {
+		entries = append(entries, p)
+	}
+	sort.Strings(entries)
+
+	return &ImportResult{
+		Report:       report,
+		PackID:       packID,
+		ManifestHash: manifest.ManifestHash,
+		MerkleRoot:   manifest.EntriesMerkleRoot,
+		Entries:      entries,
+		Manifest:     manifest,
+		ContentMap:   contentMap,
+	}, nil
+}
+
+// sanitizeName maps a receipt id to a filesystem-safe entry name.
+func sanitizeName(id string) string {
+	out := make([]rune, 0, len(id))
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			out = append(out, r)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}

--- a/core/pkg/verifier/decisionreceipt/importer_test.go
+++ b/core/pkg/verifier/decisionreceipt/importer_test.go
@@ -1,0 +1,85 @@
+package decisionreceipt
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func TestImportReceiptBuildsEvidencePack(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	signed, err := SignHelmExternal(contracts.ExternalDecisionReceipt{
+		ReceiptID: "edr-imp-1", Action: "github.create_issue", Verdict: "allow", SourceVendor: "vendor-x",
+	}, priv)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	raw, _ := json.Marshal(signed)
+	fixed := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+
+	res, err := ImportReceipt(raw, ImportOptions{PublicKeyHex: hex.EncodeToString(pub), Now: fixed})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !res.Report.Verified || res.Report.Classification != contracts.ClassCryptoConformant {
+		t.Fatalf("verified=%v class=%s", res.Report.Verified, res.Report.Classification)
+	}
+	if res.ManifestHash == "" {
+		t.Fatal("missing manifest hash")
+	}
+
+	want := map[string]bool{
+		"manifest.json": false,
+		"host_evidence/helm_external.v1/source.json": false,
+		"receipts/external_edr-imp-1.json":           false,
+		"compatibility/import_manifest.json":         false,
+	}
+	for _, e := range res.Entries {
+		if _, ok := want[e]; ok {
+			want[e] = true
+		}
+	}
+	for path, found := range want {
+		if !found {
+			t.Fatalf("missing pack entry %q in %v", path, res.Entries)
+		}
+	}
+
+	// Determinism: same input + same Now => identical manifest hash.
+	res2, err := ImportReceipt(raw, ImportOptions{PublicKeyHex: hex.EncodeToString(pub), Now: fixed})
+	if err != nil {
+		t.Fatalf("import 2: %v", err)
+	}
+	if res2.ManifestHash != res.ManifestHash {
+		t.Fatalf("non-deterministic manifest hash: %s vs %s", res.ManifestHash, res2.ManifestHash)
+	}
+}
+
+func TestImportReceiptUnverifiedStillImports(t *testing.T) {
+	_, priv, _ := ed25519.GenerateKey(rand.Reader)
+	signed, _ := SignHelmExternal(contracts.ExternalDecisionReceipt{ReceiptID: "edr-imp-2", Action: "x"}, priv)
+	raw, _ := json.Marshal(signed)
+
+	// No trusted key -> unverified, but the pack is still built (honestly labeled).
+	res, err := ImportReceipt(raw, ImportOptions{})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Report.Verified {
+		t.Fatal("expected unverified (no trusted key)")
+	}
+	if res.Report.Classification != contracts.ClassUnverified {
+		t.Fatalf("class=%s, want unverified", res.Report.Classification)
+	}
+	if res.ManifestHash == "" {
+		t.Fatal("pack should still be built for an unverified receipt")
+	}
+}

--- a/examples/decision-receipt/README.md
+++ b/examples/decision-receipt/README.md
@@ -33,5 +33,30 @@ receipt as proof it cannot verify. The strongest level an external decision rece
 can reach is `crypto_conformant` (decision-level proof) — execution proof requires a
 HELM verdict-bound effect permit, which these formats do not carry.
 
+## Re-anchor it as an EvidencePack
+
+Importing a verified external receipt turns it into a content-addressed,
+tamper-evident HELM **EvidencePack** — the verbatim source, the normalized
+receipt, and a `compatibility/import_manifest.json` that records the
+classification and limitations (so it is never mistaken for execution proof):
+
+```sh
+helm-ai-kernel import receipt \
+  examples/decision-receipt/helm_external_example.json \
+  --out ./imported-pack \
+  --public-key "$(cat examples/decision-receipt/public_key.hex)"
+```
+
+```
+Imported helm_external.v1  classification=crypto_conformant
+EvidencePack: ./imported-pack
+  manifest_hash: sha256:...
+  entries (4):
+    compatibility/import_manifest.json
+    host_evidence/helm_external.v1/source.json
+    manifest.json
+    receipts/external_edr-demo-0001.json
+```
+
 See `protocols/specs/receipts/HELM_RECEIPT_SPEC_v1.0.md` for the full taxonomy and
 classification ladder.


### PR DESCRIPTION
## `helm-ai-kernel import receipt` — verify, then re-anchor as portable evidence

Builds on the merged receipt-compat layer (#388/#389). Extends the wedge from *verify* to *re-anchor as a HELM EvidencePack*.

```
helm-ai-kernel import receipt <file> --out <dir> [--format <id>] [--public-key <hex>] [--json]
```

### What it does
`decisionreceipt.ImportReceipt` verifies an external receipt/bundle, then builds a **content-addressed, tamper-evident EvidencePack** via `evidencepack.Builder`:
- `host_evidence/<format>/source.json` — verbatim source (provenance)
- `receipts/external_<id>.json` — normalized receipt(s), carrying their classification
- `compatibility/import_manifest.json` — the honest "what this does NOT prove" record (classification + limitations)
- `manifest.json` — deterministic manifest hash + entries Merkle root

An **unverifiable** receipt is still imported, honestly labeled (`classification=unverified`, exit 1) — re-anchoring an unverifiable claim is legitimate, labeled evidence; it's never silently upgraded.

### CLI niceties
- New `import` subcommand (init/`Register`) + `writeEvidencePack`.
- Generalized the shared `reorderFlagsFirst(args, valueFlags)` helper so both `verify` and `import` accept flags after the positional file.

### Live demo (verified locally)
```
$ helm-ai-kernel import receipt examples/decision-receipt/helm_external_example.json \
    --out ./pack --public-key "$(cat examples/decision-receipt/public_key.hex)"
Imported helm_external.v1  classification=crypto_conformant
EvidencePack: ./pack
  manifest_hash: sha256:ad1a7e46e0e848...
  entries (4): compatibility/import_manifest.json, host_evidence/helm_external.v1/source.json, manifest.json, receipts/external_edr-demo-0001.json
```

### Verification
- `gofmt`/`go vet` clean; new files lint-clean; `decisionreceipt` + `cmd/helm-ai-kernel` tests green (pack entries present, deterministic manifest hash, unverified-still-imports, CLI writes pack / requires `--out`).

### Follow-on
Make the produced pack pass `helm-ai-kernel verify pack` (canonical index/seal layout) and emit a ProofGraph attestation node linking the external receipt; AAR/ACTA adapters once vendor vectors land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)