### PR TITLE
chore: ignore stray root binary + define RLM input evidence boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ helm.yaml
 *.tgz
 sdk/ts/*.tgz
 version-status.json
+/helm-ai-kernel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,4 @@ Welcome to the **helm-ai-kernel** repository. This is the core, open-source exec
 1. All API and Protobuf mutations must sync to `contracts-proto` and `contracts-api-catalog`.
 2. Maintain strict zero-dependency boundaries on volatile commercial components.
 3. Every functional path must maintain green unit/integration tests and high coverage metrics.
+4. Treat RLM outputs as input evidence only. They become Kernel truth only when represented through existing verdict, receipt, ProofGraph, EvidencePack, contract, conformance, or verifier paths; do not add a separate RLM proof universe.

--- a/docs/KERNEL_SCOPE.md
+++ b/docs/KERNEL_SCOPE.md
@@ -23,6 +23,14 @@ After this page you should know what this surface is for, which source files own
 
 Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the inventory manifest points to code, schemas, tests, examples, or an owner doc that proves the claim.
 
+## RLM Input Evidence Boundary
+
+RLM outputs can help maintainers inspect large repos, logs, PDFs, receipts, and
+EvidencePacks. They are input evidence only until represented through existing
+Kernel contracts: verdicts, signed receipts, ProofGraph refs, EvidencePacks,
+conformance fixtures, verifier code, or release evidence. Do not add a new RLM
+proof universe or describe RLM output itself as Kernel verification.
+
 > **Canonical architecture**: see [ARCHITECTURE.md](ARCHITECTURE.md) for the
 > normative trust boundary model and TCB definition. For the canonical
 > 8-package TCB inventory, see [ARCHITECTURE.md](ARCHITECTURE.md).


### PR DESCRIPTION
Two small housekeeping changes that were sitting on local `main` (direct push to `main` is blocked by branch protection, so routing through a PR).

## Changes
- **`.gitignore`** — anchor `/helm-ai-kernel` so a stray root-level build artifact stays ignored. `make build` outputs to `bin/helm-ai-kernel`; a bare `go build ./cmd/...` from the repo root drops a 76MB binary that the existing `core/helm-ai-kernel` rule did not match. (commit `4e8f4d8`)
- **`AGENTS.md` + `docs/KERNEL_SCOPE.md`** — define the RLM input evidence boundary. (commit `5d8a8ed8`, pre-existing local work)

## Notes
- No source/behavior changes; docs + ignore only.
- Bundled per maintainer direction despite the two changes being unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)