### PR TITLE
docs: use signup wording for local proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ drafts a policy from a scan, then starts the local Kernel and Console proof.
 
 ## Trust Box
 
-- No cloud account required for the local proof.
+- No signup required for the local proof.
 - No model API key required.
 - No Docker required.
 - No production credentials required.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -22,7 +22,7 @@ By the end you should have a local Claude Code or Codex MCP entry, a PreToolUse
 hook, draft policy artifacts under `~/.helm-ai-kernel`, a local Kernel on
 `127.0.0.1:7714`, a Console served from the same origin at `/console`, a signed
 `DENY` receipt for a blocked tool call, and offline-verifiable proof artifacts.
-Hosted Console pairing, paid tiers, and Enterprise automation remain next-step
+Hosted console pairing, paid plans, and Enterprise automation remain next-step
 paths after the local proof succeeds.
 
 ```mermaid


### PR DESCRIPTION
## Summary
- replace the stale public phrase 'No cloud account required' with 'No signup required' for the local proof path

## Validation
- rg check for no-cloud-account wording in README/quickstart
- git diff --check