### PR TITLE
docs: clarify kernel boundary limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ No cloud account. No model key. No Docker. No production credentials.
 | Run approved work | `ALLOW` | receipt + evidence |
 | Export a review bundle | verify offline | EvidencePack |
 
+HELM only governs effects that reach its boundary. For example, evals showed
+network egress blocks firing when an agent actually dispatched a LAN or
+non-allowlisted HTTPS request. Prompt-only manipulation, model refusal, or an
+agent that never attempts the tool call needs model, app, and sandbox controls
+alongside HELM.
+
 ## One Example
 
 ```text


### PR DESCRIPTION
## Summary
- Add a short README caveat that HELM governs effects once they reach the Kernel boundary.
- Call out that prompt-only manipulation, model refusal, or no tool attempt needs model, app, and sandbox controls alongside HELM.
- Keep the language aligned with MIN-779 claim-hygiene requirements.

Linear: MIN-779

## Validation
- `mise trust mise.toml` (repo config only pins Go `1.25.10`)
- `make docs-coverage docs-truth`
