### PR TITLE
fix(prg): cache requirement-set CEL programs

### DIFF
--- a/core/pkg/guardian/guardian.go
+++ b/core/pkg/guardian/guardian.go
@@ -234,6 +234,12 @@ func NewGuardian(signer crypto.Signer, ruleGraph *prg.Graph, reg *pkg_artifact.R
 		g.clock = wallClock{}
 	}
 
+	if g.pe != nil {
+		if err := g.pe.CompileGraph(g.prg); err != nil {
+			slog.Warn("[guardian] PRG graph precompile failed", "error", err)
+		}
+	}
+
 	return g
 }
 

--- a/core/pkg/policy/reconcile/reconcile.go
+++ b/core/pkg/policy/reconcile/reconcile.go
@@ -583,6 +583,15 @@ func (s *AtomicSnapshotStore) Swap(scope PolicyScope, snapshot *EffectivePolicyS
 	if snapshot == nil {
 		return fmt.Errorf("nil policy snapshot")
 	}
+	if snapshot.Graph != nil {
+		engine, err := prg.NewPolicyEngine()
+		if err != nil {
+			return fmt.Errorf("create policy engine for snapshot graph: %w", err)
+		}
+		if err := engine.CompileGraph(snapshot.Graph); err != nil {
+			return fmt.Errorf("compile policy snapshot graph: %w", err)
+		}
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.snapshots[scope.Normalize().Key()] = snapshot

--- a/core/pkg/policy/reconcile/reconcile_test.go
+++ b/core/pkg/policy/reconcile/reconcile_test.go
@@ -75,6 +75,39 @@ func testCompiler(_ context.Context, head PolicyHead, _ []byte) (*EffectivePolic
 	}, nil
 }
 
+func TestAtomicSnapshotStoreRejectsInvalidPRGGraph(t *testing.T) {
+	scope := DefaultScope
+	graph := prg.NewGraph()
+	if err := graph.AddRule("deploy", prg.RequirementSet{
+		ID:    "bad-rule",
+		Logic: prg.AND,
+		Requirements: []prg.Requirement{
+			{ID: "bad", Expression: "not valid cel !!!"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewAtomicSnapshotStore()
+	err := store.Swap(scope, &EffectivePolicySnapshot{
+		TenantID:    scope.TenantID,
+		WorkspaceID: scope.WorkspaceID,
+		PolicyEpoch: 1,
+		PolicyHash:  "sha256:bad",
+		Validation:  ValidationStatus{Status: StatusActive},
+		Graph:       graph,
+	})
+	if err == nil {
+		t.Fatal("expected invalid graph to be rejected before activation")
+	}
+	if !strings.Contains(err.Error(), "compile policy snapshot graph") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := store.Get(scope); ok {
+		t.Fatal("invalid snapshot graph should not be installed")
+	}
+}
+
 func TestReconcilerInstallsInitialSnapshotAndUpdatesOnPoll(t *testing.T) {
 	scope := DefaultScope
 	bundle := []byte("policy-v1")

--- a/core/pkg/prg/engine.go
+++ b/core/pkg/prg/engine.go
@@ -33,28 +33,26 @@ func NewPolicyEngine() (*PolicyEngine, error) {
 	}, nil
 }
 
-func (pe *PolicyEngine) Evaluate(expression string, input map[string]interface{}) (bool, error) {
+func (pe *PolicyEngine) compileProgram(expression string) (cel.Program, error) {
 	expression = policycel.RewritePRGTaintContains(expression)
 
-	// 1. Check Cache
 	pe.mu.RLock()
 	prg, hit := pe.prgCache[expression]
 	pe.mu.RUnlock()
 
 	if !hit {
-		// 2. Compile (Double Checked Locking)
 		pe.mu.Lock()
 		if prg, hit = pe.prgCache[expression]; !hit {
 			ast, issues := pe.env.Compile(expression)
 			if issues != nil && issues.Err() != nil {
 				pe.mu.Unlock()
-				return false, fmt.Errorf("CEL compile error: %w", issues.Err())
+				return nil, fmt.Errorf("CEL compile error: %w", issues.Err())
 			}
 
 			p, err := pe.env.Program(ast)
 			if err != nil {
 				pe.mu.Unlock()
-				return false, fmt.Errorf("CEL program error: %w", err)
+				return nil, fmt.Errorf("CEL program error: %w", err)
 			}
 			pe.prgCache[expression] = p
 			prg = p
@@ -62,7 +60,15 @@ func (pe *PolicyEngine) Evaluate(expression string, input map[string]interface{}
 		pe.mu.Unlock()
 	}
 
-	// 3. Eval
+	return prg, nil
+}
+
+func (pe *PolicyEngine) Evaluate(expression string, input map[string]interface{}) (bool, error) {
+	prg, err := pe.compileProgram(expression)
+	if err != nil {
+		return false, err
+	}
+
 	out, _, err := prg.Eval(input)
 	if err != nil {
 		return false, fmt.Errorf("CEL eval error: %w", err)
@@ -76,87 +82,155 @@ func (pe *PolicyEngine) Evaluate(expression string, input map[string]interface{}
 	return allowed, nil
 }
 
+// CompileRequirementSet precompiles and caches every CEL expression in a
+// requirement tree. Callers that install immutable policy snapshots can use it
+// to surface expression errors once at load time rather than at decision time.
+func (pe *PolicyEngine) CompileRequirementSet(rs RequirementSet) error {
+	for _, req := range rs.Requirements {
+		if req.Expression == "" {
+			continue
+		}
+		if _, err := pe.compileProgram(req.Expression); err != nil {
+			return fmt.Errorf("compile error in req %s: %w", req.ID, err)
+		}
+	}
+	for _, child := range rs.Children {
+		if err := pe.CompileRequirementSet(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// CompileGraph precompiles every CEL expression in a policy graph.
+func (pe *PolicyEngine) CompileGraph(graph *Graph) error {
+	if graph == nil {
+		return nil
+	}
+	for actionID, rule := range graph.Rules {
+		if err := pe.CompileRequirementSet(rule); err != nil {
+			return fmt.Errorf("compile rule %s: %w", actionID, err)
+		}
+	}
+	return nil
+}
+
 // EvaluateRequirementSet recursively evaluates a RequirementSet against the input.
 func (pe *PolicyEngine) EvaluateRequirementSet(rs RequirementSet, input map[string]interface{}) (bool, error) {
+	activation := map[string]interface{}{"input": input, "taint": input["taint"]}
+	return pe.evaluateRequirementSet(rs, input, activation)
+}
+
+func (pe *PolicyEngine) evaluateRequirementSet(rs RequirementSet, input map[string]interface{}, activation map[string]interface{}) (bool, error) {
 	if len(rs.Requirements) == 0 && len(rs.Children) == 0 {
 		return true, nil
 	}
 
-	leafResults, err := pe.evaluateLeaves(rs.Requirements, input)
-	if err != nil {
-		return false, err
+	logic := rs.Logic
+	if logic == "" {
+		logic = AND
 	}
 
-	childResults, err := pe.evaluateChildren(rs.Children, input)
-	if err != nil {
-		return false, err
+	switch logic {
+	case AND:
+		for _, req := range rs.Requirements {
+			result, err := pe.evaluateRequirement(req, input, activation)
+			if err != nil {
+				return false, err
+			}
+			if !result {
+				return false, nil
+			}
+		}
+		for _, child := range rs.Children {
+			result, err := pe.evaluateRequirementSet(child, input, activation)
+			if err != nil {
+				return false, err
+			}
+			if !result {
+				return false, nil
+			}
+		}
+		return true, nil
+	case OR:
+		for _, req := range rs.Requirements {
+			result, err := pe.evaluateRequirement(req, input, activation)
+			if err != nil {
+				return false, err
+			}
+			if result {
+				return true, nil
+			}
+		}
+		for _, child := range rs.Children {
+			result, err := pe.evaluateRequirementSet(child, input, activation)
+			if err != nil {
+				return false, err
+			}
+			if result {
+				return true, nil
+			}
+		}
+		return false, nil
+	case NOT:
+		for _, req := range rs.Requirements {
+			result, err := pe.evaluateRequirement(req, input, activation)
+			if err != nil {
+				return false, err
+			}
+			if !result {
+				return true, nil
+			}
+		}
+		for _, child := range rs.Children {
+			result, err := pe.evaluateRequirementSet(child, input, activation)
+			if err != nil {
+				return false, err
+			}
+			if !result {
+				return true, nil
+			}
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown logic operator: %s", rs.Logic)
 	}
-
-	return combineResults(rs.Logic, append(leafResults, childResults...))
 }
 
-func (pe *PolicyEngine) evaluateLeaves(reqs []Requirement, input map[string]interface{}) ([]bool, error) {
-	results := make([]bool, 0, len(reqs))
-	activation := map[string]interface{}{"input": input, "taint": input["taint"]}
-
-	for _, req := range reqs {
-		// If CEL expression exists, it takes precedence
-		if req.Expression != "" {
-			expression := policycel.RewritePRGTaintContains(req.Expression)
-			ast, issues := pe.env.Compile(expression)
-			if issues != nil && issues.Err() != nil {
-				return nil, fmt.Errorf("compile error in req %s: %w", req.ID, issues.Err())
-			}
-			prog, err := pe.env.Program(ast)
-			if err != nil {
-				return nil, fmt.Errorf("program error in req %s: %w", req.ID, err)
-			}
-			out, _, err := prog.Eval(activation)
-			if err != nil {
-				return nil, fmt.Errorf("eval error in req %s: %w", req.ID, err)
-			}
-			val, ok := out.Value().(bool)
-			if !ok {
-				return nil, fmt.Errorf("req %s did not return bool", req.ID)
-			}
-			results = append(results, val)
-			continue
-		}
-
-		// Legacy ArtifactType check (for backward compatibility and simple policies)
-		if req.ArtifactType != "" {
-			artifacts, ok := input["artifacts"].([]*pkg_artifact.ArtifactEnvelope)
-			if !ok {
-				results = append(results, false)
-				continue
-			}
-			found := false
-			for _, art := range artifacts {
-				if art.Type == req.ArtifactType {
-					found = true
-					break
-				}
-			}
-			results = append(results, found)
-			continue
-		}
-
-		// No expression and no artifact type = always pass (open policy)
-		results = append(results, true)
-	}
-	return results, nil
-}
-
-func (pe *PolicyEngine) evaluateChildren(children []RequirementSet, input map[string]interface{}) ([]bool, error) {
-	results := make([]bool, 0, len(children))
-	for _, child := range children {
-		val, err := pe.EvaluateRequirementSet(child, input)
+func (pe *PolicyEngine) evaluateRequirement(req Requirement, input map[string]interface{}, activation map[string]interface{}) (bool, error) {
+	// If CEL expression exists, it takes precedence.
+	if req.Expression != "" {
+		prog, err := pe.compileProgram(req.Expression)
 		if err != nil {
-			return nil, err
+			return false, fmt.Errorf("compile error in req %s: %w", req.ID, err)
 		}
-		results = append(results, val)
+		out, _, err := prog.Eval(activation)
+		if err != nil {
+			return false, fmt.Errorf("eval error in req %s: %w", req.ID, err)
+		}
+		val, ok := out.Value().(bool)
+		if !ok {
+			return false, fmt.Errorf("req %s did not return bool", req.ID)
+		}
+		return val, nil
 	}
-	return results, nil
+
+	// Legacy ArtifactType check (for backward compatibility and simple policies).
+	if req.ArtifactType != "" {
+		artifacts, ok := input["artifacts"].([]*pkg_artifact.ArtifactEnvelope)
+		if !ok {
+			return false, nil
+		}
+		for _, art := range artifacts {
+			if art.Type == req.ArtifactType {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	// No expression and no artifact type = always pass (open policy).
+	return true, nil
 }
 
 func combineResults(logic LogicOperator, results []bool) (bool, error) {

--- a/core/pkg/prg/engine_cache_test.go
+++ b/core/pkg/prg/engine_cache_test.go
@@ -1,0 +1,229 @@
+package prg
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestEvaluateRequirementSet_CachesCompiledRequirementExpressions(t *testing.T) {
+	pe, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := RequirementSet{
+		ID:    "cached",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "level", Expression: `input["level"] >= 3`},
+		},
+	}
+
+	for i := 0; i < 2; i++ {
+		result, err := pe.EvaluateRequirementSet(rs, map[string]interface{}{"level": 4})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !result {
+			t.Fatal("expected requirement set to pass")
+		}
+	}
+
+	pe.mu.RLock()
+	_, cached := pe.prgCache[`input["level"] >= 3`]
+	cacheSize := len(pe.prgCache)
+	pe.mu.RUnlock()
+	if !cached {
+		t.Fatal("expected requirement expression to be cached")
+	}
+	if cacheSize != 1 {
+		t.Fatalf("expected one compiled program, got %d", cacheSize)
+	}
+}
+
+func TestCompileRequirementSet_DetectsCompileErrorBeforeEvaluation(t *testing.T) {
+	pe, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := RequirementSet{
+		ID:    "bad-snapshot",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "bad", Expression: "not valid cel !!!"},
+		},
+	}
+
+	if err := pe.CompileRequirementSet(rs); err == nil {
+		t.Fatal("expected compile error before requirement-set evaluation")
+	}
+}
+
+func TestCompileGraph_DetectsNestedRequirementCompileError(t *testing.T) {
+	pe, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	graph := NewGraph()
+	if err := graph.AddRule("deploy", RequirementSet{
+		ID:    "parent",
+		Logic: AND,
+		Children: []RequirementSet{
+			{
+				ID:    "child",
+				Logic: AND,
+				Requirements: []Requirement{
+					{ID: "bad", Expression: "not valid cel !!!"},
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := pe.CompileGraph(graph); err == nil {
+		t.Fatal("expected graph precompile to reject nested invalid CEL")
+	}
+}
+
+func TestEvaluateRequirementSet_ANDShortCircuits(t *testing.T) {
+	pe, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := RequirementSet{
+		ID:    "and-short-circuit",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "deny-first", Expression: "false"},
+			{ID: "would-fail-if-compiled", Expression: "not valid cel !!!"},
+		},
+	}
+
+	result, err := pe.EvaluateRequirementSet(rs, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("expected short-circuit to avoid later compile error: %v", err)
+	}
+	if result {
+		t.Fatal("expected AND to deny on first false requirement")
+	}
+}
+
+func TestEvaluateRequirementSet_ORShortCircuits(t *testing.T) {
+	pe, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := RequirementSet{
+		ID:    "or-short-circuit",
+		Logic: OR,
+		Requirements: []Requirement{
+			{ID: "allow-first", Expression: "true"},
+			{ID: "would-fail-if-compiled", Expression: "not valid cel !!!"},
+		},
+	}
+
+	result, err := pe.EvaluateRequirementSet(rs, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("expected short-circuit to avoid later compile error: %v", err)
+	}
+	if !result {
+		t.Fatal("expected OR to allow on first true requirement")
+	}
+}
+
+func TestEvaluateRequirementSet_NOTShortCircuits(t *testing.T) {
+	pe, err := NewPolicyEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rs := RequirementSet{
+		ID:    "not-short-circuit",
+		Logic: NOT,
+		Requirements: []Requirement{
+			{ID: "false-first", Expression: "false"},
+			{ID: "would-fail-if-compiled", Expression: "not valid cel !!!"},
+		},
+	}
+
+	result, err := pe.EvaluateRequirementSet(rs, map[string]interface{}{})
+	if err != nil {
+		t.Fatalf("expected short-circuit to avoid later compile error: %v", err)
+	}
+	if !result {
+		t.Fatal("expected NOT to pass when the first child result is false")
+	}
+}
+
+func BenchmarkEvaluateRequirementSet_CachedRequirements(b *testing.B) {
+	for _, n := range []int{1, 50, 1000} {
+		b.Run(fmt.Sprintf("all_true_n=%d", n), func(b *testing.B) {
+			pe, err := NewPolicyEngine()
+			if err != nil {
+				b.Fatal(err)
+			}
+			rs, input := benchmarkRequirementSet(n, false)
+			if err := pe.CompileRequirementSet(rs); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := pe.EvaluateRequirementSet(rs, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !result {
+					b.Fatal("expected requirement set to pass")
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkEvaluateRequirementSet_ANDShortCircuit(b *testing.B) {
+	for _, n := range []int{1, 50, 1000} {
+		b.Run(fmt.Sprintf("first_false_n=%d", n), func(b *testing.B) {
+			pe, err := NewPolicyEngine()
+			if err != nil {
+				b.Fatal(err)
+			}
+			rs, input := benchmarkRequirementSet(n, true)
+			if err := pe.CompileRequirementSet(rs); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result, err := pe.EvaluateRequirementSet(rs, input)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if result {
+					b.Fatal("expected requirement set to short-circuit false")
+				}
+			}
+		})
+	}
+}
+
+func benchmarkRequirementSet(n int, firstFalse bool) (RequirementSet, map[string]interface{}) {
+	reqs := make([]Requirement, 0, n)
+	input := make(map[string]interface{}, n)
+	for i := 0; i < n; i++ {
+		value := i
+		operator := "=="
+		if firstFalse && i == 0 {
+			value = -1
+			operator = "=="
+		}
+		key := fmt.Sprintf("v%d", i)
+		input[key] = i
+		reqs = append(reqs, Requirement{
+			ID:         key,
+			Expression: fmt.Sprintf(`input["%s"] %s %d`, key, operator, value),
+		})
+	}
+	return RequirementSet{ID: "bench", Logic: AND, Requirements: reqs}, input
+}

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-18T22:46:51Z
-# Commit: b31a6f3108fb6d270df5e5f435591445f0574a5a
+# Generated: 2026-06-19T15:34:02Z
+# Commit: 570511dbd5ccce7457d650a881d2d70cf3f6bad1
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md
@@ -556,7 +556,7 @@ dc423304ca0632036914933638314609e621ab311743a2b320338b5bfe8028f6  core/pkg/guard
 3bf046b9f5630ade87ed4fc4d31c5a0223e5ef3e24b9427ec7fa268282a2e555  core/pkg/guardian/compliance_checker_test.go
 33b80ff2f4dc9eba8c135cb61ac232deb9be30e84fe63585e31f6ddfeadd19b1  core/pkg/guardian/decision_fuzz_test.go
 d23c84456f34f27e6cb7fd113211028dbd88c34980fe81e3b74a307d701a4bfd  core/pkg/guardian/extended2_test.go
-8363f8d303578652aec17a8732f58e86e5cb9074497e3558adfa85fbf5bd33b3  core/pkg/guardian/guardian.go
+970e43223496a9a6b72615b4922cb4132408282857ed0e9549fa143ba4662f27  core/pkg/guardian/guardian.go
 aa4ea979d3f36460d50808f0ccee6bd48eb97cbc3c888d53b2971701b704e462  core/pkg/guardian/guardian_additional_coverage_test.go
 05d2907a744570e725955e9967f578b098389dee199fa7af7d54c2381f770a54  core/pkg/guardian/guardian_behavior_coverage_test.go
 56f3550cf20de46141e69f9ebccfdb54b3b83d9425d60ac92587f6ca74a4399b  core/pkg/guardian/guardian_bench_test.go


### PR DESCRIPTION
## Summary
- Route PRG requirement-set CEL evaluation through the existing compiled-program cache.
- Add recursive AND/OR/NOT short-circuiting so denied/allowed results stop before later requirements compile/evaluate.
- Add explicit requirement-set/graph precompile APIs, prewarm Guardian static graphs, and reject invalid PRG snapshot graphs before activation.
- Add regression tests and benchmarks for cached evaluation and 1/50/1000 requirement sets.

## Validation
- go test ./core/pkg/prg ./core/pkg/policy/reconcile ./core/pkg/guardian
- go test ./core/pkg/prg -run '^$' -bench 'BenchmarkEvaluateRequirementSet_(CachedRequirements|ANDShortCircuit)$' -benchtime=100ms\n- go test ./core/pkg/...\n- git diff --check\n- bash tools/verify-boundary.sh\n- python3 scripts/check_documentation_coverage.py\n- python3 scripts/check_documentation_truth.py\n\nLinear: MIN-808