### PR TITLE
test(policy): cover reconcile fault handling

### DIFF
--- a/core/pkg/guardian/guardian_core_coverage_test.go
+++ b/core/pkg/guardian/guardian_core_coverage_test.go
@@ -59,6 +59,24 @@ func (s *guardianCoverageSnapshotStore) Swap(scope policyreconcile.PolicyScope, 
 	return nil
 }
 
+func (s *guardianCoverageSnapshotStore) Invalidate(scope policyreconcile.PolicyScope, reason string) (*policyreconcile.EffectivePolicySnapshot, bool) {
+	if s.snapshots == nil {
+		return nil, false
+	}
+	key := scope.Normalize().Key()
+	snapshot, ok := s.snapshots[key]
+	if !ok || snapshot == nil {
+		return nil, false
+	}
+	expired := *snapshot
+	expired.Validation = policyreconcile.ValidationStatus{Status: policyreconcile.StatusInvalid, Reason: strings.TrimSpace(reason), Hash: snapshot.PolicyHash}
+	expired.Graph = nil
+	expired.PDP = nil
+	expired.PolicyLayers = nil
+	s.snapshots[key] = &expired
+	return &expired, true
+}
+
 type guardianCoverageSignOnly struct {
 	failIntent bool
 }

--- a/core/pkg/policy/reconcile/reconcile.go
+++ b/core/pkg/policy/reconcile/reconcile.go
@@ -39,7 +39,10 @@ const (
 	StatusSourceError   = "source_error"
 	StatusCompileError  = "compile_error"
 	StatusValidateError = "validate_error"
+	DefaultLKGMaxAge    = 10 * time.Minute
 )
+
+const lkgExpiredReasonText = "last-known-good snapshot expired"
 
 var (
 	ErrPolicyNotReady          = errors.New("policy not ready")
@@ -116,6 +119,7 @@ type EffectivePolicySnapshot struct {
 	EmergencyExpiresAt   time.Time        `json:"emergency_expires_at,omitempty"`
 	SourceRefs           []string         `json:"source_refs,omitempty"`
 	Validation           ValidationStatus `json:"validation"`
+	InstalledAt          time.Time        `json:"installed_at,omitempty"`
 
 	Graph        *prg.Graph              `json:"-"`
 	PDP          pdp.PolicyDecisionPoint `json:"-"`
@@ -133,6 +137,7 @@ func (s *EffectivePolicySnapshot) Scope() PolicyScope {
 type PolicySnapshotStore interface {
 	Get(scope PolicyScope) (*EffectivePolicySnapshot, bool)
 	Swap(scope PolicyScope, snapshot *EffectivePolicySnapshot) error
+	Invalidate(scope PolicyScope, reason string) (*EffectivePolicySnapshot, bool)
 }
 
 // SnapshotCompiler turns verified policy bytes into an effective snapshot.
@@ -210,19 +215,23 @@ type Reconciler struct {
 	emergencyVerifier EmergencyCapsuleVerifier
 	requireSignature  bool
 	keepLastKnownGood bool
+	lkgMaxAge         time.Duration
+	now               func() time.Time
 
 	mu     sync.Mutex
 	status map[string]ReconcileStatus
 }
 
 type ReconcilerConfig struct {
-	Source            PolicySource
-	Store             PolicySnapshotStore
-	Compiler          SnapshotCompiler
-	Verifier          SignatureVerifier
-	EmergencyVerifier EmergencyCapsuleVerifier
-	RequireSignature  bool
-	KeepLastKnownGood bool
+	Source              PolicySource
+	Store               PolicySnapshotStore
+	Compiler            SnapshotCompiler
+	Verifier            SignatureVerifier
+	EmergencyVerifier   EmergencyCapsuleVerifier
+	RequireSignature    bool
+	KeepLastKnownGood   bool
+	LastKnownGoodMaxAge time.Duration
+	Clock               func() time.Time
 }
 
 func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
@@ -235,6 +244,14 @@ func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
 	if cfg.Compiler == nil {
 		return nil, fmt.Errorf("policy reconciler compiler is required")
 	}
+	now := cfg.Clock
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	lkgMaxAge := cfg.LastKnownGoodMaxAge
+	if cfg.KeepLastKnownGood && lkgMaxAge <= 0 {
+		lkgMaxAge = DefaultLKGMaxAge
+	}
 	return &Reconciler{
 		source:            cfg.Source,
 		store:             cfg.Store,
@@ -243,6 +260,8 @@ func NewReconciler(cfg ReconcilerConfig) (*Reconciler, error) {
 		emergencyVerifier: cfg.EmergencyVerifier,
 		requireSignature:  cfg.RequireSignature,
 		keepLastKnownGood: cfg.KeepLastKnownGood,
+		lkgMaxAge:         lkgMaxAge,
+		now:               now,
 		status:            make(map[string]ReconcileStatus),
 	}, nil
 }
@@ -276,8 +295,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, scope PolicyScope) (Reconcil
 	head, err := r.source.Head(ctx, scope)
 	if err != nil {
 		status.Reason = err.Error()
-		r.remember(status)
-		return status, err
+		return r.invalid(status, err)
 	}
 	head.Scope = head.Scope.Normalize()
 	if head.Scope.Key() != scope.Key() {
@@ -360,6 +378,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, scope PolicyScope) (Reconcil
 		status.Reason = err.Error()
 		return r.invalid(status, err)
 	}
+	snapshot.InstalledAt = r.now()
 	if err := r.store.Swap(scope, snapshot); err != nil {
 		status.Reason = err.Error()
 		return status, err
@@ -402,19 +421,48 @@ func (r *Reconciler) LastStatus(scope PolicyScope) (ReconcileStatus, bool) {
 }
 
 func (r *Reconciler) invalid(status ReconcileStatus, err error) (ReconcileStatus, error) {
-	status.SnapshotStatus = StatusInvalid
-	if installed, ok := r.store.Get(PolicyScope{TenantID: status.TenantID, WorkspaceID: status.WorkspaceID}); ok && r.keepLastKnownGood {
+	scope := PolicyScope{TenantID: status.TenantID, WorkspaceID: status.WorkspaceID}
+	if installed, ok := r.store.Get(scope); ok && r.keepLastKnownGood {
 		status.PolicyHash = installed.PolicyHash
 		status.PolicyEpoch = installed.PolicyEpoch
 		status.InstalledPolicyHash = installed.PolicyHash
 		status.InstalledPolicyEpoch = installed.PolicyEpoch
-		status.SnapshotStatus = installed.Validation.Status
+		if r.lastKnownGoodFresh(installed) {
+			status.SnapshotStatus = installed.Validation.Status
+			r.remember(status)
+			return status, err
+		}
+		reason := fmt.Sprintf("%s after %s", lkgExpiredReasonText, r.lkgMaxAge)
+		status.SnapshotStatus = StatusInvalid
+		if status.Reason == "" {
+			status.Reason = reason
+		} else {
+			status.Reason += "; " + reason
+		}
+		if expired, expiredOK := r.store.Invalidate(scope, reason); expiredOK && expired != nil {
+			status.SnapshotStatus = expired.Validation.Status
+		}
+		r.remember(status)
+		return status, err
 	}
-	if status.ReconcileStatus == StatusSourceError {
-		status.ReconcileStatus = StatusInvalid
+	if status.SnapshotStatus == "" {
+		status.SnapshotStatus = StatusInvalid
 	}
 	r.remember(status)
 	return status, err
+}
+
+func (r *Reconciler) lastKnownGoodFresh(snapshot *EffectivePolicySnapshot) bool {
+	if snapshot == nil || !r.keepLastKnownGood {
+		return false
+	}
+	if snapshot.Validation.Status != "" && snapshot.Validation.Status != StatusActive {
+		return false
+	}
+	if r.lkgMaxAge <= 0 || snapshot.InstalledAt.IsZero() {
+		return true
+	}
+	return r.now().Sub(snapshot.InstalledAt) <= r.lkgMaxAge
 }
 
 func (r *Reconciler) remember(status ReconcileStatus) {
@@ -583,10 +631,30 @@ func (s *AtomicSnapshotStore) Swap(scope PolicyScope, snapshot *EffectivePolicyS
 	if snapshot == nil {
 		return fmt.Errorf("nil policy snapshot")
 	}
+	if snapshot.InstalledAt.IsZero() {
+		snapshot.InstalledAt = time.Now().UTC()
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.snapshots[scope.Normalize().Key()] = snapshot
 	return nil
+}
+
+func (s *AtomicSnapshotStore) Invalidate(scope PolicyScope, reason string) (*EffectivePolicySnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := scope.Normalize().Key()
+	snapshot, ok := s.snapshots[key]
+	if !ok || snapshot == nil {
+		return nil, false
+	}
+	expired := *snapshot
+	expired.Validation = ValidationStatus{Status: StatusInvalid, Reason: strings.TrimSpace(reason), Hash: snapshot.PolicyHash}
+	expired.Graph = nil
+	expired.PDP = nil
+	expired.PolicyLayers = nil
+	s.snapshots[key] = &expired
+	return &expired, true
 }
 
 // MountedFileSource is the OSS/local policy backend. The mounted file is

--- a/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
+++ b/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
@@ -284,6 +284,9 @@ func (failingStore) Get(PolicyScope) (*EffectivePolicySnapshot, bool) { return n
 func (failingStore) Swap(PolicyScope, *EffectivePolicySnapshot) error {
 	return errors.New("swap failed")
 }
+func (failingStore) Invalidate(PolicyScope, string) (*EffectivePolicySnapshot, bool) {
+	return nil, false
+}
 
 func TestScopeAndHelperBranches(t *testing.T) {
 	if DefaultScope != (*EffectivePolicySnapshot)(nil).Scope() {

--- a/core/pkg/policy/reconcile/reconcile_test.go
+++ b/core/pkg/policy/reconcile/reconcile_test.go
@@ -421,6 +421,105 @@ func TestReconcilerInvalidUpdateKeepsLastKnownGood(t *testing.T) {
 	}
 }
 
+func TestReconcilerCompileFaultKeepsFreshLastKnownGood(t *testing.T) {
+	scope := DefaultScope
+	bundle := []byte("policy-v1")
+	compileFails := false
+	source := &mutableSource{
+		head:   PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(bundle)},
+		bundle: bundle,
+	}
+	store := NewAtomicSnapshotStore()
+	reconciler, err := NewReconciler(ReconcilerConfig{
+		Source: source,
+		Store:  store,
+		Compiler: func(ctx context.Context, head PolicyHead, bundle []byte) (*EffectivePolicySnapshot, error) {
+			if compileFails {
+				return nil, errors.New("broken TOML")
+			}
+			return testCompiler(ctx, head, bundle)
+		},
+		KeepLastKnownGood: true,
+	})
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(context.Background(), scope); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+
+	next := []byte("policy-v2")
+	source.head = PolicyHead{Scope: scope, PolicyEpoch: 2, PolicyHash: HashBytes(next)}
+	source.bundle = next
+	compileFails = true
+	status, err := reconciler.Reconcile(context.Background(), scope)
+	if err == nil || status.ReconcileStatus != StatusCompileError {
+		t.Fatalf("expected compile failure, got status=%+v err=%v", status, err)
+	}
+	current, ok := store.Get(scope)
+	if !ok || current.PolicyEpoch != 1 || current.PolicyHash != HashBytes(bundle) || current.Validation.Status != StatusActive {
+		t.Fatalf("fresh last-known-good was not preserved after compile fault: %+v", current)
+	}
+	if status.SnapshotStatus != StatusActive || status.InstalledPolicyEpoch != 1 {
+		t.Fatalf("status did not report preserved last-known-good: %+v", status)
+	}
+}
+
+func TestReconcilerSourceOutageExpiresLastKnownGoodFailClosed(t *testing.T) {
+	scope := DefaultScope
+	now := time.Date(2026, 6, 19, 12, 0, 0, 0, time.UTC)
+	bundle := []byte("policy-v1")
+	source := &mutableSource{
+		head:   PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(bundle)},
+		bundle: bundle,
+	}
+	store := NewAtomicSnapshotStore()
+	reconciler, err := NewReconciler(ReconcilerConfig{
+		Source:              source,
+		Store:               store,
+		Compiler:            testCompiler,
+		KeepLastKnownGood:   true,
+		LastKnownGoodMaxAge: 10 * time.Minute,
+		Clock:               func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("new reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(context.Background(), scope); err != nil {
+		t.Fatalf("initial reconcile: %v", err)
+	}
+
+	source.err = errors.New("control plane unavailable")
+	now = now.Add(5 * time.Minute)
+	status, err := reconciler.Reconcile(context.Background(), scope)
+	if err == nil || status.ReconcileStatus != StatusSourceError {
+		t.Fatalf("expected source outage, got status=%+v err=%v", status, err)
+	}
+	current, ok := store.Get(scope)
+	if !ok || current.PolicyEpoch != 1 || current.Validation.Status != StatusActive {
+		t.Fatalf("last-known-good should remain active during fresh outage: %+v", current)
+	}
+	if status.SnapshotStatus != StatusActive || status.InstalledPolicyEpoch != 1 {
+		t.Fatalf("status did not bind fresh last-known-good: %+v", status)
+	}
+
+	now = now.Add(10*time.Minute + time.Nanosecond)
+	status, err = reconciler.Reconcile(context.Background(), scope)
+	if err == nil || status.SnapshotStatus != StatusInvalid || !strings.Contains(status.Reason, lkgExpiredReasonText) {
+		t.Fatalf("expected expired LKG failure, got status=%+v err=%v", status, err)
+	}
+	current, ok = store.Get(scope)
+	if !ok {
+		t.Fatal("expired snapshot should remain available as invalid evidence")
+	}
+	if current.Validation.Status != StatusInvalid || !strings.Contains(current.Validation.Reason, lkgExpiredReasonText) {
+		t.Fatalf("expired LKG was not invalidated: %+v", current)
+	}
+	if current.Graph != nil || current.PDP != nil || len(current.PolicyLayers) != 0 {
+		t.Fatalf("expired LKG retained executable policy material: %+v", current)
+	}
+}
+
 func TestReconcilerInitialSnapshotRequired(t *testing.T) {
 	scope := DefaultScope
 	source := &mutableSource{head: PolicyHead{Scope: scope}, err: ErrPolicyNotReady}

--- a/docs/RUNTIME_POLICY_RECONCILIATION.md
+++ b/docs/RUNTIME_POLICY_RECONCILIATION.md
@@ -17,6 +17,9 @@ verification, compile, validation, and atomic snapshot swap.
 - Bad signatures do not install a snapshot.
 - Malformed bundles do not partially install.
 - Unavailable sources preserve last-known-good snapshots when one exists.
+- Last-known-good snapshots are bounded to 10 minutes by default; after expiry,
+  source, compile, validation, signature, or hash faults invalidate the snapshot
+  so Guardian fails closed.
 - Initial startup without a valid source fails closed.
 - Reconcile status records policy epoch/hash, bundle ref, source refs, and the
   `policy_reconcile` audit event marker for operator evidence.

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-06-18T22:46:51Z
-# Commit: b31a6f3108fb6d270df5e5f435591445f0574a5a
+# Generated: 2026-06-19T16:06:12Z
+# Commit: 570511dbd5ccce7457d650a881d2d70cf3f6bad1
 # Format: SHA256  PATH
 #
 e548051f46925cf89e8a1034415fb60e88bb62b6d1dd80cfbb4b71b8b53dfb3d  core/pkg/kernel/README.md
@@ -561,7 +561,7 @@ aa4ea979d3f36460d50808f0ccee6bd48eb97cbc3c888d53b2971701b704e462  core/pkg/guard
 05d2907a744570e725955e9967f578b098389dee199fa7af7d54c2381f770a54  core/pkg/guardian/guardian_behavior_coverage_test.go
 56f3550cf20de46141e69f9ebccfdb54b3b83d9425d60ac92587f6ca74a4399b  core/pkg/guardian/guardian_bench_test.go
 85459f0cd76631d94c0ea0e886eb90237c1b29ae7512b542ed4cd4995101f532  core/pkg/guardian/guardian_contracts_test.go
-ba0ea6cc0860f51873387f491d29cf35006ce4cfd129a97a75130324aef51f9d  core/pkg/guardian/guardian_core_coverage_test.go
+f137f3dbf56b413cc8f7ff93463f6dd0f074decbcaea7a4e086540f5e46eb2fb  core/pkg/guardian/guardian_core_coverage_test.go
 a7e35f40e542f1d03d0d4b2f8aa3f514dbebd301754a74f5c2090ac2489bb80e  core/pkg/guardian/guardian_delegation_test.go
 1c6069fc10f370e11aefe4cab278c3994d29a72fe616aad5420aa6876bb05bde  core/pkg/guardian/guardian_edge_cases_test.go
 d7ad656ec37a80da9538c9435229f2e06214ccdde857fdf81e86dbb18d4ad7d7  core/pkg/guardian/guardian_intervention_test.go


### PR DESCRIPTION
## Summary
- bound policy reconciler last-known-good snapshots to a 10-minute default and invalidate expired snapshots so Guardian fails closed
- route source-head faults through the same LKG preservation/expiry path as hash, signature, compile, and validation faults
- add fault-injection coverage for fresh compile faults, 5-minute source outage preservation, and >10-minute fail-closed expiry
- document the LKG expiry behavior and refresh the protected boundary manifest

## Linear
- MIN-795

## Validation
- go test ./core/pkg/policy/reconcile
- go test ./core/pkg/guardian ./core/cmd/helm-ai-kernel
- python3 scripts/check_documentation_coverage.py
- python3 scripts/check_documentation_truth.py
- bash tools/verify-boundary.sh
- go test ./core/pkg/...
- git diff --check