### PR TITLE
Fix Homebrew formula release generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ codegen-java:
 		-I$(PROTO_DIR) $(PROTO_FILES)
 
 codegen-rust:
-	cd sdk/rust && cargo build --features codegen
+	cd sdk/rust && CARGO_HTTP_MULTIPLEXING=false cargo build --features codegen
 
 codegen-check: codegen
 	@git diff --exit-code -- \

--- a/scripts/release/dry_run.sh
+++ b/scripts/release/dry_run.sh
@@ -87,6 +87,14 @@ if "Mindburn-Labs/helm-ai-kernel" not in formula:
     raise SystemExit("Homebrew formula does not point at Mindburn-Labs/helm-ai-kernel")
 if "helm-ai-kernel-launchpad-data.tar" not in formula or "launch matrix --json" not in formula:
     raise SystemExit("Homebrew formula does not install or test Launchpad data")
+if not formula.startswith("# frozen_string_literal: true\n\nclass HelmAiKernel < Formula\n"):
+    raise SystemExit("Homebrew formula has invalid leading indentation")
+if "\n\n\n" in formula:
+    raise SystemExit("Homebrew formula contains extra blank lines")
+if formula.find("on_macos do") > formula.find('resource "launchpad-data" do'):
+    raise SystemExit("Homebrew formula platform blocks must precede resources")
+if '\nresource("console-web").stage do' in formula:
+    raise SystemExit("Homebrew formula console install block is under-indented")
 
 with tarfile.open(assets / "sample-policy-material.tar", "r") as tar:
     members = set(tar.getnames())

--- a/scripts/release/homebrew_formula.rb
+++ b/scripts/release/homebrew_formula.rb
@@ -58,73 +58,72 @@ def asset_url(repo, tag, artifact)
   "https://github.com/#{repo}/releases/download/#{tag}/#{artifact}"
 end
 
-console_resource = ""
+console_resource = "\n"
 console_install = ""
 if !options[:console_bundle].to_s.empty?
-  console_resource = %Q[
-
-    resource "console-web" do
-      url "#{asset_url(options[:repo], tag, options[:console_bundle])}"
-      sha256 "#{options[:console_bundle_checksum]}"
-    end
-]
-  console_install = %Q[
-
-      resource("console-web").stage do
-        (pkgshare/"console").install Dir["*"]
-      end
-]
+  console_resource = [
+    "",
+    '  resource "console-web" do',
+    "    url \"#{asset_url(options[:repo], tag, options[:console_bundle])}\"",
+    "    sha256 \"#{options[:console_bundle_checksum]}\"",
+    "  end",
+    ""
+  ].join("\n")
+  console_install = [
+    "",
+    '    resource("console-web").stage do',
+    '      (pkgshare/"console").install Dir["*"]',
+    "    end"
+  ].join("\n")
 end
 
 puts <<~RUBY
-  # frozen_string_literal: true
+# frozen_string_literal: true
 
-  class HelmAiKernel < Formula
-    desc "Fail-closed execution firewall for AI agents"
-    homepage "https://github.com/#{options[:repo]}"
-    version "#{version}"
-    license "Apache-2.0"
+class HelmAiKernel < Formula
+  desc "Fail-closed execution firewall for AI agents"
+  homepage "https://github.com/#{options[:repo]}"
+  version "#{version}"
+  license "Apache-2.0"
 
-    resource "launchpad-data" do
-      url "#{asset_url(options[:repo], tag, "helm-ai-kernel-launchpad-data.tar")}"
-      sha256 "#{options[:launchpad_data_checksum]}"
-    end
-#{console_resource}
-
-    on_macos do
-      if Hardware::CPU.arm?
-        url "#{asset_url(options[:repo], tag, ARCHES["darwin-arm64"])}"
-        sha256 "#{checksums[ARCHES["darwin-arm64"]]}"
-      else
-        url "#{asset_url(options[:repo], tag, ARCHES["darwin-amd64"])}"
-        sha256 "#{checksums[ARCHES["darwin-amd64"]]}"
-      end
-    end
-
-    on_linux do
-      if Hardware::CPU.arm?
-        url "#{asset_url(options[:repo], tag, ARCHES["linux-arm64"])}"
-        sha256 "#{checksums[ARCHES["linux-arm64"]]}"
-      else
-        url "#{asset_url(options[:repo], tag, ARCHES["linux-amd64"])}"
-        sha256 "#{checksums[ARCHES["linux-amd64"]]}"
-      end
-    end
-
-    def install
-      binary = Dir["helm-ai-kernel-*"].first || "helm-ai-kernel"
-      bin.install binary => "helm-ai-kernel"
-      resource("launchpad-data").stage do
-        pkgshare.install "registry"
-        pkgshare.install "policies"
-      end
-#{console_install}
-    end
-
-    test do
-      assert_match version.to_s, shell_output("\#{bin}/helm-ai-kernel version 2>&1")
-      assert_match "openclaw", shell_output("\#{bin}/helm-ai-kernel launch matrix --json")
-      assert_path_exists pkgshare/"console/index.html" if resources.map(&:name).include?("console-web")
+  on_macos do
+    if Hardware::CPU.arm?
+      url "#{asset_url(options[:repo], tag, ARCHES["darwin-arm64"])}"
+      sha256 "#{checksums[ARCHES["darwin-arm64"]]}"
+    else
+      url "#{asset_url(options[:repo], tag, ARCHES["darwin-amd64"])}"
+      sha256 "#{checksums[ARCHES["darwin-amd64"]]}"
     end
   end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "#{asset_url(options[:repo], tag, ARCHES["linux-arm64"])}"
+      sha256 "#{checksums[ARCHES["linux-arm64"]]}"
+    else
+      url "#{asset_url(options[:repo], tag, ARCHES["linux-amd64"])}"
+      sha256 "#{checksums[ARCHES["linux-amd64"]]}"
+    end
+  end
+
+  resource "launchpad-data" do
+    url "#{asset_url(options[:repo], tag, "helm-ai-kernel-launchpad-data.tar")}"
+    sha256 "#{options[:launchpad_data_checksum]}"
+  end#{console_resource}
+  def install
+    binary = Dir["helm-ai-kernel-*"].first || "helm-ai-kernel"
+    bin.install binary => "helm-ai-kernel"
+
+    resource("launchpad-data").stage do
+      pkgshare.install "registry"
+      pkgshare.install "policies"
+    end#{console_install}
+  end
+
+  test do
+    assert_match version.to_s, shell_output("\#{bin}/helm-ai-kernel version 2>&1")
+    assert_match "openclaw", shell_output("\#{bin}/helm-ai-kernel launch matrix --json")
+    assert_path_exists pkgshare/"console/index.html" if resources.map(&:name).include?("console-web")
+  end
+end
 RUBY


### PR DESCRIPTION
## Summary
- Emit Homebrew formulae at column 1 with platform URL blocks before resources
- Preserve optional Console web resources without indentation or blank-line drift
- Add release dry-run assertions for formula indentation, blank lines, component order, and Console install indentation

## Validation
- ruby -c scripts/release/homebrew_formula.rb
- Generated Console formula: ruby -c and `HOMEBREW_NO_AUTO_UPDATE=1 brew style .../Formula/helm-ai-kernel.rb`
- bash scripts/release/dry_run.sh

## Release context
- Future-proof fix for the Homebrew formula generator; the already-published v0.5.18 tap PR remains byte-compatible with the existing release artifact.