### PR TITLE
[SPEND4] Implement provider catalog, terms profiles, BYOK, managed accounts, and route policies

### DIFF
--- a/core/pkg/modelcatalog/account.go
+++ b/core/pkg/modelcatalog/account.go
@@ -1,0 +1,254 @@
+// Package modelcatalog is the kernel-owned provider catalog.
+//
+// It binds three source-owned facts together so that multi-provider routing is
+// explicit, contract-aware, and auditable BEFORE any spend is claimed:
+//
+//   - the provider/model capability record (contracts.ModelProvider);
+//   - the provider account record that says HOW HELM is allowed to reach a
+//     provider (managed org account, BYOK, partner, or self-hosted) and WHERE
+//     its credential lives — by opaque reference only;
+//   - the provider terms profile (resale/retention/region/contract refs) that
+//     defines the legal and commercial boundary of the route.
+//
+// Credential boundary: a ProviderAccount never carries a secret. It carries a
+// CredentialRef — an opaque pointer into the kernel credential store. Agents
+// receive spend authority (an AgentSpendEnvelope), never provider-key
+// authority. The catalog refuses to construct an account whose CredentialRef
+// looks like an inline secret, and exposes no API that returns secret material.
+package modelcatalog
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+)
+
+// AccountMode describes how HELM is allowed to route through a provider account.
+//
+// It is a superset of economic.ProviderAccountMode: the spend-authority package
+// models BYOK / DIRECT / MANAGED_ORG_ACCOUNT for billing, while the catalog also
+// needs to distinguish PARTNER resale relationships and SELF_HOSTED weights that
+// have no external provider credential at all.
+type AccountMode string
+
+const (
+	// AccountManaged is a HELM-managed organization account. HELM holds the
+	// provider credential and bills the tenant through a governed usage balance.
+	AccountManaged AccountMode = "MANAGED"
+	// AccountBYOK is a bring-your-own-key account. The tenant's credential is
+	// held in the kernel credential store and never surfaced to agents.
+	AccountBYOK AccountMode = "BYOK"
+	// AccountPartner is a partner/reseller relationship governed by a contract.
+	AccountPartner AccountMode = "PARTNER"
+	// AccountSelfHosted is a tenant-operated endpoint (e.g. local vLLM) that
+	// needs no external provider credential.
+	AccountSelfHosted AccountMode = "SELF_HOSTED"
+)
+
+// valid reports whether the mode is a known catalog account mode.
+func (m AccountMode) valid() bool {
+	switch m {
+	case AccountManaged, AccountBYOK, AccountPartner, AccountSelfHosted:
+		return true
+	default:
+		return false
+	}
+}
+
+// RequiresCredential reports whether the mode needs a credential reference.
+// Self-hosted endpoints are reachable without an external provider key.
+func (m AccountMode) RequiresCredential() bool {
+	return m == AccountManaged || m == AccountBYOK || m == AccountPartner
+}
+
+// ToTermsAccountMode maps the catalog account mode onto the economic terms
+// vocabulary so a terms profile can be matched against an account. PARTNER and
+// SELF_HOSTED have no direct billing analogue and map to DIRECT.
+func (m AccountMode) ToTermsAccountMode() economic.ProviderAccountMode {
+	switch m {
+	case AccountManaged:
+		return economic.ProviderAccountManagedOrgAccount
+	case AccountBYOK:
+		return economic.ProviderAccountBYOK
+	default:
+		return economic.ProviderAccountDirect
+	}
+}
+
+// HealthState is the routability of a provider account.
+type HealthState string
+
+const (
+	// HealthUnknown means no probe has reported yet. Fails closed: an account
+	// with unknown health is not routable.
+	HealthUnknown HealthState = "UNKNOWN"
+	// HealthHealthy means the account is routable.
+	HealthHealthy HealthState = "HEALTHY"
+	// HealthDegraded means the account is impaired but may still be escalated.
+	HealthDegraded HealthState = "DEGRADED"
+	// HealthUnhealthy means the account must not be dispatched to.
+	HealthUnhealthy HealthState = "UNHEALTHY"
+)
+
+// AccountHealth is a point-in-time health view for a provider account.
+//
+// It is advisory evidence the router consumes; it never carries credentials.
+// Staleness is fail-closed: a probe older than the account's MaxHealthAge is
+// treated as UNKNOWN.
+type AccountHealth struct {
+	State       HealthState `json:"state"`
+	Detail      string      `json:"detail,omitempty"`
+	ObservedAt  time.Time   `json:"observed_at"`
+	LatencyP95  int         `json:"latency_p95_ms,omitempty"`
+	ErrorRatePM int         `json:"error_rate_per_mille,omitempty"`
+}
+
+// effectiveState returns the health state, downgrading to UNKNOWN when the probe
+// is older than maxAge (maxAge <= 0 disables the staleness check).
+func (h AccountHealth) effectiveState(now time.Time, maxAge time.Duration) HealthState {
+	if h.State == "" {
+		return HealthUnknown
+	}
+	if maxAge > 0 && !h.ObservedAt.IsZero() && now.Sub(h.ObservedAt) > maxAge {
+		return HealthUnknown
+	}
+	return h.State
+}
+
+// ProviderAccount is the kernel-owned record of one routable way to reach a
+// provider. It is the join point between a capability record, a credential, and
+// a terms profile — and it is the object that keeps provider keys away from
+// agents.
+type ProviderAccount struct {
+	ID             string      `json:"id"`
+	TenantID       string      `json:"tenant_id,omitempty"`
+	ProviderID     string      `json:"provider_id"`
+	Mode           AccountMode `json:"mode"`
+	TermsProfileID string      `json:"terms_profile_id"`
+	// CredentialRef is an opaque pointer into the kernel credential store.
+	// It MUST NOT contain secret material; the catalog rejects inline secrets.
+	CredentialRef string        `json:"credential_ref,omitempty"`
+	Endpoint      string        `json:"endpoint,omitempty"`
+	Regions       []string      `json:"regions,omitempty"`
+	Enabled       bool          `json:"enabled"`
+	Approved      bool          `json:"approved"`
+	MaxHealthAge  time.Duration `json:"max_health_age,omitempty"`
+	Health        AccountHealth `json:"health"`
+	ContentHash   string        `json:"content_hash"`
+}
+
+// credentialRefLooksLikeSecret rejects values that look like inline secret
+// material rather than an opaque store reference. This is a defense-in-depth
+// check for the "provider creds never exposed" invariant — a CredentialRef is a
+// handle (e.g. "kcred://tenant/openai/primary"), never a key.
+func credentialRefLooksLikeSecret(ref string) bool {
+	r := strings.TrimSpace(ref)
+	if r == "" {
+		return false
+	}
+	lower := strings.ToLower(r)
+	for _, prefix := range []string{"sk-", "sk_", "pk-", "pk_", "ghp_", "xoxb-", "bearer ", "aws_", "akia"} {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	// Long, opaque, delimiter-free strings are almost certainly raw secrets.
+	if len(r) >= 40 && !strings.ContainsAny(r, ":/@ ") {
+		return true
+	}
+	return false
+}
+
+// NewProviderAccount creates a disabled, unapproved provider account and computes
+// its content hash. New accounts start unapproved: a provider cannot enter the
+// routable catalog without an explicit approval step (Catalog.ApproveAccount).
+func NewProviderAccount(id, providerID string, mode AccountMode, termsProfileID, credentialRef string) (*ProviderAccount, error) {
+	a := &ProviderAccount{
+		ID:             id,
+		ProviderID:     providerID,
+		Mode:           mode,
+		TermsProfileID: termsProfileID,
+		CredentialRef:  strings.TrimSpace(credentialRef),
+		Health:         AccountHealth{State: HealthUnknown},
+		MaxHealthAge:   5 * time.Minute,
+	}
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+	a.ContentHash = a.computeHash()
+	return a, nil
+}
+
+// Validate enforces structural and credential-boundary invariants.
+func (a *ProviderAccount) Validate() error {
+	if a == nil {
+		return errors.New("provider_account: account is nil")
+	}
+	if a.ID == "" {
+		return errors.New("provider_account: id is required")
+	}
+	if a.ProviderID == "" {
+		return errors.New("provider_account: provider_id is required")
+	}
+	if !a.Mode.valid() {
+		return fmt.Errorf("provider_account: unknown mode %q", a.Mode)
+	}
+	if a.TermsProfileID == "" {
+		return errors.New("provider_account: terms_profile_id is required")
+	}
+	if a.Mode.RequiresCredential() && a.CredentialRef == "" {
+		return fmt.Errorf("provider_account: credential_ref is required for mode %s", a.Mode)
+	}
+	if credentialRefLooksLikeSecret(a.CredentialRef) {
+		return errors.New("provider_account: credential_ref must be an opaque store reference, not an inline secret")
+	}
+	if a.MaxHealthAge < 0 {
+		return errors.New("provider_account: max_health_age cannot be negative")
+	}
+	return nil
+}
+
+// Routable reports whether the account may currently receive dispatch and, if
+// not, the canonical spend reason code explaining why. The boolean is true only
+// for an enabled, approved account whose effective health is HEALTHY.
+//
+// Fail-closed ordering: approval and enablement gate first, then health. A
+// DEGRADED account is reported as not-routable but the caller may choose to
+// escalate; an UNHEALTHY or UNKNOWN account is a hard deny.
+func (a *ProviderAccount) Routable(now time.Time) (bool, economic.SpendReasonCode) {
+	if a == nil {
+		return false, economic.SpendReasonProviderNotAllowed
+	}
+	if !a.Approved {
+		return false, economic.SpendReasonApprovalRequired
+	}
+	if !a.Enabled {
+		return false, economic.SpendReasonProviderNotAllowed
+	}
+	switch a.Health.effectiveState(now, a.MaxHealthAge) {
+	case HealthHealthy:
+		return true, economic.SpendReasonOKWithinEnvelope
+	case HealthDegraded:
+		return false, economic.SpendReasonApprovalRequired
+	default:
+		return false, economic.SpendReasonProviderNotAllowed
+	}
+}
+
+func (a *ProviderAccount) computeHash() string {
+	return hashCanonical(struct {
+		ID             string      `json:"id"`
+		TenantID       string      `json:"tenant_id,omitempty"`
+		ProviderID     string      `json:"provider_id"`
+		Mode           AccountMode `json:"mode"`
+		TermsProfileID string      `json:"terms_profile_id"`
+		CredentialRef  string      `json:"credential_ref,omitempty"`
+		Endpoint       string      `json:"endpoint,omitempty"`
+		Regions        []string    `json:"regions,omitempty"`
+		Enabled        bool        `json:"enabled"`
+		Approved       bool        `json:"approved"`
+	}{a.ID, a.TenantID, a.ProviderID, a.Mode, a.TermsProfileID, a.CredentialRef, a.Endpoint, a.Regions, a.Enabled, a.Approved})
+}

--- a/core/pkg/modelcatalog/catalog.go
+++ b/core/pkg/modelcatalog/catalog.go
@@ -1,0 +1,166 @@
+package modelcatalog
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+)
+
+// ErrUnknownProvider is returned when a provider id is not in the catalog.
+var ErrUnknownProvider = errors.New("modelcatalog: unknown provider")
+
+// ErrUnknownAccount is returned when an account id is not in the catalog.
+var ErrUnknownAccount = errors.New("modelcatalog: unknown account")
+
+// ErrUnknownTermsProfile is returned when a terms profile id is not in the catalog.
+var ErrUnknownTermsProfile = errors.New("modelcatalog: unknown terms profile")
+
+// Catalog is the kernel-owned registry of providers, the accounts that can reach
+// them, and the terms profiles that bound them. It is the single source the
+// router consults to decide whether a route is permissible before dispatch.
+//
+// The catalog is fail-closed by construction: a provider must be approved before
+// any of its accounts can route, and a terms profile must validate before it can
+// gate a route. The catalog never stores or returns credential material.
+type Catalog struct {
+	providers map[string]contracts.ModelProvider
+	accounts  map[string]*ProviderAccount
+	terms     map[string]*economic.ProviderTermsProfile
+}
+
+// NewCatalog returns an empty catalog.
+func NewCatalog() *Catalog {
+	return &Catalog{
+		providers: make(map[string]contracts.ModelProvider),
+		accounts:  make(map[string]*ProviderAccount),
+		terms:     make(map[string]*economic.ProviderTermsProfile),
+	}
+}
+
+// AddProvider registers a provider capability record. A provider with no
+// ProviderID, no capabilities, or no regions is rejected. Re-adding an existing
+// id overwrites the capability record but never silently re-approves accounts.
+func (c *Catalog) AddProvider(p contracts.ModelProvider) error {
+	if p.ProviderID == "" {
+		return errors.New("modelcatalog: provider_id is required")
+	}
+	if len(p.Capabilities) == 0 {
+		return fmt.Errorf("modelcatalog: provider %s has no capabilities", p.ProviderID)
+	}
+	if len(p.Regions) == 0 {
+		return fmt.Errorf("modelcatalog: provider %s has no regions", p.ProviderID)
+	}
+	c.providers[p.ProviderID] = p
+	return nil
+}
+
+// AddTermsProfile registers a validated provider terms profile.
+func (c *Catalog) AddTermsProfile(p *economic.ProviderTermsProfile) error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if _, ok := c.providers[p.ProviderID]; !ok {
+		return fmt.Errorf("%w: %s (terms profile %s)", ErrUnknownProvider, p.ProviderID, p.ID)
+	}
+	c.terms[p.ID] = p
+	return nil
+}
+
+// AddAccount registers a provider account. The referenced provider and terms
+// profile must already exist, and the terms profile must belong to the same
+// provider. Accounts are registered unapproved; approval is a distinct step.
+func (c *Catalog) AddAccount(a *ProviderAccount) error {
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if _, ok := c.providers[a.ProviderID]; !ok {
+		return fmt.Errorf("%w: %s (account %s)", ErrUnknownProvider, a.ProviderID, a.ID)
+	}
+	tp, ok := c.terms[a.TermsProfileID]
+	if !ok {
+		return fmt.Errorf("%w: %s (account %s)", ErrUnknownTermsProfile, a.TermsProfileID, a.ID)
+	}
+	if tp.ProviderID != a.ProviderID {
+		return fmt.Errorf("modelcatalog: terms profile %s is for provider %s, not %s", tp.ID, tp.ProviderID, a.ProviderID)
+	}
+	a.ContentHash = a.computeHash()
+	c.accounts[a.ID] = a
+	return nil
+}
+
+// ApproveAccount marks an account approved and enabled. This is the explicit
+// new-provider approval gate: an account cannot route until it passes through
+// here, satisfying the "new-provider approval" done-gate.
+func (c *Catalog) ApproveAccount(accountID string) error {
+	a, ok := c.accounts[accountID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownAccount, accountID)
+	}
+	a.Approved = true
+	a.Enabled = true
+	a.ContentHash = a.computeHash()
+	return nil
+}
+
+// SetAccountHealth records a health observation for an account.
+func (c *Catalog) SetAccountHealth(accountID string, health AccountHealth) error {
+	a, ok := c.accounts[accountID]
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrUnknownAccount, accountID)
+	}
+	if health.ObservedAt.IsZero() {
+		health.ObservedAt = time.Now().UTC()
+	}
+	a.Health = health
+	return nil
+}
+
+// Provider returns the capability record for a provider id.
+func (c *Catalog) Provider(providerID string) (contracts.ModelProvider, bool) {
+	p, ok := c.providers[providerID]
+	return p, ok
+}
+
+// Account returns the account record for an account id.
+func (c *Catalog) Account(accountID string) (*ProviderAccount, bool) {
+	a, ok := c.accounts[accountID]
+	return a, ok
+}
+
+// TermsProfile returns the terms profile for a profile id.
+func (c *Catalog) TermsProfile(profileID string) (*economic.ProviderTermsProfile, bool) {
+	p, ok := c.terms[profileID]
+	return p, ok
+}
+
+// Providers returns the registered providers sorted by id for deterministic
+// iteration. The returned slice is a copy.
+func (c *Catalog) Providers() []contracts.ModelProvider {
+	out := make([]contracts.ModelProvider, 0, len(c.providers))
+	for _, p := range c.providers {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ProviderID < out[j].ProviderID })
+	return out
+}
+
+// ApprovedAccountsForProvider returns the approved, enabled accounts for a
+// provider, sorted by account id. Unapproved or disabled accounts are excluded;
+// this is the routable surface the router iterates.
+func (c *Catalog) ApprovedAccountsForProvider(providerID string) []*ProviderAccount {
+	var out []*ProviderAccount
+	for _, a := range c.accounts {
+		if a.ProviderID == providerID && a.Approved && a.Enabled {
+			out = append(out, a)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// ProviderCount returns the number of registered providers.
+func (c *Catalog) ProviderCount() int { return len(c.providers) }

--- a/core/pkg/modelcatalog/catalog_test.go
+++ b/core/pkg/modelcatalog/catalog_test.go
@@ -1,0 +1,216 @@
+package modelcatalog
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+)
+
+func freshTermsProfile(t *testing.T, id, providerID string, mode AccountMode, now time.Time) *economic.ProviderTermsProfile {
+	t.Helper()
+	tp := economic.NewProviderTermsProfile(id, providerID, mode.ToTermsAccountMode(), "v1", "legal-review://"+providerID)
+	tp.DataRetentionDays = 30
+	if tp.RequiresContractForManagedBilling {
+		tp.ContractRef = "contract://" + providerID
+	}
+	exp := now.Add(24 * time.Hour)
+	tp.ExpiresAt = &exp
+	if err := tp.Validate(); err != nil {
+		t.Fatalf("seed terms profile invalid: %v", err)
+	}
+	return tp
+}
+
+func TestDefaultCatalog_HasAtLeastThreeProviders(t *testing.T) {
+	now := time.Now().UTC()
+	c, err := DefaultCatalog(now)
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	if c.ProviderCount() < 3 {
+		t.Fatalf("catalog has %d providers, want >= 3", c.ProviderCount())
+	}
+	// Every seeded provider must have an approved, routable account.
+	for _, p := range c.Providers() {
+		accts := c.ApprovedAccountsForProvider(p.ProviderID)
+		if len(accts) == 0 {
+			t.Fatalf("provider %s has no approved account", p.ProviderID)
+		}
+		if ok, code := accts[0].Routable(now); !ok {
+			t.Fatalf("provider %s account not routable: %s", p.ProviderID, code)
+		}
+	}
+}
+
+func TestProviderAccount_NewProviderApprovalGate(t *testing.T) {
+	now := time.Now().UTC()
+	a, err := NewProviderAccount("acct:p", "example:p", AccountManaged, "terms:p", "kcred://example/p")
+	if err != nil {
+		t.Fatalf("NewProviderAccount: %v", err)
+	}
+	// A freshly created account is unapproved and therefore not routable.
+	if a.Approved {
+		t.Fatal("new account must not be pre-approved")
+	}
+	if ok, code := a.Routable(now); ok || code != economic.SpendReasonApprovalRequired {
+		t.Fatalf("unapproved account routable=%v code=%s, want false/ERR_APPROVAL_REQUIRED", ok, code)
+	}
+}
+
+func TestCatalog_ApproveAccountMakesRoutable(t *testing.T) {
+	now := time.Now().UTC()
+	c := NewCatalog()
+	if err := c.AddProvider(contracts.ModelProvider{
+		ProviderID:   "example:p",
+		Name:         "P",
+		Capabilities: []string{"TEXT"},
+		Regions:      []string{"US"},
+		RiskTier:     "LOW",
+		Active:       true,
+	}); err != nil {
+		t.Fatalf("AddProvider: %v", err)
+	}
+	if err := c.AddTermsProfile(freshTermsProfile(t, "terms:p", "example:p", AccountManaged, now)); err != nil {
+		t.Fatalf("AddTermsProfile: %v", err)
+	}
+	acct, err := NewProviderAccount("acct:p", "example:p", AccountManaged, "terms:p", "kcred://example/p")
+	if err != nil {
+		t.Fatalf("NewProviderAccount: %v", err)
+	}
+	if err := c.AddAccount(acct); err != nil {
+		t.Fatalf("AddAccount: %v", err)
+	}
+	// Before approval: not in the approved set.
+	if got := c.ApprovedAccountsForProvider("example:p"); len(got) != 0 {
+		t.Fatalf("approved accounts before approval = %d, want 0", len(got))
+	}
+	if err := c.ApproveAccount("acct:p"); err != nil {
+		t.Fatalf("ApproveAccount: %v", err)
+	}
+	if err := c.SetAccountHealth("acct:p", AccountHealth{State: HealthHealthy, ObservedAt: now}); err != nil {
+		t.Fatalf("SetAccountHealth: %v", err)
+	}
+	got := c.ApprovedAccountsForProvider("example:p")
+	if len(got) != 1 {
+		t.Fatalf("approved accounts after approval = %d, want 1", len(got))
+	}
+	if ok, _ := got[0].Routable(now); !ok {
+		t.Fatal("approved healthy account should be routable")
+	}
+}
+
+func TestProviderAccount_UnhealthyAndStaleHealthFailClosed(t *testing.T) {
+	now := time.Now().UTC()
+	base := func() *ProviderAccount {
+		a, err := NewProviderAccount("acct:p", "example:p", AccountManaged, "terms:p", "kcred://example/p")
+		if err != nil {
+			t.Fatalf("NewProviderAccount: %v", err)
+		}
+		a.Approved = true
+		a.Enabled = true
+		return a
+	}
+
+	cases := []struct {
+		name     string
+		health   AccountHealth
+		wantOK   bool
+		wantCode economic.SpendReasonCode
+	}{
+		{"healthy", AccountHealth{State: HealthHealthy, ObservedAt: now}, true, economic.SpendReasonOKWithinEnvelope},
+		{"unhealthy denies", AccountHealth{State: HealthUnhealthy, ObservedAt: now}, false, economic.SpendReasonProviderNotAllowed},
+		{"degraded escalates", AccountHealth{State: HealthDegraded, ObservedAt: now}, false, economic.SpendReasonApprovalRequired},
+		{"unknown denies", AccountHealth{State: HealthUnknown, ObservedAt: now}, false, economic.SpendReasonProviderNotAllowed},
+		{"stale probe denies", AccountHealth{State: HealthHealthy, ObservedAt: now.Add(-time.Hour)}, false, economic.SpendReasonProviderNotAllowed},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := base()
+			a.Health = tc.health
+			ok, code := a.Routable(now)
+			if ok != tc.wantOK || code != tc.wantCode {
+				t.Fatalf("Routable = (%v,%s), want (%v,%s)", ok, code, tc.wantOK, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestProviderAccount_RejectsInlineSecret is the credential-boundary regression:
+// the catalog must refuse a CredentialRef that looks like raw secret material,
+// enforcing "provider creds never exposed to agents" at construction time.
+func TestProviderAccount_RejectsInlineSecret(t *testing.T) {
+	secrets := []string{
+		"sk-abc123def456ghi789jkl012mno345pqr678stu",
+		"ghp_0123456789abcdef0123456789abcdef0123",
+		"AKIAIOSFODNN7EXAMPLE",
+		"Bearer eyJhbGciOiJIUzI1NiIsInR5cC16IkpXVCJ9",
+		"0123456789abcdef0123456789abcdef01234567", // 40-char opaque blob
+	}
+	for _, s := range secrets {
+		if _, err := NewProviderAccount("acct:p", "example:p", AccountBYOK, "terms:p", s); err == nil {
+			t.Fatalf("NewProviderAccount accepted inline secret %q, want rejection", s)
+		}
+	}
+	// An opaque store reference is accepted.
+	if _, err := NewProviderAccount("acct:p", "example:p", AccountBYOK, "terms:p", "kcred://tenant/example/primary"); err != nil {
+		t.Fatalf("NewProviderAccount rejected opaque ref: %v", err)
+	}
+}
+
+// TestProviderAccount_NoSecretInSerialization asserts the account record never
+// carries secret material in its JSON form — only the opaque reference.
+func TestProviderAccount_NoSecretInSerialization(t *testing.T) {
+	a, err := NewProviderAccount("acct:p", "example:p", AccountBYOK, "terms:p", "kcred://tenant/example/primary")
+	if err != nil {
+		t.Fatalf("NewProviderAccount: %v", err)
+	}
+	blob, err := json.Marshal(a)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(blob)
+	if strings.Contains(s, "sk-") || strings.Contains(s, "secret") || strings.Contains(s, "api_key") {
+		t.Fatalf("serialized account leaks secret-shaped material: %s", s)
+	}
+	if !strings.Contains(s, "kcred://") {
+		t.Fatalf("serialized account dropped credential_ref handle: %s", s)
+	}
+}
+
+func TestCatalog_RejectsMissingDepsAndModeCredentialRules(t *testing.T) {
+	now := time.Now().UTC()
+	c := NewCatalog()
+
+	// Terms profile referencing an unknown provider is rejected.
+	tp := freshTermsProfile(t, "terms:p", "example:p", AccountManaged, now)
+	if err := c.AddTermsProfile(tp); err == nil {
+		t.Fatal("AddTermsProfile for unknown provider should fail")
+	}
+
+	if err := c.AddProvider(contracts.ModelProvider{
+		ProviderID: "example:p", Name: "P", Capabilities: []string{"TEXT"}, Regions: []string{"US"}, RiskTier: "LOW", Active: true,
+	}); err != nil {
+		t.Fatalf("AddProvider: %v", err)
+	}
+	if err := c.AddTermsProfile(tp); err != nil {
+		t.Fatalf("AddTermsProfile: %v", err)
+	}
+
+	// Self-hosted account needs no credential.
+	sh, err := NewProviderAccount("acct:sh", "example:p", AccountSelfHosted, "terms:p", "")
+	if err != nil {
+		t.Fatalf("self-hosted account should not require credential: %v", err)
+	}
+	if err := c.AddAccount(sh); err != nil {
+		t.Fatalf("AddAccount(self-hosted): %v", err)
+	}
+
+	// BYOK account without a credential is rejected.
+	if _, err := NewProviderAccount("acct:byok", "example:p", AccountBYOK, "terms:p", ""); err == nil {
+		t.Fatal("BYOK account without credential_ref should fail")
+	}
+}

--- a/core/pkg/modelcatalog/hash.go
+++ b/core/pkg/modelcatalog/hash.go
@@ -1,0 +1,14 @@
+package modelcatalog
+
+import "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+
+// hashCanonical returns a deterministic "sha256:"-prefixed digest over the JCS
+// (RFC 8785) canonical form of value, matching the repo-wide canonicalization
+// discipline used by EvidencePacks and ProofGraph.
+func hashCanonical(value any) string {
+	h, err := canonicalize.CanonicalHash(value)
+	if err != nil {
+		return ""
+	}
+	return "sha256:" + h
+}

--- a/core/pkg/modelcatalog/seed.go
+++ b/core/pkg/modelcatalog/seed.go
@@ -1,0 +1,89 @@
+package modelcatalog
+
+import (
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+)
+
+// DefaultCatalog builds a provider-neutral catalog with at least three
+// providers, one validated terms profile per provider, and one approved account
+// per provider exercising the managed, BYOK, and self-hosted account modes.
+//
+// It satisfies the ">=3 providers in catalog" acceptance criterion and gives the
+// router a realistic, contract-aware surface to score against. Provider records
+// are intentionally neutral (no current-provider claims) so public code does not
+// drift with commercial provider release cycles; deployments generate a live
+// catalog from verified source metadata.
+//
+// now seeds health-observation timestamps so callers can drive deterministic
+// staleness tests.
+func DefaultCatalog(now time.Time) (*Catalog, error) {
+	c := NewCatalog()
+
+	providers := contracts.KnownModelProviders()
+	for _, p := range providers {
+		if err := c.AddProvider(p); err != nil {
+			return nil, err
+		}
+	}
+
+	// One terms profile + one approved account per seeded provider. Modes rotate
+	// across MANAGED, BYOK, SELF_HOSTED so the catalog covers the account-mode
+	// matrix. PARTNER is exercised directly in router tests.
+	modes := []AccountMode{AccountManaged, AccountBYOK, AccountSelfHosted}
+	for i, p := range providers {
+		mode := modes[i%len(modes)]
+		tp := economic.NewProviderTermsProfile(
+			"terms:"+p.ProviderID,
+			p.ProviderID,
+			mode.ToTermsAccountMode(),
+			"v1",
+			"legal-review://"+p.ProviderID,
+		)
+		tp.Jurisdiction = firstRegion(p.Regions)
+		tp.DataRetentionDays = 30
+		tp.EffectiveAt = now
+		if tp.RequiresContractForManagedBilling {
+			tp.ContractRef = "contract://" + p.ProviderID
+		}
+		expiry := now.Add(365 * 24 * time.Hour)
+		tp.ExpiresAt = &expiry
+		if err := c.AddTermsProfile(tp); err != nil {
+			return nil, err
+		}
+
+		credRef := ""
+		if mode.RequiresCredential() {
+			credRef = "kcred://" + p.ProviderID + "/primary"
+		}
+		acct, err := NewProviderAccount("acct:"+p.ProviderID, p.ProviderID, mode, tp.ID, credRef)
+		if err != nil {
+			return nil, err
+		}
+		acct.Regions = p.Regions
+		if err := c.AddAccount(acct); err != nil {
+			return nil, err
+		}
+		if err := c.ApproveAccount(acct.ID); err != nil {
+			return nil, err
+		}
+		if err := c.SetAccountHealth(acct.ID, AccountHealth{
+			State:      HealthHealthy,
+			ObservedAt: now,
+			LatencyP95: p.Latency95th,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+func firstRegion(regions []string) string {
+	if len(regions) == 0 {
+		return ""
+	}
+	return regions[0]
+}

--- a/core/pkg/router/policy.go
+++ b/core/pkg/router/policy.go
@@ -1,0 +1,222 @@
+// Package router is the kernel-owned, contract-aware model route engine.
+//
+// The router turns a route request into a fail-closed verdict (ALLOW / DENY /
+// ESCALATE) against a modelcatalog.Catalog. It is the gate that makes
+// multi-provider routing explicit and auditable before any spend is claimed:
+//
+//   - a forbidden provider or model is denied before dispatch;
+//   - a stale or invalid provider terms profile blocks the route before
+//     dispatch;
+//   - an unhealthy provider account denies, and a degraded one escalates;
+//   - region and retention participate in route scoring, not just cost/latency.
+//
+// The router never sees credentials. It selects a provider account and emits a
+// RoutePolicyHash that downstream spend-authority objects (RouteQuote,
+// BudgetVerdictReceipt) bind to; the gateway resolves the account's opaque
+// credential reference at dispatch time, outside agent reach.
+package router
+
+import (
+	"errors"
+	"sort"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+// RouteMode is the optimization/pinning strategy a route policy applies.
+type RouteMode string
+
+const (
+	// RouteModePinned forces a single provider+model; any deviation is denied.
+	RouteModePinned RouteMode = "pinned"
+	// RouteModeCostFirst prefers the cheapest compliant candidate.
+	RouteModeCostFirst RouteMode = "cost_first"
+	// RouteModeLatencyFirst prefers the lowest-latency compliant candidate.
+	RouteModeLatencyFirst RouteMode = "latency_first"
+	// RouteModeQualityFirst prefers the highest-quality compliant candidate.
+	RouteModeQualityFirst RouteMode = "quality_first"
+	// RouteModeBalanced blends cost, latency, quality, region, and retention.
+	RouteModeBalanced RouteMode = "balanced"
+	// RouteModeComplianceFirst prefers the candidate with the strongest
+	// compliance posture (shortest retention, matching region/jurisdiction).
+	RouteModeComplianceFirst RouteMode = "compliance_first"
+	// RouteModeRegionPinned requires the candidate to serve a pinned region.
+	RouteModeRegionPinned RouteMode = "region_pinned"
+	// RouteModeProviderPinned forces a single provider, any of its models.
+	RouteModeProviderPinned RouteMode = "provider_pinned"
+	// RouteModeModelPinned forces a single model across any provider that serves it.
+	RouteModeModelPinned RouteMode = "model_pinned"
+)
+
+// RouteModes returns the full normative route-mode vocabulary.
+func RouteModes() []RouteMode {
+	return []RouteMode{
+		RouteModePinned,
+		RouteModeCostFirst,
+		RouteModeLatencyFirst,
+		RouteModeQualityFirst,
+		RouteModeBalanced,
+		RouteModeComplianceFirst,
+		RouteModeRegionPinned,
+		RouteModeProviderPinned,
+		RouteModeModelPinned,
+	}
+}
+
+func (m RouteMode) valid() bool {
+	for _, known := range RouteModes() {
+		if m == known {
+			return true
+		}
+	}
+	return false
+}
+
+// ScoreWeights are the per-dimension weights used by RouteModeBalanced. Each
+// weight scales a normalized 0..1 sub-score; higher total score wins. Zero
+// values fall back to BalancedDefaultWeights so an unset policy is still usable.
+type ScoreWeights struct {
+	Cost      float64 `json:"cost"`
+	Latency   float64 `json:"latency"`
+	Quality   float64 `json:"quality"`
+	Region    float64 `json:"region"`
+	Retention float64 `json:"retention"`
+}
+
+// BalancedDefaultWeights is the default blend for RouteModeBalanced.
+func BalancedDefaultWeights() ScoreWeights {
+	return ScoreWeights{Cost: 0.3, Latency: 0.2, Quality: 0.2, Region: 0.15, Retention: 0.15}
+}
+
+func (w ScoreWeights) orDefault() ScoreWeights {
+	if w == (ScoreWeights{}) {
+		return BalancedDefaultWeights()
+	}
+	return w
+}
+
+// RoutePolicy is the kernel-owned, hashable description of how a route must be
+// chosen. Its canonical hash is the RoutePolicyHash that RouteQuote and
+// BudgetVerdictReceipt bind to, so a dispatch can be audited back to the exact
+// policy that authorized it.
+type RoutePolicy struct {
+	ID       string    `json:"id"`
+	TenantID string    `json:"tenant_id,omitempty"`
+	Mode     RouteMode `json:"mode"`
+
+	// PinnedProviderID / PinnedModelID constrain the candidate set for the
+	// pinned, provider_pinned, and model_pinned modes.
+	PinnedProviderID string `json:"pinned_provider_id,omitempty"`
+	PinnedModelID    string `json:"pinned_model_id,omitempty"`
+
+	// RequiredRegion constrains region_pinned and contributes to scoring/
+	// compliance. Empty means "no region constraint".
+	RequiredRegion string `json:"required_region,omitempty"`
+
+	// MaxDataRetentionDays denies a candidate whose terms profile retains data
+	// longer than this. Zero means "no retention ceiling".
+	MaxDataRetentionDays int `json:"max_data_retention_days,omitempty"`
+
+	// MaxRiskTier is the highest provider risk tier allowed (LOW<MEDIUM<HIGH<CRITICAL).
+	// Empty means "no risk ceiling".
+	MaxRiskTier string `json:"max_risk_tier,omitempty"`
+
+	// Weights tunes RouteModeBalanced. Ignored by single-dimension modes.
+	Weights ScoreWeights `json:"weights,omitempty"`
+}
+
+// Validate ensures the policy is well-formed and that pinning modes carry the
+// pin they require. A malformed policy can authorize nothing.
+func (p *RoutePolicy) Validate() error {
+	if p == nil {
+		return errors.New("route_policy: policy is nil")
+	}
+	if p.ID == "" {
+		return errors.New("route_policy: id is required")
+	}
+	if !p.Mode.valid() {
+		return errors.New("route_policy: unknown mode " + string(p.Mode))
+	}
+	switch p.Mode {
+	case RouteModePinned:
+		if p.PinnedProviderID == "" || p.PinnedModelID == "" {
+			return errors.New("route_policy: pinned mode requires pinned_provider_id and pinned_model_id")
+		}
+	case RouteModeProviderPinned:
+		if p.PinnedProviderID == "" {
+			return errors.New("route_policy: provider_pinned mode requires pinned_provider_id")
+		}
+	case RouteModeModelPinned:
+		if p.PinnedModelID == "" {
+			return errors.New("route_policy: model_pinned mode requires pinned_model_id")
+		}
+	case RouteModeRegionPinned:
+		if p.RequiredRegion == "" {
+			return errors.New("route_policy: region_pinned mode requires required_region")
+		}
+	}
+	if p.MaxDataRetentionDays < 0 {
+		return errors.New("route_policy: max_data_retention_days cannot be negative")
+	}
+	return nil
+}
+
+// Hash returns the canonical "sha256:"-prefixed RoutePolicyHash. Weights are
+// normalized to the effective blend so two policies that resolve to the same
+// behavior hash identically.
+func (p *RoutePolicy) Hash() string {
+	h, err := canonicalize.CanonicalHash(struct {
+		ID                   string       `json:"id"`
+		TenantID             string       `json:"tenant_id,omitempty"`
+		Mode                 RouteMode    `json:"mode"`
+		PinnedProviderID     string       `json:"pinned_provider_id,omitempty"`
+		PinnedModelID        string       `json:"pinned_model_id,omitempty"`
+		RequiredRegion       string       `json:"required_region,omitempty"`
+		MaxDataRetentionDays int          `json:"max_data_retention_days,omitempty"`
+		MaxRiskTier          string       `json:"max_risk_tier,omitempty"`
+		Weights              ScoreWeights `json:"weights"`
+	}{p.ID, p.TenantID, p.Mode, p.PinnedProviderID, p.PinnedModelID, p.RequiredRegion, p.MaxDataRetentionDays, p.MaxRiskTier, p.effectiveWeights()})
+	if err != nil {
+		return ""
+	}
+	return "sha256:" + h
+}
+
+func (p *RoutePolicy) effectiveWeights() ScoreWeights {
+	if p.Mode == RouteModeBalanced {
+		return p.Weights.orDefault()
+	}
+	return p.Weights
+}
+
+// riskTierRank ranks provider risk tiers for ceiling comparisons. Unknown tiers
+// rank highest (most restrictive to admit) so an unrecognized tier fails closed.
+func riskTierRank(tier string) int {
+	switch tier {
+	case "LOW":
+		return 1
+	case "MEDIUM":
+		return 2
+	case "HIGH":
+		return 3
+	case "CRITICAL":
+		return 4
+	default:
+		return 99
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, v := range values {
+		if v == target {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedRegions(regions []string) []string {
+	out := append([]string(nil), regions...)
+	sort.Strings(out)
+	return out
+}

--- a/core/pkg/router/router.go
+++ b/core/pkg/router/router.go
@@ -1,0 +1,327 @@
+package router
+
+import (
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/modelcatalog"
+)
+
+// Request is a fully-specified route request. The router never trusts an agent
+// for credentials: the caller provides only intent (model, region, capability)
+// plus the spend envelope that grants spend — not provider-key — authority.
+type Request struct {
+	TenantID string `json:"tenant_id,omitempty"`
+	// RequestedModelID is the model the caller wants. Required.
+	RequestedModelID string `json:"requested_model_id"`
+	// RequestedProviderID optionally narrows to one provider.
+	RequestedProviderID string `json:"requested_provider_id,omitempty"`
+	// Region is the region the workload must run in, if constrained.
+	Region string `json:"region,omitempty"`
+	// RequiredCapabilities must all be present on the provider record.
+	RequiredCapabilities []string `json:"required_capabilities,omitempty"`
+	// Envelope is the agent spend envelope. Its AllowedProviders/AllowedModels
+	// are the authoritative agent-facing allow-list; the router enforces it
+	// before any catalog candidate is considered.
+	Envelope *economic.AgentSpendEnvelope `json:"-"`
+}
+
+// Candidate is one provider/model/account the router evaluated, with its score.
+type Candidate struct {
+	ProviderID string  `json:"provider_id"`
+	ModelID    string  `json:"model_id"`
+	AccountID  string  `json:"account_id"`
+	Score      float64 `json:"score"`
+}
+
+// Decision is the fail-closed outcome of a route evaluation.
+type Decision struct {
+	Verdict         economic.BudgetVerdict   `json:"verdict"`
+	ReasonCode      economic.SpendReasonCode `json:"reason_code"`
+	Reason          string                   `json:"reason"`
+	Selected        *Candidate               `json:"selected,omitempty"`
+	RoutePolicyHash string                   `json:"route_policy_hash"`
+	Considered      []Candidate              `json:"considered,omitempty"`
+}
+
+func deny(code economic.SpendReasonCode, reason, policyHash string) Decision {
+	return Decision{Verdict: economic.BudgetVerdictDeny, ReasonCode: code, Reason: reason, RoutePolicyHash: policyHash}
+}
+
+func escalateDecision(code economic.SpendReasonCode, reason, policyHash string) Decision {
+	return Decision{Verdict: economic.BudgetVerdictEscalate, ReasonCode: code, Reason: reason, RoutePolicyHash: policyHash}
+}
+
+// Router evaluates route requests against a catalog under a route policy.
+type Router struct {
+	catalog *modelcatalog.Catalog
+}
+
+// New returns a router bound to a catalog.
+func New(catalog *modelcatalog.Catalog) (*Router, error) {
+	if catalog == nil {
+		return nil, errors.New("router: catalog is required")
+	}
+	return &Router{catalog: catalog}, nil
+}
+
+// Decide selects a route or refuses, fail-closed. It enforces, in order:
+//  1. structural validity of policy and request;
+//  2. the agent spend envelope allow-list (forbidden provider/model -> DENY);
+//  3. policy pins (pinned/provider_pinned/model_pinned/region_pinned);
+//  4. per-candidate compliance — terms profile validity & freshness, retention
+//     ceiling, region, risk tier, and account health;
+//  5. mode-specific scoring, where region and retention participate.
+//
+// A DEGRADED account on the winning route yields ESCALATE; an empty compliant
+// set yields DENY (or ESCALATE) with the most specific reason observed.
+func (r *Router) Decide(req Request, policy *RoutePolicy, now time.Time) Decision {
+	if err := policy.Validate(); err != nil {
+		return deny(economic.SpendReasonProviderContractNeeded, "invalid route policy: "+err.Error(), "")
+	}
+	policyHash := policy.Hash()
+
+	if req.RequestedModelID == "" {
+		return deny(economic.SpendReasonModelNotAllowed, "requested_model_id is required", policyHash)
+	}
+	if req.Envelope == nil {
+		return deny(economic.SpendReasonEnvelopeNotFound, "spend envelope is required for routing", policyHash)
+	}
+
+	// Agent-facing allow-list gates first: the envelope is the agent's authority.
+	// A provider or model outside it is denied before any catalog lookup, so a
+	// compromised or over-reaching agent cannot widen its provider reach.
+	if req.RequestedProviderID != "" && !req.Envelope.AllowsProvider(req.RequestedProviderID) {
+		return deny(economic.SpendReasonProviderNotAllowed, "requested provider is not in the spend envelope allow-list", policyHash)
+	}
+	if !req.Envelope.AllowsModel(req.RequestedModelID) {
+		return deny(economic.SpendReasonModelNotAllowed, "requested model is not in the spend envelope allow-list", policyHash)
+	}
+
+	providerIDs, pinReason := r.candidateProviderIDs(req, policy)
+	if len(providerIDs) == 0 {
+		return deny(pinReason.code, pinReason.reason, policyHash)
+	}
+
+	cands, lastDeny := r.buildCandidates(req, policy, providerIDs, now)
+	if len(cands) == 0 {
+		if lastDeny.code == "" {
+			return deny(economic.SpendReasonProviderNotAllowed, "no compliant route candidate", policyHash)
+		}
+		if lastDeny.escalate {
+			return escalateDecision(lastDeny.code, lastDeny.reason, policyHash)
+		}
+		return deny(lastDeny.code, lastDeny.reason, policyHash)
+	}
+
+	r.scoreCandidates(cands, policy)
+	sort.SliceStable(cands, func(i, j int) bool {
+		if cands[i].cand.Score != cands[j].cand.Score {
+			return cands[i].cand.Score > cands[j].cand.Score
+		}
+		if cands[i].cand.ProviderID != cands[j].cand.ProviderID {
+			return cands[i].cand.ProviderID < cands[j].cand.ProviderID
+		}
+		return cands[i].cand.AccountID < cands[j].cand.AccountID
+	})
+
+	considered := make([]Candidate, 0, len(cands))
+	for _, sc := range cands {
+		considered = append(considered, sc.cand)
+	}
+	winner := cands[0]
+
+	verdict := economic.BudgetVerdictAllow
+	reasonCode := economic.SpendReasonOKWithinEnvelope
+	reason := "route selected within policy and envelope"
+	if winner.degraded {
+		verdict = economic.BudgetVerdictEscalate
+		reasonCode = economic.SpendReasonApprovalRequired
+		reason = "selected account is degraded; route requires approval"
+	}
+
+	sel := winner.cand
+	return Decision{
+		Verdict:         verdict,
+		ReasonCode:      reasonCode,
+		Reason:          reason,
+		Selected:        &sel,
+		RoutePolicyHash: policyHash,
+		Considered:      considered,
+	}
+}
+
+type denyInfo struct {
+	code     economic.SpendReasonCode
+	reason   string
+	escalate bool
+}
+
+// candidateProviderIDs resolves which providers are eligible under the policy
+// pins and the requested provider. Returns the provider id set and, when empty,
+// the reason it is empty.
+func (r *Router) candidateProviderIDs(req Request, policy *RoutePolicy) ([]string, denyInfo) {
+	want := func(id string) bool {
+		return req.RequestedProviderID == "" || req.RequestedProviderID == id
+	}
+
+	switch policy.Mode {
+	case RouteModePinned, RouteModeProviderPinned:
+		if req.RequestedProviderID != "" && req.RequestedProviderID != policy.PinnedProviderID {
+			return nil, denyInfo{economic.SpendReasonProviderNotAllowed, "requested provider conflicts with pinned provider", false}
+		}
+		if _, ok := r.catalog.Provider(policy.PinnedProviderID); !ok {
+			return nil, denyInfo{economic.SpendReasonProviderNotAllowed, "pinned provider is not in the catalog", false}
+		}
+		return []string{policy.PinnedProviderID}, denyInfo{}
+	default:
+		var ids []string
+		for _, p := range r.catalog.Providers() {
+			if want(p.ProviderID) {
+				ids = append(ids, p.ProviderID)
+			}
+		}
+		if len(ids) == 0 {
+			return nil, denyInfo{economic.SpendReasonProviderNotAllowed, "requested provider is not in the catalog", false}
+		}
+		return ids, denyInfo{}
+	}
+}
+
+type scoredCandidate struct {
+	cand     Candidate
+	degraded bool
+	// raw scoring inputs retained for blended scoring
+	costPerMTok float64
+	latencyMS   int
+	retention   int
+	regionMatch bool
+}
+
+// buildCandidates filters the eligible providers down to compliant routes. Each
+// rejection is fail-closed and records the most specific reason, so an empty
+// result still explains itself.
+func (r *Router) buildCandidates(req Request, policy *RoutePolicy, providerIDs []string, now time.Time) ([]scoredCandidate, denyInfo) {
+	var out []scoredCandidate
+	var last denyInfo
+
+	for _, providerID := range providerIDs {
+		prov, ok := r.catalog.Provider(providerID)
+		if !ok {
+			last = denyInfo{economic.SpendReasonProviderNotAllowed, "provider not in catalog", false}
+			continue
+		}
+
+		modelID := req.RequestedModelID
+		if policy.Mode == RouteModePinned || policy.Mode == RouteModeModelPinned {
+			if policy.PinnedModelID != modelID {
+				last = denyInfo{economic.SpendReasonModelNotAllowed, "requested model conflicts with pinned model", false}
+				continue
+			}
+		}
+
+		if !hasAllCapabilities(prov.Capabilities, req.RequiredCapabilities) {
+			last = denyInfo{economic.SpendReasonModelNotAllowed, "provider lacks a required capability", false}
+			continue
+		}
+
+		if policy.MaxRiskTier != "" && riskTierRank(prov.RiskTier) > riskTierRank(policy.MaxRiskTier) {
+			last = denyInfo{economic.SpendReasonProviderNotAllowed, "provider risk tier exceeds policy ceiling", false}
+			continue
+		}
+
+		region := req.Region
+		if policy.Mode == RouteModeRegionPinned {
+			region = policy.RequiredRegion
+		} else if region == "" {
+			region = policy.RequiredRegion
+		}
+		regionMatch := region == "" || containsString(prov.Regions, region)
+		if region != "" && !regionMatch {
+			last = denyInfo{economic.SpendReasonProviderNotAllowed, "provider does not serve required region " + region, false}
+			continue
+		}
+
+		accounts := r.catalog.ApprovedAccountsForProvider(providerID)
+		if len(accounts) == 0 {
+			// No approved account => provider not yet admitted (new-provider gate).
+			last = denyInfo{economic.SpendReasonApprovalRequired, "provider has no approved account", true}
+			continue
+		}
+
+		for _, acct := range accounts {
+			tp, ok := r.catalog.TermsProfile(acct.TermsProfileID)
+			if !ok {
+				last = denyInfo{economic.SpendReasonProviderContractNeeded, "account terms profile is missing", false}
+				continue
+			}
+			if err := tp.Validate(); err != nil {
+				last = denyInfo{economic.SpendReasonProviderContractNeeded, "account terms profile is invalid: " + err.Error(), false}
+				continue
+			}
+			if termsProfileStale(tp, now) {
+				last = denyInfo{economic.SpendReasonProviderContractNeeded, "account terms profile is expired/stale", false}
+				continue
+			}
+			if policy.MaxDataRetentionDays > 0 && tp.DataRetentionDays > policy.MaxDataRetentionDays {
+				last = denyInfo{economic.SpendReasonProviderContractNeeded, "account retention exceeds policy ceiling", false}
+				continue
+			}
+
+			routable, hcode := acct.Routable(now)
+			if !routable {
+				esc := hcode == economic.SpendReasonApprovalRequired
+				last = denyInfo{hcode, "account not routable (health/approval): " + acct.ID, esc}
+				if !esc {
+					continue
+				}
+				out = append(out, newScoredCandidate(prov, modelID, acct, tp, regionMatch, true))
+				continue
+			}
+
+			out = append(out, newScoredCandidate(prov, modelID, acct, tp, regionMatch, false))
+		}
+	}
+
+	return out, last
+}
+
+func newScoredCandidate(prov contracts.ModelProvider, modelID string, acct *modelcatalog.ProviderAccount, tp *economic.ProviderTermsProfile, regionMatch, degraded bool) scoredCandidate {
+	return scoredCandidate{
+		cand: Candidate{
+			ProviderID: prov.ProviderID,
+			ModelID:    modelID,
+			AccountID:  acct.ID,
+		},
+		degraded:    degraded,
+		costPerMTok: prov.CostPerMTok,
+		latencyMS:   prov.Latency95th,
+		retention:   tp.DataRetentionDays,
+		regionMatch: regionMatch,
+	}
+}
+
+func hasAllCapabilities(have, want []string) bool {
+	for _, w := range want {
+		if !containsString(have, w) {
+			return false
+		}
+	}
+	return true
+}
+
+func termsProfileStale(tp *economic.ProviderTermsProfile, now time.Time) bool {
+	if tp == nil {
+		return true
+	}
+	if tp.ExpiresAt != nil && !now.Before(*tp.ExpiresAt) {
+		return true
+	}
+	if tp.EffectiveAt.After(now) {
+		return true
+	}
+	return false
+}

--- a/core/pkg/router/router_test.go
+++ b/core/pkg/router/router_test.go
@@ -1,0 +1,350 @@
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/modelcatalog"
+)
+
+// Provider ids and economics come from contracts.KnownModelProviders():
+//
+//	example:frontier-reasoning  cost 10.0  lat 2500  regions US,EU      MANAGED
+//	example:vision-tool         cost  5.0  lat 2000  regions US,EU,APAC BYOK
+//	example:local-open-weight   cost  0.0  lat 1000  regions LOCAL      SELF_HOSTED
+const (
+	provFrontier = "example:frontier-reasoning"
+	provVision   = "example:vision-tool"
+	provLocal    = "example:local-open-weight"
+)
+
+func knownLikeProvider(id string) contracts.ModelProvider {
+	return contracts.ModelProvider{
+		ProviderID:   id,
+		Name:         id,
+		Capabilities: []string{"TEXT", "CODE"},
+		Regions:      []string{"US", "EU"},
+		RiskTier:     "LOW",
+		MaxTokens:    100000,
+		CostPerMTok:  7.5,
+		Latency95th:  2200,
+		Active:       true,
+	}
+}
+
+// fullEnvelope grants spend authority across all three seeded providers/models.
+func fullEnvelope(t *testing.T) *economic.AgentSpendEnvelope {
+	t.Helper()
+	e := economic.NewAgentSpendEnvelope("env-1", "tenant-1", "agent-1", "principal-1", "budget-1", "USD", economic.SpendPeriodMonthly, 100000, 5000, "sha256:policy")
+	e.AllowedProviders = []string{provFrontier, provVision, provLocal}
+	e.AllowedModels = []string{provFrontier, provVision, provLocal}
+	if err := e.Validate(); err != nil {
+		t.Fatalf("envelope invalid: %v", err)
+	}
+	return e
+}
+
+func newRouter(t *testing.T, now time.Time) *Router {
+	t.Helper()
+	c, err := modelcatalog.DefaultCatalog(now)
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	r, err := New(c)
+	if err != nil {
+		t.Fatalf("New router: %v", err)
+	}
+	return r
+}
+
+func balancedPolicy() *RoutePolicy {
+	return &RoutePolicy{ID: "rp-balanced", Mode: RouteModeBalanced}
+}
+
+// --- Done-gate denial tests ------------------------------------------------
+
+// Forbidden model: the requested model is outside the agent spend envelope.
+func TestDecide_DeniesForbiddenModel(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	e := fullEnvelope(t)
+	e.AllowedModels = []string{provVision} // frontier no longer allowed
+
+	dec := r.Decide(Request{RequestedModelID: provFrontier, Envelope: e}, balancedPolicy(), now)
+	if dec.Verdict != economic.BudgetVerdictDeny || dec.ReasonCode != economic.SpendReasonModelNotAllowed {
+		t.Fatalf("got (%s,%s), want (DENY,ERR_SPEND_MODEL_NOT_ALLOWED): %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+	if dec.RoutePolicyHash == "" {
+		t.Fatal("denial must still carry a route_policy_hash for audit")
+	}
+}
+
+// Forbidden provider: a pinned provider request outside the envelope is denied.
+func TestDecide_DeniesForbiddenProvider(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	e := fullEnvelope(t)
+	e.AllowedProviders = []string{provVision, provLocal} // frontier not allowed
+
+	dec := r.Decide(Request{
+		RequestedModelID:    provFrontier,
+		RequestedProviderID: provFrontier,
+		Envelope:            e,
+	}, balancedPolicy(), now)
+	if dec.Verdict != economic.BudgetVerdictDeny || dec.ReasonCode != economic.SpendReasonProviderNotAllowed {
+		t.Fatalf("got (%s,%s), want (DENY,ERR_SPEND_PROVIDER_NOT_ALLOWED): %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+}
+
+// Stale terms profile: an expired terms profile blocks the route BEFORE dispatch.
+func TestDecide_DeniesStaleTermsProfile(t *testing.T) {
+	now := time.Now().UTC()
+	c, err := modelcatalog.DefaultCatalog(now)
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	// Expire the frontier provider's terms profile in the past.
+	tp, ok := c.TermsProfile("terms:" + provFrontier)
+	if !ok {
+		t.Fatal("seed terms profile missing")
+	}
+	past := now.Add(-time.Hour)
+	tp.ExpiresAt = &past
+
+	r, err := New(c)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Pin to the frontier provider so the stale terms profile is the deciding gate.
+	pol := &RoutePolicy{ID: "rp-pin", Mode: RouteModeProviderPinned, PinnedProviderID: provFrontier}
+	dec := r.Decide(Request{RequestedModelID: provFrontier, RequestedProviderID: provFrontier, Envelope: fullEnvelope(t)}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictDeny || dec.ReasonCode != economic.SpendReasonProviderContractNeeded {
+		t.Fatalf("got (%s,%s), want (DENY,ERR_PROVIDER_CONTRACT_NEEDED): %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+}
+
+// Unhealthy account: an UNHEALTHY account denies before dispatch.
+func TestDecide_DeniesUnhealthyAccount(t *testing.T) {
+	now := time.Now().UTC()
+	c, err := modelcatalog.DefaultCatalog(now)
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	if err := c.SetAccountHealth("acct:"+provFrontier, modelcatalog.AccountHealth{State: modelcatalog.HealthUnhealthy, ObservedAt: now}); err != nil {
+		t.Fatalf("SetAccountHealth: %v", err)
+	}
+	r, err := New(c)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pol := &RoutePolicy{ID: "rp-pin", Mode: RouteModeProviderPinned, PinnedProviderID: provFrontier}
+	dec := r.Decide(Request{RequestedModelID: provFrontier, RequestedProviderID: provFrontier, Envelope: fullEnvelope(t)}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictDeny || dec.ReasonCode != economic.SpendReasonProviderNotAllowed {
+		t.Fatalf("got (%s,%s), want (DENY,ERR_SPEND_PROVIDER_NOT_ALLOWED): %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+}
+
+// Degraded account: maps to ESCALATE, not DENY.
+func TestDecide_EscalatesDegradedAccount(t *testing.T) {
+	now := time.Now().UTC()
+	c, err := modelcatalog.DefaultCatalog(now)
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	if err := c.SetAccountHealth("acct:"+provFrontier, modelcatalog.AccountHealth{State: modelcatalog.HealthDegraded, ObservedAt: now}); err != nil {
+		t.Fatalf("SetAccountHealth: %v", err)
+	}
+	r, err := New(c)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	pol := &RoutePolicy{ID: "rp-pin", Mode: RouteModeProviderPinned, PinnedProviderID: provFrontier}
+	dec := r.Decide(Request{RequestedModelID: provFrontier, RequestedProviderID: provFrontier, Envelope: fullEnvelope(t)}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictEscalate || dec.ReasonCode != economic.SpendReasonApprovalRequired {
+		t.Fatalf("got (%s,%s), want (ESCALATE,ERR_APPROVAL_REQUIRED): %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+}
+
+// New-provider approval: a provider whose account is not approved cannot route.
+// We register a fourth provider with an unapproved account and pin to it.
+func TestDecide_DeniesUnapprovedNewProvider(t *testing.T) {
+	now := time.Now().UTC()
+	c, err := modelcatalog.DefaultCatalog(now)
+	if err != nil {
+		t.Fatalf("DefaultCatalog: %v", err)
+	}
+	const provNew = "example:new-entrant"
+	if err := c.AddProvider(knownLikeProvider(provNew)); err != nil {
+		t.Fatalf("AddProvider: %v", err)
+	}
+	tp := economic.NewProviderTermsProfile("terms:"+provNew, provNew, economic.ProviderAccountManagedOrgAccount, "v1", "legal://new")
+	tp.ContractRef = "contract://new"
+	tp.EffectiveAt = now
+	exp := now.Add(24 * time.Hour)
+	tp.ExpiresAt = &exp
+	if err := c.AddTermsProfile(tp); err != nil {
+		t.Fatalf("AddTermsProfile: %v", err)
+	}
+	acct, err := modelcatalog.NewProviderAccount("acct:"+provNew, provNew, modelcatalog.AccountManaged, "terms:"+provNew, "kcred://new/primary")
+	if err != nil {
+		t.Fatalf("NewProviderAccount: %v", err)
+	}
+	if err := c.AddAccount(acct); err != nil {
+		t.Fatalf("AddAccount: %v", err)
+	}
+	// Deliberately DO NOT approve acct:new-entrant.
+
+	r, err := New(c)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	e := fullEnvelope(t)
+	e.AllowedProviders = append(e.AllowedProviders, provNew)
+	e.AllowedModels = append(e.AllowedModels, provNew)
+	pol := &RoutePolicy{ID: "rp-pin", Mode: RouteModeProviderPinned, PinnedProviderID: provNew}
+	dec := r.Decide(Request{RequestedModelID: provNew, RequestedProviderID: provNew, Envelope: e}, pol, now)
+	if dec.Verdict == economic.BudgetVerdictAllow {
+		t.Fatalf("unapproved new provider must not ALLOW, got %s/%s", dec.Verdict, dec.ReasonCode)
+	}
+	if dec.ReasonCode != economic.SpendReasonApprovalRequired {
+		t.Fatalf("got reason %s, want ERR_APPROVAL_REQUIRED: %s", dec.ReasonCode, dec.Reason)
+	}
+
+	// After approval, the same request succeeds.
+	if err := c.ApproveAccount("acct:" + provNew); err != nil {
+		t.Fatalf("ApproveAccount: %v", err)
+	}
+	if err := c.SetAccountHealth("acct:"+provNew, modelcatalog.AccountHealth{State: modelcatalog.HealthHealthy, ObservedAt: now}); err != nil {
+		t.Fatalf("SetAccountHealth: %v", err)
+	}
+	dec = r.Decide(Request{RequestedModelID: provNew, RequestedProviderID: provNew, Envelope: e}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictAllow {
+		t.Fatalf("approved provider should ALLOW, got %s/%s: %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+}
+
+// --- Happy path + scoring --------------------------------------------------
+
+func TestDecide_AllowsAndSelects(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	dec := r.Decide(Request{RequestedModelID: provVision, RequestedProviderID: provVision, Envelope: fullEnvelope(t)}, balancedPolicy(), now)
+	if dec.Verdict != economic.BudgetVerdictAllow {
+		t.Fatalf("got %s/%s, want ALLOW: %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+	if dec.Selected == nil || dec.Selected.ProviderID != provVision {
+		t.Fatalf("selected = %+v, want provider %s", dec.Selected, provVision)
+	}
+	if dec.RoutePolicyHash == "" {
+		t.Fatal("ALLOW must carry route_policy_hash")
+	}
+}
+
+// cost_first with a concrete model resolves to that provider and must report the
+// cheapest as selected when the model is the cheapest provider.
+func TestDecide_CostFirstSelectsCheapest(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	e := fullEnvelope(t)
+	pol := &RoutePolicy{ID: "rp-cost", Mode: RouteModeCostFirst}
+	dec := r.Decide(Request{RequestedModelID: provLocal, Envelope: e}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictAllow || dec.Selected == nil {
+		t.Fatalf("got %s/%s, want ALLOW with selection: %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+	if dec.Selected.ProviderID != provLocal {
+		t.Fatalf("cost_first selected %s, want %s (cheapest)", dec.Selected.ProviderID, provLocal)
+	}
+}
+
+// Region/retention participate in scoring: a compliance_first policy with a
+// region requirement that only some providers serve must select a region match.
+func TestDecide_RegionParticipatesInScoring(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	e := fullEnvelope(t)
+	// APAC is only served by vision-tool among the seed providers.
+	pol := &RoutePolicy{ID: "rp-region", Mode: RouteModeComplianceFirst, RequiredRegion: "APAC"}
+	dec := r.Decide(Request{RequestedModelID: provVision, Region: "APAC", Envelope: e}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictAllow || dec.Selected == nil {
+		t.Fatalf("got %s/%s, want ALLOW: %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+	if dec.Selected.ProviderID != provVision {
+		t.Fatalf("region scoring selected %s, want %s (only APAC provider)", dec.Selected.ProviderID, provVision)
+	}
+
+	// A region nobody serves denies before dispatch.
+	dec = r.Decide(Request{RequestedModelID: provVision, Region: "ANTARCTICA", Envelope: e}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictDeny {
+		t.Fatalf("unservable region should DENY, got %s/%s", dec.Verdict, dec.ReasonCode)
+	}
+}
+
+// Retention ceiling participates: a policy retention cap below the account's
+// retention denies the route.
+func TestDecide_RetentionCeilingDenies(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	e := fullEnvelope(t)
+	// Seed retention is 30 days; cap at 7 forces a contract-needed denial.
+	pol := &RoutePolicy{ID: "rp-ret", Mode: RouteModeProviderPinned, PinnedProviderID: provVision, MaxDataRetentionDays: 7}
+	dec := r.Decide(Request{RequestedModelID: provVision, RequestedProviderID: provVision, Envelope: e}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictDeny || dec.ReasonCode != economic.SpendReasonProviderContractNeeded {
+		t.Fatalf("got (%s,%s), want (DENY,ERR_PROVIDER_CONTRACT_NEEDED): %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+}
+
+// Pinned mode denies a model mismatch.
+func TestDecide_PinnedModeRejectsMismatch(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	e := fullEnvelope(t)
+	pol := &RoutePolicy{ID: "rp-pinned", Mode: RouteModePinned, PinnedProviderID: provVision, PinnedModelID: provVision}
+	// Request the frontier model under a vision pin: model mismatch -> deny.
+	dec := r.Decide(Request{RequestedModelID: provFrontier, Envelope: e}, pol, now)
+	if dec.Verdict != economic.BudgetVerdictDeny {
+		t.Fatalf("pinned mismatch should DENY, got %s/%s: %s", dec.Verdict, dec.ReasonCode, dec.Reason)
+	}
+}
+
+func TestDecide_InvalidPolicyDenies(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	// pinned mode without pins is structurally invalid.
+	dec := r.Decide(Request{RequestedModelID: provVision, Envelope: fullEnvelope(t)}, &RoutePolicy{ID: "bad", Mode: RouteModePinned}, now)
+	if dec.Verdict != economic.BudgetVerdictDeny || dec.ReasonCode != economic.SpendReasonProviderContractNeeded {
+		t.Fatalf("got (%s,%s), want (DENY,ERR_PROVIDER_CONTRACT_NEEDED)", dec.Verdict, dec.ReasonCode)
+	}
+}
+
+func TestDecide_DeterministicSelection(t *testing.T) {
+	now := time.Now().UTC()
+	r := newRouter(t, now)
+	e := fullEnvelope(t)
+	pol := balancedPolicy()
+	first := r.Decide(Request{RequestedModelID: provVision, RequestedProviderID: provVision, Envelope: e}, pol, now)
+	if first.Selected == nil {
+		t.Fatalf("expected a selection, got %s/%s: %s", first.Verdict, first.ReasonCode, first.Reason)
+	}
+	for i := 0; i < 5; i++ {
+		again := r.Decide(Request{RequestedModelID: provVision, RequestedProviderID: provVision, Envelope: e}, pol, now)
+		if again.Selected == nil || again.Selected.AccountID != first.Selected.AccountID || again.RoutePolicyHash != first.RoutePolicyHash {
+			t.Fatalf("non-deterministic route: %+v vs %+v", again.Selected, first.Selected)
+		}
+	}
+}
+
+func TestRouteModes_CountAndPolicyHashStability(t *testing.T) {
+	if len(RouteModes()) != 9 {
+		t.Fatalf("want 9 route modes, got %d", len(RouteModes()))
+	}
+	p := &RoutePolicy{ID: "rp", Mode: RouteModeBalanced}
+	if p.Hash() != p.Hash() {
+		t.Fatal("policy hash must be stable")
+	}
+	q := &RoutePolicy{ID: "rp", Mode: RouteModeCostFirst}
+	if p.Hash() == q.Hash() {
+		t.Fatal("policies with different modes must hash differently")
+	}
+}

--- a/core/pkg/router/scoring.go
+++ b/core/pkg/router/scoring.go
@@ -1,0 +1,136 @@
+package router
+
+// scoreCandidates assigns each candidate a 0..1 score according to the policy
+// mode and mutates cand.Score in place. Higher is better.
+//
+// Single-dimension modes optimize one axis; RouteModeBalanced and
+// RouteModeComplianceFirst blend axes so that region match and data retention
+// genuinely participate in selection — not just cost and latency. A degraded
+// candidate keeps its score (so it can still be surfaced) but the caller maps a
+// degraded winner to ESCALATE.
+func (r *Router) scoreCandidates(cands []scoredCandidate, policy *RoutePolicy) {
+	minCost, maxCost := costRange(cands)
+	minLat, maxLat := latencyRange(cands)
+	minRet, maxRet := retentionRange(cands)
+
+	for i := range cands {
+		c := &cands[i]
+		costScore := invNorm(c.costPerMTok, minCost, maxCost)     // cheaper -> higher
+		latScore := invNorm(float64(c.latencyMS), minLat, maxLat) // faster -> higher
+		retScore := invNorm(float64(c.retention), minRet, maxRet) // less retention -> higher
+		regionScore := 0.0
+		if c.regionMatch {
+			regionScore = 1.0
+		}
+		// Quality is modeled from cost when no explicit quality signal exists: a
+		// costlier frontier model is treated as higher quality. This keeps
+		// quality_first meaningfully different from cost_first.
+		qualScore := norm(c.costPerMTok, minCost, maxCost)
+
+		switch policy.Mode {
+		case RouteModeCostFirst:
+			c.cand.Score = costScore
+		case RouteModeLatencyFirst:
+			c.cand.Score = latScore
+		case RouteModeQualityFirst:
+			c.cand.Score = qualScore
+		case RouteModeComplianceFirst:
+			// Compliance posture: retention (lower is better) and region match
+			// dominate; cost breaks ties.
+			c.cand.Score = 0.5*retScore + 0.4*regionScore + 0.1*costScore
+		case RouteModeRegionPinned:
+			// Region already gated; prefer cheaper within region.
+			c.cand.Score = 0.7*regionScore + 0.3*costScore
+		case RouteModePinned, RouteModeProviderPinned, RouteModeModelPinned:
+			// Candidate set is already pinned; pick cheapest deterministically.
+			c.cand.Score = costScore
+		case RouteModeBalanced:
+			w := policy.effectiveWeights()
+			total := w.Cost + w.Latency + w.Quality + w.Region + w.Retention
+			if total <= 0 {
+				total = 1
+			}
+			c.cand.Score = (w.Cost*costScore +
+				w.Latency*latScore +
+				w.Quality*qualScore +
+				w.Region*regionScore +
+				w.Retention*retScore) / total
+		default:
+			c.cand.Score = costScore
+		}
+	}
+}
+
+// norm maps v into 0..1 within [min,max]; higher v -> higher score.
+func norm(v, min, max float64) float64 {
+	if max <= min {
+		return 1.0
+	}
+	s := (v - min) / (max - min)
+	return clamp01(s)
+}
+
+// invNorm maps v into 0..1 within [min,max]; lower v -> higher score.
+func invNorm(v, min, max float64) float64 {
+	return 1.0 - norm(v, min, max)
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+func costRange(cands []scoredCandidate) (float64, float64) {
+	if len(cands) == 0 {
+		return 0, 0
+	}
+	min, max := cands[0].costPerMTok, cands[0].costPerMTok
+	for _, c := range cands[1:] {
+		if c.costPerMTok < min {
+			min = c.costPerMTok
+		}
+		if c.costPerMTok > max {
+			max = c.costPerMTok
+		}
+	}
+	return min, max
+}
+
+func latencyRange(cands []scoredCandidate) (float64, float64) {
+	if len(cands) == 0 {
+		return 0, 0
+	}
+	min, max := float64(cands[0].latencyMS), float64(cands[0].latencyMS)
+	for _, c := range cands[1:] {
+		v := float64(c.latencyMS)
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return min, max
+}
+
+func retentionRange(cands []scoredCandidate) (float64, float64) {
+	if len(cands) == 0 {
+		return 0, 0
+	}
+	min, max := float64(cands[0].retention), float64(cands[0].retention)
+	for _, c := range cands[1:] {
+		v := float64(c.retention)
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	return min, max
+}


### PR DESCRIPTION
## MIN-469 — [SPEND4] Provider catalog, terms profiles, BYOK/managed/partner/self-hosted accounts, route policies

Makes provider routing **explicit, contract-aware, and auditable before any multi-provider spend claim**. Two new kernel-owned packages build on the existing `contracts/economic` spend-authority surface (`ProviderTermsProfile`, `AgentSpendEnvelope`, `RouteQuote`, `BudgetVerdictReceipt`, `SpendReasonCode`) and the existing `contracts` model-routing types (`ModelProvider`). No protobuf, OpenAPI, or json-schema surface is touched, so no contract sync is required.

### What's implemented

**`core/pkg/modelcatalog/`** — provider catalog, account records, health views
- `ProviderAccount` records spanning all four account modes: `MANAGED`, `BYOK`, `PARTNER`, `SELF_HOSTED`.
- **Credential boundary (kernel invariant):** an account carries an opaque `CredentialRef` (e.g. `kcred://tenant/provider/primary`) — never a secret. Construction rejects inline-secret-shaped values (`sk-`, `ghp_`, `AKIA…`, long opaque blobs, etc.). No API returns secret material. Agents receive spend authority via the envelope, never provider-key authority.
- `AccountHealth` views (`HEALTHY` / `DEGRADED` / `UNHEALTHY` / `UNKNOWN`), fail-closed: unknown or stale (probe older than `MaxHealthAge`) is not routable.
- `Catalog` binds capability records + `ProviderTermsProfile` (resale/retention/region/contract refs) + accounts; enforces an **explicit new-provider approval gate** (`ApproveAccount`) before any account can route.
- `DefaultCatalog` seeds **≥3 provider-neutral providers** (no current-provider claims).

**`core/pkg/router/`** — contract-aware route policy + scoring + fail-closed verdict
- `RoutePolicy` with all **nine route modes**: `pinned`, `cost_first`, `latency_first`, `quality_first`, `balanced`, `compliance_first`, `region_pinned`, `provider_pinned`, `model_pinned`.
- Canonical **`RoutePolicyHash`** (JCS/RFC 8785 + SHA-256) — fills the previously dangling `route_policy_hash` that `RouteQuote`/`BudgetVerdictReceipt` already require, so a dispatch audits back to the exact authorizing policy.
- `Decide()` is fail-closed and ordered so the agent spend-envelope allow-list gates **before any catalog/credential access**:
  - forbidden provider / forbidden model → **DENY**;
  - stale or invalid terms profile → **DENY before dispatch** (`ERR_PROVIDER_CONTRACT_NEEDED`);
  - unhealthy account → **DENY**; degraded account → **ESCALATE**;
  - **region and retention participate in scoring** (not just cost/latency), with hard region/retention ceilings.

### Acceptance criteria mapping
- Provider creds never exposed to agents — credential-boundary validator + serialization test.
- Terms profile blocks a route before dispatch — `TestDecide_DeniesStaleTermsProfile`, retention-ceiling test.
- Unhealthy account → DENY/ESCALATE — `TestDecide_DeniesUnhealthyAccount`, `TestDecide_EscalatesDegradedAccount`.
- Region/retention participate in route scoring — `TestDecide_RegionParticipatesInScoring`, `TestDecide_RetentionCeilingDenies`.
- ≥3 providers in catalog — `TestDefaultCatalog_HasAtLeastThreeProviders`.

### Done gate (denial/failure tests)
forbidden provider, forbidden model, stale terms profile, unhealthy account, new-provider approval — all present and passing, plus creds-never-exposed and deterministic-selection.

### Gate + boundary results
- **Build:** `make build` — PASS; `go build ./...` (core) — PASS.
- **Test:** `go test -race ./core/pkg/{modelcatalog,router}` — PASS (21 test funcs); full `make test` — PASS (253 ok / 0 fail).
- **Lint:** `make lint` (docs-coverage, docs-truth, `go vet ./...`, gofmt) — PASS.
- **Boundary:** N/A — no `.proto`/OpenAPI/json-schema changes; new leaf packages consume existing contracts only. RLM not used. No parallel proof universe introduced.

### What remains (follow-ups, out of scope here)
- Wire `router.Decide` into the LIG gateway dispatch path so `RoutePolicyHash`/selected account flow into `NewRouteQuote` / `NewBudgetVerdictReceipt` end to end.
- Persistent catalog/account store + live health probes (current catalog is in-memory).
- Per-model capability granularity (the seed models provider==model identity).

Refs MIN-469. Draft — no merge/deploy (Phase-0 freeze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)