### PR TITLE
[DEMO-FINANCE] Payment above limit routes to approval

### DIFF
--- a/core/cmd/helm-ai-kernel/demo_cmd.go
+++ b/core/cmd/helm-ai-kernel/demo_cmd.go
@@ -28,11 +28,12 @@ import (
 //	2 = config error
 func runDemoCmd(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "Usage: helm-ai-kernel demo <organization|research-lab|mcp> [flags]")
+		fmt.Fprintln(stderr, "Usage: helm-ai-kernel demo <organization|research-lab|finance|mcp> [flags]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Subcommands:")
 		fmt.Fprintln(stderr, "  organization  Run the canonical starter organization demo")
 		fmt.Fprintln(stderr, "  research-lab  Run a research-lab reference scenario")
+		fmt.Fprintln(stderr, "  finance       Run the finance payment-approval escalation demo")
 		fmt.Fprintln(stderr, "  mcp           Run the MCP governance proof scenarios")
 		return 2
 	}
@@ -42,14 +43,17 @@ func runDemoCmd(args []string, stdout, stderr io.Writer) int {
 		return runDemoScenario("organization", args[1:], stdout, stderr)
 	case "research-lab":
 		return runDemoScenario("research-lab", args[1:], stdout, stderr)
+	case "finance":
+		return runDemoFinance(args[1:], stdout, stderr)
 	case "mcp":
 		return runMCPProof(args[1:], stdout, stderr)
 	case "--help", "-h":
-		fmt.Fprintln(stdout, "Usage: helm-ai-kernel demo <organization|research-lab|mcp> [flags]")
+		fmt.Fprintln(stdout, "Usage: helm-ai-kernel demo <organization|research-lab|finance|mcp> [flags]")
 		fmt.Fprintln(stdout, "")
 		fmt.Fprintln(stdout, "Subcommands:")
 		fmt.Fprintln(stdout, "  organization  Run the canonical starter organization demo")
 		fmt.Fprintln(stdout, "  research-lab  Run a research-lab reference scenario")
+		fmt.Fprintln(stdout, "  finance       Run the finance payment-approval escalation demo")
 		fmt.Fprintln(stdout, "  mcp           Run the MCP governance proof scenarios")
 		return 0
 	default:

--- a/core/cmd/helm-ai-kernel/demo_finance_cmd.go
+++ b/core/cmd/helm-ai-kernel/demo_finance_cmd.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
+	evidencepkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidencepack"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/financedemo"
+)
+
+// financeDemoPolicyID is the policy identity bound into the finance demo's
+// EvidencePack manifest.
+const financeDemoPolicyID = "finance.payments.approval"
+
+// runDemoFinance implements `helm-ai-kernel demo finance` — a deterministic,
+// scripted proof that a payment above a policy limit is escalated for approval
+// before it can execute. It performs NO real payment: the connector/action
+// boundary is stubbed and every execution receipt is marked simulated
+// (risk:r3-external-effect).
+//
+// Exit codes: 0 success, 1 verification failure, 2 config error.
+func runDemoFinance(args []string, stdout, stderr io.Writer) int {
+	cmd := flag.NewFlagSet("demo finance", flag.ContinueOnError)
+	cmd.SetOutput(stderr)
+	var (
+		outDir       string
+		limitDollars int64
+		payDollars   int64
+		jsonOut      bool
+	)
+	cmd.StringVar(&outDir, "out", "data/evidence-finance", "Output directory for the EvidencePack")
+	cmd.Int64Var(&limitDollars, "limit", 10000, "Approval threshold in whole dollars")
+	cmd.Int64Var(&payDollars, "amount", 42500, "Payment amount in whole dollars (above limit triggers escalation)")
+	cmd.BoolVar(&jsonOut, "json", false, "Emit the scenario result as JSON instead of the narrative")
+	if err := cmd.Parse(args); err != nil {
+		return 2
+	}
+
+	res, err := financedemo.RunScenario(financedemo.ScenarioInput{
+		LimitCents:   limitDollars * 100,
+		PaymentCents: payDollars * 100,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: finance scenario failed: %v\n", err)
+		return 2
+	}
+	if err := res.VerifyChain(); err != nil {
+		fmt.Fprintf(stderr, "Error: receipt chain verification failed: %v\n", err)
+		return 1
+	}
+
+	if jsonOut {
+		data, err := json.MarshalIndent(res, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: %v\n", err)
+			return 2
+		}
+		fmt.Fprintln(stdout, string(data))
+		return 0
+	}
+
+	printFinanceNarrative(stdout, res)
+
+	fmt.Fprintf(stdout, "\n%sExporting EvidencePack...%s\n", ColorBold, ColorReset)
+	if err := writeFinanceEvidencePack(outDir, res); err != nil {
+		fmt.Fprintf(stderr, "Error sealing EvidencePack: %v\n", err)
+		return 2
+	}
+	fmt.Fprintf(stdout, "  📦 %d receipts → %s/\n", len(res.Receipts), outDir)
+	fmt.Fprintf(stdout, "  🔏 Sealed (dev-local) → %s/%s\n", outDir, evidencepkg.EvidencePackSealPath)
+	fmt.Fprintf(stdout, "  🔍 Verify: helm-ai-kernel verify %s\n", outDir)
+
+	fmt.Fprintf(stdout, "\n%s🎉 Finance demo complete.%s Payment above limit escalated, approved, then executed (simulated).\n", ColorBold+ColorGreen, ColorReset)
+	return 0
+}
+
+func printFinanceNarrative(stdout io.Writer, res *financedemo.ScenarioResult) {
+	p := res.Policy
+	instr := res.Instruction
+	fmt.Fprintf(stdout, "\n%s💳 HELM Demo: Finance Payment Approval%s\n", ColorBold+ColorBlue, ColorReset)
+	fmt.Fprintf(stdout, "%s   Scenario: vendor payment above policy limit routes to CFO/Finance approval%s\n", ColorGray, ColorReset)
+	fmt.Fprintf(stdout, "%s   Mode: deterministic scripted smoke (no real payment; connector stubbed)%s\n\n", ColorYellow, ColorReset)
+
+	fmt.Fprintf(stdout, "%sThreshold policy:%s %s\n", ColorBold, ColorReset, p.PolicyID)
+	fmt.Fprintf(stdout, "  • Limit:    $%s above which approval is required\n", dollars(p.ApprovalRequiredAboveCents))
+	fmt.Fprintf(stdout, "  • Approval: quorum %d of %v\n", p.ApprovalQuorum, p.RequiredApprovers)
+	fmt.Fprintf(stdout, "  • Hash:     %s\n\n", p.PolicyHash)
+
+	fmt.Fprintf(stdout, "%sConnector/action context:%s\n", ColorBold, ColorReset)
+	fmt.Fprintf(stdout, "  • Connector: %s  Action: %s\n", instr.ConnectorID, instr.Action)
+	fmt.Fprintf(stdout, "  • Vendor:    %s  Invoice: %s\n", instr.Vendor, instr.InvoiceRef)
+	fmt.Fprintf(stdout, "  • Amount:    $%s %s\n\n", dollars(instr.AmountCents), instr.Currency)
+
+	for _, r := range res.Receipts {
+		icon, color := "✅", ColorGreen
+		switch r.Verdict {
+		case "ESCALATE":
+			icon, color = "⛔", ColorYellow
+		case "PENDING":
+			icon, color = "⏳", ColorYellow
+		case "DENY":
+			icon, color = "❌", ColorRed
+		}
+		fmt.Fprintf(stdout, "  %s %s[%s]%s %s → %s%s%s %s(%s, L=%d)%s\n",
+			icon, color, r.Verdict, ColorReset,
+			r.Principal, ColorBold, r.Action, ColorReset,
+			ColorGray, r.ReasonCode, r.Lamport, ColorReset)
+	}
+
+	fmt.Fprintf(stdout, "\n%sHuman approval result:%s state=%s ceremony_hash=%s\n", ColorBold, ColorReset, res.Ceremony.State, res.Ceremony.CeremonyHash)
+	fmt.Fprintf(stdout, "%sExecution receipt:%s simulated=%t hash=%s\n", ColorBold, ColorReset, res.ExecutionReceipt.Simulated, res.ExecutionReceipt.ContentHash)
+	fmt.Fprintf(stdout, "%sProof chain:%s %d receipts, root=%s\n", ColorBold, ColorReset, len(res.Receipts), res.RootHash)
+}
+
+func dollars(cents int64) string {
+	return fmt.Sprintf("%d.%02d", cents/100, cents%100)
+}
+
+// writeFinanceEvidencePack seals a canonical, dev-local EvidencePack under
+// outDir so that `helm-ai-kernel verify <outDir>` accepts it. It mirrors the
+// organization demo's §3.1 layout: receipts under 02_PROOFGRAPH/receipts/, a
+// canonical manifest, 01_SCORE.json, 00_INDEX.json, then an in-place dev-local
+// seal. All timestamps are the deterministic finance demo clock.
+func writeFinanceEvidencePack(outDir string, res *financedemo.ScenarioResult) error {
+	if len(res.Receipts) == 0 {
+		return fmt.Errorf("no receipts to seal")
+	}
+	if err := conform.CreateEvidencePackDirs(outDir); err != nil {
+		return err
+	}
+
+	packID := "demo-finance"
+	builder := evidencepack.NewBuilder(packID, res.Policy.TenantID, res.Instruction.PaymentID, financeDemoPolicyID).
+		WithCreatedAt(financedemo.FixedClock())
+	for i, r := range res.Receipts {
+		if err := builder.AddReceipt(fmt.Sprintf("%03d_%s", i+1, r.ReceiptID), r); err != nil {
+			return err
+		}
+	}
+	// Bind the threshold policy, approval ceremony, and execution receipt into
+	// the pack so a verifier sees every acceptance artifact, not just the chain.
+	if err := builder.AddPolicyDecision("payment_policy", res.Policy); err != nil {
+		return err
+	}
+	if err := builder.AddPolicyDecision("approval_ceremony", res.Ceremony); err != nil {
+		return err
+	}
+	if err := builder.AddReceipt("execution_receipt", res.ExecutionReceipt); err != nil {
+		return err
+	}
+	manifest, _, err := builder.Build()
+	if err != nil {
+		return err
+	}
+	manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "04_EXPORTS", "evidence_manifest.json"), append(manifestJSON, '\n'), 0o600); err != nil {
+		return err
+	}
+
+	receiptsDir := filepath.Join(outDir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		return err
+	}
+	for i, r := range res.Receipts {
+		data, err := json.MarshalIndent(r, "", "  ")
+		if err != nil {
+			return err
+		}
+		fname := fmt.Sprintf("%03d_%s.json", i+1, r.ReceiptID)
+		if err := os.WriteFile(filepath.Join(receiptsDir, fname), append(data, '\n'), 0o600); err != nil {
+			return err
+		}
+	}
+
+	proofGraph := map[string]any{
+		"version":         "1.0.0",
+		"pack_id":         packID,
+		"scenario":        "finance-payment-approval",
+		"tenant_id":       res.Policy.TenantID,
+		"payment_id":      res.Instruction.PaymentID,
+		"receipt_count":   len(res.Receipts),
+		"lamport_final":   res.LamportFinal,
+		"root_hash":       res.RootHash,
+		"topo_order_rule": "lamport_monotonic",
+		"manifest_hash":   manifest.ManifestHash,
+		"entries_root":    manifest.EntriesMerkleRoot,
+		"policy_hash":     res.Policy.PolicyHash,
+		"ceremony_hash":   res.Ceremony.CeremonyHash,
+		"execution_hash":  res.ExecutionReceipt.ContentHash,
+		"pre_verdict":     string(res.PreApprovalVerdict.Verdict),
+	}
+	proofGraphJSON, err := json.MarshalIndent(proofGraph, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, "02_PROOFGRAPH", "proofgraph.json"), append(proofGraphJSON, '\n'), 0o600); err != nil {
+		return err
+	}
+
+	score := map[string]any{
+		"pass":           true,
+		"run_id":         packID,
+		"scope":          "demo-finance",
+		"receipt_count":  len(res.Receipts),
+		"escalate_path":  "pre-execution",
+		"effect":         "simulated",
+		"tenant_id":      res.Policy.TenantID,
+		"payment_id":     res.Instruction.PaymentID,
+		"pre_verdict":    string(res.PreApprovalVerdict.Verdict),
+		"approval_state": string(res.Ceremony.State),
+	}
+	scoreJSON, err := json.MarshalIndent(score, "", "  ")
+	if err != nil {
+		return err
+	}
+	scoreJSON = append(scoreJSON, '\n')
+	if err := os.WriteFile(filepath.Join(outDir, "01_SCORE.json"), scoreJSON, 0o600); err != nil {
+		return err
+	}
+	scoreSum := sha256.Sum256(scoreJSON)
+	if err := os.WriteFile(filepath.Join(outDir, "01_SCORE.json.sha256"), []byte(hex.EncodeToString(scoreSum[:])+"\n"), 0o600); err != nil {
+		return err
+	}
+
+	if err := writeFinanceEvidenceIndex(outDir, packID); err != nil {
+		return err
+	}
+
+	if _, err := evidencepkg.SealEvidencePack(context.Background(), outDir, evidencepkg.SealEvidencePackOptions{
+		PackID:   packID,
+		Profile:  evidencepkg.EvidenceTrustProfileDevLocal,
+		SignedAt: financedemo.FixedClock(),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeFinanceEvidenceIndex walks the pack directory and writes 00_INDEX.json,
+// mirroring the conform engine's index format. Entries are sorted by path for
+// deterministic output.
+func writeFinanceEvidenceIndex(outDir, runID string) error {
+	type indexEntry struct {
+		Path        string `json:"path"`
+		SHA256      string `json:"sha256"`
+		SizeBytes   int64  `json:"size_bytes"`
+		ContentType string `json:"content_type"`
+	}
+	var entries []indexEntry
+	err := filepath.Walk(outDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(outDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "00_INDEX.json" || rel == evidencepkg.EvidencePackSealPath {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(data)
+		ct := "application/json"
+		if filepath.Ext(rel) != ".json" {
+			ct = "text/plain"
+		}
+		entries = append(entries, indexEntry{
+			Path:        rel,
+			SHA256:      hex.EncodeToString(sum[:]),
+			SizeBytes:   info.Size(),
+			ContentType: ct,
+		})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	index := map[string]any{
+		"run_id":          runID,
+		"profile":         string(conform.ProfileCore),
+		"created_at":      financedemo.FixedClock(),
+		"topo_order_rule": "lamport_monotonic",
+		"entries":         entries,
+	}
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outDir, "00_INDEX.json"), append(data, '\n'), 0o600)
+}

--- a/core/cmd/helm-ai-kernel/demo_finance_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/demo_finance_cmd_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/financedemo"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/verifier"
+)
+
+// TestDemoFinance_EscalatesAndSealsVerifiablePack runs the deterministic finance
+// demo end to end: an above-limit payment must escalate before execution, the
+// effect must be simulated, and the EvidencePack must seal and verify offline.
+func TestDemoFinance_EscalatesAndSealsVerifiablePack(t *testing.T) {
+	out := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := runDemoFinance([]string{"--out", out}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("demo finance failed with code %d: stderr=%s", code, stderr.String())
+	}
+
+	report, err := verifier.VerifyBundle(out)
+	if err != nil {
+		t.Fatalf("VerifyBundle returned error: %v", err)
+	}
+	if !report.Verified {
+		for _, c := range report.Checks {
+			if !c.Pass {
+				t.Logf("FAILED check %s: %s", c.Name, c.Reason)
+			}
+		}
+		t.Fatalf("finance demo pack did not verify: %s", report.Summary)
+	}
+	if report.SealState != "valid" {
+		t.Errorf("seal state = %q, want valid", report.SealState)
+	}
+	if report.SignatureValidCount < 1 {
+		t.Errorf("signature_valid_count = %d, want >= 1", report.SignatureValidCount)
+	}
+
+	// The proofgraph must exist alongside the sealed receipts.
+	if _, err := filepath.Glob(filepath.Join(out, "02_PROOFGRAPH", "receipts", "*.json")); err != nil {
+		t.Fatalf("glob receipts: %v", err)
+	}
+}
+
+// TestDemoFinance_JSONShowsEscalateBeforeExecute asserts the proof log records
+// the ESCALATE verdict and that approval precedes a simulated execution.
+func TestDemoFinance_JSONShowsEscalateBeforeExecute(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runDemoFinance([]string{"--json"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("demo finance --json failed with code %d: stderr=%s", code, stderr.String())
+	}
+
+	var res financedemo.ScenarioResult
+	if err := json.Unmarshal(stdout.Bytes(), &res); err != nil {
+		t.Fatalf("demo finance --json output is not valid ScenarioResult JSON: %v", err)
+	}
+	if string(res.PreApprovalVerdict.Verdict) != "ESCALATE" {
+		t.Errorf("pre-approval verdict should be ESCALATE, got %s", res.PreApprovalVerdict.Verdict)
+	}
+	if res.Ceremony == nil || string(res.Ceremony.State) != "approved" {
+		t.Errorf("ceremony should be approved")
+	}
+	if res.ExecutionReceipt == nil || !res.ExecutionReceipt.Simulated {
+		t.Errorf("execution receipt must be simulated (no real payment)")
+	}
+	if res.ExecutionReceipt != nil && res.ExecutionReceipt.ApprovalCeremonyHash == "" {
+		t.Errorf("execution receipt must bind the approval ceremony hash")
+	}
+}
+
+// TestDemoFinance_AmountBelowLimitFailsScenario confirms the demo is the
+// above-limit path: an amount below the configured limit is a config error
+// because the scenario asserts ESCALATE.
+func TestDemoFinance_AmountBelowLimitFailsScenario(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runDemoFinance([]string{"--limit", "10000", "--amount", "500", "--json"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("below-limit amount should be a config error (exit 2), got %d: %s", code, stderr.String())
+	}
+}

--- a/core/pkg/financedemo/connector.go
+++ b/core/pkg/financedemo/connector.go
@@ -1,0 +1,273 @@
+package financedemo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// PaymentInstruction is the connector/action context for one payment: which
+// connector and action would move funds, to whom, and how much. It is the
+// stubbed boundary's input. No field carries a live credential or endpoint —
+// the demo never reaches a real payment rail.
+type PaymentInstruction struct {
+	PaymentID       string `json:"payment_id"`
+	TenantID        string `json:"tenant_id"`
+	ConnectorID     string `json:"connector_id"`
+	Action          string `json:"action"`
+	Vendor          string `json:"vendor"`
+	InvoiceRef      string `json:"invoice_ref"`
+	AmountCents     int64  `json:"amount_cents"`
+	Currency        string `json:"currency"`
+	RequestedBy     string `json:"requested_by"`
+	InstructionHash string `json:"instruction_hash"`
+}
+
+// NewPaymentInstruction builds a payment instruction and seals its hash.
+func NewPaymentInstruction(paymentID, tenantID, connectorID, action, vendor, invoiceRef string, amountCents int64, currency, requestedBy string) *PaymentInstruction {
+	p := &PaymentInstruction{
+		PaymentID:   paymentID,
+		TenantID:    tenantID,
+		ConnectorID: connectorID,
+		Action:      action,
+		Vendor:      vendor,
+		InvoiceRef:  invoiceRef,
+		AmountCents: amountCents,
+		Currency:    currency,
+		RequestedBy: requestedBy,
+	}
+	p.InstructionHash = p.computeHash()
+	return p
+}
+
+// Validate ensures the instruction is well-formed before any boundary decision.
+func (p *PaymentInstruction) Validate() error {
+	if p == nil {
+		return errors.New("payment_instruction: instruction is nil")
+	}
+	if p.PaymentID == "" {
+		return errors.New("payment_instruction: payment_id is required")
+	}
+	if p.TenantID == "" {
+		return errors.New("payment_instruction: tenant_id is required")
+	}
+	if p.ConnectorID == "" {
+		return errors.New("payment_instruction: connector_id is required")
+	}
+	if p.Action == "" {
+		return errors.New("payment_instruction: action is required")
+	}
+	if p.Vendor == "" {
+		return errors.New("payment_instruction: vendor is required")
+	}
+	if p.AmountCents <= 0 {
+		return errors.New("payment_instruction: amount_cents must be positive")
+	}
+	if p.Currency == "" {
+		return errors.New("payment_instruction: currency is required")
+	}
+	if p.RequestedBy == "" {
+		return errors.New("payment_instruction: requested_by is required")
+	}
+	return nil
+}
+
+func (p *PaymentInstruction) computeHash() string {
+	return hashCanonical(struct {
+		PaymentID   string `json:"payment_id"`
+		TenantID    string `json:"tenant_id"`
+		ConnectorID string `json:"connector_id"`
+		Action      string `json:"action"`
+		Vendor      string `json:"vendor"`
+		InvoiceRef  string `json:"invoice_ref"`
+		AmountCents int64  `json:"amount_cents"`
+		Currency    string `json:"currency"`
+		RequestedBy string `json:"requested_by"`
+	}{p.PaymentID, p.TenantID, p.ConnectorID, p.Action, p.Vendor, p.InvoiceRef, p.AmountCents, p.Currency, p.RequestedBy})
+}
+
+// PaymentExecutionReceipt is the content-addressed proof that the stubbed
+// connector executed (or, for the demo's safety, *simulated*) the payment. It
+// binds the instruction, the authorizing ceremony, and the pre-execution
+// verdict so a verifier can prove the effect only happened after approval.
+type PaymentExecutionReceipt struct {
+	ReceiptID            string               `json:"receipt_id"`
+	PaymentID            string               `json:"payment_id"`
+	TenantID             string               `json:"tenant_id"`
+	ConnectorID          string               `json:"connector_id"`
+	Action               string               `json:"action"`
+	AmountCents          int64                `json:"amount_cents"`
+	Currency             string               `json:"currency"`
+	Verdict              contracts.Verdict    `json:"verdict"`
+	ReasonCode           contracts.ReasonCode `json:"reason_code"`
+	Simulated            bool                 `json:"simulated"`
+	InstructionHash      string               `json:"instruction_hash"`
+	DecisionHash         string               `json:"decision_hash"`
+	ApprovalCeremonyHash string               `json:"approval_ceremony_hash"`
+	ExecutedAt           time.Time            `json:"executed_at"`
+	ContentHash          string               `json:"content_hash"`
+}
+
+func (r *PaymentExecutionReceipt) computeHash() string {
+	return hashCanonical(struct {
+		ReceiptID            string               `json:"receipt_id"`
+		PaymentID            string               `json:"payment_id"`
+		TenantID             string               `json:"tenant_id"`
+		ConnectorID          string               `json:"connector_id"`
+		Action               string               `json:"action"`
+		AmountCents          int64                `json:"amount_cents"`
+		Currency             string               `json:"currency"`
+		Verdict              contracts.Verdict    `json:"verdict"`
+		ReasonCode           contracts.ReasonCode `json:"reason_code"`
+		Simulated            bool                 `json:"simulated"`
+		InstructionHash      string               `json:"instruction_hash"`
+		DecisionHash         string               `json:"decision_hash"`
+		ApprovalCeremonyHash string               `json:"approval_ceremony_hash"`
+	}{r.ReceiptID, r.PaymentID, r.TenantID, r.ConnectorID, r.Action, r.AmountCents, r.Currency, r.Verdict, r.ReasonCode, r.Simulated, r.InstructionHash, r.DecisionHash, r.ApprovalCeremonyHash})
+}
+
+// StubPaymentConnector is the fail-closed, side-effect-free payment boundary.
+//
+// It NEVER contacts a real payment rail. risk:r3-external-effect is honored by
+// construction: Execute returns a *simulated* receipt and refuses entirely
+// unless a sealed, approved approval ceremony authorizes the instruction.
+type StubPaymentConnector struct {
+	// now is injectable so execution receipts are deterministic in tests/demo.
+	now func() time.Time
+}
+
+// NewStubPaymentConnector returns a connector with the given clock. A nil clock
+// defaults to the wall clock.
+func NewStubPaymentConnector(now func() time.Time) *StubPaymentConnector {
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	return &StubPaymentConnector{now: now}
+}
+
+// Execute is the connector/action boundary. It is the security-critical gate:
+//
+//   - it requires a pre-execution verdict that already cleared approval (ALLOW),
+//   - for any escalated payment it requires a sealed approval ceremony whose
+//     state is approved AND whose distinct approvers meet the policy quorum,
+//   - it performs NO real effect (Simulated is always true).
+//
+// Any missing or non-approved authorization fails closed with an error and no
+// receipt — the boundary cannot be tricked into moving funds without approval.
+func (c *StubPaymentConnector) Execute(instr *PaymentInstruction, decision PaymentVerdict, policy *PaymentApprovalPolicy, ceremony *contracts.ApprovalCeremony) (*PaymentExecutionReceipt, error) {
+	if err := instr.Validate(); err != nil {
+		return nil, err
+	}
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+	if decision.Verdict != contracts.VerdictAllow {
+		return nil, fmt.Errorf("stub_payment_connector: refusing to execute payment %s: pre-execution verdict is %s/%s, not ALLOW", instr.PaymentID, decision.Verdict, decision.ReasonCode)
+	}
+	if decision.AmountCents != instr.AmountCents {
+		return nil, errors.New("stub_payment_connector: decision amount does not match instruction amount")
+	}
+
+	ceremonyHash := ""
+	// A payment that the policy says needs approval can only execute behind a
+	// satisfied ceremony. A within-limit payment may execute without one.
+	if policy.RequiresApproval(instr.AmountCents) {
+		if err := approvalSatisfiesPolicy(ceremony, policy, instr); err != nil {
+			return nil, err
+		}
+		ceremonyHash = ceremony.CeremonyHash
+	}
+
+	receipt := &PaymentExecutionReceipt{
+		ReceiptID:            "pay-rcpt-" + shortHash(instr.InstructionHash),
+		PaymentID:            instr.PaymentID,
+		TenantID:             instr.TenantID,
+		ConnectorID:          instr.ConnectorID,
+		Action:               instr.Action,
+		AmountCents:          instr.AmountCents,
+		Currency:             instr.Currency,
+		Verdict:              contracts.VerdictAllow,
+		ReasonCode:           decision.ReasonCode,
+		Simulated:            true, // r3: never a real effect.
+		InstructionHash:      instr.InstructionHash,
+		DecisionHash:         decision.DecisionHash,
+		ApprovalCeremonyHash: ceremonyHash,
+		ExecutedAt:           c.now(),
+	}
+	receipt.ContentHash = receipt.computeHash()
+	return receipt, nil
+}
+
+// approvalSatisfiesPolicy enforces the dual-control + quorum invariant that
+// authorizes an above-limit payment. It mirrors the SPEND5 correctionApproved
+// rule (sealed, approved, approver distinct from requester) and additionally
+// requires the configured quorum of policy-recognized approvers and that the
+// ceremony actually binds this payment instruction.
+func approvalSatisfiesPolicy(a *contracts.ApprovalCeremony, policy *PaymentApprovalPolicy, instr *PaymentInstruction) error {
+	if a == nil {
+		return errors.New("stub_payment_connector: above-limit payment requires an approval ceremony")
+	}
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if a.CeremonyHash == "" || a.CeremonyHash != sealedCeremonyHash(a) {
+		return errors.New("stub_payment_connector: approval ceremony is not sealed")
+	}
+	if a.State != contracts.ApprovalCeremonyAllowed {
+		return fmt.Errorf("stub_payment_connector: approval ceremony state is %q, not approved", a.State)
+	}
+	if a.Subject != paymentSubject(instr) {
+		return errors.New("stub_payment_connector: approval ceremony does not bind this payment")
+	}
+
+	// Count distinct approvers that the policy recognizes and that are not the
+	// requester (dual control). The count must meet the policy quorum.
+	allowed := make(map[string]struct{}, len(policy.RequiredApprovers))
+	for _, ap := range policy.RequiredApprovers {
+		allowed[ap] = struct{}{}
+	}
+	seen := make(map[string]struct{}, len(a.Approvers))
+	distinct := 0
+	for _, approver := range a.Approvers {
+		if approver == "" || approver == a.RequestedBy {
+			continue
+		}
+		if _, ok := allowed[approver]; !ok {
+			continue
+		}
+		if _, dup := seen[approver]; dup {
+			continue
+		}
+		seen[approver] = struct{}{}
+		distinct++
+	}
+	if distinct < policy.ApprovalQuorum {
+		return fmt.Errorf("stub_payment_connector: approval quorum not met: %d of %d required policy approvers", distinct, policy.ApprovalQuorum)
+	}
+	return nil
+}
+
+// paymentSubject is the canonical subject string an approval ceremony must
+// carry to authorize a given payment instruction.
+func paymentSubject(instr *PaymentInstruction) string {
+	return "payment:" + instr.PaymentID
+}
+
+// sealedCeremonyHash recomputes the ceremony's seal so the connector can detect
+// a tampered or unsealed ceremony.
+func sealedCeremonyHash(a *contracts.ApprovalCeremony) string {
+	sealed, err := a.Seal()
+	if err != nil {
+		return ""
+	}
+	return sealed.CeremonyHash
+}
+
+func shortHash(h string) string {
+	sum := sha256.Sum256([]byte(h))
+	return hex.EncodeToString(sum[:])[:12]
+}

--- a/core/pkg/financedemo/financedemo_test.go
+++ b/core/pkg/financedemo/financedemo_test.go
@@ -1,0 +1,363 @@
+package financedemo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// --- Threshold policy verdict (escalate is the gate) ---------------------------
+
+func TestPolicy_EscalatesAboveLimit(t *testing.T) {
+	p := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"cfo@acme", "controller@acme"}, 2)
+	if err := p.Validate(); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+
+	above := p.Evaluate(1_000_001)
+	if above.Verdict != contracts.VerdictEscalate {
+		t.Fatalf("payment above limit: want ESCALATE, got %s", above.Verdict)
+	}
+	if above.ReasonCode != contracts.ReasonApprovalRequired {
+		t.Fatalf("payment above limit: want APPROVAL_REQUIRED reason, got %s", above.ReasonCode)
+	}
+
+	atLimit := p.Evaluate(1_000_000)
+	if atLimit.Verdict != contracts.VerdictEscalate {
+		t.Fatalf("payment at limit: want ESCALATE (>=), got %s", atLimit.Verdict)
+	}
+}
+
+func TestPolicy_AllowsWithinLimit(t *testing.T) {
+	p := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"cfo@acme"}, 1)
+	below := p.Evaluate(999_999)
+	if below.Verdict != contracts.VerdictAllow {
+		t.Fatalf("payment below limit: want ALLOW, got %s", below.Verdict)
+	}
+	if below.ReasonCode != ReasonWithinLimit {
+		t.Fatalf("payment below limit: want OK_WITHIN_PAYMENT_LIMIT, got %s", below.ReasonCode)
+	}
+}
+
+func TestPolicy_NonPositiveAmountFailsClosed(t *testing.T) {
+	p := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"cfo@acme"}, 1)
+	for _, amt := range []int64{0, -1, -5000} {
+		v := p.Evaluate(amt)
+		if v.Verdict != contracts.VerdictEscalate {
+			t.Fatalf("non-positive amount %d: want fail-closed ESCALATE, got %s", amt, v.Verdict)
+		}
+	}
+}
+
+func TestPolicy_VerdictHashIsStable(t *testing.T) {
+	p := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"cfo@acme", "controller@acme"}, 2)
+	a := p.Evaluate(4_250_000)
+	b := p.Evaluate(4_250_000)
+	if a.DecisionHash == "" || a.DecisionHash != b.DecisionHash {
+		t.Fatalf("verdict hash not stable: %q vs %q", a.DecisionHash, b.DecisionHash)
+	}
+	if !strings.HasPrefix(a.DecisionHash, "sha256:") {
+		t.Fatalf("verdict hash missing sha256 prefix: %q", a.DecisionHash)
+	}
+}
+
+func TestPolicy_InvalidConfigsRejected(t *testing.T) {
+	cases := map[string]*PaymentApprovalPolicy{
+		"no threshold":       NewPaymentApprovalPolicy("p", "t", "finance", "USD", 0, []string{"cfo"}, 1),
+		"negative threshold": NewPaymentApprovalPolicy("p", "t", "finance", "USD", -1, []string{"cfo"}, 1),
+		"no approvers":       NewPaymentApprovalPolicy("p", "t", "finance", "USD", 100, nil, 1),
+		"quorum too high":    NewPaymentApprovalPolicy("p", "t", "finance", "USD", 100, []string{"cfo"}, 2),
+		"zero quorum":        NewPaymentApprovalPolicy("p", "t", "finance", "USD", 100, []string{"cfo"}, 0),
+	}
+	for name, p := range cases {
+		if err := p.Validate(); err == nil {
+			t.Fatalf("%s: expected validation error, got nil", name)
+		}
+	}
+}
+
+func TestPolicy_TamperedHashRejected(t *testing.T) {
+	p := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"cfo@acme"}, 1)
+	p.ApprovalRequiredAboveCents = 50 // mutate after sealing, do not recompute
+	if err := p.Validate(); err == nil {
+		t.Fatal("tampered policy_hash must be rejected")
+	}
+}
+
+// --- Connector boundary: the security-critical fail-closed invariants ----------
+
+func approvedCeremonyFor(instr *PaymentInstruction, policy *PaymentApprovalPolicy, requester string, approvers []string) *contracts.ApprovalCeremony {
+	c, err := approveCeremony(instr, policy, requester, approvers)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func baseSetup() (*PaymentInstruction, *PaymentApprovalPolicy) {
+	policy := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"cfo@acme", "controller@acme"}, 2)
+	instr := NewPaymentInstruction("pay-1", "acme", "stub-ap", "vendor_payment.send", "Northwind", "INV-1", 4_250_000, "USD", "clerk@acme")
+	return instr, policy
+}
+
+func TestConnector_RefusesEscalateVerdict(t *testing.T) {
+	instr, policy := baseSetup()
+	escalate := policy.Evaluate(instr.AmountCents) // ESCALATE
+	ceremony := approvedCeremonyFor(instr, policy, instr.RequestedBy, policy.RequiredApprovers)
+
+	conn := NewStubPaymentConnector(FixedClock)
+	_, err := conn.Execute(instr, escalate, policy, ceremony)
+	if err == nil {
+		t.Fatal("connector must refuse a payment whose pre-execution verdict is ESCALATE")
+	}
+	if !strings.Contains(err.Error(), "not ALLOW") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func allowVerdict(instr *PaymentInstruction, policy *PaymentApprovalPolicy) PaymentVerdict {
+	v := policy.Evaluate(instr.AmountCents)
+	v.Verdict = contracts.VerdictAllow
+	v.ReasonCode = contracts.ReasonCode("OK_APPROVED")
+	v.DecisionHash = v.computeHash()
+	return v
+}
+
+func TestConnector_RefusesAboveLimitWithoutCeremony(t *testing.T) {
+	instr, policy := baseSetup()
+	v := allowVerdict(instr, policy)
+	conn := NewStubPaymentConnector(FixedClock)
+	_, err := conn.Execute(instr, v, policy, nil)
+	if err == nil {
+		t.Fatal("above-limit payment must require an approval ceremony")
+	}
+	if !strings.Contains(err.Error(), "requires an approval ceremony") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConnector_RefusesUnapprovedCeremony(t *testing.T) {
+	instr, policy := baseSetup()
+	v := allowVerdict(instr, policy)
+
+	ceremony := contracts.ApprovalCeremony{
+		ApprovalID:  "appr-x",
+		Subject:     paymentSubject(instr),
+		Action:      instr.Action,
+		State:       contracts.ApprovalCeremonyPending, // NOT approved
+		RequestedBy: instr.RequestedBy,
+		Approvers:   policy.RequiredApprovers,
+		CreatedAt:   FixedClock(),
+		UpdatedAt:   FixedClock(),
+	}
+	sealed, err := ceremony.Seal()
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	conn := NewStubPaymentConnector(FixedClock)
+	if _, err := conn.Execute(instr, v, policy, &sealed); err == nil {
+		t.Fatal("connector must refuse a pending (unapproved) ceremony")
+	}
+}
+
+func TestConnector_RefusesUnsealedCeremony(t *testing.T) {
+	instr, policy := baseSetup()
+	v := allowVerdict(instr, policy)
+
+	// Approved but never sealed (CeremonyHash empty).
+	ceremony := &contracts.ApprovalCeremony{
+		ApprovalID:  "appr-x",
+		Subject:     paymentSubject(instr),
+		Action:      instr.Action,
+		State:       contracts.ApprovalCeremonyAllowed,
+		RequestedBy: instr.RequestedBy,
+		Approvers:   policy.RequiredApprovers,
+		CreatedAt:   FixedClock(),
+		UpdatedAt:   FixedClock(),
+	}
+	conn := NewStubPaymentConnector(FixedClock)
+	if _, err := conn.Execute(instr, v, policy, ceremony); err == nil {
+		t.Fatal("connector must refuse an unsealed ceremony")
+	}
+}
+
+func TestConnector_RefusesTamperedCeremony(t *testing.T) {
+	instr, policy := baseSetup()
+	v := allowVerdict(instr, policy)
+	ceremony := approvedCeremonyFor(instr, policy, instr.RequestedBy, policy.RequiredApprovers)
+
+	// Tamper after sealing: change content but keep the stale seal hash.
+	ceremony.Action = "vendor_payment.send.evil"
+	conn := NewStubPaymentConnector(FixedClock)
+	if _, err := conn.Execute(instr, v, policy, ceremony); err == nil {
+		t.Fatal("connector must refuse a ceremony whose seal no longer matches its content")
+	}
+}
+
+func TestConnector_RefusesQuorumNotMet(t *testing.T) {
+	instr, policy := baseSetup() // quorum 2
+	v := allowVerdict(instr, policy)
+	// Only one approver actually signs.
+	ceremony := approvedCeremonyFor(instr, policy, instr.RequestedBy, []string{"cfo@acme"})
+	conn := NewStubPaymentConnector(FixedClock)
+	if _, err := conn.Execute(instr, v, policy, ceremony); err == nil {
+		t.Fatal("connector must refuse when approval quorum is not met")
+	}
+}
+
+func TestConnector_RefusesSelfApproval(t *testing.T) {
+	// Dual control: the requester cannot be the approving party.
+	policy := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"clerk@acme", "cfo@acme"}, 1)
+	instr := NewPaymentInstruction("pay-1", "acme", "stub-ap", "vendor_payment.send", "Northwind", "INV-1", 4_250_000, "USD", "clerk@acme")
+	v := allowVerdict(instr, policy)
+	// The only "approver" is the requester themselves.
+	ceremony := approvedCeremonyFor(instr, policy, "clerk@acme", []string{"clerk@acme"})
+	conn := NewStubPaymentConnector(FixedClock)
+	if _, err := conn.Execute(instr, v, policy, ceremony); err == nil {
+		t.Fatal("connector must refuse self-approval (dual control)")
+	}
+}
+
+func TestConnector_RefusesCeremonyBindingWrongPayment(t *testing.T) {
+	instr, policy := baseSetup()
+	other := NewPaymentInstruction("pay-OTHER", "acme", "stub-ap", "vendor_payment.send", "Northwind", "INV-99", 4_250_000, "USD", "clerk@acme")
+	v := allowVerdict(instr, policy)
+	// Ceremony is for a DIFFERENT payment.
+	ceremony := approvedCeremonyFor(other, policy, instr.RequestedBy, policy.RequiredApprovers)
+	conn := NewStubPaymentConnector(FixedClock)
+	if _, err := conn.Execute(instr, v, policy, ceremony); err == nil {
+		t.Fatal("connector must refuse a ceremony bound to a different payment")
+	}
+}
+
+func TestConnector_RefusesAmountMismatch(t *testing.T) {
+	instr, policy := baseSetup()
+	v := allowVerdict(instr, policy)
+	v.AmountCents = instr.AmountCents - 1 // verdict no longer matches instruction
+	ceremony := approvedCeremonyFor(instr, policy, instr.RequestedBy, policy.RequiredApprovers)
+	conn := NewStubPaymentConnector(FixedClock)
+	if _, err := conn.Execute(instr, v, policy, ceremony); err == nil {
+		t.Fatal("connector must refuse when verdict amount != instruction amount")
+	}
+}
+
+func TestConnector_ExecutesWhenApprovedAndSimulatesOnly(t *testing.T) {
+	instr, policy := baseSetup()
+	v := allowVerdict(instr, policy)
+	ceremony := approvedCeremonyFor(instr, policy, instr.RequestedBy, policy.RequiredApprovers)
+	conn := NewStubPaymentConnector(FixedClock)
+	rcpt, err := conn.Execute(instr, v, policy, ceremony)
+	if err != nil {
+		t.Fatalf("approved payment must execute: %v", err)
+	}
+	if !rcpt.Simulated {
+		t.Fatal("r3 safety: execution receipt must be Simulated=true (no real effect)")
+	}
+	if rcpt.Verdict != contracts.VerdictAllow {
+		t.Fatalf("execution receipt verdict: want ALLOW, got %s", rcpt.Verdict)
+	}
+	if rcpt.ApprovalCeremonyHash != ceremony.CeremonyHash {
+		t.Fatal("execution receipt must bind the authorizing ceremony hash")
+	}
+	if rcpt.ContentHash == "" || rcpt.ContentHash != rcpt.computeHash() {
+		t.Fatal("execution receipt content hash must be stable and present")
+	}
+}
+
+func TestConnector_WithinLimitExecutesWithoutCeremony(t *testing.T) {
+	policy := NewPaymentApprovalPolicy("finance.payments", "acme", "finance", "USD", 1_000_000, []string{"cfo@acme"}, 1)
+	instr := NewPaymentInstruction("pay-small", "acme", "stub-ap", "vendor_payment.send", "Northwind", "INV-2", 500_000, "USD", "clerk@acme")
+	v := policy.Evaluate(instr.AmountCents) // ALLOW within limit
+	if v.Verdict != contracts.VerdictAllow {
+		t.Fatalf("within-limit precondition: want ALLOW, got %s", v.Verdict)
+	}
+	conn := NewStubPaymentConnector(FixedClock)
+	rcpt, err := conn.Execute(instr, v, policy, nil)
+	if err != nil {
+		t.Fatalf("within-limit payment should execute without a ceremony: %v", err)
+	}
+	if rcpt.ApprovalCeremonyHash != "" {
+		t.Fatal("within-limit payment should not reference a ceremony")
+	}
+}
+
+// --- End-to-end scenario + determinism -----------------------------------------
+
+func TestRunScenario_EscalatesThenExecutesAfterApproval(t *testing.T) {
+	res, err := RunScenario(ScenarioInput{})
+	if err != nil {
+		t.Fatalf("scenario failed: %v", err)
+	}
+	if res.PreApprovalVerdict.Verdict != contracts.VerdictEscalate {
+		t.Fatalf("pre-approval verdict: want ESCALATE, got %s", res.PreApprovalVerdict.Verdict)
+	}
+	if res.Ceremony == nil || res.Ceremony.State != contracts.ApprovalCeremonyAllowed {
+		t.Fatal("scenario must record an approved ceremony")
+	}
+	if res.ExecutionReceipt == nil || !res.ExecutionReceipt.Simulated {
+		t.Fatal("scenario must produce a simulated execution receipt")
+	}
+	if err := res.VerifyChain(); err != nil {
+		t.Fatalf("scenario receipt chain must verify: %v", err)
+	}
+
+	// The escalation must appear in the proof log BEFORE the execution step.
+	escIdx, execIdx := -1, -1
+	for i, r := range res.Receipts {
+		switch r.Step {
+		case "policy_escalated":
+			escIdx = i
+		case "payment_executed":
+			execIdx = i
+		}
+	}
+	if escIdx < 0 || execIdx < 0 {
+		t.Fatalf("missing escalation/execution steps: esc=%d exec=%d", escIdx, execIdx)
+	}
+	if escIdx >= execIdx {
+		t.Fatalf("escalation (idx %d) must precede execution (idx %d)", escIdx, execIdx)
+	}
+	if res.Receipts[escIdx].Verdict != string(contracts.VerdictEscalate) {
+		t.Fatalf("escalation step verdict: want ESCALATE, got %s", res.Receipts[escIdx].Verdict)
+	}
+}
+
+func TestRunScenario_IsDeterministic(t *testing.T) {
+	a, err := RunScenario(ScenarioInput{})
+	if err != nil {
+		t.Fatalf("run a: %v", err)
+	}
+	b, err := RunScenario(ScenarioInput{})
+	if err != nil {
+		t.Fatalf("run b: %v", err)
+	}
+	if a.RootHash == "" || a.RootHash != b.RootHash {
+		t.Fatalf("scenario root hash not deterministic: %q vs %q", a.RootHash, b.RootHash)
+	}
+	if a.Policy.PolicyHash != b.Policy.PolicyHash {
+		t.Fatal("policy hash not deterministic")
+	}
+	if a.Ceremony.CeremonyHash != b.Ceremony.CeremonyHash {
+		t.Fatal("ceremony hash not deterministic")
+	}
+	if a.ExecutionReceipt.ContentHash != b.ExecutionReceipt.ContentHash {
+		t.Fatal("execution receipt hash not deterministic")
+	}
+}
+
+func TestRunScenario_QuorumShortfallBlocksExecution(t *testing.T) {
+	// Approvers configured for quorum 2, but only one signs => scenario fails at
+	// the connector boundary, proving the gate cannot be bypassed end to end.
+	_, err := RunScenario(ScenarioInput{
+		Approvers:        []string{"cfo@acme.example", "finance-controller@acme.example"},
+		Quorum:           2,
+		ApproverDecision: []string{"cfo@acme.example"},
+	})
+	if err == nil {
+		t.Fatal("scenario must fail when the approval quorum is not met")
+	}
+	if !strings.Contains(err.Error(), "quorum not met") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/core/pkg/financedemo/policy.go
+++ b/core/pkg/financedemo/policy.go
@@ -1,0 +1,181 @@
+// Package financedemo proves the Finance department workflow: a payment above a
+// policy limit is escalated for human approval BEFORE it can execute.
+//
+// It is a deterministic, scripted demonstration. It reuses existing kernel
+// building blocks rather than introducing a parallel proof universe:
+//
+//   - the canonical verdict taxonomy (contracts.Verdict ALLOW|ESCALATE) and
+//     reason-code registry (contracts.ReasonApprovalRequired),
+//   - the dual-control approval ceremony (contracts.ApprovalCeremony), the same
+//     type SPEND5 uses to gate manual ledger corrections,
+//   - content-addressed receipts sealed into an EvidencePack.
+//
+// This component is risk:r3-external-effect. It performs NO real payment and
+// dispatches NO live external side effect: the connector/action boundary is a
+// stub (see connector.go) that only executes once a sealed, approved ceremony
+// authorizes it. The boundary fails closed.
+package financedemo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// PaymentReasonCode mirrors the canonical reason-code vocabulary for the two
+// finance-relevant outcomes. They are deliberately a subset of the kernel
+// contracts registry so the demo never invents a new verdict universe.
+const (
+	// ReasonWithinLimit is the ALLOW reason for a payment at or below the limit.
+	ReasonWithinLimit = contracts.ReasonCode("OK_WITHIN_PAYMENT_LIMIT")
+	// ReasonApprovalRequired is the canonical ESCALATE reason; a payment above
+	// the policy limit requires human approval before execution.
+	ReasonApprovalRequired = contracts.ReasonApprovalRequired
+)
+
+// PaymentApprovalPolicy is the finance threshold policy. A payment whose amount
+// is at or above ApprovalRequiredAboveCents must be escalated for approval by a
+// quorum of named approvers (e.g. CFO / Finance controller) before execution.
+//
+// It is the finance-native projection of the same "approval gate above a
+// ceiling" rule that AgentSpendEnvelope.RequiresApproval enforces for AI spend
+// (SPEND3); keeping it here lets the demo read as a payment limit, not a model
+// budget, while preserving the identical ESCALATE invariant.
+type PaymentApprovalPolicy struct {
+	PolicyID                   string   `json:"policy_id"`
+	TenantID                   string   `json:"tenant_id"`
+	Department                 string   `json:"department"`
+	Currency                   string   `json:"currency"`
+	ApprovalRequiredAboveCents int64    `json:"approval_required_above_cents"`
+	RequiredApprovers          []string `json:"required_approvers"`
+	ApprovalQuorum             int      `json:"approval_quorum"`
+	PolicyHash                 string   `json:"policy_hash"`
+}
+
+// NewPaymentApprovalPolicy builds a policy and computes its content hash.
+func NewPaymentApprovalPolicy(policyID, tenantID, department, currency string, approvalAboveCents int64, requiredApprovers []string, quorum int) *PaymentApprovalPolicy {
+	p := &PaymentApprovalPolicy{
+		PolicyID:                   policyID,
+		TenantID:                   tenantID,
+		Department:                 department,
+		Currency:                   currency,
+		ApprovalRequiredAboveCents: approvalAboveCents,
+		RequiredApprovers:          requiredApprovers,
+		ApprovalQuorum:             quorum,
+	}
+	p.PolicyHash = p.computeHash()
+	return p
+}
+
+// Validate ensures the threshold policy is well-formed. A non-positive
+// threshold, an empty approver set, or a quorum that cannot be met all fail
+// closed: a policy that cannot escalate is not a safe finance policy.
+func (p *PaymentApprovalPolicy) Validate() error {
+	if p == nil {
+		return errors.New("payment_approval_policy: policy is nil")
+	}
+	if p.PolicyID == "" {
+		return errors.New("payment_approval_policy: policy_id is required")
+	}
+	if p.TenantID == "" {
+		return errors.New("payment_approval_policy: tenant_id is required")
+	}
+	if p.Department == "" {
+		return errors.New("payment_approval_policy: department is required")
+	}
+	if p.Currency == "" {
+		return errors.New("payment_approval_policy: currency is required")
+	}
+	if p.ApprovalRequiredAboveCents <= 0 {
+		return errors.New("payment_approval_policy: approval_required_above_cents must be positive")
+	}
+	if len(p.RequiredApprovers) == 0 {
+		return errors.New("payment_approval_policy: at least one required approver is required")
+	}
+	if p.ApprovalQuorum <= 0 {
+		return errors.New("payment_approval_policy: approval_quorum must be positive")
+	}
+	if p.ApprovalQuorum > len(p.RequiredApprovers) {
+		return errors.New("payment_approval_policy: approval_quorum cannot exceed the number of required approvers")
+	}
+	if p.PolicyHash != "" && p.PolicyHash != p.computeHash() {
+		return errors.New("payment_approval_policy: policy_hash mismatch")
+	}
+	return nil
+}
+
+// RequiresApproval reports whether a payment amount crosses the approval gate.
+func (p *PaymentApprovalPolicy) RequiresApproval(amountCents int64) bool {
+	return p != nil && amountCents >= p.ApprovalRequiredAboveCents
+}
+
+// PaymentVerdict is the auditable pre-execution decision for one payment.
+type PaymentVerdict struct {
+	Verdict      contracts.Verdict    `json:"verdict"`
+	ReasonCode   contracts.ReasonCode `json:"reason_code"`
+	Reason       string               `json:"reason"`
+	AmountCents  int64                `json:"amount_cents"`
+	LimitCents   int64                `json:"limit_cents"`
+	PolicyHash   string               `json:"policy_hash"`
+	DecisionHash string               `json:"decision_hash"`
+}
+
+// Evaluate returns the fail-closed verdict for a payment amount. A payment at
+// or above the limit is ESCALATE/APPROVAL_REQUIRED; otherwise it is ALLOW. A
+// non-positive amount fails closed as ESCALATE so a malformed payment can never
+// silently bypass the approval gate.
+func (p *PaymentApprovalPolicy) Evaluate(amountCents int64) PaymentVerdict {
+	v := PaymentVerdict{
+		AmountCents: amountCents,
+		LimitCents:  p.ApprovalRequiredAboveCents,
+		PolicyHash:  p.PolicyHash,
+	}
+	switch {
+	case amountCents <= 0:
+		v.Verdict = contracts.VerdictEscalate
+		v.ReasonCode = ReasonApprovalRequired
+		v.Reason = "payment amount must be positive; escalating for review"
+	case p.RequiresApproval(amountCents):
+		v.Verdict = contracts.VerdictEscalate
+		v.ReasonCode = ReasonApprovalRequired
+		v.Reason = fmt.Sprintf("payment of %d %s is above the %d %s policy limit and requires approval", amountCents, p.Currency, p.ApprovalRequiredAboveCents, p.Currency)
+	default:
+		v.Verdict = contracts.VerdictAllow
+		v.ReasonCode = ReasonWithinLimit
+		v.Reason = "payment is within the policy limit"
+	}
+	v.DecisionHash = v.computeHash()
+	return v
+}
+
+func (p *PaymentApprovalPolicy) computeHash() string {
+	return hashCanonical(struct {
+		PolicyID           string   `json:"policy_id"`
+		TenantID           string   `json:"tenant_id"`
+		Department         string   `json:"department"`
+		Currency           string   `json:"currency"`
+		ApprovalAboveCents int64    `json:"approval_required_above_cents"`
+		RequiredApprovers  []string `json:"required_approvers"`
+		ApprovalQuorum     int      `json:"approval_quorum"`
+	}{p.PolicyID, p.TenantID, p.Department, p.Currency, p.ApprovalRequiredAboveCents, p.RequiredApprovers, p.ApprovalQuorum})
+}
+
+func (v PaymentVerdict) computeHash() string {
+	return hashCanonical(struct {
+		Verdict     contracts.Verdict    `json:"verdict"`
+		ReasonCode  contracts.ReasonCode `json:"reason_code"`
+		AmountCents int64                `json:"amount_cents"`
+		LimitCents  int64                `json:"limit_cents"`
+		PolicyHash  string               `json:"policy_hash"`
+	}{v.Verdict, v.ReasonCode, v.AmountCents, v.LimitCents, v.PolicyHash})
+}
+
+func hashCanonical(value any) string {
+	canon, _ := json.Marshal(value)
+	h := sha256.Sum256(canon)
+	return "sha256:" + hex.EncodeToString(h[:])
+}

--- a/core/pkg/financedemo/scenario.go
+++ b/core/pkg/financedemo/scenario.go
@@ -1,0 +1,309 @@
+package financedemo
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// fixedClock is the deterministic timestamp the demo uses everywhere a time is
+// hashed or recorded, so the scenario, its receipts, and the EvidencePack are
+// byte-reproducible across runs and machines.
+var fixedClock = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// FixedClock returns the deterministic demo clock.
+func FixedClock() time.Time { return fixedClock }
+
+// ScenarioReceipt is one Lamport-ordered, hash-chained step in the finance
+// workflow. The chain is what the EvidencePack seals and a verifier replays.
+type ScenarioReceipt struct {
+	ReceiptID  string `json:"receipt_id"`
+	Step       string `json:"step"`
+	Principal  string `json:"principal"`
+	Action     string `json:"action"`
+	Connector  string `json:"connector,omitempty"`
+	Verdict    string `json:"verdict"`
+	ReasonCode string `json:"reason_code"`
+	Lamport    uint64 `json:"lamport_clock"`
+	PrevHash   string `json:"prev_hash"`
+	Hash       string `json:"hash"`
+	// DecisionHash binds this step's governance decision. It mirrors the chain
+	// hash so each receipt is independently decision-bound for the EvidencePack
+	// verifier (policy_decision_hashes); the richer domain hashes (policy,
+	// ceremony, execution) are carried in Detail.
+	DecisionHash string            `json:"decision_hash"`
+	Detail       map[string]string `json:"detail,omitempty"`
+}
+
+// ScenarioResult is the full, deterministic output of the finance demo. Every
+// acceptance artifact the issue asks for is a field here.
+type ScenarioResult struct {
+	Policy             *PaymentApprovalPolicy      `json:"policy"`               // threshold policy
+	Instruction        *PaymentInstruction         `json:"instruction"`          // connector/action context
+	PreApprovalVerdict PaymentVerdict              `json:"pre_approval_verdict"` // ESCALATE before execution
+	Ceremony           *contracts.ApprovalCeremony `json:"approval_ceremony"`    // CFO/Finance approval requirement + result
+	ExecutionReceipt   *PaymentExecutionReceipt    `json:"execution_receipt"`    // receipt (with hashes)
+	Receipts           []ScenarioReceipt           `json:"receipts"`             // hash-chained proof log
+	RootHash           string                      `json:"root_hash"`
+	LamportFinal       uint64                      `json:"lamport_final"`
+}
+
+// ScenarioInput parameterizes the demo. Zero values fall back to the canonical
+// "Acme Finance" reference scenario.
+type ScenarioInput struct {
+	TenantID         string
+	Department       string
+	Currency         string
+	LimitCents       int64
+	PaymentCents     int64
+	Vendor           string
+	InvoiceRef       string
+	ConnectorID      string
+	Action           string
+	Requester        string
+	Approvers        []string
+	Quorum           int
+	ApproverDecision []string // subset of Approvers that actually approve
+}
+
+func (in ScenarioInput) withDefaults() ScenarioInput {
+	if in.TenantID == "" {
+		in.TenantID = "acme-corp"
+	}
+	if in.Department == "" {
+		in.Department = "finance"
+	}
+	if in.Currency == "" {
+		in.Currency = "USD"
+	}
+	if in.LimitCents == 0 {
+		in.LimitCents = 1_000_000 // $10,000.00 policy limit
+	}
+	if in.PaymentCents == 0 {
+		in.PaymentCents = 4_250_000 // $42,500.00 vendor invoice (above limit)
+	}
+	if in.Vendor == "" {
+		in.Vendor = "Northwind Logistics"
+	}
+	if in.InvoiceRef == "" {
+		in.InvoiceRef = "INV-2026-0042"
+	}
+	if in.ConnectorID == "" {
+		in.ConnectorID = "stub-ap-payments"
+	}
+	if in.Action == "" {
+		in.Action = "vendor_payment.send"
+	}
+	if in.Requester == "" {
+		in.Requester = "ap-clerk@acme.example"
+	}
+	if len(in.Approvers) == 0 {
+		in.Approvers = []string{"cfo@acme.example", "finance-controller@acme.example"}
+	}
+	if in.Quorum == 0 {
+		in.Quorum = 2
+	}
+	if in.ApproverDecision == nil {
+		in.ApproverDecision = in.Approvers
+	}
+	return in
+}
+
+// RunScenario executes the deterministic finance escalation workflow and
+// returns the full proof set. It performs NO real side effect.
+//
+// The flow is:
+//  1. Build the threshold policy.
+//  2. Build the payment instruction (connector/action context).
+//  3. Evaluate the payment -> ESCALATE/APPROVAL_REQUIRED (above the limit),
+//     proving the payment cannot execute yet.
+//  4. Open an approval ceremony naming the required approvers (CFO/Finance).
+//  5. Record the human approval result (ceremony -> approved, sealed).
+//  6. Re-evaluate as an approval-cleared ALLOW and run the stubbed connector,
+//     which fails closed unless the sealed ceremony meets policy.
+//  7. Emit a hash-chained receipt log over every step.
+func RunScenario(in ScenarioInput) (*ScenarioResult, error) {
+	in = in.withDefaults()
+
+	policy := NewPaymentApprovalPolicy("finance.payments.approval", in.TenantID, in.Department, in.Currency, in.LimitCents, in.Approvers, in.Quorum)
+	if err := policy.Validate(); err != nil {
+		return nil, err
+	}
+
+	instr := NewPaymentInstruction(
+		"pay-"+shortHash(in.InvoiceRef),
+		in.TenantID, in.ConnectorID, in.Action, in.Vendor, in.InvoiceRef,
+		in.PaymentCents, in.Currency, in.Requester,
+	)
+	if err := instr.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Pre-approval verdict: above the limit -> ESCALATE. This is the gate.
+	preVerdict := policy.Evaluate(instr.AmountCents)
+	if preVerdict.Verdict != contracts.VerdictEscalate {
+		// This demo is specifically the above-limit path; a within-limit amount
+		// here would mean the scenario was misconfigured.
+		return nil, fmt.Errorf("financedemo: expected ESCALATE for payment above limit, got %s", preVerdict.Verdict)
+	}
+
+	r := &ScenarioResult{
+		Policy:             policy,
+		Instruction:        instr,
+		PreApprovalVerdict: preVerdict,
+	}
+
+	emit := r.receiptEmitter()
+
+	emit("policy_published", "finance-admin@acme.example", "PUBLISH_PAYMENT_POLICY", "", string(contracts.VerdictAllow), "POLICY_PUBLISHED", map[string]string{
+		"policy_hash": policy.PolicyHash,
+		"limit_cents": fmt.Sprintf("%d", policy.ApprovalRequiredAboveCents),
+		"quorum":      fmt.Sprintf("%d", policy.ApprovalQuorum),
+	})
+	emit("payment_requested", in.Requester, "REQUEST_PAYMENT", instr.ConnectorID, "PENDING", "PAYMENT_SUBMITTED", map[string]string{
+		"vendor":           instr.Vendor,
+		"invoice_ref":      instr.InvoiceRef,
+		"amount_cents":     fmt.Sprintf("%d", instr.AmountCents),
+		"instruction_hash": instr.InstructionHash,
+	})
+	// The escalation step: the payment is blocked from executing.
+	emit("policy_escalated", "helm-kernel", "EVALUATE_PAYMENT", instr.ConnectorID, string(preVerdict.Verdict), string(preVerdict.ReasonCode), map[string]string{
+		"decision_hash": preVerdict.DecisionHash,
+		"limit_cents":   fmt.Sprintf("%d", preVerdict.LimitCents),
+		"amount_cents":  fmt.Sprintf("%d", preVerdict.AmountCents),
+	})
+
+	// Open + resolve the approval ceremony (the human approval result).
+	ceremony, err := approveCeremony(instr, policy, in.Requester, in.ApproverDecision)
+	if err != nil {
+		return nil, err
+	}
+	r.Ceremony = ceremony
+	emit("approval_recorded", approversLabel(in.ApproverDecision), "APPROVE_PAYMENT", instr.ConnectorID, string(contracts.VerdictAllow), "APPROVAL_GRANTED", map[string]string{
+		"ceremony_hash": ceremony.CeremonyHash,
+		"approvers":     approversLabel(ceremony.Approvers),
+		"quorum_met":    fmt.Sprintf("%d/%d", len(in.ApproverDecision), policy.ApprovalQuorum),
+	})
+
+	// Post-approval: the verdict clears to ALLOW and the stubbed connector runs.
+	postVerdict := preVerdict
+	postVerdict.Verdict = contracts.VerdictAllow
+	postVerdict.ReasonCode = contracts.ReasonCode("OK_APPROVED")
+	postVerdict.Reason = "payment approved by required approvers"
+	postVerdict.DecisionHash = postVerdict.computeHash()
+
+	connector := NewStubPaymentConnector(FixedClock)
+	execReceipt, err := connector.Execute(instr, postVerdict, policy, ceremony)
+	if err != nil {
+		return nil, err
+	}
+	r.ExecutionReceipt = execReceipt
+	emit("payment_executed", "helm-kernel", "EXECUTE_PAYMENT", instr.ConnectorID, string(execReceipt.Verdict), string(execReceipt.ReasonCode), map[string]string{
+		"execution_receipt_hash": execReceipt.ContentHash,
+		"simulated":              fmt.Sprintf("%t", execReceipt.Simulated),
+		"approval_ceremony_hash": execReceipt.ApprovalCeremonyHash,
+	})
+
+	r.RootHash = r.lastHash()
+	r.LamportFinal = uint64(len(r.Receipts))
+	return r, nil
+}
+
+// approveCeremony builds an approval ceremony bound to the payment, records the
+// approver decision, and seals it. The resulting ceremony is the human approval
+// result the connector boundary requires.
+func approveCeremony(instr *PaymentInstruction, policy *PaymentApprovalPolicy, requester string, approvers []string) (*contracts.ApprovalCeremony, error) {
+	if len(approvers) == 0 {
+		return nil, errors.New("financedemo: at least one approver decision is required")
+	}
+	ceremony := contracts.ApprovalCeremony{
+		ApprovalID:  "appr-" + shortHash(instr.InstructionHash),
+		Subject:     paymentSubject(instr),
+		Action:      instr.Action,
+		State:       contracts.ApprovalCeremonyAllowed,
+		RequestedBy: requester,
+		Approvers:   approvers,
+		Quorum:      policy.ApprovalQuorum,
+		AuthMethod:  "demo-scripted",
+		Reason:      fmt.Sprintf("approve %s payment to %s (invoice %s)", instr.Currency, instr.Vendor, instr.InvoiceRef),
+		CreatedAt:   fixedClock,
+		UpdatedAt:   fixedClock,
+	}
+	sealed, err := ceremony.Seal()
+	if err != nil {
+		return nil, fmt.Errorf("financedemo: seal approval ceremony: %w", err)
+	}
+	return &sealed, nil
+}
+
+// receiptEmitter returns a closure that appends a Lamport-ordered, hash-chained
+// receipt to the result. The chain is deterministic: no wall clock enters a
+// hashed field.
+func (r *ScenarioResult) receiptEmitter() func(step, principal, action, connector, verdict, reason string, detail map[string]string) ScenarioReceipt {
+	return func(step, principal, action, connector, verdict, reason string, detail map[string]string) ScenarioReceipt {
+		lamport := uint64(len(r.Receipts)) + 1
+		prev := r.lastHash()
+		preimage := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%d|%s", step, principal, action, connector, verdict, reason, lamport, prev)
+		sum := sha256.Sum256([]byte(preimage))
+		hash := hex.EncodeToString(sum[:])
+		rec := ScenarioReceipt{
+			ReceiptID:    fmt.Sprintf("fin-rcpt-%s-%d", hash[:8], lamport),
+			Step:         step,
+			Principal:    principal,
+			Action:       action,
+			Connector:    connector,
+			Verdict:      verdict,
+			ReasonCode:   reason,
+			Lamport:      lamport,
+			PrevHash:     prev,
+			Hash:         hash,
+			DecisionHash: "sha256:" + hash,
+			Detail:       detail,
+		}
+		r.Receipts = append(r.Receipts, rec)
+		return rec
+	}
+}
+
+func (r *ScenarioResult) lastHash() string {
+	if len(r.Receipts) == 0 {
+		return ""
+	}
+	return r.Receipts[len(r.Receipts)-1].Hash
+}
+
+// VerifyChain re-derives the receipt chain and reports the first break, if any.
+// It is the deterministic-replay check the demo and tests run on the proof log.
+func (r *ScenarioResult) VerifyChain() error {
+	prev := ""
+	for _, rec := range r.Receipts {
+		if rec.PrevHash != prev {
+			return fmt.Errorf("financedemo: chain break at lamport %d: prev_hash mismatch", rec.Lamport)
+		}
+		preimage := fmt.Sprintf("%s|%s|%s|%s|%s|%s|%d|%s", rec.Step, rec.Principal, rec.Action, rec.Connector, rec.Verdict, rec.ReasonCode, rec.Lamport, rec.PrevHash)
+		sum := sha256.Sum256([]byte(preimage))
+		if got := hex.EncodeToString(sum[:]); got != rec.Hash {
+			return fmt.Errorf("financedemo: chain break at lamport %d: hash mismatch", rec.Lamport)
+		}
+		prev = rec.Hash
+	}
+	return nil
+}
+
+func approversLabel(approvers []string) string {
+	out := ""
+	for i, a := range approvers {
+		if i > 0 {
+			out += "+"
+		}
+		out += a
+	}
+	if out == "" {
+		return "none"
+	}
+	return out
+}


### PR DESCRIPTION
Refs MIN-449. **Draft** — stacked on SPEND5 (PR #426), which is stacked on SPEND3 (#) and base. Base branch: `codex/min-470-spend5-usage-ledger`.

## What this implements

A deterministic, scripted demonstration proving the Finance workflow: **a payment above a policy limit is escalated for human approval BEFORE it can execute.** `risk:r3-external-effect` is honored by construction — no real payment, no live external side effect; the connector/action boundary is a stub and every execution receipt is marked `simulated`.

Maps each acceptance criterion onto an existing kernel building block (no parallel proof universe):

| Acceptance criterion | Building block (reused) |
|---|---|
| Threshold policy | `financedemo.PaymentApprovalPolicy` — finance projection of the SPEND3 approval-above-ceiling rule; `amount >= limit -> ESCALATE` |
| CFO/Finance approval requirement | `contracts.ApprovalCeremony` (the SPEND5 dual-control ceremony type) with named approvers + quorum |
| Connector/action context | `financedemo.PaymentInstruction` (connector id, action, vendor, invoice) |
| Human approval result | sealed ceremony, state `pending -> approved` |
| Receipt (+ hashes) | `PaymentExecutionReceipt` content-hashed; chained `ScenarioReceipt` log with `decision_hash` |
| EvidencePack proof | `evidencepack.Builder` + `evidence.SealEvidencePack` (dev-local), verifies offline |

### Files
- `core/pkg/financedemo/policy.go` — threshold policy + fail-closed verdict (canonical `contracts.Verdict` ALLOW/ESCALATE).
- `core/pkg/financedemo/connector.go` — fail-closed stub connector; above-limit payments execute only behind a **sealed, approved, quorum-met** ceremony that binds the payment; `Simulated` is always true.
- `core/pkg/financedemo/scenario.go` — deterministic end-to-end `RunScenario` (fixed clock) emitting a Lamport-ordered, hash-chained receipt log.
- `core/cmd/helm-ai-kernel/demo_finance_cmd.go` — `helm-ai-kernel demo finance` (`--out/--limit/--amount/--json`); seals a verifiable EvidencePack.
- `core/cmd/helm-ai-kernel/demo_cmd.go` — registers the `finance` subcommand.
- `*_test.go` — failure-mode + determinism + offline-verify coverage.

### Deterministic smoke path
```
helm-ai-kernel demo finance --out data/evidence-finance
# ESCALATE at L=3 (pre-execution), approval at L=4, simulated execute at L=5
# seals EvidencePack -> helm-ai-kernel verify data/evidence-finance => VERIFIED
```
Artifacts: receipt chain hashes (`root_hash`), policy/ceremony/execution content hashes, and the sealed EvidencePack manifest (`manifest_hash`, `entries_merkle_root`). Two runs produce byte-identical manifests.

## Gate + preflight results
- `make build` — **PASS**
- `go test ./core/pkg/...` — **PASS** (0 failures); `core/pkg/financedemo` 20 tests; cmd tests PASS; `-race` clean.
- `make lint` — **PASS** (docs-coverage, docs-truth, `go vet`, gofmt).
- `make verify-fixtures` — **PASS** (golden roots, canonicalization vectors).
- `make crucible` — **PASS** (12/12 use-cases, incl. UC-003 Approval Ceremony).
- EvidencePack verifies offline via `verifier.VerifyBundle` (seal valid, sig 1/1, dev-local).

### Failure modes covered (financial/security invariants — not faked)
escalate-as-gate; within-limit allow; non-positive fail-closed; tampered policy hash; connector refuses ESCALATE verdict / missing / unapproved / unsealed / tampered ceremony / quorum shortfall / self-approval (dual control) / wrong-payment binding / amount mismatch; determinism; end-to-end quorum-shortfall block.

## Boundary
No protobuf, contract (`contracts-proto`/`contracts-catalog`), JSON-schema, or OpenAPI changes — contracts-sync **N/A**. New code lives in `core/pkg/financedemo` and `core/cmd/helm-ai-kernel` (outside protected manifest scope), so no new boundary drift.

## What remains / blockers
- `make verify-boundary` reports **1 pre-existing stale file**: `core/pkg/contracts/economic/usage_balance.go`. This is **not from this PR** — it was added by SPEND5 (`c4dec852`) after the protected manifest was last regenerated at SPEND3 (`fdf12ea4`); I did not modify it. Regenerating the manifest belongs to SPEND5 (PR #426) before merge. Verified: file absent at the manifest's commit; `git diff` shows it unchanged by this branch.
- Demo is intentionally the above-limit ESCALATE path; a within-limit `--amount` is a config error (exit 2) by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)