### PR TITLE
[SPEND8] Make spend receipts business-readable and EvidencePack/offline-verifiable

### DIFF
--- a/core/pkg/contracts/economic/spend_authority.go
+++ b/core/pkg/contracts/economic/spend_authority.go
@@ -406,6 +406,20 @@ func (q *RouteQuote) Reseal() string {
 	return q.ContentHash
 }
 
+// CanonicalContentHash returns the deterministic hash for the quote body without
+// mutating ContentHash. Used by offline EvidencePack verification.
+func (q *RouteQuote) CanonicalContentHash() string {
+	if q == nil {
+		return ""
+	}
+	return q.computeHash()
+}
+
+// HasCanonicalContentHash reports whether ContentHash matches the quote body.
+func (q *RouteQuote) HasCanonicalContentHash() bool {
+	return q != nil && q.ContentHash != "" && q.ContentHash == q.computeHash()
+}
+
 // Validate ensures the route quote is dispatch-safe.
 func (q *RouteQuote) Validate() error {
 	if q == nil {
@@ -633,6 +647,17 @@ func (r *BudgetVerdictReceipt) CanonicalContentHash() string {
 	return r.computeHash()
 }
 
+// Reseal recomputes ContentHash after hash-relevant fields (e.g. PrincipalID)
+// are set following construction, before the receipt is signed or bound. It
+// returns the deterministic hash.
+func (r *BudgetVerdictReceipt) Reseal() string {
+	if r == nil {
+		return ""
+	}
+	r.ContentHash = r.computeHash()
+	return r.ContentHash
+}
+
 func (r *BudgetVerdictReceipt) validateCore() error {
 	if r == nil {
 		return errors.New("budget_verdict_receipt: receipt is nil")
@@ -824,6 +849,20 @@ func (r *UsageReceipt) Reseal() string {
 	return r.ContentHash
 }
 
+// CanonicalContentHash returns the deterministic hash for the usage receipt body
+// without mutating ContentHash. Used by offline EvidencePack verification.
+func (r *UsageReceipt) CanonicalContentHash() string {
+	if r == nil {
+		return ""
+	}
+	return r.computeHash()
+}
+
+// HasCanonicalContentHash reports whether ContentHash matches the receipt body.
+func (r *UsageReceipt) HasCanonicalContentHash() bool {
+	return r != nil && r.ContentHash != "" && r.ContentHash == r.computeHash()
+}
+
 // Validate ensures the usage receipt can support reconciliation.
 func (r *UsageReceipt) Validate() error {
 	if r == nil {
@@ -997,6 +1036,20 @@ func (s *SettlementReceipt) Reseal() string {
 	}
 	s.ContentHash = s.computeHash()
 	return s.ContentHash
+}
+
+// CanonicalContentHash returns the deterministic hash for the settlement receipt
+// body without mutating ContentHash. Used by offline EvidencePack verification.
+func (s *SettlementReceipt) CanonicalContentHash() string {
+	if s == nil {
+		return ""
+	}
+	return s.computeHash()
+}
+
+// HasCanonicalContentHash reports whether ContentHash matches the receipt body.
+func (s *SettlementReceipt) HasCanonicalContentHash() bool {
+	return s != nil && s.ContentHash != "" && s.ContentHash == s.computeHash()
 }
 
 // Validate ensures the settlement can be used as financial evidence.

--- a/core/pkg/contracts/economic/spend_receipt_views.go
+++ b/core/pkg/contracts/economic/spend_receipt_views.go
@@ -1,0 +1,416 @@
+// spend_receipt_views.go renders the SPEND3/5 spend receipts (RouteQuote,
+// BudgetVerdictReceipt, UsageReceipt, SettlementReceipt) into business-readable
+// VIEWS so a non-engineer can answer six questions about any spend:
+//
+//	who proposed / approved it    -> AgentID / PrincipalID / Approvers
+//	which policy governed it       -> RoutePolicyHash / PolicyHash
+//	which data was involved        -> RequestedModelID + content hashes (NOT the prompt body)
+//	what actually happened         -> verdict + requested/selected route + fallback
+//	how much it cost               -> quoted / actual / provider cost / platform fee / debit
+//	what proves it                 -> receipt ContentHash + EvidencePackRef
+//
+// These views are a presentation layer over the source-owned receipts: they add
+// no new financial truth and recompute nothing. The receipts already store only
+// hashes + metadata for sensitive payloads, so a view can never surface a prompt
+// body. The RedactionProfile makes that guarantee explicit and enforceable for
+// the free-form Metadata maps that ride along on RouteQuote / UsageReceipt.
+package economic
+
+import (
+	"sort"
+	"strings"
+)
+
+// SpendReceiptKind identifies which spend receipt a view was rendered from. The
+// values double as ProofGraph/EvidencePack node labels so a business view maps
+// cleanly onto the kernel's attestation node taxonomy.
+type SpendReceiptKind string
+
+const (
+	SpendReceiptKindRoute      SpendReceiptKind = "ROUTE_RECEIPT"
+	SpendReceiptKindBudget     SpendReceiptKind = "BUDGET_VERDICT_RECEIPT"
+	SpendReceiptKindUsage      SpendReceiptKind = "USAGE_RECEIPT"
+	SpendReceiptKindSettlement SpendReceiptKind = "SETTLEMENT_RECEIPT"
+)
+
+// RedactionProfile controls which fields are allowed to cross from the spend
+// receipts into a business graph / EvidencePack. The default profile keeps the
+// prompt body OFF-graph: receipts only ever carry hashes + metadata, and this
+// profile additionally strips any metadata key that could smuggle prompt text
+// (or other sensitive payloads) through the free-form Metadata maps.
+//
+// The contract is fail-closed for prompt bodies: with RedactPromptBody=true
+// (the default) any metadata key flagged as prompt-bearing is dropped before it
+// reaches a view, so the business graph stores hashes + metadata only.
+type RedactionProfile struct {
+	// Name identifies the profile in audit output.
+	Name string `json:"name"`
+	// RedactPromptBody drops prompt-bearing metadata keys. Default profile: true.
+	RedactPromptBody bool `json:"redact_prompt_body"`
+	// DeniedMetadataKeys are dropped from every view's metadata (case-insensitive).
+	DeniedMetadataKeys []string `json:"denied_metadata_keys,omitempty"`
+	// DeniedMetadataSubstrings drop any metadata key containing the substring
+	// (case-insensitive), catching variants like "prompt", "prompt_text",
+	// "messages", "completion_body" without enumerating every key.
+	DeniedMetadataSubstrings []string `json:"denied_metadata_substrings,omitempty"`
+}
+
+// DefaultRedactionProfile returns the launch-default profile: prompt body stays
+// off-graph. This is the profile the business views use unless a caller opts
+// into a wider profile for an internal, access-controlled surface.
+func DefaultRedactionProfile() RedactionProfile {
+	return RedactionProfile{
+		Name:             "default-prompt-off-graph",
+		RedactPromptBody: true,
+		DeniedMetadataKeys: []string{
+			"prompt", "prompt_body", "prompt_text", "input", "input_body",
+			"messages", "completion", "completion_body", "output_text",
+			"system_prompt", "user_message", "request_body", "response_body",
+		},
+		DeniedMetadataSubstrings: []string{
+			"prompt", "message", "completion", "_body", "payload", "transcript",
+		},
+	}
+}
+
+// redactedKey reports whether a metadata key must be dropped under the profile.
+func (p RedactionProfile) redactedKey(key string) bool {
+	lk := strings.ToLower(strings.TrimSpace(key))
+	for _, denied := range p.DeniedMetadataKeys {
+		if lk == strings.ToLower(denied) {
+			return true
+		}
+	}
+	if p.RedactPromptBody {
+		for _, sub := range p.DeniedMetadataSubstrings {
+			if sub != "" && strings.Contains(lk, strings.ToLower(sub)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// redactMetadata returns a copy of md with denied keys removed and a sorted,
+// deterministic list of the keys that were redacted (for the audit trail).
+func (p RedactionProfile) redactMetadata(md map[string]string) (map[string]string, []string) {
+	if len(md) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string, len(md))
+	var redacted []string
+	for k, v := range md {
+		if p.redactedKey(k) {
+			redacted = append(redacted, k)
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		out = nil
+	}
+	sort.Strings(redacted)
+	return out, redacted
+}
+
+// RouteHop is one provider/model option in a business-readable fallback chain.
+type RouteHop struct {
+	ProviderID        string `json:"provider_id"`
+	ModelID           string `json:"model_id"`
+	PriceSnapshotHash string `json:"price_snapshot_hash"`
+}
+
+// RouteReceiptView answers "what did the router propose and why" for a RouteQuote.
+type RouteReceiptView struct {
+	Kind SpendReceiptKind `json:"kind"`
+
+	// Who
+	TenantID    string `json:"tenant_id"`
+	AgentID     string `json:"agent_id"`
+	PrincipalID string `json:"principal_id,omitempty"`
+
+	// What happened (route)
+	RequestedProviderID string     `json:"requested_provider_id,omitempty"`
+	RequestedModelID    string     `json:"requested_model_id"`
+	SelectedProviderID  string     `json:"selected_provider_id"`
+	SelectedModelID     string     `json:"selected_model_id"`
+	ModelSubstituted    bool       `json:"model_substituted"`
+	FallbackChain       []RouteHop `json:"fallback_chain,omitempty"`
+	Verdict             string     `json:"verdict"`
+	ReasonCode          string     `json:"reason_code"`
+
+	// How much (quote)
+	QuotedAmountCents int64  `json:"quoted_amount_cents"`
+	MaxAmountCents    int64  `json:"max_amount_cents"`
+	Currency          string `json:"currency"`
+
+	// Which policy / which data (hashes only)
+	RoutePolicyHash           string `json:"route_policy_hash"`
+	ProviderPriceSnapshotHash string `json:"provider_price_snapshot_hash"`
+
+	// What proves it
+	ContentHash string `json:"content_hash"`
+
+	// Audit of redaction
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	RedactedFields  []string          `json:"redacted_fields,omitempty"`
+	RedactionPolicy string            `json:"redaction_policy"`
+}
+
+// BudgetVerdictView answers "who approved, under which policy" for a verdict.
+type BudgetVerdictView struct {
+	Kind SpendReceiptKind `json:"kind"`
+
+	// Who
+	TenantID    string   `json:"tenant_id"`
+	AgentID     string   `json:"agent_id"`
+	PrincipalID string   `json:"principal_id,omitempty"`
+	Approvers   []string `json:"approvers,omitempty"`
+
+	// What happened (decision)
+	Verdict        string `json:"verdict"` // ALLOW / DENY / ESCALATE
+	ReasonCode     string `json:"reason_code"`
+	ProviderID     string `json:"provider_id"`
+	ModelID        string `json:"model_id"`
+	ApprovalNeeded bool   `json:"approval_needed"`
+
+	// How much
+	QuotedAmountCents int64  `json:"quoted_amount_cents"`
+	MaxAmountCents    int64  `json:"max_amount_cents"`
+	Currency          string `json:"currency"`
+
+	// Which policy / envelope (hashes only)
+	EnvelopeHash    string `json:"envelope_hash,omitempty"`
+	RoutePolicyHash string `json:"route_policy_hash"`
+	DecisionHash    string `json:"decision_hash"`
+
+	// What proves it
+	ContentHash     string `json:"content_hash"`
+	EvidencePackRef string `json:"evidence_pack_ref"`
+	SignatureKeyID  string `json:"signature_key_id,omitempty"`
+
+	RedactionPolicy string `json:"redaction_policy"`
+}
+
+// UsageReceiptView answers "what actually happened and how much" post-dispatch.
+type UsageReceiptView struct {
+	Kind SpendReceiptKind `json:"kind"`
+
+	// Who
+	TenantID string `json:"tenant_id"`
+	AgentID  string `json:"agent_id"`
+
+	// What happened
+	ProviderID        string `json:"provider_id"`
+	ModelID           string `json:"model_id"`
+	ProviderRequestID string `json:"provider_request_id,omitempty"`
+	Verdict           string `json:"verdict"`
+	ReasonCode        string `json:"reason_code"`
+
+	// How much (full cost breakdown)
+	QuotedAmountCents int64  `json:"quoted_amount_cents"`
+	ActualAmountCents int64  `json:"actual_amount_cents"`
+	ProviderCostCents int64  `json:"provider_cost_cents"`
+	PlatformFeeCents  int64  `json:"platform_fee_cents"`
+	BalanceDebitCents int64  `json:"balance_debit_cents"`
+	Currency          string `json:"currency"`
+	// SettledVia tells a business reader whether the spend hit a prepaid balance
+	// or accrued to an invoice. Derived from the presence of a balance debit.
+	SettledVia string `json:"settled_via"` // "BALANCE_DEBIT" or "INVOICE_ACCRUAL"
+
+	// Which policy / which data (hashes only)
+	PolicyHash                string `json:"policy_hash"`
+	ProviderPriceSnapshotHash string `json:"provider_price_snapshot_hash"`
+
+	// What proves it
+	ContentHash           string `json:"content_hash"`
+	SettlementReceiptHash string `json:"settlement_receipt_hash,omitempty"`
+	EvidencePackRef       string `json:"evidence_pack_ref"`
+
+	Metadata        map[string]string `json:"metadata,omitempty"`
+	RedactedFields  []string          `json:"redacted_fields,omitempty"`
+	RedactionPolicy string            `json:"redaction_policy"`
+}
+
+// LedgerMovementView is one business-readable double-entry movement.
+type LedgerMovementView struct {
+	AccountID   string `json:"account_id"`
+	Direction   string `json:"direction"` // DEBIT / CREDIT
+	AmountCents int64  `json:"amount_cents"`
+	Currency    string `json:"currency"`
+	Reference   string `json:"reference,omitempty"`
+}
+
+// SettlementReceiptView answers "what moved on the ledger and what proves it".
+type SettlementReceiptView struct {
+	Kind SpendReceiptKind `json:"kind"`
+
+	TenantID          string `json:"tenant_id"`
+	TreasuryAccountID string `json:"treasury_account_id"`
+
+	// What moved
+	LedgerMovements []LedgerMovementView `json:"ledger_movements"`
+	TotalDebits     int64                `json:"total_debits_cents"`
+	TotalCredits    int64                `json:"total_credits_cents"`
+	Currency        string               `json:"currency"`
+	Balanced        bool                 `json:"balanced"`
+
+	// Links / correction references
+	UsageReceiptID         string `json:"usage_receipt_id"`
+	SourceUsageReceiptHash string `json:"source_usage_receipt_hash"`
+
+	// What proves it
+	ContentHash     string `json:"content_hash"`
+	EvidencePackRef string `json:"evidence_pack_ref"`
+
+	RedactionPolicy string `json:"redaction_policy"`
+}
+
+// NewRouteReceiptView renders a RouteQuote into a business-readable view under
+// the given redaction profile. The prompt body never appears: only the model
+// id, hashes, and redacted metadata cross into the view.
+func NewRouteReceiptView(q *RouteQuote, profile RedactionProfile) RouteReceiptView {
+	if q == nil {
+		return RouteReceiptView{Kind: SpendReceiptKindRoute, RedactionPolicy: profile.Name}
+	}
+	md, redacted := profile.redactMetadata(q.Metadata)
+	chain := make([]RouteHop, 0, len(q.FallbackChain))
+	for _, hop := range q.FallbackChain {
+		chain = append(chain, RouteHop{
+			ProviderID:        hop.ProviderID,
+			ModelID:           hop.ModelID,
+			PriceSnapshotHash: hop.PriceSnapshotHash,
+		})
+	}
+	return RouteReceiptView{
+		Kind:                      SpendReceiptKindRoute,
+		TenantID:                  q.TenantID,
+		AgentID:                   q.AgentID,
+		PrincipalID:               q.PrincipalID,
+		RequestedProviderID:       q.RequestedProviderID,
+		RequestedModelID:          q.RequestedModelID,
+		SelectedProviderID:        q.SelectedProviderID,
+		SelectedModelID:           q.SelectedModelID,
+		ModelSubstituted:          q.ModelSubstituted,
+		FallbackChain:             chain,
+		Verdict:                   string(q.BudgetVerdict),
+		ReasonCode:                string(q.ReasonCode),
+		QuotedAmountCents:         q.QuotedAmountCents,
+		MaxAmountCents:            q.MaxAmountCents,
+		Currency:                  q.Currency,
+		RoutePolicyHash:           q.RoutePolicyHash,
+		ProviderPriceSnapshotHash: q.ProviderPriceSnapshotHash,
+		ContentHash:               q.ContentHash,
+		Metadata:                  md,
+		RedactedFields:            redacted,
+		RedactionPolicy:           profile.Name,
+	}
+}
+
+// NewBudgetVerdictView renders a BudgetVerdictReceipt into a business view.
+// approvers may be nil for an ALLOW; for ESCALATE it carries the required
+// approver roles/ids so a business reader can answer "who must approve".
+func NewBudgetVerdictView(r *BudgetVerdictReceipt, approvers []string, profile RedactionProfile) BudgetVerdictView {
+	if r == nil {
+		return BudgetVerdictView{Kind: SpendReceiptKindBudget, RedactionPolicy: profile.Name}
+	}
+	return BudgetVerdictView{
+		Kind:              SpendReceiptKindBudget,
+		TenantID:          r.TenantID,
+		AgentID:           r.AgentID,
+		PrincipalID:       r.PrincipalID,
+		Approvers:         append([]string(nil), approvers...),
+		Verdict:           string(r.BudgetVerdict),
+		ReasonCode:        string(r.ReasonCode),
+		ProviderID:        r.ProviderID,
+		ModelID:           r.ModelID,
+		ApprovalNeeded:    r.BudgetVerdict == BudgetVerdictEscalate,
+		QuotedAmountCents: r.QuotedAmountCents,
+		MaxAmountCents:    r.MaxAmountCents,
+		Currency:          r.Currency,
+		EnvelopeHash:      r.EnvelopeHash,
+		RoutePolicyHash:   r.RoutePolicyHash,
+		DecisionHash:      r.DecisionHash,
+		ContentHash:       r.ContentHash,
+		EvidencePackRef:   r.EvidencePackRef,
+		SignatureKeyID:    r.SignatureKeyID,
+		RedactionPolicy:   profile.Name,
+	}
+}
+
+// NewUsageReceiptView renders a UsageReceipt into a business view.
+func NewUsageReceiptView(r *UsageReceipt, profile RedactionProfile) UsageReceiptView {
+	if r == nil {
+		return UsageReceiptView{Kind: SpendReceiptKindUsage, RedactionPolicy: profile.Name}
+	}
+	md, redacted := profile.redactMetadata(r.Metadata)
+	settledVia := "INVOICE_ACCRUAL"
+	if r.BalanceDebitCents > 0 {
+		settledVia = "BALANCE_DEBIT"
+	}
+	return UsageReceiptView{
+		Kind:                      SpendReceiptKindUsage,
+		TenantID:                  r.TenantID,
+		AgentID:                   r.AgentID,
+		ProviderID:                r.ProviderID,
+		ModelID:                   r.ModelID,
+		ProviderRequestID:         r.ProviderRequestID,
+		Verdict:                   string(r.BudgetVerdict),
+		ReasonCode:                string(r.ReasonCode),
+		QuotedAmountCents:         r.QuotedAmountCents,
+		ActualAmountCents:         r.ActualAmountCents,
+		ProviderCostCents:         r.ProviderCostCents,
+		PlatformFeeCents:          r.PlatformFeeCents,
+		BalanceDebitCents:         r.BalanceDebitCents,
+		Currency:                  r.Currency,
+		SettledVia:                settledVia,
+		PolicyHash:                r.PolicyHash,
+		ProviderPriceSnapshotHash: r.ProviderPriceSnapshotHash,
+		ContentHash:               r.ContentHash,
+		SettlementReceiptHash:     r.SettlementReceiptHash,
+		EvidencePackRef:           r.EvidencePackRef,
+		Metadata:                  md,
+		RedactedFields:            redacted,
+		RedactionPolicy:           profile.Name,
+	}
+}
+
+// NewSettlementReceiptView renders a SettlementReceipt into a business view,
+// summing debits and credits so a business reader sees the net ledger movement.
+func NewSettlementReceiptView(s *SettlementReceipt, profile RedactionProfile) SettlementReceiptView {
+	if s == nil {
+		return SettlementReceiptView{Kind: SpendReceiptKindSettlement, RedactionPolicy: profile.Name}
+	}
+	movements := make([]LedgerMovementView, 0, len(s.LedgerEntries))
+	var debits, credits int64
+	for _, e := range s.LedgerEntries {
+		movements = append(movements, LedgerMovementView{
+			AccountID:   e.AccountID,
+			Direction:   string(e.Direction),
+			AmountCents: e.AmountCents,
+			Currency:    e.Currency,
+			Reference:   e.Reference,
+		})
+		switch e.Direction {
+		case SettlementDebit:
+			debits += e.AmountCents
+		case SettlementCredit:
+			credits += e.AmountCents
+		}
+	}
+	return SettlementReceiptView{
+		Kind:                   SpendReceiptKindSettlement,
+		TenantID:               s.TenantID,
+		TreasuryAccountID:      s.TreasuryAccountID,
+		LedgerMovements:        movements,
+		TotalDebits:            debits,
+		TotalCredits:           credits,
+		Currency:               s.Currency,
+		Balanced:               s.Balanced(),
+		UsageReceiptID:         s.UsageReceiptID,
+		SourceUsageReceiptHash: s.SourceUsageReceiptHash,
+		ContentHash:            s.ContentHash,
+		EvidencePackRef:        s.EvidencePackRef,
+		RedactionPolicy:        profile.Name,
+	}
+}

--- a/core/pkg/contracts/economic/spend_receipt_views_test.go
+++ b/core/pkg/contracts/economic/spend_receipt_views_test.go
@@ -1,0 +1,172 @@
+package economic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sensitivePrompt is a synthetic prompt body that must NEVER reach a business
+// view or EvidencePack under the default redaction profile.
+const sensitivePrompt = "PATIENT SSN 123-45-6789 diagnosis confidential"
+
+func buildRouteQuoteWithPromptMetadata(t *testing.T) *RouteQuote {
+	t.Helper()
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	decision := newSpendAuthorityDecision(BudgetVerdictAllow, SpendReasonOKWithinEnvelope, "within envelope", 50_000, "sha256:env")
+	q := NewRouteQuote(
+		"rq-1", "tenant-1", "intent-1", "env-1", "agent-1",
+		ModelRoute{ProviderID: "openai", ModelID: "gpt-4o", PriceSnapshotHash: "sha256:price"},
+		1_500, 3_000, "USD", "sha256:route-policy", now.Add(time.Hour), decision,
+	)
+	q.PrincipalID = "user:alice"
+	q.RequestedProviderID = "openai"
+	q.FallbackChain = []ModelRoute{{ProviderID: "anthropic", ModelID: "claude-haiku", PriceSnapshotHash: "sha256:price-ah"}}
+	// Operator metadata that includes a prompt body plus a benign key. The
+	// benign key must survive; the prompt-bearing keys must be redacted.
+	q.Metadata = map[string]string{
+		"prompt_body":     sensitivePrompt,
+		"prompt":          sensitivePrompt,
+		"messages":        sensitivePrompt,
+		"request_body":    sensitivePrompt,
+		"workspace_label": "finance-q2",
+	}
+	q.Reseal()
+	return q
+}
+
+func TestDefaultRedactionProfile_KeepsPromptBodyOffGraph(t *testing.T) {
+	q := buildRouteQuoteWithPromptMetadata(t)
+	view := NewRouteReceiptView(q, DefaultRedactionProfile())
+
+	// Benign metadata survives.
+	if view.Metadata["workspace_label"] != "finance-q2" {
+		t.Fatalf("expected benign metadata to survive, got %#v", view.Metadata)
+	}
+	// Prompt-bearing keys are stripped.
+	for _, banned := range []string{"prompt_body", "prompt", "messages", "request_body"} {
+		if _, ok := view.Metadata[banned]; ok {
+			t.Fatalf("metadata key %q must be redacted, view metadata: %#v", banned, view.Metadata)
+		}
+	}
+	// The redacted-fields audit trail records exactly what was stripped.
+	if len(view.RedactedFields) != 4 {
+		t.Fatalf("expected 4 redacted fields, got %v", view.RedactedFields)
+	}
+
+	// Hard guarantee: the marshaled view must not contain the prompt body bytes.
+	blob, err := json.Marshal(view)
+	if err != nil {
+		t.Fatalf("marshal view: %v", err)
+	}
+	if strings.Contains(string(blob), "123-45-6789") {
+		t.Fatalf("prompt body leaked into RouteReceiptView JSON: %s", blob)
+	}
+	if view.RedactionPolicy != "default-prompt-off-graph" {
+		t.Fatalf("unexpected redaction policy name: %s", view.RedactionPolicy)
+	}
+}
+
+func TestUsageReceiptView_RedactsPromptMetadataAndDerivesSettlement(t *testing.T) {
+	r := NewUsageReceipt("ur-1", "tenant-1", "rq-1", "intent-1", "env-1", "agent-1", "openai", "gpt-4o", 1_500, 1_000, 100, "USD", "sha256:policy", "evidence://ur-1")
+	r.ProviderRequestID = "prov-req-1"
+	r.ProviderPriceSnapshotHash = "sha256:price"
+	r.Metadata = map[string]string{
+		"completion_body": sensitivePrompt,
+		"region":          "us-east-1",
+	}
+	r.Reseal()
+
+	view := NewUsageReceiptView(r, DefaultRedactionProfile())
+	if view.SettledVia != "BALANCE_DEBIT" {
+		t.Fatalf("expected BALANCE_DEBIT, got %s", view.SettledVia)
+	}
+	if view.ProviderCostCents != 1_000 || view.PlatformFeeCents != 100 || view.ActualAmountCents != 1_100 {
+		t.Fatalf("cost breakdown wrong: %+v", view)
+	}
+	if _, ok := view.Metadata["completion_body"]; ok {
+		t.Fatalf("completion_body must be redacted: %#v", view.Metadata)
+	}
+	if view.Metadata["region"] != "us-east-1" {
+		t.Fatalf("benign region metadata must survive: %#v", view.Metadata)
+	}
+	blob, _ := json.Marshal(view)
+	if strings.Contains(string(blob), "123-45-6789") {
+		t.Fatalf("prompt body leaked into UsageReceiptView: %s", blob)
+	}
+}
+
+func TestUsageReceiptView_InvoiceAccrualWhenNoDebit(t *testing.T) {
+	r := NewUsageReceipt("ur-2", "tenant-1", "rq-2", "intent-2", "env-1", "agent-1", "openai", "gpt-4o", 1_500, 1_000, 100, "USD", "sha256:policy", "evidence://ur-2")
+	r.BalanceDebitCents = 0 // invoice accrual path
+	r.Reseal()
+	view := NewUsageReceiptView(r, DefaultRedactionProfile())
+	if view.SettledVia != "INVOICE_ACCRUAL" {
+		t.Fatalf("expected INVOICE_ACCRUAL when no balance debit, got %s", view.SettledVia)
+	}
+}
+
+func TestBudgetVerdictView_EscalateSurfacesApprovers(t *testing.T) {
+	decision := newSpendAuthorityDecision(BudgetVerdictEscalate, SpendReasonApprovalRequired, "needs approval", 0, "sha256:env")
+	r := NewBudgetVerdictReceipt("bv-1", "tenant-1", "intent-1", "env-1", "agent-1", "openai", "gpt-4o", 1_500, 3_000, "USD", "sha256:price", "sha256:route-policy", "evidence://bv-1", decision)
+	r.PrincipalID = "user:alice"
+
+	view := NewBudgetVerdictView(r, []string{"role:finance-approver"}, DefaultRedactionProfile())
+	if view.Verdict != "ESCALATE" {
+		t.Fatalf("expected ESCALATE, got %s", view.Verdict)
+	}
+	if !view.ApprovalNeeded {
+		t.Fatalf("expected ApprovalNeeded for ESCALATE")
+	}
+	if len(view.Approvers) != 1 || view.Approvers[0] != "role:finance-approver" {
+		t.Fatalf("expected approver surfaced, got %v", view.Approvers)
+	}
+	if view.EnvelopeHash != "sha256:env" || view.RoutePolicyHash != "sha256:route-policy" {
+		t.Fatalf("policy/envelope hashes not surfaced: %+v", view)
+	}
+	if view.DecisionHash != decision.ContentHash {
+		t.Fatalf("decision hash not bound: %s vs %s", view.DecisionHash, decision.ContentHash)
+	}
+}
+
+func TestSettlementReceiptView_SumsMovementsAndCorrectionRefs(t *testing.T) {
+	entries := []SettlementLedgerEntry{
+		{ID: "le-1", AccountID: "balance-1", Direction: SettlementDebit, AmountCents: 1_100, Currency: "USD", Reference: "usage:ur-1"},
+		{ID: "le-2", AccountID: "treasury-1", Direction: SettlementCredit, AmountCents: 1_100, Currency: "USD", Reference: "usage:ur-1"},
+	}
+	s := NewSettlementReceipt("st-1", "tenant-1", "ur-1", "rq-1", "treasury-1", "sha256:usage", "USD", "evidence://st-1", entries)
+
+	view := NewSettlementReceiptView(s, DefaultRedactionProfile())
+	if !view.Balanced {
+		t.Fatalf("expected balanced settlement view")
+	}
+	if view.TotalDebits != 1_100 || view.TotalCredits != 1_100 {
+		t.Fatalf("debit/credit totals wrong: %+v", view)
+	}
+	if len(view.LedgerMovements) != 2 {
+		t.Fatalf("expected 2 ledger movements, got %d", len(view.LedgerMovements))
+	}
+	// Correction reference: the source usage receipt hash links the settlement
+	// back to the usage it settles (the audit "what proves it" anchor).
+	if view.SourceUsageReceiptHash != "sha256:usage" || view.UsageReceiptID != "ur-1" {
+		t.Fatalf("correction/source refs not surfaced: %+v", view)
+	}
+}
+
+// TestWiderProfile_PromptOffByPolicyChoice documents that a non-default profile
+// (for an internal, access-controlled surface) can keep metadata the default
+// strips, but explicitly denied keys still go regardless.
+func TestWiderProfile_PromptOffByPolicyChoice(t *testing.T) {
+	q := buildRouteQuoteWithPromptMetadata(t)
+	// A profile that does NOT redact prompt body: only explicitly denied keys go.
+	wide := RedactionProfile{Name: "internal-wide", RedactPromptBody: false, DeniedMetadataKeys: []string{"prompt_body"}}
+	view := NewRouteReceiptView(q, wide)
+	if _, ok := view.Metadata["prompt_body"]; ok {
+		t.Fatalf("explicitly denied key must still be stripped")
+	}
+	// Substring-only keys are retained under the wide profile by policy choice.
+	if _, ok := view.Metadata["messages"]; !ok {
+		t.Fatalf("wide profile should retain messages metadata, got %#v", view.Metadata)
+	}
+}

--- a/core/pkg/evidencepack/spend_evidence.go
+++ b/core/pkg/evidencepack/spend_evidence.go
@@ -1,0 +1,323 @@
+// spend_evidence.go exports HELM spend receipts (SPEND3/5: RouteQuote,
+// BudgetVerdictReceipt, UsageReceipt, SettlementReceipt) into a deterministic,
+// content-addressed EvidencePack and verifies that pack OFFLINE — with no
+// provider console, no network, and no live ledger.
+//
+// The pack carries two layers that align with Kernel ProofGraph/EvidencePack
+// semantics:
+//
+//   - receipts/*.json  — the source-owned receipts (hashes + metadata only).
+//     These back the cryptographic proof: every receipt is re-hashed offline
+//     against its own canonical content hash.
+//   - views/*.json     — the business-readable VIEWS rendered under a
+//     RedactionProfile. By default the prompt body stays OFF-graph: views never
+//     contain a prompt body, and prompt-bearing metadata keys are stripped.
+//
+// Offline verification re-derives the manifest hash from the pack bytes, checks
+// each receipt's canonical content hash, re-validates the cross-receipt
+// financial invariants (debit == provider cost + platform fee; settlement
+// debits == credits; settlement binds the usage-receipt hash), and proves no
+// prompt body leaked into the business views. None of this touches a provider.
+package evidencepack
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+)
+
+// Spend pack entry paths. Receipts and views are kept in distinct trees so a
+// verifier can prove the receipt layer cryptographically while a business reader
+// consumes the view layer.
+const (
+	spendRouteReceiptPath      = "receipts/route_quote.json"
+	spendBudgetReceiptPath     = "receipts/budget_verdict.json"
+	spendUsageReceiptPath      = "receipts/usage.json"
+	spendSettlementReceiptPath = "receipts/settlement.json"
+
+	spendRouteViewPath      = "views/route_receipt_view.json"
+	spendBudgetViewPath     = "views/budget_verdict_view.json"
+	spendUsageViewPath      = "views/usage_receipt_view.json"
+	spendSettlementViewPath = "views/settlement_receipt_view.json"
+
+	spendRedactionProfilePath = "views/redaction_profile.json"
+)
+
+// SpendReceiptSet is the full set of SPEND3/5 receipts for one governed spend.
+// RouteQuote and BudgetVerdictReceipt are produced pre-dispatch; UsageReceipt
+// and SettlementReceipt post-dispatch. A pack may be built pre-dispatch (route
+// + budget only) or for the completed lifecycle (all four).
+type SpendReceiptSet struct {
+	RouteQuote *economic.RouteQuote
+	Budget     *economic.BudgetVerdictReceipt
+	Usage      *economic.UsageReceipt
+	Settlement *economic.SettlementReceipt
+	// Approvers carries required approver roles/ids for an ESCALATE verdict so
+	// the BudgetVerdict view can answer "who must approve". May be nil.
+	Approvers []string
+}
+
+// BuildSpendEvidencePack renders the receipt set into a deterministic
+// EvidencePack manifest + content map using the given redaction profile. The
+// business views never contain a prompt body. Pass packID/actorDID/intentID and
+// the governing policy hash so the pack manifest binds to the kernel intent.
+func BuildSpendEvidencePack(packID, actorDID, intentID, policyHash string, set SpendReceiptSet, profile economic.RedactionProfile) (*Manifest, map[string][]byte, error) {
+	if set.RouteQuote == nil && set.Budget == nil && set.Usage == nil && set.Settlement == nil {
+		return nil, nil, errors.New("spend evidence pack: at least one receipt is required")
+	}
+
+	b := NewBuilder(packID, actorDID, intentID, policyHash)
+
+	// Receipt layer (cryptographic proof) + view layer (business readable).
+	if set.RouteQuote != nil {
+		if err := addJSON(b, spendRouteReceiptPath, set.RouteQuote); err != nil {
+			return nil, nil, err
+		}
+		if err := addJSON(b, spendRouteViewPath, economic.NewRouteReceiptView(set.RouteQuote, profile)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if set.Budget != nil {
+		if err := addJSON(b, spendBudgetReceiptPath, set.Budget); err != nil {
+			return nil, nil, err
+		}
+		if err := addJSON(b, spendBudgetViewPath, economic.NewBudgetVerdictView(set.Budget, set.Approvers, profile)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if set.Usage != nil {
+		if err := addJSON(b, spendUsageReceiptPath, set.Usage); err != nil {
+			return nil, nil, err
+		}
+		if err := addJSON(b, spendUsageViewPath, economic.NewUsageReceiptView(set.Usage, profile)); err != nil {
+			return nil, nil, err
+		}
+	}
+	if set.Settlement != nil {
+		if err := addJSON(b, spendSettlementReceiptPath, set.Settlement); err != nil {
+			return nil, nil, err
+		}
+		if err := addJSON(b, spendSettlementViewPath, economic.NewSettlementReceiptView(set.Settlement, profile)); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// Record the redaction profile so a verifier can confirm which profile
+	// governed the export (and that prompt-body redaction was on).
+	if err := addJSON(b, spendRedactionProfilePath, profile); err != nil {
+		return nil, nil, err
+	}
+
+	return b.Build()
+}
+
+func addJSON(b *Builder, path string, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("spend evidence pack: marshal %s: %w", path, err)
+	}
+	b.AddRawEntry(path, "application/json", data)
+	return nil
+}
+
+// SpendVerificationResult is the structured outcome of an offline verification.
+// It is itself deterministic and content-addressable, so it can be attached to
+// a run as the offline-verify artifact.
+type SpendVerificationResult struct {
+	PackID       string `json:"pack_id"`
+	ManifestHash string `json:"manifest_hash"`
+	// ReceiptsVerified lists each receipt path whose canonical content hash matched.
+	ReceiptsVerified []string `json:"receipts_verified"`
+	// InvariantsChecked lists the financial invariants that were re-validated.
+	InvariantsChecked []string `json:"invariants_checked"`
+	// PromptBodyOffGraph is true when no business view contained a prompt body.
+	PromptBodyOffGraph bool `json:"prompt_body_off_graph"`
+	// Offline is always true: verification used only the pack bytes.
+	Offline bool `json:"offline"`
+	OK      bool `json:"ok"`
+}
+
+// promptBodyMarkers are field substrings that must never appear in a business
+// view. They mirror the default RedactionProfile's denied keys. Offline
+// verification scans every view JSON for these to prove the prompt body stayed
+// off-graph by default.
+var promptBodyMarkers = []string{
+	"prompt_body", "prompt_text", "\"prompt\"", "system_prompt",
+	"request_body", "response_body", "completion_body", "messages",
+}
+
+// VerifySpendEvidenceOffline verifies a spend EvidencePack using only the pack
+// content map — no provider console, no network, no live ledger. It:
+//
+//  1. recomputes the manifest hash from the manifest entries and confirms it
+//     matches the embedded manifest_hash and every entry's content hash;
+//  2. re-hashes each receipt against its own canonical content hash;
+//  3. re-validates the cross-receipt financial invariants;
+//  4. proves no business view contains a prompt body.
+//
+// It returns a structured result and an error describing the first failure.
+func VerifySpendEvidenceOffline(contents map[string][]byte) (*SpendVerificationResult, error) {
+	manifestJSON, ok := contents["manifest.json"]
+	if !ok {
+		return nil, errors.New("spend evidence verify: manifest.json missing")
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(manifestJSON, &manifest); err != nil {
+		return nil, fmt.Errorf("spend evidence verify: decode manifest: %w", err)
+	}
+
+	res := &SpendVerificationResult{PackID: manifest.PackID, ManifestHash: manifest.ManifestHash, Offline: true}
+
+	// (1) Manifest hash + per-entry content-hash integrity.
+	if err := verifyManifestIntegrity(&manifest, contents); err != nil {
+		return res, err
+	}
+
+	// (2)+(3) Per-receipt canonical content-hash checks and financial invariants.
+	verified, err := verifySpendReceipts(contents, &res.InvariantsChecked)
+	if err != nil {
+		return res, err
+	}
+	sort.Strings(verified)
+	res.ReceiptsVerified = verified
+
+	// (4) Prompt body must not appear in any view.
+	if err := verifyNoPromptBody(contents); err != nil {
+		return res, err
+	}
+	res.PromptBodyOffGraph = true
+
+	res.OK = true
+	return res, nil
+}
+
+// verifyManifestIntegrity recomputes the manifest hash and checks every listed
+// entry's content hash against the bytes actually present in the pack.
+func verifyManifestIntegrity(manifest *Manifest, contents map[string][]byte) error {
+	recomputed, err := ComputeManifestHash(manifest)
+	if err != nil {
+		return fmt.Errorf("spend evidence verify: recompute manifest hash: %w", err)
+	}
+	if recomputed != manifest.ManifestHash {
+		return fmt.Errorf("spend evidence verify: manifest hash mismatch: embedded %s, recomputed %s", manifest.ManifestHash, recomputed)
+	}
+	for _, entry := range manifest.Entries {
+		data, ok := contents[entry.Path]
+		if !ok {
+			return fmt.Errorf("spend evidence verify: manifest entry %s missing from pack", entry.Path)
+		}
+		if got := HashContent(data); got != entry.ContentHash {
+			return fmt.Errorf("spend evidence verify: content hash mismatch for %s: manifest %s, actual %s", entry.Path, entry.ContentHash, got)
+		}
+	}
+	return nil
+}
+
+// verifySpendReceipts re-hashes each receipt present in the pack against its own
+// canonical content hash and re-validates the cross-receipt invariants.
+func verifySpendReceipts(contents map[string][]byte, invariants *[]string) ([]string, error) {
+	var verified []string
+
+	if raw, ok := contents[spendRouteReceiptPath]; ok {
+		route := &economic.RouteQuote{}
+		if err := json.Unmarshal(raw, route); err != nil {
+			return nil, fmt.Errorf("spend evidence verify: decode route quote: %w", err)
+		}
+		if !route.HasCanonicalContentHash() {
+			return nil, fmt.Errorf("spend evidence verify: route quote content hash mismatch (have %s, want %s)", route.ContentHash, route.CanonicalContentHash())
+		}
+		verified = append(verified, spendRouteReceiptPath)
+	}
+
+	if raw, ok := contents[spendBudgetReceiptPath]; ok {
+		budget := &economic.BudgetVerdictReceipt{}
+		if err := json.Unmarshal(raw, budget); err != nil {
+			return nil, fmt.Errorf("spend evidence verify: decode budget verdict: %w", err)
+		}
+		if !budget.HasCanonicalContentHash() {
+			return nil, fmt.Errorf("spend evidence verify: budget verdict content hash mismatch (have %s, want %s)", budget.ContentHash, budget.CanonicalContentHash())
+		}
+		verified = append(verified, spendBudgetReceiptPath)
+	}
+
+	var usage *economic.UsageReceipt
+	if raw, ok := contents[spendUsageReceiptPath]; ok {
+		usage = &economic.UsageReceipt{}
+		if err := json.Unmarshal(raw, usage); err != nil {
+			return nil, fmt.Errorf("spend evidence verify: decode usage receipt: %w", err)
+		}
+		if !usage.HasCanonicalContentHash() {
+			return nil, fmt.Errorf("spend evidence verify: usage receipt content hash mismatch (have %s, want %s)", usage.ContentHash, usage.CanonicalContentHash())
+		}
+		// Debit invariant: actual == provider cost + platform fee == balance debit.
+		if usage.ActualAmountCents != usage.ProviderCostCents+usage.PlatformFeeCents {
+			return nil, fmt.Errorf("spend evidence verify: usage debit invariant broken: actual %d != provider %d + fee %d", usage.ActualAmountCents, usage.ProviderCostCents, usage.PlatformFeeCents)
+		}
+		if usage.BalanceDebitCents != usage.ActualAmountCents {
+			return nil, fmt.Errorf("spend evidence verify: usage balance debit %d != actual %d", usage.BalanceDebitCents, usage.ActualAmountCents)
+		}
+		*invariants = append(*invariants, "usage.actual==provider_cost+platform_fee", "usage.balance_debit==actual")
+		verified = append(verified, spendUsageReceiptPath)
+	}
+
+	if raw, ok := contents[spendSettlementReceiptPath]; ok {
+		settlement := &economic.SettlementReceipt{}
+		if err := json.Unmarshal(raw, settlement); err != nil {
+			return nil, fmt.Errorf("spend evidence verify: decode settlement receipt: %w", err)
+		}
+		if !settlement.HasCanonicalContentHash() {
+			return nil, fmt.Errorf("spend evidence verify: settlement receipt content hash mismatch (have %s, want %s)", settlement.ContentHash, settlement.CanonicalContentHash())
+		}
+		if !settlement.Balanced() {
+			return nil, errors.New("spend evidence verify: settlement ledger is not balanced (debits != credits)")
+		}
+		*invariants = append(*invariants, "settlement.debits==credits")
+		// Settlement must bind the usage receipt it settles. This is the
+		// authoritative direction: source_usage_receipt_hash is sealed AFTER the
+		// usage receipt's final hash, so it is a stable link. The reverse field
+		// (usage.SettlementReceiptHash) is sealed mutually and is intentionally
+		// not required to equal the final settlement hash.
+		if usage != nil {
+			if settlement.SourceUsageReceiptHash != usage.ContentHash {
+				return nil, fmt.Errorf("spend evidence verify: settlement source_usage_receipt_hash %s does not bind usage receipt hash %s", settlement.SourceUsageReceiptHash, usage.ContentHash)
+			}
+			if settlement.UsageReceiptID != "" && usage.ID != "" && settlement.UsageReceiptID != usage.ID {
+				return nil, fmt.Errorf("spend evidence verify: settlement usage_receipt_id %s does not match usage receipt id %s", settlement.UsageReceiptID, usage.ID)
+			}
+			*invariants = append(*invariants, "settlement.binds_usage_receipt_hash")
+		}
+		verified = append(verified, spendSettlementReceiptPath)
+	}
+
+	if len(verified) == 0 {
+		return nil, errors.New("spend evidence verify: pack contains no spend receipts")
+	}
+	return verified, nil
+}
+
+// verifyNoPromptBody scans every business view in the pack for prompt-body
+// markers, proving the prompt body stayed off-graph by default.
+func verifyNoPromptBody(contents map[string][]byte) error {
+	for path, data := range contents {
+		if !strings.HasPrefix(path, "views/") {
+			continue
+		}
+		// The redaction profile is a policy document that names the keys it
+		// redacts (e.g. "prompt_body"); it is not a spend view and must be
+		// exempt from the marker scan, otherwise it would self-trip.
+		if path == spendRedactionProfilePath {
+			continue
+		}
+		lower := strings.ToLower(string(data))
+		for _, marker := range promptBodyMarkers {
+			if strings.Contains(lower, marker) {
+				return fmt.Errorf("spend evidence verify: prompt-body marker %q found in business view %s", marker, path)
+			}
+		}
+	}
+	return nil
+}

--- a/core/pkg/evidencepack/spend_evidence_test.go
+++ b/core/pkg/evidencepack/spend_evidence_test.go
@@ -1,0 +1,224 @@
+package evidencepack
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+)
+
+// buildSpendReceiptSet builds a fully-linked, valid set of SPEND3/5 receipts the
+// same way the inferencegateway engine does (mutual settlement<->usage hash
+// binding), so the offline verifier is exercised against realistic receipts.
+func buildSpendReceiptSet(t *testing.T) SpendReceiptSet {
+	t.Helper()
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+
+	decision := economicAllow(50_000, "sha256:env")
+	quote := economic.NewRouteQuote(
+		"rq-1", "tenant-1", "intent-1", "env-1", "agent-1",
+		economic.ModelRoute{ProviderID: "openai", ModelID: "gpt-4o", PriceSnapshotHash: "sha256:price"},
+		1_500, 3_000, "USD", "sha256:route-policy", now.Add(time.Hour), decision,
+	)
+	quote.PrincipalID = "user:alice"
+	quote.Reseal()
+
+	budget := economic.NewBudgetVerdictReceipt(
+		"bv-1", "tenant-1", "intent-1", "env-1", "agent-1", "openai", "gpt-4o",
+		1_500, 3_000, "USD", "sha256:price", "sha256:route-policy", "evidence://pack-1", decision,
+	)
+
+	usage := economic.NewUsageReceipt(
+		"ur-1", "tenant-1", "rq-1", "intent-1", "env-1", "agent-1", "openai", "gpt-4o",
+		1_500, 1_000, 100, "USD", "sha256:policy", "evidence://pack-1",
+	)
+	usage.ProviderRequestID = "prov-req-1"
+	usage.ProviderPriceSnapshotHash = "sha256:price"
+
+	entries := []economic.SettlementLedgerEntry{
+		{ID: "sle-ur-1-debit", AccountID: "balance-1", Direction: economic.SettlementDebit, AmountCents: usage.BalanceDebitCents, Currency: "USD", Reference: "balance:balance-1"},
+		{ID: "sle-ur-1-credit", AccountID: "treasury-1", Direction: economic.SettlementCredit, AmountCents: usage.BalanceDebitCents, Currency: "USD", Reference: "treasury:treasury-1"},
+	}
+	settlement := economic.NewSettlementReceipt("settle-ur-1", "tenant-1", "ur-1", "rq-1", "treasury-1", usage.ContentHash, "USD", "evidence://pack-1", entries)
+
+	// Mirror the engine's mutual binding order.
+	usage.LedgerEntryIDs = []string{entries[0].ID, entries[1].ID}
+	usage.SettlementReceiptHash = settlement.ContentHash
+	usage.Reseal()
+	settlement.SourceUsageReceiptHash = usage.ContentHash
+	settlement.Reseal()
+
+	return SpendReceiptSet{RouteQuote: quote, Budget: budget, Usage: usage, Settlement: settlement}
+}
+
+// economicAllow builds an ALLOW spend decision with a canonical content hash.
+func economicAllow(remaining int64, envHash string) economic.SpendAuthorityDecision {
+	d := economic.SpendAuthorityDecision{
+		Verdict:        economic.BudgetVerdictAllow,
+		ReasonCode:     economic.SpendReasonOKWithinEnvelope,
+		Reason:         "within envelope",
+		RemainingCents: remaining,
+		EnvelopeHash:   envHash,
+	}
+	d.ContentHash = d.CanonicalContentHash()
+	return d
+}
+
+func TestBuildAndVerifySpendEvidenceOffline(t *testing.T) {
+	set := buildSpendReceiptSet(t)
+	manifest, contents, err := BuildSpendEvidencePack("pack-1", "did:helm:agent-1", "intent-1", "sha256:route-policy", set, economic.DefaultRedactionProfile())
+	if err != nil {
+		t.Fatalf("build pack: %v", err)
+	}
+	if manifest.ManifestHash == "" {
+		t.Fatalf("expected manifest hash")
+	}
+
+	res, err := VerifySpendEvidenceOffline(contents)
+	if err != nil {
+		t.Fatalf("offline verify failed: %v", err)
+	}
+	if !res.OK || !res.Offline || !res.PromptBodyOffGraph {
+		t.Fatalf("unexpected verification result: %+v", res)
+	}
+	if len(res.ReceiptsVerified) != 4 {
+		t.Fatalf("expected 4 receipts verified, got %v", res.ReceiptsVerified)
+	}
+	// Financial invariants must have been re-checked offline.
+	mustContain(t, res.InvariantsChecked, "usage.actual==provider_cost+platform_fee")
+	mustContain(t, res.InvariantsChecked, "settlement.debits==credits")
+	mustContain(t, res.InvariantsChecked, "settlement.binds_usage_receipt_hash")
+}
+
+func TestVerifySpendEvidenceOffline_DeterministicArchiveRoundTrip(t *testing.T) {
+	set := buildSpendReceiptSet(t)
+	_, contents, err := BuildSpendEvidencePack("pack-1", "did:helm:agent-1", "intent-1", "sha256:route-policy", set, economic.DefaultRedactionProfile())
+	if err != nil {
+		t.Fatalf("build pack: %v", err)
+	}
+
+	// Round-trip through the deterministic tar archive (the offline artifact).
+	tarA, err := Archive(contents)
+	if err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	tarB, err := Archive(contents)
+	if err != nil {
+		t.Fatalf("archive 2: %v", err)
+	}
+	if !bytes.Equal(tarA, tarB) {
+		t.Fatalf("archive is not deterministic")
+	}
+
+	restored, err := Unarchive(tarA)
+	if err != nil {
+		t.Fatalf("unarchive: %v", err)
+	}
+	res, err := VerifySpendEvidenceOffline(restored)
+	if err != nil {
+		t.Fatalf("verify after round-trip: %v", err)
+	}
+	if !res.OK {
+		t.Fatalf("expected OK after round-trip")
+	}
+}
+
+func TestVerifySpendEvidenceOffline_DetectsTamper(t *testing.T) {
+	set := buildSpendReceiptSet(t)
+	_, contents, err := BuildSpendEvidencePack("pack-1", "did:helm:agent-1", "intent-1", "sha256:route-policy", set, economic.DefaultRedactionProfile())
+	if err != nil {
+		t.Fatalf("build pack: %v", err)
+	}
+
+	// Tamper with the usage receipt amount AFTER the pack was sealed. The content
+	// hash recorded in the manifest no longer matches the tampered bytes.
+	var usage economic.UsageReceipt
+	if err := json.Unmarshal(contents[spendUsageReceiptPath], &usage); err != nil {
+		t.Fatalf("decode usage: %v", err)
+	}
+	usage.ProviderCostCents = 999_999
+	tampered, _ := json.MarshalIndent(&usage, "", "  ")
+	contents[spendUsageReceiptPath] = tampered
+
+	if _, err := VerifySpendEvidenceOffline(contents); err == nil {
+		t.Fatalf("expected tamper to be detected")
+	} else if !strings.Contains(err.Error(), "content hash mismatch") {
+		t.Fatalf("expected content hash mismatch error, got: %v", err)
+	}
+}
+
+func TestVerifySpendEvidenceOffline_RejectsPromptBodyInView(t *testing.T) {
+	set := buildSpendReceiptSet(t)
+	_, contents, err := BuildSpendEvidencePack("pack-1", "did:helm:agent-1", "intent-1", "sha256:route-policy", set, economic.DefaultRedactionProfile())
+	if err != nil {
+		t.Fatalf("build pack: %v", err)
+	}
+
+	// Forge a view that smuggles a prompt body and re-seal the manifest so the
+	// content-hash layer passes; the prompt-body guard must still reject it.
+	forged := []byte(`{"kind":"USAGE_RECEIPT","prompt_body":"PATIENT SSN 123-45-6789"}`)
+	contents[spendUsageViewPath] = forged
+	resealManifest(t, contents)
+
+	if _, err := VerifySpendEvidenceOffline(contents); err == nil {
+		t.Fatalf("expected prompt-body guard to reject forged view")
+	} else if !strings.Contains(err.Error(), "prompt-body marker") {
+		t.Fatalf("expected prompt-body marker error, got: %v", err)
+	}
+}
+
+func TestBuildSpendEvidencePack_PreDispatchOnly(t *testing.T) {
+	set := buildSpendReceiptSet(t)
+	// Pre-dispatch pack: route + budget only.
+	pre := SpendReceiptSet{RouteQuote: set.RouteQuote, Budget: set.Budget}
+	_, contents, err := BuildSpendEvidencePack("pack-pre", "did:helm:agent-1", "intent-1", "sha256:route-policy", pre, economic.DefaultRedactionProfile())
+	if err != nil {
+		t.Fatalf("build pre-dispatch pack: %v", err)
+	}
+	res, err := VerifySpendEvidenceOffline(contents)
+	if err != nil {
+		t.Fatalf("verify pre-dispatch: %v", err)
+	}
+	if len(res.ReceiptsVerified) != 2 {
+		t.Fatalf("expected 2 receipts for pre-dispatch pack, got %v", res.ReceiptsVerified)
+	}
+}
+
+// resealManifest recomputes the manifest entry hashes + manifest hash for the
+// current contents so a forged-content test can isolate a specific guard.
+func resealManifest(t *testing.T, contents map[string][]byte) {
+	t.Helper()
+	var manifest Manifest
+	if err := json.Unmarshal(contents["manifest.json"], &manifest); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	for i := range manifest.Entries {
+		data, ok := contents[manifest.Entries[i].Path]
+		if !ok {
+			continue
+		}
+		manifest.Entries[i].ContentHash = HashContent(data)
+		manifest.Entries[i].Size = int64(len(data))
+	}
+	manifest.ManifestHash = ""
+	h, err := ComputeManifestHash(&manifest)
+	if err != nil {
+		t.Fatalf("recompute manifest hash: %v", err)
+	}
+	manifest.ManifestHash = h
+	out, _ := json.MarshalIndent(&manifest, "", "  ")
+	contents["manifest.json"] = out
+}
+
+func mustContain(t *testing.T, haystack []string, needle string) {
+	t.Helper()
+	for _, h := range haystack {
+		if h == needle {
+			return
+		}
+	}
+	t.Fatalf("expected %q in %v", needle, haystack)
+}

--- a/core/pkg/inferencegateway/engine.go
+++ b/core/pkg/inferencegateway/engine.go
@@ -278,6 +278,11 @@ func (e *Engine) Quote(env *economic.AgentSpendEnvelope, req RouteRequest) (*Quo
 		snapshot.ContentHash, e.routePolicyHash, evidenceRef, decision,
 	)
 	receipt.PrincipalID = req.PrincipalID
+	// PrincipalID is part of the receipt's canonical hash, so reseal after
+	// setting it; otherwise the stored ContentHash (computed pre-PrincipalID)
+	// would not match the receipt body and the receipt would fail offline
+	// canonical-hash verification. Bind the quote to the resealed hash.
+	receipt.Reseal()
 	quote.ReceiptHash = receipt.ContentHash
 	quote.Reseal()
 	result.Receipt = receipt

--- a/core/pkg/inferencegateway/spend_evidence_export_test.go
+++ b/core/pkg/inferencegateway/spend_evidence_export_test.go
@@ -1,0 +1,81 @@
+package inferencegateway
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts/economic"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidencepack"
+)
+
+// TestSpendEvidencePackExportAndOfflineVerify drives a real governed Quote ->
+// Settle through the engine, exports the four genuine SPEND3/5 receipts into a
+// spend EvidencePack, and verifies that pack OFFLINE (no provider console). This
+// is the SPEND8 end-to-end proof that the business views + offline verifier work
+// against real engine output, not synthetic fixtures.
+func TestSpendEvidencePackExportAndOfflineVerify(t *testing.T) {
+	h := newHarness(t)
+
+	quote, err := h.engine.Quote(h.env, h.req("idem-spend8", "gpt-4o", 1000, 500))
+	if err != nil {
+		t.Fatalf("Quote() = %v", err)
+	}
+	if quote.Receipt == nil {
+		t.Fatal("expected a budget verdict receipt on ALLOW")
+	}
+
+	settle, err := h.engine.Settle(quote.Quote, "prov-req-spend8", 2, 1000, 480)
+	if err != nil {
+		t.Fatalf("Settle() = %v", err)
+	}
+
+	set := evidencepack.SpendReceiptSet{
+		RouteQuote: quote.Quote,
+		Budget:     quote.Receipt,
+		Usage:      settle.UsageReceipt,
+		Settlement: settle.SettlementReceipt,
+	}
+
+	manifest, contents, err := evidencepack.BuildSpendEvidencePack(
+		"pack-spend8", "did:helm:agent-1", quote.Quote.SpendIntentID,
+		h.engine.RoutePolicyHash(), set, economic.DefaultRedactionProfile(),
+	)
+	if err != nil {
+		t.Fatalf("build spend evidence pack: %v", err)
+	}
+	if manifest.ManifestHash == "" {
+		t.Fatal("expected manifest hash on exported pack")
+	}
+
+	res, err := evidencepack.VerifySpendEvidenceOffline(contents)
+	if err != nil {
+		t.Fatalf("offline verify of real engine receipts failed: %v", err)
+	}
+	if !res.OK || !res.PromptBodyOffGraph || !res.Offline {
+		t.Fatalf("unexpected offline verification result: %+v", res)
+	}
+	if len(res.ReceiptsVerified) != 4 {
+		t.Fatalf("expected all 4 receipts verified, got %v", res.ReceiptsVerified)
+	}
+
+	// The business view layer must render and bind the settlement back to usage.
+	usageView := economic.NewUsageReceiptView(settle.UsageReceipt, economic.DefaultRedactionProfile())
+	if usageView.SettledVia != "BALANCE_DEBIT" {
+		t.Fatalf("expected BALANCE_DEBIT for prepaid balance, got %s", usageView.SettledVia)
+	}
+	settlementView := economic.NewSettlementReceiptView(settle.SettlementReceipt, economic.DefaultRedactionProfile())
+	if !settlementView.Balanced {
+		t.Fatal("settlement view must be balanced")
+	}
+	if settlementView.SourceUsageReceiptHash != settle.UsageReceipt.ContentHash {
+		t.Fatal("settlement view must bind the usage receipt content hash")
+	}
+
+	// The exported pack bytes must never contain a literal prompt body. The
+	// engine receipts only store hashes, so the whole pack is prompt-free.
+	for path, data := range contents {
+		if strings.Contains(string(data), "123-45-6789") {
+			t.Fatalf("unexpected sensitive payload in pack entry %s", path)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Refs **MIN-473** [SPEND8]. Stacked on SPEND5 (PR #426); base is `codex/min-470-spend5-usage-ledger`. Extends HELM proof surfaces so spend evidence is both business-readable AND offline-verifiable, reusing the SPEND3/5 receipts (RouteQuote, BudgetVerdictReceipt, UsageReceipt, SettlementReceipt). Does NOT duplicate EVIDENCE1's EvidencePack narrative (PR #424) — this adds the distinct per-receipt business VIEWS + spend-path offline verification + redaction profile.

## Implemented
**Business VIEWS** — `core/pkg/contracts/economic/spend_receipt_views.go`
A non-engineer can answer who proposed/approved, which policy, which data, what happened, how much, what proves it:
- `RouteReceiptView`: requested/selected provider+model, fallback chain, quote, price-snapshot hash, route-policy hash.
- `BudgetVerdictView`: ALLOW/DENY/ESCALATE, envelope hash, policy hash, approvers (surfaced on ESCALATE).
- `UsageReceiptView`: actual usage, provider cost, platform fee, balance debit vs invoice accrual.
- `SettlementReceiptView`: ledger movements, debit/credit totals, balanced flag, source-usage-receipt hash (correction/proof ref).

**Redaction profile** — `DefaultRedactionProfile()` keeps the prompt body OFF-graph by default. Receipts already store hashes+metadata only; the profile additionally strips prompt-bearing metadata keys (case-insensitive key + substring match) so the free-form `Metadata` maps cannot smuggle a prompt body into a business view. An audit trail records exactly which keys were redacted.

**EvidencePack export + OFFLINE verification** — `core/pkg/evidencepack/spend_evidence.go`
- `BuildSpendEvidencePack` exports the four receipts (`receipts/`) plus their redacted business views (`views/`) and the redaction profile, via the existing deterministic `Builder`.
- `VerifySpendEvidenceOffline` uses only the pack bytes (no provider console, no network, no live ledger): re-derives the manifest hash, checks every entry's content hash, re-hashes each receipt against its canonical content hash, re-validates the cross-receipt financial invariants (debit == provider cost + platform fee; settlement debits == credits; settlement binds the usage-receipt hash), and proves no prompt body leaked into any view. The result struct is itself deterministic/content-addressable (the offline-verify artifact).

**Contracts alignment** — added non-mutating `CanonicalContentHash`/`HasCanonicalContentHash` to RouteQuote/UsageReceipt/SettlementReceipt (mirroring `BudgetVerdictReceipt`) for offline verification, and `BudgetVerdictReceipt.Reseal`. Fixed `Engine.Quote` to reseal the budget verdict receipt after setting `PrincipalID` (a hashed field) so the emitted receipt's `ContentHash` matches its body and verifies offline; the quote still binds the resealed receipt hash (SPEND3 binding invariant preserved).

## Done gate
- Offline verification: `evidencepack.VerifySpendEvidenceOffline` + deterministic `Archive` round-trip; artifact = `SpendVerificationResult{ManifestHash, ReceiptsVerified, InvariantsChecked, PromptBodyOffGraph, Offline, OK}`.
- Redaction test proves the prompt body is not stored in the business graph by default (`TestDefaultRedactionProfile_KeepsPromptBodyOffGraph`, `TestVerifySpendEvidenceOffline_RejectsPromptBodyInView`).
- Schema aligned with Kernel ProofGraph/EvidencePack: views map to receipt-kind node labels; receipts re-hash through the same JCS-canonical EvidencePack manifest path.

## Tests (real, not stubs)
- `spend_receipt_views_test.go`: redaction off-graph guarantee, ESCALATE approvers, cost breakdown, balance-debit vs invoice-accrual, settlement movement sums + correction refs.
- `spend_evidence_test.go`: build+verify offline (4 receipts), deterministic archive round-trip, tamper detection, prompt-body rejection, pre-dispatch (2-receipt) packs.
- `inferencegateway/spend_evidence_export_test.go`: drives a REAL engine Quote→Settle, exports the four genuine receipts, verifies offline end-to-end.

## Gate results
- `make build`: PASS
- `go test ./core/pkg/...`: PASS (252 packages, 0 failures)
- `make lint` (docs-coverage + docs-truth + `go vet ./...` + gofmt): PASS
- `make verify-fixtures`: PASS (golden EvidencePack/canonical roots unchanged — additive only)
- `go test -race` on changed pkgs: PASS
- helm-pr-preflight + helm-conformance: ran; determinism PASS, evidence integrity PASS, boundary PASS

## Boundary
No `.proto`/OpenAPI/JSON-schema changes — no contracts-proto/catalog sync required. No parallel proof universe: routed through existing receipt/EvidencePack/ProofGraph paths. RLM not used.

## Remaining / follow-ups (out of this slice)
- Surface the four views + `VerifySpendEvidenceOffline` through a `helm-ai-kernel export`/`verify` CLI subcommand and the gateway HTTP surface (this PR lands the library + verifier; engine integration is covered by the export test).
- Optional: add a signed STH/transparency anchor to the spend pack for cross-log inclusion (existing `Builder.AddTransparencySTH` hook is available).

DRAFT only — Phase-0 launch freeze (no merge/deploy/release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)