### PR TITLE
docs: close kernel community issue backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration_request.yml
+++ b/.github/ISSUE_TEMPLATE/integration_request.yml
@@ -15,6 +15,30 @@ body:
       placeholder: "Local MCP stdio server"
     validations:
       required: true
+  - type: input
+    id: project_link
+    attributes:
+      label: Project link
+      description: Public repository, package, or docs URL for the target.
+      placeholder: "https://github.com/example/project"
+    validations:
+      required: true
+  - type: textarea
+    id: capabilities
+    attributes:
+      label: Tools or capabilities involved
+      description: List the shell, DB, filesystem, cloud, browser, code, or other side-effecting capabilities.
+      placeholder: "shell.run_command, filesystem.read_file"
+    validations:
+      required: true
+  - type: textarea
+    id: side_effect_risk
+    attributes:
+      label: Side-effect risk
+      description: What could go wrong if the tool call executes without HELM governance?
+      placeholder: "destructive filesystem writes, credential exposure, production deploy"
+    validations:
+      required: true
   - type: textarea
     id: workflow
     attributes:
@@ -41,3 +65,8 @@ body:
       description: Explain how this can be tested with localhost services, temp directories, or sample policy data.
     validations:
       required: true
+  - type: textarea
+    id: policy_metadata
+    attributes:
+      label: Policy metadata needed
+      description: Name the tool args, identity, resource, risk, or receipt fields HELM would need to decide safely.

--- a/.github/ISSUE_TEMPLATE/performance_latency_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/performance_latency_feedback.yml
@@ -1,0 +1,62 @@
+name: Performance and latency feedback
+description: Report HELM latency for policy, receipt, SDK, MCP, or proxy paths.
+title: "[Performance]: "
+labels: ["community", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Include sanitized local measurements only. Do not include secrets, private prompts, customer data, or production endpoints.
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, architecture, hardware, container, or CI runner.
+      placeholder: "macOS arm64, 32 GB RAM"
+    validations:
+      required: true
+  - type: input
+    id: command
+    attributes:
+      label: HELM command or path
+      description: Command, SDK call, MCP route, or proxy path that was slow.
+      placeholder: "helm-ai-kernel proxy /v1/chat/completions"
+    validations:
+      required: true
+  - type: input
+    id: observed_latency
+    attributes:
+      label: Observed latency
+      description: Include units and sample size.
+      placeholder: "p95 42 ms over 100 calls"
+    validations:
+      required: true
+  - type: input
+    id: expected_latency
+    attributes:
+      label: Expected latency
+      description: What would be acceptable for your workflow?
+      placeholder: "p95 under 20 ms"
+  - type: input
+    id: concurrency
+    attributes:
+      label: Concurrent agents or calls
+      placeholder: "8 agents, 40 calls/sec"
+  - type: textarea
+    id: tool_context
+    attributes:
+      label: MCP server or tool type
+      description: Shell, DB, filesystem, cloud, browser, code, or other tool class.
+  - type: dropdown
+    id: suspected_area
+    attributes:
+      label: Suspected latency area
+      options:
+        - policy evaluation
+        - receipt signing
+        - evidence export
+        - network/proxy
+        - SDK/client
+        - unknown
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/receipt_evidencepack_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/receipt_evidencepack_feedback.yml
@@ -1,0 +1,43 @@
+name: Receipt and EvidencePack feedback
+description: Report missing or confusing proof fields from receipts or EvidencePacks.
+title: "[Proof feedback]: "
+labels: ["community", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep public issues sanitized. Do not include secrets, private prompts, customer data, private endpoints, or unredacted production receipts.
+  - type: textarea
+    id: receipt_fields
+    attributes:
+      label: Receipt fields reviewed
+      description: Which receipt, ProofGraph, or EvidencePack fields did you inspect?
+    validations:
+      required: true
+  - type: textarea
+    id: missing_information
+    attributes:
+      label: Missing information
+      description: What information did your audit, incident-response, or integration workflow need but not find?
+    validations:
+      required: true
+  - type: textarea
+    id: confusing_information
+    attributes:
+      label: Confusing or redundant information
+      description: What was present but unclear, duplicated, or hard to trust?
+  - type: textarea
+    id: workflow_requirements
+    attributes:
+      label: Audit or incident-response requirement
+      description: What would your real workflow require before accepting this proof?
+  - type: textarea
+    id: integration_context
+    attributes:
+      label: Agent framework or MCP context
+      description: Name the agent framework, MCP server, tool class, or local fixture involved.
+  - type: textarea
+    id: source_links
+    attributes:
+      label: Sanitized source links
+      description: Public docs, fixture hashes, demo output, or issue links.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -76,6 +76,7 @@ flowchart TD
 | OpenTelemetry GenAI | `helm-ai-kernel proxy` with telemetry enabled | telemetry export shape | [`examples/otel-genai`](../examples/otel-genai) | `go test ./examples/otel-genai/...` |
 | OpenCLAW | local example harness | compatibility with OpenCLAW-style policy material | [`examples/openclaw`](../examples/openclaw) | `make docs-truth` |
 | Policy examples | `helm-ai-kernel bundle build <source>` | CEL, Rego, Cedar bundle inputs | [`examples/policies`](../examples/policies) | `make docs-truth` |
+| Policy-pack examples | `helm-ai-kernel serve --policy examples/policy-packs/<pack>.toml` | runnable allow/deny reference packs, including destructive operation deny/escalate guidance | [`examples/policy-packs`](../examples/policy-packs) | `cd core/cmd/helm-ai-kernel && go test . -run TestPolicyPackExamplesLoad -count=1` |
 | Starters | selected starter README | scaffolded integrations only where source exists | [`examples/starters`](../examples/starters) | `make docs-truth` |
 
 ## Common Environment

--- a/docs/EXECUTION_SECURITY_MODEL.md
+++ b/docs/EXECUTION_SECURITY_MODEL.md
@@ -81,6 +81,25 @@ HELM implements three independent, composable layers of execution security.
 Each layer addresses a distinct class of threat and operates at a different
 point in the execution lifecycle. No single layer is sufficient on its own.
 
+## Guarantees And Non-Guarantees
+
+HELM AI Kernel does:
+
+- enforce deny-by-default policy at MCP and OpenAI-compatible dispatch boundaries;
+- emit signed receipts for `ALLOW`, `DENY`, and `ESCALATE` decisions;
+- quarantine unknown MCP servers and tools until they are inspected and approved;
+- produce offline-verifiable EvidencePacks for source-backed receipt material.
+
+HELM AI Kernel does not:
+
+- protect against a compromised host kernel, runtime, or operator account;
+- make reads safe when policy already allows the agent to read sensitive files;
+- replace secret scanning, network firewalls, endpoint controls, or OS sandboxing;
+- prevent prompt injection at generation time; enforcement happens at dispatch;
+- capture side effects from tools that bypass the HELM proxy or MCP boundary;
+- certify every MCP tool schema through static analysis;
+- certify compliance with a regulatory standard by itself.
+
 ```
                 ┌─────────────────────────────────────────┐
                 │        Agent / Orchestrator              │

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ Or run the binary directly with an explicit port:
 | `mcp_client/` | Simple MCP and OpenAI-compatible invocation flow | `cd examples/mcp_client && HELM_URL=http://127.0.0.1:7714 bash main.sh` |
 | `openclaw/` | Browser split-compute runtime-adapter contract | Documentation-only contract example. |
 | `otel-genai/` | OpenTelemetry GenAI semantic convention smoke example | `cd examples/otel-genai && go test ./...` |
-| `policy-packs/` | Runnable example serve-policy wrappers plus JSON reference packs for shell, DB, CI/CD, and cloud mutation scenarios | `cd core/cmd/helm-ai-kernel && go test . -run TestPolicyPackExamplesLoad -count=1` |
+| `policy-packs/` | Runnable example serve-policy wrappers plus JSON reference packs for shell, destructive operations, DB, CI/CD, and cloud mutation scenarios | `cd core/cmd/helm-ai-kernel && go test . -run TestPolicyPackExamplesLoad -count=1` |
 | `policies/` | CEL, Rego, and Cedar policy fixtures | See `examples/policies/README.md`. |
 | `receipt_verification/` | Python and TypeScript receipt verification examples | Requires a running HELM boundary with receipts. |
 | `starters/` | Provider starter layouts for OpenAI, Anthropic, Google, and Codex profiles | See `examples/starters/README.md`. |

--- a/examples/policy-packs/README.md
+++ b/examples/policy-packs/README.md
@@ -19,6 +19,7 @@ go test . -run TestPolicyPackExamplesLoad -count=1
 | Pack | Purpose |
 | --- | --- |
 | `policy.shell.safe-by-default.toml` | Allow read-only shell and git status actions; keep destructive shell and git operations outside the allow graph. |
+| `policy.destructive-operations.toml` | Multi-surface deny/escalate template for destructive shell, DB, cloud, Kubernetes, git, and secret-exposure actions. |
 | `policy.db.readonly.toml` | Allow database reads and explains; keep writes, schema changes, and destructive operations outside the allow graph. |
 | `policy.cicd.approval-required.toml` | Allow CI status/log reads; keep deploys, secret changes, and workflow mutations outside the allow graph. |
 | `policy.cloud.mutations.toml` | Allow cloud inventory reads; keep IAM, network, storage, and Kubernetes mutations outside the allow graph. |

--- a/examples/policy-packs/policy.destructive-operations.json
+++ b/examples/policy-packs/policy.destructive-operations.json
@@ -1,0 +1,69 @@
+{
+  "pack_id": "policy.destructive-operations.v1",
+  "label": "Destructive Operations",
+  "version": 1,
+  "scope": {
+    "category": "multi-surface",
+    "intended_use": "Local deny/escalate evaluation for destructive shell, database, cloud, git, and secret-exposure actions"
+  },
+  "actions": [
+    {
+      "action": "safe.readonly.inspect",
+      "enabled": true,
+      "description": "Allow readonly status, list, explain, and dry-run inspection.",
+      "expression": "input.effect == 'read' || input.effect == 'dry_run'"
+    },
+    {
+      "action": "shell.recursive_force_delete",
+      "enabled": false,
+      "description": "DENY rm -rf and recursive force deletion. False-positive risk: temp-fixture cleanup; use a scoped ESCALATE review when cleanup is expected.",
+      "patterns": ["rm -rf", "rm -fr"],
+      "recommended_verdict": "DENY",
+      "escalate_variant": "ESCALATE only for reviewed temp directories with receipt capture"
+    },
+    {
+      "action": "shell.raw_disk_or_fs_destroy",
+      "enabled": false,
+      "description": "DENY raw disk and filesystem destruction. False-positive risk: lab image creation; require explicit reviewed fixture scope.",
+      "patterns": ["dd if=", "mkfs", "shred", "wipefs"],
+      "recommended_verdict": "DENY",
+      "escalate_variant": "ESCALATE for disposable lab devices only"
+    },
+    {
+      "action": "db.destructive_mutation",
+      "enabled": false,
+      "description": "DENY destructive SQL mutations. False-positive risk: isolated migration test DB; require reviewed database identity.",
+      "patterns": ["DROP DATABASE", "DROP TABLE", "TRUNCATE", "DELETE FROM"],
+      "recommended_verdict": "DENY",
+      "escalate_variant": "ESCALATE for named non-production databases with backup proof"
+    },
+    {
+      "action": "cloud.destroy_or_namespace_delete",
+      "enabled": false,
+      "description": "DENY infrastructure destruction. False-positive risk: preview-stack teardown; require deployment target, approver, and rollback evidence.",
+      "patterns": ["terraform destroy", "kubectl delete namespace"],
+      "recommended_verdict": "DENY",
+      "escalate_variant": "ESCALATE for preview environments with owner approval"
+    },
+    {
+      "action": "git.destructive_history_or_clean",
+      "enabled": false,
+      "description": "DENY destructive git history/worktree commands. False-positive risk: local scratch branches; require branch and remotes proof.",
+      "patterns": ["git push --force", "git clean -fdx"],
+      "recommended_verdict": "DENY",
+      "escalate_variant": "ESCALATE for explicitly named local-only scratch worktrees"
+    },
+    {
+      "action": "secrets.print_known_paths",
+      "enabled": false,
+      "description": "DENY printing known secret paths or environment dumps. False-positive risk: redacted secret inventory; require sanitizer proof.",
+      "patterns": ["cat .env", "cat ~/.ssh/", "printenv", "env"],
+      "recommended_verdict": "DENY",
+      "escalate_variant": "ESCALATE for redacted inventory commands with output filter receipts"
+    }
+  ],
+  "notes": [
+    "Example only: disabled actions stay outside the allow graph. A real integration should map raw commands to action IDs, emit receipts, and verify the EvidencePack.",
+    "The ESCALATE variants are guidance for review policy authors; this file does not grant approval by itself."
+  ]
+}

--- a/examples/policy-packs/policy.destructive-operations.toml
+++ b/examples/policy-packs/policy.destructive-operations.toml
@@ -1,0 +1,11 @@
+name = "policy.destructive-operations"
+profile = "example_destructive_operations"
+reference_pack = "./policy.destructive-operations.json"
+
+[server]
+bind = "127.0.0.1"
+port = 7714
+
+[receipts]
+store = "sqlite"
+path = "./data/policy-packs/destructive-operations.receipts.db"


### PR DESCRIPTION
## Summary
- add dedicated receipt/EvidencePack and performance issue templates
- expand the integration request template with project link, capability, risk, and policy metadata fields
- document explicit execution-security non-guarantees
- add a destructive-operations policy-pack example covering deny/escalate guidance for shell, DB, cloud/Kubernetes, git, and secret-exposure actions

## Validation
- /usr/bin/python3 scripts/check_documentation_coverage.py
- /usr/bin/python3 scripts/check_documentation_truth.py
- /usr/bin/python3 JSON parse for examples/policy-packs/*.json
- /usr/bin/ruby YAML parse for .github/ISSUE_TEMPLATE/*.yml
- cd core/cmd/helm-ai-kernel && env -u GOROOT /usr/local/go/bin/go test . -run TestPolicyPackExamplesLoad -count=1

Closes #310
Closes #312
Closes #313
Closes #314
Closes #315