### PR TITLE
Align account plan id SDK types

### DIFF
--- a/api/openapi/helm.openapi.yaml
+++ b/api/openapi/helm.openapi.yaml
@@ -4944,8 +4944,8 @@ components:
         workspace_id: { type: string }
         plan:
           type: string
-          enum: [free, individual, enterprise]
-        plan_alias: { type: string }
+          enum: [free, individual, developer, team, scale, enterprise]
+        plan_id: { type: string }
         edition: { type: string }
         deployment_mode: { type: string }
         account_lifecycle: { type: string }
@@ -4962,8 +4962,8 @@ components:
         workspace_id: { type: string }
         plan:
           type: string
-          enum: [free, individual, enterprise]
-        plan_alias: { type: string }
+          enum: [free, individual, developer, team, scale, enterprise]
+        plan_id: { type: string }
         capabilities:
           $ref: '#/components/schemas/EntitlementCapabilities'
         limits:

--- a/sdk/go/client/types_gen.go
+++ b/sdk/go/client/types_gen.go
@@ -1337,7 +1337,7 @@ type AccountEntitlements struct {
 	TenantId             *string                  `json:"tenant_id,omitempty"`
 	WorkspaceId          *string                  `json:"workspace_id,omitempty"`
 	Plan                 interface{}              `json:"plan,omitempty"`
-	PlanAlias            *string                  `json:"plan_alias,omitempty"`
+	PlanId               *string                  `json:"plan_id,omitempty"`
 	Capabilities         *EntitlementCapabilities `json:"capabilities,omitempty"`
 	Limits               *EntitlementLimits       `json:"limits,omitempty"`
 	Source               *string                  `json:"source,omitempty"`
@@ -1493,36 +1493,36 @@ func (o *AccountEntitlements) SetPlan(v interface{}) {
 	o.Plan = v
 }
 
-// GetPlanAlias returns the PlanAlias field value if set, zero value otherwise.
-func (o *AccountEntitlements) GetPlanAlias() string {
-	if o == nil || IsNil(o.PlanAlias) {
+// GetPlanId returns the PlanId field value if set, zero value otherwise.
+func (o *AccountEntitlements) GetPlanId() string {
+	if o == nil || IsNil(o.PlanId) {
 		var ret string
 		return ret
 	}
-	return *o.PlanAlias
+	return *o.PlanId
 }
 
-// GetPlanAliasOk returns a tuple with the PlanAlias field value if set, nil otherwise
+// GetPlanIdOk returns a tuple with the PlanId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AccountEntitlements) GetPlanAliasOk() (*string, bool) {
-	if o == nil || IsNil(o.PlanAlias) {
+func (o *AccountEntitlements) GetPlanIdOk() (*string, bool) {
+	if o == nil || IsNil(o.PlanId) {
 		return nil, false
 	}
-	return o.PlanAlias, true
+	return o.PlanId, true
 }
 
-// HasPlanAlias returns a boolean if a field has been set.
-func (o *AccountEntitlements) HasPlanAlias() bool {
-	if o != nil && !IsNil(o.PlanAlias) {
+// HasPlanId returns a boolean if a field has been set.
+func (o *AccountEntitlements) HasPlanId() bool {
+	if o != nil && !IsNil(o.PlanId) {
 		return true
 	}
 
 	return false
 }
 
-// SetPlanAlias gets a reference to the given string and assigns it to the PlanAlias field.
-func (o *AccountEntitlements) SetPlanAlias(v string) {
-	o.PlanAlias = &v
+// SetPlanId gets a reference to the given string and assigns it to the PlanId field.
+func (o *AccountEntitlements) SetPlanId(v string) {
+	o.PlanId = &v
 }
 
 // GetCapabilities returns the Capabilities field value if set, zero value otherwise.
@@ -1675,8 +1675,8 @@ func (o AccountEntitlements) ToMap() (map[string]interface{}, error) {
 	if o.Plan != nil {
 		toSerialize["plan"] = o.Plan
 	}
-	if !IsNil(o.PlanAlias) {
-		toSerialize["plan_alias"] = o.PlanAlias
+	if !IsNil(o.PlanId) {
+		toSerialize["plan_id"] = o.PlanId
 	}
 	if !IsNil(o.Capabilities) {
 		toSerialize["capabilities"] = o.Capabilities
@@ -1716,7 +1716,7 @@ func (o *AccountEntitlements) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "tenant_id")
 		delete(additionalProperties, "workspace_id")
 		delete(additionalProperties, "plan")
-		delete(additionalProperties, "plan_alias")
+		delete(additionalProperties, "plan_id")
 		delete(additionalProperties, "capabilities")
 		delete(additionalProperties, "limits")
 		delete(additionalProperties, "source")
@@ -1783,7 +1783,7 @@ type AccountSession struct {
 	TenantId             *string     `json:"tenant_id,omitempty"`
 	WorkspaceId          *string     `json:"workspace_id,omitempty"`
 	Plan                 interface{} `json:"plan,omitempty"`
-	PlanAlias            *string     `json:"plan_alias,omitempty"`
+	PlanId               *string     `json:"plan_id,omitempty"`
 	Edition              *string     `json:"edition,omitempty"`
 	DeploymentMode       *string     `json:"deployment_mode,omitempty"`
 	AccountLifecycle     *string     `json:"account_lifecycle,omitempty"`
@@ -1973,36 +1973,36 @@ func (o *AccountSession) SetPlan(v interface{}) {
 	o.Plan = v
 }
 
-// GetPlanAlias returns the PlanAlias field value if set, zero value otherwise.
-func (o *AccountSession) GetPlanAlias() string {
-	if o == nil || IsNil(o.PlanAlias) {
+// GetPlanId returns the PlanId field value if set, zero value otherwise.
+func (o *AccountSession) GetPlanId() string {
+	if o == nil || IsNil(o.PlanId) {
 		var ret string
 		return ret
 	}
-	return *o.PlanAlias
+	return *o.PlanId
 }
 
-// GetPlanAliasOk returns a tuple with the PlanAlias field value if set, nil otherwise
+// GetPlanIdOk returns a tuple with the PlanId field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *AccountSession) GetPlanAliasOk() (*string, bool) {
-	if o == nil || IsNil(o.PlanAlias) {
+func (o *AccountSession) GetPlanIdOk() (*string, bool) {
+	if o == nil || IsNil(o.PlanId) {
 		return nil, false
 	}
-	return o.PlanAlias, true
+	return o.PlanId, true
 }
 
-// HasPlanAlias returns a boolean if a field has been set.
-func (o *AccountSession) HasPlanAlias() bool {
-	if o != nil && !IsNil(o.PlanAlias) {
+// HasPlanId returns a boolean if a field has been set.
+func (o *AccountSession) HasPlanId() bool {
+	if o != nil && !IsNil(o.PlanId) {
 		return true
 	}
 
 	return false
 }
 
-// SetPlanAlias gets a reference to the given string and assigns it to the PlanAlias field.
-func (o *AccountSession) SetPlanAlias(v string) {
-	o.PlanAlias = &v
+// SetPlanId gets a reference to the given string and assigns it to the PlanId field.
+func (o *AccountSession) SetPlanId(v string) {
+	o.PlanId = &v
 }
 
 // GetEdition returns the Edition field value if set, zero value otherwise.
@@ -2222,8 +2222,8 @@ func (o AccountSession) ToMap() (map[string]interface{}, error) {
 	if o.Plan != nil {
 		toSerialize["plan"] = o.Plan
 	}
-	if !IsNil(o.PlanAlias) {
-		toSerialize["plan_alias"] = o.PlanAlias
+	if !IsNil(o.PlanId) {
+		toSerialize["plan_id"] = o.PlanId
 	}
 	if !IsNil(o.Edition) {
 		toSerialize["edition"] = o.Edition
@@ -2270,7 +2270,7 @@ func (o *AccountSession) UnmarshalJSON(data []byte) (err error) {
 		delete(additionalProperties, "tenant_id")
 		delete(additionalProperties, "workspace_id")
 		delete(additionalProperties, "plan")
-		delete(additionalProperties, "plan_alias")
+		delete(additionalProperties, "plan_id")
 		delete(additionalProperties, "edition")
 		delete(additionalProperties, "deployment_mode")
 		delete(additionalProperties, "account_lifecycle")

--- a/sdk/java/src/main/java/labs/mindburn/helm/TypesGen.java
+++ b/sdk/java/src/main/java/labs/mindburn/helm/TypesGen.java
@@ -1563,7 +1563,7 @@ public static class A2AAgentCardSkillsInner {
   AccountEntitlements.JSON_PROPERTY_TENANT_ID,
   AccountEntitlements.JSON_PROPERTY_WORKSPACE_ID,
   AccountEntitlements.JSON_PROPERTY_PLAN,
-  AccountEntitlements.JSON_PROPERTY_PLAN_ALIAS,
+  AccountEntitlements.JSON_PROPERTY_PLAN_ID,
   AccountEntitlements.JSON_PROPERTY_CAPABILITIES,
   AccountEntitlements.JSON_PROPERTY_LIMITS,
   AccountEntitlements.JSON_PROPERTY_SOURCE,
@@ -1587,6 +1587,12 @@ public static class AccountEntitlements {
     FREE("free"),
 
     INDIVIDUAL("individual"),
+
+    DEVELOPER("developer"),
+
+    TEAM("team"),
+
+    SCALE("scale"),
 
     ENTERPRISE("enterprise");
 
@@ -1620,8 +1626,8 @@ public static class AccountEntitlements {
   public static final String JSON_PROPERTY_PLAN = "plan";
   private JsonNullable<PlanEnum> plan = JsonNullable.<PlanEnum>of(null);
 
-  public static final String JSON_PROPERTY_PLAN_ALIAS = "plan_alias";
-  private String planAlias;
+  public static final String JSON_PROPERTY_PLAN_ID = "plan_id";
+  private String planId;
 
   public static final String JSON_PROPERTY_CAPABILITIES = "capabilities";
   private EntitlementCapabilities capabilities;
@@ -1746,28 +1752,28 @@ public static class AccountEntitlements {
   }
 
 
-  public AccountEntitlements planAlias(String planAlias) {
-    this.planAlias = planAlias;
+  public AccountEntitlements planId(String planId) {
+    this.planId = planId;
     return this;
   }
 
    /**
-   * Get planAlias
-   * @return planAlias
+   * Get planId
+   * @return planId
   **/
   @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_PLAN_ALIAS)
+  @JsonProperty(JSON_PROPERTY_PLAN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public String getPlanAlias() {
-    return planAlias;
+  public String getPlanId() {
+    return planId;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_PLAN_ALIAS)
+  @JsonProperty(JSON_PROPERTY_PLAN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setPlanAlias(String planAlias) {
-    this.planAlias = planAlias;
+  public void setPlanId(String planId) {
+    this.planId = planId;
   }
 
 
@@ -1887,7 +1893,7 @@ public static class AccountEntitlements {
         Objects.equals(this.tenantId, accountEntitlements.tenantId) &&
         Objects.equals(this.workspaceId, accountEntitlements.workspaceId) &&
         equalsNullable(this.plan, accountEntitlements.plan) &&
-        Objects.equals(this.planAlias, accountEntitlements.planAlias) &&
+        Objects.equals(this.planId, accountEntitlements.planId) &&
         Objects.equals(this.capabilities, accountEntitlements.capabilities) &&
         Objects.equals(this.limits, accountEntitlements.limits) &&
         Objects.equals(this.source, accountEntitlements.source) &&
@@ -1900,7 +1906,7 @@ public static class AccountEntitlements {
 
   @Override
   public int hashCode() {
-    return Objects.hash(principalId, tenantId, workspaceId, hashCodeNullable(plan), planAlias, capabilities, limits, source, updatedAt);
+    return Objects.hash(principalId, tenantId, workspaceId, hashCodeNullable(plan), planId, capabilities, limits, source, updatedAt);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -1918,7 +1924,7 @@ public static class AccountEntitlements {
     sb.append("    tenantId: ").append(toIndentedString(tenantId)).append("\n");
     sb.append("    workspaceId: ").append(toIndentedString(workspaceId)).append("\n");
     sb.append("    plan: ").append(toIndentedString(plan)).append("\n");
-    sb.append("    planAlias: ").append(toIndentedString(planAlias)).append("\n");
+    sb.append("    planId: ").append(toIndentedString(planId)).append("\n");
     sb.append("    capabilities: ").append(toIndentedString(capabilities)).append("\n");
     sb.append("    limits: ").append(toIndentedString(limits)).append("\n");
     sb.append("    source: ").append(toIndentedString(source)).append("\n");
@@ -1990,9 +1996,9 @@ public static class AccountEntitlements {
       joiner.add(String.format("%splan%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getPlan()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
-    // add `plan_alias` to the URL query string
-    if (getPlanAlias() != null) {
-      joiner.add(String.format("%splan_alias%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getPlanAlias()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    // add `plan_id` to the URL query string
+    if (getPlanId() != null) {
+      joiner.add(String.format("%splan_id%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getPlanId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
     // add `capabilities` to the URL query string
@@ -2044,7 +2050,7 @@ public static class AccountEntitlements {
   AccountSession.JSON_PROPERTY_TENANT_ID,
   AccountSession.JSON_PROPERTY_WORKSPACE_ID,
   AccountSession.JSON_PROPERTY_PLAN,
-  AccountSession.JSON_PROPERTY_PLAN_ALIAS,
+  AccountSession.JSON_PROPERTY_PLAN_ID,
   AccountSession.JSON_PROPERTY_EDITION,
   AccountSession.JSON_PROPERTY_DEPLOYMENT_MODE,
   AccountSession.JSON_PROPERTY_ACCOUNT_LIFECYCLE,
@@ -2073,6 +2079,12 @@ public static class AccountSession {
     FREE("free"),
 
     INDIVIDUAL("individual"),
+
+    DEVELOPER("developer"),
+
+    TEAM("team"),
+
+    SCALE("scale"),
 
     ENTERPRISE("enterprise");
 
@@ -2106,8 +2118,8 @@ public static class AccountSession {
   public static final String JSON_PROPERTY_PLAN = "plan";
   private JsonNullable<PlanEnum> plan = JsonNullable.<PlanEnum>of(null);
 
-  public static final String JSON_PROPERTY_PLAN_ALIAS = "plan_alias";
-  private String planAlias;
+  public static final String JSON_PROPERTY_PLAN_ID = "plan_id";
+  private String planId;
 
   public static final String JSON_PROPERTY_EDITION = "edition";
   private String edition;
@@ -2263,28 +2275,28 @@ public static class AccountSession {
   }
 
 
-  public AccountSession planAlias(String planAlias) {
-    this.planAlias = planAlias;
+  public AccountSession planId(String planId) {
+    this.planId = planId;
     return this;
   }
 
    /**
-   * Get planAlias
-   * @return planAlias
+   * Get planId
+   * @return planId
   **/
   @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_PLAN_ALIAS)
+  @JsonProperty(JSON_PROPERTY_PLAN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
-  public String getPlanAlias() {
-    return planAlias;
+  public String getPlanId() {
+    return planId;
   }
 
 
-  @JsonProperty(JSON_PROPERTY_PLAN_ALIAS)
+  @JsonProperty(JSON_PROPERTY_PLAN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setPlanAlias(String planAlias) {
-    this.planAlias = planAlias;
+  public void setPlanId(String planId) {
+    this.planId = planId;
   }
 
 
@@ -2455,7 +2467,7 @@ public static class AccountSession {
         Objects.equals(this.tenantId, accountSession.tenantId) &&
         Objects.equals(this.workspaceId, accountSession.workspaceId) &&
         equalsNullable(this.plan, accountSession.plan) &&
-        Objects.equals(this.planAlias, accountSession.planAlias) &&
+        Objects.equals(this.planId, accountSession.planId) &&
         Objects.equals(this.edition, accountSession.edition) &&
         Objects.equals(this.deploymentMode, accountSession.deploymentMode) &&
         Objects.equals(this.accountLifecycle, accountSession.accountLifecycle) &&
@@ -2470,7 +2482,7 @@ public static class AccountSession {
 
   @Override
   public int hashCode() {
-    return Objects.hash(sessionId, principalId, tenantId, workspaceId, hashCodeNullable(plan), planAlias, edition, deploymentMode, accountLifecycle, offerCode, source, expiresAt);
+    return Objects.hash(sessionId, principalId, tenantId, workspaceId, hashCodeNullable(plan), planId, edition, deploymentMode, accountLifecycle, offerCode, source, expiresAt);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -2489,7 +2501,7 @@ public static class AccountSession {
     sb.append("    tenantId: ").append(toIndentedString(tenantId)).append("\n");
     sb.append("    workspaceId: ").append(toIndentedString(workspaceId)).append("\n");
     sb.append("    plan: ").append(toIndentedString(plan)).append("\n");
-    sb.append("    planAlias: ").append(toIndentedString(planAlias)).append("\n");
+    sb.append("    planId: ").append(toIndentedString(planId)).append("\n");
     sb.append("    edition: ").append(toIndentedString(edition)).append("\n");
     sb.append("    deploymentMode: ").append(toIndentedString(deploymentMode)).append("\n");
     sb.append("    accountLifecycle: ").append(toIndentedString(accountLifecycle)).append("\n");
@@ -2568,9 +2580,9 @@ public static class AccountSession {
       joiner.add(String.format("%splan%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getPlan()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
-    // add `plan_alias` to the URL query string
-    if (getPlanAlias() != null) {
-      joiner.add(String.format("%splan_alias%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getPlanAlias()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
+    // add `plan_id` to the URL query string
+    if (getPlanId() != null) {
+      joiner.add(String.format("%splan_id%s=%s", prefix, suffix, URLEncoder.encode(String.valueOf(getPlanId()), StandardCharsets.UTF_8).replaceAll("\\+", "%20")));
     }
 
     // add `edition` to the URL query string

--- a/sdk/python/helm_sdk/types_gen.py
+++ b/sdk/python/helm_sdk/types_gen.py
@@ -402,13 +402,13 @@ class AccountEntitlements(BaseModel):
     tenant_id: Optional[StrictStr] = None
     workspace_id: Optional[StrictStr] = None
     plan: Optional[Any] = None
-    plan_alias: Optional[StrictStr] = None
+    plan_id: Optional[StrictStr] = None
     capabilities: Optional[EntitlementCapabilities] = None
     limits: Optional[EntitlementLimits] = None
     source: Optional[StrictStr] = None
     updated_at: Optional[datetime] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["principal_id", "tenant_id", "workspace_id", "plan", "plan_alias", "capabilities", "limits", "source", "updated_at"]
+    __properties: ClassVar[List[str]] = ["principal_id", "tenant_id", "workspace_id", "plan", "plan_id", "capabilities", "limits", "source", "updated_at"]
 
     @field_validator('plan')
     @classmethod
@@ -417,8 +417,8 @@ class AccountEntitlements(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['free', 'individual', 'enterprise']):
-            raise ValueError("must be one of enum values ('free', 'individual', 'enterprise')")
+        if value not in set(['free', 'individual', 'developer', 'team', 'scale', 'enterprise']):
+            raise ValueError("must be one of enum values ('free', 'individual', 'developer', 'team', 'scale', 'enterprise')")
         return value
 
     model_config = ConfigDict(
@@ -494,7 +494,7 @@ class AccountEntitlements(BaseModel):
             "tenant_id": obj.get("tenant_id"),
             "workspace_id": obj.get("workspace_id"),
             "plan": obj.get("plan"),
-            "plan_alias": obj.get("plan_alias"),
+            "plan_id": obj.get("plan_id"),
             "capabilities": EntitlementCapabilities.from_dict(obj["capabilities"]) if obj.get("capabilities") is not None else None,
             "limits": EntitlementLimits.from_dict(obj["limits"]) if obj.get("limits") is not None else None,
             "source": obj.get("source"),
@@ -532,7 +532,7 @@ class AccountSession(BaseModel):
     tenant_id: Optional[StrictStr] = None
     workspace_id: Optional[StrictStr] = None
     plan: Optional[Any] = None
-    plan_alias: Optional[StrictStr] = None
+    plan_id: Optional[StrictStr] = None
     edition: Optional[StrictStr] = None
     deployment_mode: Optional[StrictStr] = None
     account_lifecycle: Optional[StrictStr] = None
@@ -540,7 +540,7 @@ class AccountSession(BaseModel):
     source: Optional[StrictStr] = None
     expires_at: Optional[datetime] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["session_id", "principal_id", "tenant_id", "workspace_id", "plan", "plan_alias", "edition", "deployment_mode", "account_lifecycle", "offer_code", "source", "expires_at"]
+    __properties: ClassVar[List[str]] = ["session_id", "principal_id", "tenant_id", "workspace_id", "plan", "plan_id", "edition", "deployment_mode", "account_lifecycle", "offer_code", "source", "expires_at"]
 
     @field_validator('plan')
     @classmethod
@@ -549,8 +549,8 @@ class AccountSession(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['free', 'individual', 'enterprise']):
-            raise ValueError("must be one of enum values ('free', 'individual', 'enterprise')")
+        if value not in set(['free', 'individual', 'developer', 'team', 'scale', 'enterprise']):
+            raise ValueError("must be one of enum values ('free', 'individual', 'developer', 'team', 'scale', 'enterprise')")
         return value
 
     model_config = ConfigDict(
@@ -621,7 +621,7 @@ class AccountSession(BaseModel):
             "tenant_id": obj.get("tenant_id"),
             "workspace_id": obj.get("workspace_id"),
             "plan": obj.get("plan"),
-            "plan_alias": obj.get("plan_alias"),
+            "plan_id": obj.get("plan_id"),
             "edition": obj.get("edition"),
             "deployment_mode": obj.get("deployment_mode"),
             "account_lifecycle": obj.get("account_lifecycle"),

--- a/sdk/rust/src/types_gen.rs
+++ b/sdk/rust/src/types_gen.rs
@@ -192,8 +192,8 @@ pub struct AccountEntitlements {
     pub workspace_id: Option<String>,
     #[serde(rename = "plan", default, skip_serializing_if = "Option::is_none")]
     pub plan: Option<Option<AccountEntitlementsPlan>>,
-    #[serde(rename = "plan_alias", skip_serializing_if = "Option::is_none")]
-    pub plan_alias: Option<String>,
+    #[serde(rename = "plan_id", skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
     #[serde(rename = "capabilities", skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<Box<EntitlementCapabilities>>,
     #[serde(rename = "limits", skip_serializing_if = "Option::is_none")]
@@ -211,7 +211,7 @@ impl AccountEntitlements {
             tenant_id: None,
             workspace_id: None,
             plan: None,
-            plan_alias: None,
+            plan_id: None,
             capabilities: None,
             limits: None,
             source: None,
@@ -226,6 +226,12 @@ pub enum AccountEntitlementsPlan {
     Free,
     #[serde(rename = "individual")]
     Individual,
+    #[serde(rename = "developer")]
+    Developer,
+    #[serde(rename = "team")]
+    Team,
+    #[serde(rename = "scale")]
+    Scale,
     #[serde(rename = "enterprise")]
     Enterprise,
 }
@@ -259,8 +265,8 @@ pub struct AccountSession {
     pub workspace_id: Option<String>,
     #[serde(rename = "plan", default, skip_serializing_if = "Option::is_none")]
     pub plan: Option<Option<AccountSessionPlan>>,
-    #[serde(rename = "plan_alias", skip_serializing_if = "Option::is_none")]
-    pub plan_alias: Option<String>,
+    #[serde(rename = "plan_id", skip_serializing_if = "Option::is_none")]
+    pub plan_id: Option<String>,
     #[serde(rename = "edition", skip_serializing_if = "Option::is_none")]
     pub edition: Option<String>,
     #[serde(rename = "deployment_mode", skip_serializing_if = "Option::is_none")]
@@ -283,7 +289,7 @@ impl AccountSession {
             tenant_id: None,
             workspace_id: None,
             plan: None,
-            plan_alias: None,
+            plan_id: None,
             edition: None,
             deployment_mode: None,
             account_lifecycle: None,
@@ -300,6 +306,12 @@ pub enum AccountSessionPlan {
     Free,
     #[serde(rename = "individual")]
     Individual,
+    #[serde(rename = "developer")]
+    Developer,
+    #[serde(rename = "team")]
+    Team,
+    #[serde(rename = "scale")]
+    Scale,
     #[serde(rename = "enterprise")]
     Enterprise,
 }

--- a/sdk/ts/src/types.gen.ts
+++ b/sdk/ts/src/types.gen.ts
@@ -491,7 +491,7 @@ export interface AccountEntitlements {
      * @type {string}
      * @memberof AccountEntitlements
      */
-    plan_alias?: string;
+    plan_id?: string;
     /**
      *
      * @type {EntitlementCapabilities}
@@ -525,6 +525,9 @@ export interface AccountEntitlements {
 export const AccountEntitlementsPlanEnum = {
     Free: 'free',
     Individual: 'individual',
+    Developer: 'developer',
+    Team: 'team',
+    Scale: 'scale',
     Enterprise: 'enterprise'
 } as const;
 export type AccountEntitlementsPlanEnum = typeof AccountEntitlementsPlanEnum[keyof typeof AccountEntitlementsPlanEnum];
@@ -551,7 +554,7 @@ export function AccountEntitlementsFromJSONTyped(json: any, ignoreDiscriminator:
         'tenant_id': json['tenant_id'] == null ? undefined : json['tenant_id'],
         'workspace_id': json['workspace_id'] == null ? undefined : json['workspace_id'],
         'plan': json['plan'] == null ? undefined : json['plan'],
-        'plan_alias': json['plan_alias'] == null ? undefined : json['plan_alias'],
+        'plan_id': json['plan_id'] == null ? undefined : json['plan_id'],
         'capabilities': json['capabilities'] == null ? undefined : EntitlementCapabilitiesFromJSON(json['capabilities']),
         'limits': json['limits'] == null ? undefined : EntitlementLimitsFromJSON(json['limits']),
         'source': json['source'] == null ? undefined : json['source'],
@@ -569,7 +572,7 @@ export function AccountEntitlementsToJSON(value?: AccountEntitlements | null): a
         'tenant_id': value['tenant_id'],
         'workspace_id': value['workspace_id'],
         'plan': value['plan'],
-        'plan_alias': value['plan_alias'],
+        'plan_id': value['plan_id'],
         'capabilities': EntitlementCapabilitiesToJSON(value['capabilities']),
         'limits': EntitlementLimitsToJSON(value['limits']),
         'source': value['source'],
@@ -632,7 +635,7 @@ export interface AccountSession {
      * @type {string}
      * @memberof AccountSession
      */
-    plan_alias?: string;
+    plan_id?: string;
     /**
      *
      * @type {string}
@@ -678,6 +681,9 @@ export interface AccountSession {
 export const AccountSessionPlanEnum = {
     Free: 'free',
     Individual: 'individual',
+    Developer: 'developer',
+    Team: 'team',
+    Scale: 'scale',
     Enterprise: 'enterprise'
 } as const;
 export type AccountSessionPlanEnum = typeof AccountSessionPlanEnum[keyof typeof AccountSessionPlanEnum];
@@ -705,7 +711,7 @@ export function AccountSessionFromJSONTyped(json: any, ignoreDiscriminator: bool
         'tenant_id': json['tenant_id'] == null ? undefined : json['tenant_id'],
         'workspace_id': json['workspace_id'] == null ? undefined : json['workspace_id'],
         'plan': json['plan'] == null ? undefined : json['plan'],
-        'plan_alias': json['plan_alias'] == null ? undefined : json['plan_alias'],
+        'plan_id': json['plan_id'] == null ? undefined : json['plan_id'],
         'edition': json['edition'] == null ? undefined : json['edition'],
         'deployment_mode': json['deployment_mode'] == null ? undefined : json['deployment_mode'],
         'account_lifecycle': json['account_lifecycle'] == null ? undefined : json['account_lifecycle'],
@@ -726,7 +732,7 @@ export function AccountSessionToJSON(value?: AccountSession | null): any {
         'tenant_id': value['tenant_id'],
         'workspace_id': value['workspace_id'],
         'plan': value['plan'],
-        'plan_alias': value['plan_alias'],
+        'plan_id': value['plan_id'],
         'edition': value['edition'],
         'deployment_mode': value['deployment_mode'],
         'account_lifecycle': value['account_lifecycle'],


### PR DESCRIPTION
## Summary
- rename account session/entitlement OpenAPI plan_alias fields to plan_id
- expand account plan enums to free/developer/team/scale/enterprise
- regenerate Go, Java, Python, Rust, and TypeScript SDK types from the OpenAPI spec

## Validation
- make sdk-openapi-check
- make test-sdk-go-standalone
- make test-sdk-ts
- make test-sdk-py
- cd sdk/rust && cargo clean && CARGO_HTTP_MULTIPLEXING=false cargo test
- make test-sdk-java
- git diff --check