### PR TITLE
Follow up MIN-494 launchpad multi-arch safety cut

### DIFF
--- a/.github/workflows/helm-integration.yml
+++ b/.github/workflows/helm-integration.yml
@@ -81,10 +81,11 @@ jobs:
 
   launchpad-positive:
     name: openclaw + hermes positive (real OPENROUTER_API_KEY)
-    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'launchpad-live-test') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [baseline]
+    env:
+      RUN_LIVE_POSITIVE: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'launchpad-live-test') }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -129,6 +130,10 @@ jobs:
           GHCR_USERNAME: ${{ github.actor }}
           GHCR_TOKEN: ${{ github.token }}
         run: |
+          if [[ "${RUN_LIVE_POSITIVE}" != "true" ]]; then
+            echo "::notice::launchpad-live-test label not present; required positive check recorded without burning OpenRouter tokens"
+            exit 0
+          fi
           if [[ -z "${OPENROUTER_API_KEY}" ]]; then
             echo "::warning::HELM_LAUNCHPAD_CI_OPENROUTER_API_KEY secret not configured — skipping positive scenario"
             exit 0

--- a/.github/workflows/launchpad-artifacts.yml
+++ b/.github/workflows/launchpad-artifacts.yml
@@ -218,7 +218,7 @@ jobs:
           push: true
           provenance: true
           sbom: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           labels: |
             org.opencontainers.image.source=https://github.com/${{ matrix.upstream_repo }}
             org.opencontainers.image.revision=${{ steps.upstream.outputs.commit }}
@@ -449,7 +449,7 @@ jobs:
           push: true
           provenance: true
           sbom: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -848,7 +848,7 @@
         "nodeSelector": {
           "type": "object",
           "additionalProperties": { "type": "string" },
-          "description": "nodeSelector applied to every launchpad-app Pod. Launchpad app images publish multi-arch manifests; leave empty for Kubernetes to schedule by node architecture, or set an explicit selector such as `kubernetes.io/arch: amd64` when operators want pinning."
+          "description": "nodeSelector applied to every launchpad-app Pod. Current chart-pinned launchpad app digests are linux/amd64-only; the artifact workflow publishes multi-arch candidates, but keep `kubernetes.io/arch: amd64` until a digest re-pin lands with linux/arm64 manifests."
         },
         "networkPolicy": {
           "type": "object",

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -848,7 +848,7 @@
         "nodeSelector": {
           "type": "object",
           "additionalProperties": { "type": "string" },
-          "description": "nodeSelector applied to every launchpad-app Pod. The published openclaw/hermes images are linux/amd64 only — until multi-arch builds land, keep `kubernetes.io/arch: amd64` here."
+          "description": "nodeSelector applied to every launchpad-app Pod. Launchpad app images publish multi-arch manifests; leave empty for Kubernetes to schedule by node architecture, or set an explicit selector such as `kubernetes.io/arch: amd64` when operators want pinning."
         },
         "networkPolicy": {
           "type": "object",

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -286,11 +286,10 @@ openrouter:
 # docs/launchpad/K8S_SMOKE.md for the conformance map between
 # registry/launchpad/apps/{openclaw,hermes}.yaml and these templates.
 launchpadApps:
-  # All launchpad-app Pods land on amd64 nodes — openclaw/hermes images are
-  # built linux/amd64 only by .github/workflows/launchpad-artifacts.yml. Until
-  # multi-arch builds land (GAP #11 in audit), this is a hard constraint.
-  nodeSelector:
-    kubernetes.io/arch: amd64
+  # Launchpad app images are published as multi-arch manifests. Leave empty to
+  # let Kubernetes schedule for the node architecture, or set an explicit
+  # selector such as kubernetes.io/arch: amd64 when operators want pinning.
+  nodeSelector: {}
 
   # NetworkPolicy default-deny with explicit DNS + 443 egress allowance for
   # the sidecar proxy. Enforcement requires a CNI that honors NetworkPolicy

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -286,10 +286,11 @@ openrouter:
 # docs/launchpad/K8S_SMOKE.md for the conformance map between
 # registry/launchpad/apps/{openclaw,hermes}.yaml and these templates.
 launchpadApps:
-  # Launchpad app images are published as multi-arch manifests. Leave empty to
-  # let Kubernetes schedule for the node architecture, or set an explicit
-  # selector such as kubernetes.io/arch: amd64 when operators want pinning.
-  nodeSelector: {}
+  # Current chart-pinned launchpad app digests are linux/amd64-only. The
+  # launchpad artifact workflow now publishes multi-arch candidates, but keep
+  # this selector until a digest re-pin lands with linux/arm64 manifests.
+  nodeSelector:
+    kubernetes.io/arch: amd64
 
   # NetworkPolicy default-deny with explicit DNS + 443 egress allowance for
   # the sidecar proxy. Enforcement requires a CNI that honors NetworkPolicy

--- a/docs/launchpad/K8S_SMOKE.md
+++ b/docs/launchpad/K8S_SMOKE.md
@@ -143,10 +143,11 @@ on the cluster — the k8s analogue of the docker sandbox-leak audit.
 
 ## Known limitations
 
-- **Single-arch images.** openclaw, hermes, and the egress proxy are
-  built `linux/amd64` only by `.github/workflows/launchpad-artifacts.yml`.
-  Every launchpad-app Pod carries `nodeSelector: kubernetes.io/arch=amd64`.
-  Multi-arch support is tracked separately.
+- **Image architecture pinning.** openclaw, hermes, and the egress proxy
+  publish `linux/amd64,linux/arm64` manifests. The chart default leaves
+  `launchpadApps.nodeSelector` empty so Kubernetes schedules by node
+  architecture. Operators may set `kubernetes.io/arch` explicitly when they
+  want pinning for a particular cluster pool.
 - **CNI enforcement.** The NetworkPolicy object is created
   unconditionally, but enforcement requires a CNI that honors it. The
   smoke driver opts minikube into Calico (`--cni=calico`). On the

--- a/docs/launchpad/K8S_SMOKE.md
+++ b/docs/launchpad/K8S_SMOKE.md
@@ -143,11 +143,11 @@ on the cluster — the k8s analogue of the docker sandbox-leak audit.
 
 ## Known limitations
 
-- **Image architecture pinning.** openclaw, hermes, and the egress proxy
-  publish `linux/amd64,linux/arm64` manifests. The chart default leaves
-  `launchpadApps.nodeSelector` empty so Kubernetes schedules by node
-  architecture. Operators may set `kubernetes.io/arch` explicitly when they
-  want pinning for a particular cluster pool.
+- **Image architecture pinning.** The launchpad artifact workflow now
+  publishes `linux/amd64,linux/arm64` candidates, but the chart-pinned
+  openclaw, hermes, and egress-proxy digests remain `linux/amd64` until a
+  follow-up digest re-pin lands. The chart keeps
+  `launchpadApps.nodeSelector.kubernetes.io/arch: amd64` during that gap.
 - **CNI enforcement.** The NetworkPolicy object is created
   unconditionally, but enforcement requires a CNI that honors it. The
   smoke driver opts minikube into Calico (`--cni=calico`). On the

--- a/scripts/ci/launchpad_k8s_smoke.sh
+++ b/scripts/ci/launchpad_k8s_smoke.sh
@@ -35,9 +35,11 @@ OPENROUTER_KEY_FAKE="sk-fake-1234567890"
 KEEP_CLUSTER="${LAUNCHPAD_SMOKE_KEEP_CLUSTER:-0}"
 FRESH_CLUSTER="${LAUNCHPAD_SMOKE_FRESH_CLUSTER:-1}"
 PRE_LOAD_LAUNCHPAD_IMAGES="${LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_IMAGES:-0}"
+PRE_LOAD_LAUNCHPAD_PLATFORM="${LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_PLATFORM:-linux/amd64}"
 GHCR_SECRET_NAME="${LAUNCHPAD_SMOKE_GHCR_SECRET_NAME:-ghcr-read}"
 GHCR_USERNAME="${GHCR_USERNAME:-}"
 GHCR_TOKEN="${GHCR_TOKEN:-}"
+KUBE_HELM_CMD="${KUBE_HELM_CMD:-}"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/launchpad-k8s-smoke.XXXXXX")"
 
 usage() {
@@ -54,6 +56,8 @@ Environment overrides:
   LAUNCHPAD_SMOKE_FRESH_CLUSTER set to 0 to reuse an existing minikube profile (assumes the cluster is already running and kernel image is loaded)
   LAUNCHPAD_SMOKE_GHCR_SECRET_NAME Secret name for private GHCR pulls (default ghcr-read)
   LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_IMAGES set to 1 for debug-only host pull + minikube image load verification
+  LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_PLATFORM platform for debug-only launchpad image preload (default linux/amd64)
+  KUBE_HELM_CMD                  Kubernetes Helm binary to use when `helm` is occupied by HELM verifier
   GHCR_USERNAME                  GitHub/GHCR username for positive/negative launchpad app image pulls
   GHCR_TOKEN                     GitHub token with read:packages for private GHCR launchpad app image pulls
   OPENROUTER_API_KEY            real key for the positive scenario; ignored on negative
@@ -81,9 +85,25 @@ require() {
         exit 1
     }
 }
+kube_helm() {
+    if [ -n "$KUBE_HELM_CMD" ]; then
+        "$KUBE_HELM_CMD" "$@"
+        return
+    fi
+    if command -v kube-helm >/dev/null 2>&1; then
+        kube-helm "$@"
+        return
+    fi
+    if command -v helm >/dev/null 2>&1 && helm version --short 2>/dev/null | grep -q '^v3\.'; then
+        helm "$@"
+        return
+    fi
+    echo "::error::Kubernetes Helm v3 is required. Set KUBE_HELM_CMD when the helm command is occupied by the HELM verifier." >&2
+    exit 1
+}
 require minikube
 require kubectl
-require helm
+kube_helm version --short >/dev/null
 require docker
 require python3
 require jq
@@ -144,7 +164,7 @@ cleanup() {
         # Best-effort namespace teardown so the next run starts clean. The
         # cluster itself stays around when KEEP_CLUSTER=1 (local iteration);
         # only the smoke namespace is sacrificed.
-        helm uninstall "$RELEASE" -n "$NAMESPACE" --ignore-not-found --wait --timeout 60s 2>/dev/null || true
+        kube_helm uninstall "$RELEASE" -n "$NAMESPACE" --ignore-not-found --wait --timeout 60s 2>/dev/null || true
         kubectl delete namespace "$NAMESPACE" --wait=false 2>/dev/null || true
     fi
     rm -rf "$TMP_DIR"
@@ -210,7 +230,7 @@ if [ "$PRE_LOAD_LAUNCHPAD_IMAGES" = "1" ] && [ "$MODE" != "baseline" ]; then
         exit 1
     fi
     for img in "${preload_images[@]}"; do
-        docker pull --platform=linux/amd64 "$img"
+        docker pull --platform="$PRE_LOAD_LAUNCHPAD_PLATFORM" "$img"
         minikube -p "$PROFILE" image load "$img"
         if ! minikube -p "$PROFILE" image ls 2>/dev/null | grep -qF "$img"; then
             echo "::error::minikube image load did not make $img resolvable in the node; use the GHCR imagePullSecret path" >&2
@@ -266,7 +286,7 @@ case "$MODE" in
     negative) helm_args+=(--timeout 8m) ;;
 esac
 
-helm upgrade --install "${helm_args[@]}"
+kube_helm upgrade --install "${helm_args[@]}"
 echo "::endgroup::"
 
 assert_pod_ready() {
@@ -355,7 +375,7 @@ case "$MODE" in
     baseline)
         echo "::group::stage 5 — baseline assertions"
         kubectl -n "$NAMESPACE" rollout status "deployment/${RELEASE}-helm-ai-kernel" --timeout=180s
-        helm test "$RELEASE" -n "$NAMESPACE" 2>&1 || {
+        kube_helm test "$RELEASE" -n "$NAMESPACE" 2>&1 || {
             # Baseline has no launchpad apps and the test Pod is gated on at
             # least one app being enabled — `helm test` is a no-op then.
             echo "no test hooks rendered for baseline (expected)"
@@ -368,7 +388,7 @@ case "$MODE" in
         assert_pod_ready openclaw 6m
         assert_job_succeeded hermes 3m
         echo "helm test"
-        helm test "$RELEASE" -n "$NAMESPACE" --logs
+        kube_helm test "$RELEASE" -n "$NAMESPACE" --logs
         echo "openclaw kubectl exec healthcheck"
         kubectl -n "$NAMESPACE" exec \
             "deployment/${RELEASE}-helm-ai-kernel-openclaw" \
@@ -386,7 +406,7 @@ case "$MODE" in
 esac
 
 echo "::group::stage 6 — teardown + leak audit"
-helm uninstall "$RELEASE" -n "$NAMESPACE" --wait || true
+kube_helm uninstall "$RELEASE" -n "$NAMESPACE" --wait || true
 kubectl delete namespace "$NAMESPACE" --wait --timeout=120s || true
 
 # Leak audit (k8s analogue of GAP #17): after uninstall, no launchpad-app or


### PR DESCRIPTION
Triage PR opened to preserve unique local branch work before local branch cleanup.\n\nEvidence:\n- source branch: `codex/min494-multiarch-safety-followup`\n- base: `origin/main`\n- diff:  6 files changed, 44 insertions(+), 18 deletions(-)\n- git diff --check: pass\n\nCommits:\n```\n61eb9017 fix(launchpad): keep chart pinned to current amd64 digests
6b4a7319 feat(launchpad): publish multi-arch app manifests\n```\n\nValidation: no repo gate run in this triage pass. This PR is draft until the owner rebases, validates, and decides whether the work still belongs on main.