### PR TITLE
Use docs root for GitHub links

### DIFF
--- a/.bestpractices.json
+++ b/.bestpractices.json
@@ -1,7 +1,7 @@
 {
   "name": "HELM AI Kernel",
   "description": "Fail-closed execution firewall for AI agent tool calls, MCP gateways, policy enforcement, and signed receipts.",
-  "homepage_url": "https://helm.docs.mindburn.org/helm-ai-kernel",
+  "homepage_url": "https://helm.docs.mindburn.org",
   "repo_url": "https://github.com/Mindburn-Labs/helm-ai-kernel",
   "license": "Apache-2.0",
   "best_practices_url": "https://www.bestpractices.dev/projects/new?repo_url=https%3A%2F%2Fgithub.com%2FMindburn-Labs%2Fhelm-ai-kernel",

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://github.com/Mindburn-Labs/helm-ai-kernel/discussions
     about: Ask usage questions or discuss proposals before filing an issue.
   - name: Local quickstart and docs
-    url: https://helm.docs.mindburn.org/helm-ai-kernel/quickstart?utm_source=github&utm_medium=issue-template&utm_campaign=oss-traction
+    url: https://helm.docs.mindburn.org/?utm_source=github&utm_medium=issue-template&utm_campaign=oss-traction#quickstart
     about: Try the OSS kernel locally before filing integration or setup requests.
   - name: Ecosystem and first contributions
     url: https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/COMMUNITY.md

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/architecture`
+- Public route: `architecture`
 - Source document: `helm-ai-kernel/docs/ARCHITECTURE.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/benchmarks`
+- Public route: `benchmarks`
 - Source document: `helm-ai-kernel/docs/BENCHMARKS.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/conformance`
+- Public route: `conformance`
 - Source document: `helm-ai-kernel/docs/CONFORMANCE.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/DEPLOYMENT_AND_EXAMPLES.md
+++ b/docs/DEPLOYMENT_AND_EXAMPLES.md
@@ -51,7 +51,7 @@ flowchart TD
 
 | Target | Source path | Public contract |
 | --- | --- | --- |
-| Local CLI or proxy | `core/cmd/helm-ai-kernel/`, `docs/QUICKSTART.md` | Start with `/helm-ai-kernel/developer-journey`. |
+| Local CLI or proxy | `core/cmd/helm-ai-kernel/`, `docs/QUICKSTART.md` | Start with `/developer-journey`. |
 | Docker image | `Dockerfile`, `Makefile`, `docker-compose.yml` | Build and run through the retained Docker targets. |
 | Docker Compose | `docker-compose.yml` | Use for local boundary testing and example orchestration. |
 | Kubernetes Helm chart | `deploy/helm-chart/Chart.yaml`, `deploy/helm-chart/values.yaml`, `deploy/helm-chart/templates/` | Lint with `helm lint deploy/helm-chart` before applying. |
@@ -102,7 +102,7 @@ as example-only or omit a support claim.
 | Docker build fails | Confirm the local tree builds with `make build`, then rerun the Docker target. |
 | Helm chart lint fails | Check `deploy/helm-chart/values.yaml` and required Kubernetes settings. |
 | Example cannot reach the proxy | Confirm `helm-ai-kernel proxy` is running and the client base URL points at the HELM boundary. |
-| Receipt verification fails | Use `/helm-ai-kernel/verification` and compare against `examples/golden/`. |
+| Receipt verification fails | Use `/verification` and compare against `examples/golden/`. |
 
 <!-- docs-depth-final-pass -->
 

--- a/docs/DEVELOPER_SURFACE_MAP.md
+++ b/docs/DEVELOPER_SURFACE_MAP.md
@@ -65,16 +65,16 @@ flowchart TD
 
 | Need | Public page | Source truth |
 | --- | --- | --- |
-| Install on macOS, Linux, Windows/WSL, Docker, or source | `/helm-ai-kernel/developer-journey` | `docs/DEVELOPER_JOURNEY.md`, `docs/QUICKSTART.md`, `Makefile`, `.goreleaser.yml` |
-| Run the first local boundary | `/helm-ai-kernel/developer-journey` | `core/cmd/helm-ai-kernel/server_cmd.go`, `core/cmd/helm-ai-kernel/proxy_cmd.go` |
-| Point OpenAI-compatible clients at HELM | `/helm-ai-kernel/integrations/openai-compatible-proxy` | `docs/INTEGRATIONS/openai_baseurl.md`, `examples/python_openai_baseurl/`, `examples/ts_openai_baseurl/` |
-| Use MCP | `/helm-ai-kernel/integrations/mcp` | `docs/INTEGRATIONS/mcp.md`, `examples/mcp_client/`, `mcp-bundle.json` |
-| Use Python, TypeScript, JavaScript, Go, Rust, or Java | `/helm-ai-kernel/sdks` | `sdk/`, `examples/*_client/`, `examples/*openai_baseurl/` |
-| Understand policy languages and bundles | `/helm-ai-kernel/reference/protocols-and-schemas`, `/helm-ai-kernel/compatibility` | `docs/architecture/policy-languages.md`, `protocols/bundles/`, `examples/policies/` |
-| Validate conformance | `/helm-ai-kernel/conformance` | `docs/CONFORMANCE.md`, `protocols/conformance/v1/`, `tests/conformance/` |
-| Verify receipts and evidence packs | `/helm-ai-kernel/verification`, `/helm-ai-kernel/developer-journey` | `docs/VERIFICATION.md`, `examples/receipt_verification/`, `protocols/spec/evidence-pack-v1.md` |
-| Deploy with Docker or Kubernetes | `/helm-ai-kernel/deployment-and-examples` | `docker-compose.yml`, `deploy/`, `deploy/helm-chart/` |
-| Verify release artifacts | `/helm-ai-kernel/security/release-security`, `/helm-ai-kernel/publishing` | `SECURITY.md`, `RELEASE.md`, `release/`, `.github/workflows/release.yml` |
+| Install on macOS, Linux, Windows/WSL, Docker, or source | `/developer-journey` | `docs/DEVELOPER_JOURNEY.md`, `docs/QUICKSTART.md`, `Makefile`, `.goreleaser.yml` |
+| Run the first local boundary | `/developer-journey` | `core/cmd/helm-ai-kernel/server_cmd.go`, `core/cmd/helm-ai-kernel/proxy_cmd.go` |
+| Point OpenAI-compatible clients at HELM | `/integrations/openai-compatible-proxy` | `docs/INTEGRATIONS/openai_baseurl.md`, `examples/python_openai_baseurl/`, `examples/ts_openai_baseurl/` |
+| Use MCP | `/integrations/mcp` | `docs/INTEGRATIONS/mcp.md`, `examples/mcp_client/`, `mcp-bundle.json` |
+| Use Python, TypeScript, JavaScript, Go, Rust, or Java | `/sdks` | `sdk/`, `examples/*_client/`, `examples/*openai_baseurl/` |
+| Understand policy languages and bundles | `/reference/protocols-and-schemas`, `/compatibility` | `docs/architecture/policy-languages.md`, `protocols/bundles/`, `examples/policies/` |
+| Validate conformance | `/conformance` | `docs/CONFORMANCE.md`, `protocols/conformance/v1/`, `tests/conformance/` |
+| Verify receipts and evidence packs | `/verification`, `/developer-journey` | `docs/VERIFICATION.md`, `examples/receipt_verification/`, `protocols/spec/evidence-pack-v1.md` |
+| Deploy with Docker or Kubernetes | `/deployment-and-examples` | `docker-compose.yml`, `deploy/`, `deploy/helm-chart/` |
+| Verify release artifacts | `/security/release-security`, `/publishing` | `SECURITY.md`, `RELEASE.md`, `release/`, `.github/workflows/release.yml` |
 
 ## Source Truth
 

--- a/docs/EXECUTION_SECURITY_MODEL.md
+++ b/docs/EXECUTION_SECURITY_MODEL.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/execution-security-model`
+- Public route: `execution-security-model`
 - Source document: `helm-ai-kernel/docs/EXECUTION_SECURITY_MODEL.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/integrations/mcp`
+- Public route: `integrations/mcp`
 - Source document: `helm-ai-kernel/docs/INTEGRATIONS/mcp.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/INTEGRATIONS/microsoft_agent_governance_toolkit.md
+++ b/docs/INTEGRATIONS/microsoft_agent_governance_toolkit.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/integrations/microsoft-agent-governance-toolkit`
+- Public route: `integrations/microsoft-agent-governance-toolkit`
 - Source document: `helm-ai-kernel/docs/INTEGRATIONS/microsoft_agent_governance_toolkit.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/KERNEL_SCOPE.md
+++ b/docs/KERNEL_SCOPE.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/helm-ai-kernel-scope`
+- Public route: `kernel-scope`
 - Source document: `helm-ai-kernel/docs/KERNEL_SCOPE.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/OWASP_MCP_THREAT_MAPPING.md
+++ b/docs/OWASP_MCP_THREAT_MAPPING.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/owasp-mcp-threat-mapping`
+- Public route: `owasp-mcp-threat-mapping`
 - Source document: `helm-ai-kernel/docs/OWASP_MCP_THREAT_MAPPING.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -17,7 +17,7 @@ You should know which package identities are source-backed, which registry claim
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/publishing`
+- Public route: `publishing`
 - Source document: `helm-ai-kernel/docs/PUBLISHING.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -65,13 +65,13 @@ asset. Browser UI bundles are not Kernel release assets.
 
 | Need | Source path | Public route |
 | --- | --- | --- |
-| Release preparation | `RELEASE.md`, `VERSION`, `CHANGELOG.md` | `/helm-ai-kernel/publishing`, `/helm-ai-kernel/changelog` |
-| Vulnerability reporting | `SECURITY.md` | This page and `/helm-ai-kernel/publishing` |
+| Release preparation | `RELEASE.md`, `VERSION`, `CHANGELOG.md` | `/publishing`, `/changelog` |
+| Vulnerability reporting | `SECURITY.md` | This page and `/publishing` |
 | OpenSSF mapping | `BEST_PRACTICES.md` | This page |
 | SBOM and release metadata | `release/README.md`, `scripts/ci/generate_sbom.sh`, release asset `sbom.json`, release asset `release-attestation.json` | This page |
 | OpenVEX policy source | `release/vex.openvex.json`, `release/vex/policies.yaml` | This page; only claim published VEX when attached to the GitHub release |
-| Cosign and reproducible binaries | `.github/workflows/release.yml`, `scripts/release/`, `docs/VERIFICATION.md` | `/helm-ai-kernel/verification`, `/helm-ai-kernel/publishing`; Cosign verification requires attached `*.cosign.bundle` files |
-| Fuzzing | `oss-fuzz/`, Go fuzz tests under `core/pkg/` | This page and `/helm-ai-kernel/execution-security-model` |
+| Cosign and reproducible binaries | `.github/workflows/release.yml`, `scripts/release/`, `docs/VERIFICATION.md` | `/verification`, `/publishing`; Cosign verification requires attached `*.cosign.bundle` files |
+| Fuzzing | `oss-fuzz/`, Go fuzz tests under `core/pkg/` | This page and `/execution-security-model` |
 
 ## Verification Commands
 

--- a/docs/TRACTION.md
+++ b/docs/TRACTION.md
@@ -239,13 +239,13 @@ URL.
 
 | Channel | Docs link |
 | --- | --- |
-| GitHub README | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=github&utm_medium=readme&utm_campaign=oss-traction` |
-| GitHub Discussions | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=github&utm_medium=discussions&utm_campaign=oss-traction` |
-| Hacker News | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=hackernews&utm_medium=showhn&utm_campaign=oss-traction` |
-| Reddit | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=reddit&utm_medium=community&utm_campaign=oss-traction` |
-| Product Hunt | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=producthunt&utm_medium=launch&utm_campaign=oss-traction` |
-| LinkedIn | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=linkedin&utm_medium=social&utm_campaign=oss-traction` |
-| X | `https://helm.docs.mindburn.org/helm-ai-kernel?utm_source=x&utm_medium=social&utm_campaign=oss-traction` |
+| GitHub README | `https://helm.docs.mindburn.org?utm_source=github&utm_medium=readme&utm_campaign=oss-traction` |
+| GitHub Discussions | `https://helm.docs.mindburn.org?utm_source=github&utm_medium=discussions&utm_campaign=oss-traction` |
+| Hacker News | `https://helm.docs.mindburn.org?utm_source=hackernews&utm_medium=showhn&utm_campaign=oss-traction` |
+| Reddit | `https://helm.docs.mindburn.org?utm_source=reddit&utm_medium=community&utm_campaign=oss-traction` |
+| Product Hunt | `https://helm.docs.mindburn.org?utm_source=producthunt&utm_medium=launch&utm_campaign=oss-traction` |
+| LinkedIn | `https://helm.docs.mindburn.org?utm_source=linkedin&utm_medium=social&utm_campaign=oss-traction` |
+| X | `https://helm.docs.mindburn.org?utm_source=x&utm_medium=social&utm_campaign=oss-traction` |
 
 ## Discussions
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/troubleshooting`
+- Public route: `troubleshooting`
 - Source document: `helm-ai-kernel/docs/TROUBLESHOOTING.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -17,7 +17,7 @@ You should be able to run local offline verification, distinguish release metada
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/verification`
+- Public route: `verification`
 - Source document: `helm-ai-kernel/docs/VERIFICATION.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/architecture/cognitive-firewall.md
+++ b/docs/architecture/cognitive-firewall.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/architecture/cognitive-firewall`
+- Public route: `architecture/cognitive-firewall`
 - Source document: `helm-ai-kernel/docs/architecture/cognitive-firewall.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/architecture/eidas-qtsp.md
+++ b/docs/architecture/eidas-qtsp.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/architecture/eidas-qtsp`
+- Public route: `architecture/eidas-qtsp`
 - Source document: `helm-ai-kernel/docs/architecture/eidas-qtsp.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
@@ -238,4 +238,3 @@ flowchart TD
     style auditor fill:#2d3748,stroke:#4a5568,stroke-width:2px,color:#fff
     style legal fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
 ```
-

--- a/docs/architecture/policy-languages.md
+++ b/docs/architecture/policy-languages.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/architecture/policy-languages`
+- Public route: `architecture/policy-languages`
 - Source document: `helm-ai-kernel/docs/architecture/policy-languages.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
@@ -187,4 +187,3 @@ flowchart TD
     style decision fill:#2d3748,stroke:#4a5568,stroke-width:2px,color:#fff
     style receipt fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
 ```
-

--- a/docs/compliance/eu-ai-act-high-risk-pack.md
+++ b/docs/compliance/eu-ai-act-high-risk-pack.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/compliance/eu-ai-act-high-risk-pack`
+- Public route: `compliance/eu-ai-act-high-risk-pack`
 - Source document: `helm-ai-kernel/docs/compliance/eu-ai-act-high-risk-pack.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/compliance/nist-ai-agent-critical-infrastructure.md
+++ b/docs/compliance/nist-ai-agent-critical-infrastructure.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/compliance/nist-ai-agent-critical-infrastructure`
+- Public route: `compliance/nist-ai-agent-critical-infrastructure`
 - Source document: `helm-ai-kernel/docs/compliance/nist-ai-agent-critical-infrastructure.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/compliance/nist-ai-rmf-iso-42001-crosswalk.md
+++ b/docs/compliance/nist-ai-rmf-iso-42001-crosswalk.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/compliance/nist-ai-rmf-iso-42001-crosswalk`
+- Public route: `compliance/nist-ai-rmf-iso-42001-crosswalk`
 - Source document: `helm-ai-kernel/docs/compliance/nist-ai-rmf-iso-42001-crosswalk.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/developer-coverage.manifest.json
+++ b/docs/developer-coverage.manifest.json
@@ -14,231 +14,488 @@
       "category": "installer",
       "surface": "macOS Homebrew install",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/developer-journey",
-      "source_paths": ["Makefile", ".goreleaser.yml", "docs/PUBLISHING.md"],
-      "example_paths": ["docs/QUICKSTART.md"],
-      "validation_commands": ["make build", "make release-binaries-reproducible"],
-      "claim_terms": ["Homebrew", "macOS"]
+      "public_doc_slug": "developer-journey",
+      "source_paths": [
+        "Makefile",
+        ".goreleaser.yml",
+        "docs/PUBLISHING.md"
+      ],
+      "example_paths": [
+        "docs/QUICKSTART.md"
+      ],
+      "validation_commands": [
+        "make build",
+        "make release-binaries-reproducible"
+      ],
+      "claim_terms": [
+        "Homebrew",
+        "macOS"
+      ]
     },
     {
       "id": "install-linux-release",
       "category": "installer",
       "surface": "Linux release binary or source build",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/developer-journey",
-      "source_paths": ["Makefile", ".goreleaser.yml", "docs/PUBLISHING.md"],
-      "example_paths": ["docs/QUICKSTART.md"],
-      "validation_commands": ["make build", "make release-binaries-reproducible"],
-      "claim_terms": ["Linux"]
+      "public_doc_slug": "developer-journey",
+      "source_paths": [
+        "Makefile",
+        ".goreleaser.yml",
+        "docs/PUBLISHING.md"
+      ],
+      "example_paths": [
+        "docs/QUICKSTART.md"
+      ],
+      "validation_commands": [
+        "make build",
+        "make release-binaries-reproducible"
+      ],
+      "claim_terms": [
+        "Linux"
+      ]
     },
     {
       "id": "install-windows-wsl-docker",
       "category": "installer",
       "surface": "Windows via WSL2, Docker, or release binary",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/developer-journey",
-      "source_paths": ["Makefile", ".goreleaser.yml", "core/cmd/helm-ai-kernel/diskspace_windows.go"],
-      "example_paths": ["docs/QUICKSTART.md"],
-      "validation_commands": ["make release-binaries-reproducible"],
-      "claim_terms": ["Windows", "WSL"]
+      "public_doc_slug": "developer-journey",
+      "source_paths": [
+        "Makefile",
+        ".goreleaser.yml",
+        "core/cmd/helm-ai-kernel/diskspace_windows.go"
+      ],
+      "example_paths": [
+        "docs/QUICKSTART.md"
+      ],
+      "validation_commands": [
+        "make release-binaries-reproducible"
+      ],
+      "claim_terms": [
+        "Windows",
+        "WSL"
+      ]
     },
     {
       "id": "install-docker",
       "category": "deployment-target",
       "surface": "Docker and Docker Compose local boundary",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/developer-journey",
-      "source_paths": ["Dockerfile", "docker-compose.yml", "Makefile"],
-      "example_paths": ["deploy/README.md"],
-      "validation_commands": ["make docker"],
-      "claim_terms": ["Docker", "Docker Compose"]
+      "public_doc_slug": "developer-journey",
+      "source_paths": [
+        "Dockerfile",
+        "docker-compose.yml",
+        "Makefile"
+      ],
+      "example_paths": [
+        "deploy/README.md"
+      ],
+      "validation_commands": [
+        "make docker"
+      ],
+      "claim_terms": [
+        "Docker",
+        "Docker Compose"
+      ]
     },
     {
       "id": "deploy-kubernetes-helm-chart",
       "category": "deployment-target",
       "surface": "Kubernetes Helm chart",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/developer-journey",
-      "source_paths": ["deploy/helm-chart/Chart.yaml", "deploy/helm-chart/values.yaml", "deploy/helm-chart/templates/deployment.yaml"],
-      "example_paths": ["deploy/helm-chart/README.md"],
-      "validation_commands": ["helm lint deploy/helm-chart"],
-      "claim_terms": ["Kubernetes", "Helm chart"]
+      "public_doc_slug": "developer-journey",
+      "source_paths": [
+        "deploy/helm-chart/Chart.yaml",
+        "deploy/helm-chart/values.yaml",
+        "deploy/helm-chart/templates/deployment.yaml"
+      ],
+      "example_paths": [
+        "deploy/helm-chart/README.md"
+      ],
+      "validation_commands": [
+        "helm lint deploy/helm-chart"
+      ],
+      "claim_terms": [
+        "Kubernetes",
+        "Helm chart"
+      ]
     },
     {
       "id": "local-boundary-serve-proxy",
       "category": "runtime",
       "surface": "Local HELM boundary with serve and OpenAI-compatible proxy",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/developer-journey",
-      "source_paths": ["core/cmd/helm-ai-kernel/server_cmd.go", "core/cmd/helm-ai-kernel/proxy_cmd.go", "core/cmd/helm-ai-kernel/quickstart_cmd_test.go"],
-      "example_paths": ["examples/python_openai_baseurl/README.md", "examples/ts_openai_baseurl/README.md", "examples/js_openai_baseurl/README.md"],
-      "validation_commands": ["make build", "cd core && go test ./cmd/helm-ai-kernel -run 'Test.*Quickstart|Test.*Proxy' -count=1"],
-      "claim_terms": ["helm-ai-kernel serve", "helm-ai-kernel proxy"]
+      "public_doc_slug": "developer-journey",
+      "source_paths": [
+        "core/cmd/helm-ai-kernel/server_cmd.go",
+        "core/cmd/helm-ai-kernel/proxy_cmd.go",
+        "core/cmd/helm-ai-kernel/quickstart_cmd_test.go"
+      ],
+      "example_paths": [
+        "examples/python_openai_baseurl/README.md",
+        "examples/ts_openai_baseurl/README.md",
+        "examples/js_openai_baseurl/README.md"
+      ],
+      "validation_commands": [
+        "make build",
+        "cd core && go test ./cmd/helm-ai-kernel -run 'Test.*Quickstart|Test.*Proxy' -count=1"
+      ],
+      "claim_terms": [
+        "helm-ai-kernel serve",
+        "helm-ai-kernel proxy"
+      ]
     },
     {
       "id": "receipt-verification",
       "category": "verification-mode",
       "surface": "Offline and online EvidencePack verification",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/developer-journey",
-      "source_paths": ["core/cmd/helm-ai-kernel/verify_cmd.go", "core/pkg/verifier", "docs/VERIFICATION.md"],
-      "example_paths": ["examples/receipt_verification/README.md", "examples/golden/README.md"],
-      "validation_commands": ["make verify-fixtures"],
-      "claim_terms": ["offline verification", "online verification", "EvidencePack"]
+      "public_doc_slug": "developer-journey",
+      "source_paths": [
+        "core/cmd/helm-ai-kernel/verify_cmd.go",
+        "core/pkg/verifier",
+        "docs/VERIFICATION.md"
+      ],
+      "example_paths": [
+        "examples/receipt_verification/README.md",
+        "examples/golden/README.md"
+      ],
+      "validation_commands": [
+        "make verify-fixtures"
+      ],
+      "claim_terms": [
+        "offline verification",
+        "online verification",
+        "EvidencePack"
+      ]
     },
     {
       "id": "conformance-profile",
       "category": "protocol",
       "surface": "Conformance profile and L1/L2 checks",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/conformance",
-      "source_paths": ["core/cmd/helm-ai-kernel/conform.go", "core/pkg/conformance", "tests/conformance/profile-v1/checklist.yaml"],
-      "example_paths": ["docs/CONFORMANCE.md"],
-      "validation_commands": ["cd tests/conformance && go test ./..."],
-      "claim_terms": ["conformance", "L1", "L2"]
+      "public_doc_slug": "conformance",
+      "source_paths": [
+        "core/cmd/helm-ai-kernel/conform.go",
+        "core/pkg/conformance",
+        "tests/conformance/profile-v1/checklist.yaml"
+      ],
+      "example_paths": [
+        "docs/CONFORMANCE.md"
+      ],
+      "validation_commands": [
+        "cd tests/conformance && go test ./..."
+      ],
+      "claim_terms": [
+        "conformance",
+        "L1",
+        "L2"
+      ]
     },
     {
       "id": "sdk-python",
       "category": "sdk-language",
       "surface": "Python SDK",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/sdks",
-      "source_paths": ["sdk/python/pyproject.toml", "sdk/python/helm_sdk/client.py", "sdk/python/tests/test_client.py"],
-      "example_paths": ["sdk/python/README.md", "examples/python_sdk/README.md", "examples/python_openai_baseurl/README.md"],
-      "validation_commands": ["make test-sdk-py", "make sdk-examples-smoke"],
-      "claim_terms": ["Python SDK"]
+      "public_doc_slug": "sdks",
+      "source_paths": [
+        "sdk/python/pyproject.toml",
+        "sdk/python/helm_sdk/client.py",
+        "sdk/python/tests/test_client.py"
+      ],
+      "example_paths": [
+        "sdk/python/README.md",
+        "examples/python_sdk/README.md",
+        "examples/python_openai_baseurl/README.md"
+      ],
+      "validation_commands": [
+        "make test-sdk-py",
+        "make sdk-examples-smoke"
+      ],
+      "claim_terms": [
+        "Python SDK"
+      ]
     },
     {
       "id": "sdk-typescript",
       "category": "sdk-language",
       "surface": "TypeScript and JavaScript SDK",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/sdks",
-      "source_paths": ["sdk/ts/package.json", "sdk/ts/src/client.ts", "sdk/ts/src/index.test.ts"],
-      "example_paths": ["sdk/ts/README.md", "examples/ts_sdk/README.md", "examples/ts_openai_baseurl/README.md", "examples/js_openai_baseurl/README.md"],
-      "validation_commands": ["make test-sdk-ts", "make sdk-examples-smoke"],
-      "claim_terms": ["TypeScript SDK", "JavaScript"]
+      "public_doc_slug": "sdks",
+      "source_paths": [
+        "sdk/ts/package.json",
+        "sdk/ts/src/client.ts",
+        "sdk/ts/src/index.test.ts"
+      ],
+      "example_paths": [
+        "sdk/ts/README.md",
+        "examples/ts_sdk/README.md",
+        "examples/ts_openai_baseurl/README.md",
+        "examples/js_openai_baseurl/README.md"
+      ],
+      "validation_commands": [
+        "make test-sdk-ts",
+        "make sdk-examples-smoke"
+      ],
+      "claim_terms": [
+        "TypeScript SDK",
+        "JavaScript"
+      ]
     },
     {
       "id": "sdk-go",
       "category": "sdk-language",
       "surface": "Go SDK",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/sdks",
-      "source_paths": ["sdk/go/go.mod", "sdk/go/client/client.go", "sdk/go/client/types_gen.go"],
-      "example_paths": ["sdk/go/README.md", "examples/go_client/README.md"],
-      "validation_commands": ["cd sdk/go && go test ./..."],
-      "claim_terms": ["Go SDK"]
+      "public_doc_slug": "sdks",
+      "source_paths": [
+        "sdk/go/go.mod",
+        "sdk/go/client/client.go",
+        "sdk/go/client/types_gen.go"
+      ],
+      "example_paths": [
+        "sdk/go/README.md",
+        "examples/go_client/README.md"
+      ],
+      "validation_commands": [
+        "cd sdk/go && go test ./..."
+      ],
+      "claim_terms": [
+        "Go SDK"
+      ]
     },
     {
       "id": "sdk-rust",
       "category": "sdk-language",
       "surface": "Rust SDK",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/sdks",
-      "source_paths": ["sdk/rust/Cargo.toml", "sdk/rust/src/client.rs", "sdk/rust/src/types_gen.rs"],
-      "example_paths": ["sdk/rust/README.md", "examples/rust_client/README.md"],
-      "validation_commands": ["make test-sdk-rust"],
-      "claim_terms": ["Rust SDK"]
+      "public_doc_slug": "sdks",
+      "source_paths": [
+        "sdk/rust/Cargo.toml",
+        "sdk/rust/src/client.rs",
+        "sdk/rust/src/types_gen.rs"
+      ],
+      "example_paths": [
+        "sdk/rust/README.md",
+        "examples/rust_client/README.md"
+      ],
+      "validation_commands": [
+        "make test-sdk-rust"
+      ],
+      "claim_terms": [
+        "Rust SDK"
+      ]
     },
     {
       "id": "sdk-java",
       "category": "sdk-language",
       "surface": "Java SDK",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/sdks",
-      "source_paths": ["sdk/java/pom.xml", "sdk/java/README.md", "examples/java_client/Main.java"],
-      "example_paths": ["sdk/java/README.md", "examples/java_client/README.md"],
-      "validation_commands": ["make test-sdk-java"],
-      "claim_terms": ["Java SDK"]
+      "public_doc_slug": "sdks",
+      "source_paths": [
+        "sdk/java/pom.xml",
+        "sdk/java/README.md",
+        "examples/java_client/Main.java"
+      ],
+      "example_paths": [
+        "sdk/java/README.md",
+        "examples/java_client/README.md"
+      ],
+      "validation_commands": [
+        "make test-sdk-java"
+      ],
+      "claim_terms": [
+        "Java SDK"
+      ]
     },
     {
       "id": "framework-openai-baseurl",
       "category": "framework",
       "surface": "OpenAI-compatible clients through base URL",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/integrations/openai-compatible-proxy",
-      "source_paths": ["core/cmd/helm-ai-kernel/proxy_cmd.go", "sdk/python/README.md", "sdk/ts/README.md"],
-      "example_paths": ["examples/python_openai_baseurl/README.md", "examples/ts_openai_baseurl/README.md", "examples/js_openai_baseurl/README.md"],
-      "validation_commands": ["make test-sdk-py", "make test-sdk-ts"],
-      "claim_terms": ["OpenAI-compatible proxy"]
+      "public_doc_slug": "integrations/openai-compatible-proxy",
+      "source_paths": [
+        "core/cmd/helm-ai-kernel/proxy_cmd.go",
+        "sdk/python/README.md",
+        "sdk/ts/README.md"
+      ],
+      "example_paths": [
+        "examples/python_openai_baseurl/README.md",
+        "examples/ts_openai_baseurl/README.md",
+        "examples/js_openai_baseurl/README.md"
+      ],
+      "validation_commands": [
+        "make test-sdk-py",
+        "make test-sdk-ts"
+      ],
+      "claim_terms": [
+        "OpenAI-compatible proxy"
+      ]
     },
     {
       "id": "framework-agent-adapters",
       "category": "framework",
       "surface": "LangGraph, CrewAI, OpenAI Agents SDK, PydanticAI, and LlamaIndex TypeScript adapter helpers",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/compatibility",
-      "source_paths": ["sdk/ts/src/adapters/agent-frameworks.ts", "sdk/ts/src/adapters/agent-frameworks.test.ts", "docs/COMPATIBILITY.md"],
-      "example_paths": ["sdk/ts/README.md"],
-      "validation_commands": ["make test-sdk-ts"],
-      "claim_terms": ["LangGraph", "CrewAI", "OpenAI Agents SDK", "PydanticAI", "LlamaIndex"]
+      "public_doc_slug": "compatibility",
+      "source_paths": [
+        "sdk/ts/src/adapters/agent-frameworks.ts",
+        "sdk/ts/src/adapters/agent-frameworks.test.ts",
+        "docs/COMPATIBILITY.md"
+      ],
+      "example_paths": [
+        "sdk/ts/README.md"
+      ],
+      "validation_commands": [
+        "make test-sdk-ts"
+      ],
+      "claim_terms": [
+        "LangGraph",
+        "CrewAI",
+        "OpenAI Agents SDK",
+        "PydanticAI",
+        "LlamaIndex"
+      ]
     },
     {
       "id": "integration-mcp",
       "category": "protocol",
       "surface": "MCP server, OAuth scope enforcement, client config, and MCP bundle",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/integrations/mcp",
-      "source_paths": ["core/cmd/helm-ai-kernel/mcp_cmd.go", "core/cmd/helm-ai-kernel/mcp_runtime.go", "core/cmd/helm-ai-kernel/mcp_runtime_auth_test.go", "scripts/launch/demo-mcp.sh"],
-      "example_paths": ["examples/mcp_client/README.md", "examples/launch/README.md", "docs/INTEGRATIONS/mcp.md"],
-      "validation_commands": ["make mcp-pack", "make launch-smoke", "cd core && go test ./cmd/helm-ai-kernel -run TestMCP -count=1"],
-      "claim_terms": ["MCP", "OAuth"]
+      "public_doc_slug": "integrations/mcp",
+      "source_paths": [
+        "core/cmd/helm-ai-kernel/mcp_cmd.go",
+        "core/cmd/helm-ai-kernel/mcp_runtime.go",
+        "core/cmd/helm-ai-kernel/mcp_runtime_auth_test.go",
+        "scripts/launch/demo-mcp.sh"
+      ],
+      "example_paths": [
+        "examples/mcp_client/README.md",
+        "examples/launch/README.md",
+        "docs/INTEGRATIONS/mcp.md"
+      ],
+      "validation_commands": [
+        "make mcp-pack",
+        "make launch-smoke",
+        "cd core && go test ./cmd/helm-ai-kernel -run TestMCP -count=1"
+      ],
+      "claim_terms": [
+        "MCP",
+        "OAuth"
+      ]
     },
     {
       "id": "starter-anthropic",
       "category": "starter",
       "surface": "Anthropic starter layout",
       "status": "example-only",
-      "public_doc_slug": "helm-ai-kernel/compatibility",
-      "source_paths": ["examples/starters/anthropic/helm.yaml"],
-      "example_paths": ["examples/starters/anthropic/README.md", "examples/starters/anthropic/ci-smoke.sh"],
-      "validation_commands": ["bash examples/starters/anthropic/ci-smoke.sh"],
-      "claim_terms": ["Anthropic starter"]
+      "public_doc_slug": "compatibility",
+      "source_paths": [
+        "examples/starters/anthropic/helm.yaml"
+      ],
+      "example_paths": [
+        "examples/starters/anthropic/README.md",
+        "examples/starters/anthropic/ci-smoke.sh"
+      ],
+      "validation_commands": [
+        "bash examples/starters/anthropic/ci-smoke.sh"
+      ],
+      "claim_terms": [
+        "Anthropic starter"
+      ]
     },
     {
       "id": "starter-google-adk-a2a",
       "category": "starter",
       "surface": "Google ADK and A2A starter layout",
       "status": "example-only",
-      "public_doc_slug": "helm-ai-kernel/compatibility",
-      "source_paths": ["examples/starters/google/helm.yaml"],
-      "example_paths": ["examples/starters/google/README.md", "examples/starters/google/ci-smoke.sh"],
-      "validation_commands": ["bash examples/starters/google/ci-smoke.sh"],
-      "claim_terms": ["Google ADK", "A2A"]
+      "public_doc_slug": "compatibility",
+      "source_paths": [
+        "examples/starters/google/helm.yaml"
+      ],
+      "example_paths": [
+        "examples/starters/google/README.md",
+        "examples/starters/google/ci-smoke.sh"
+      ],
+      "validation_commands": [
+        "bash examples/starters/google/ci-smoke.sh"
+      ],
+      "claim_terms": [
+        "Google ADK",
+        "A2A"
+      ]
     },
     {
       "id": "policy-cel-rego-cedar",
       "category": "policy-language",
       "surface": "CEL, Rego, and Cedar policy bundles",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/compatibility",
-      "source_paths": ["core/cmd/helm-ai-kernel/bundle_cmd.go", "docs/architecture/policy-languages.md"],
-      "example_paths": ["examples/policies/README.md"],
-      "validation_commands": ["make test"],
-      "claim_terms": ["CEL", "Rego", "Cedar"]
+      "public_doc_slug": "compatibility",
+      "source_paths": [
+        "core/cmd/helm-ai-kernel/bundle_cmd.go",
+        "docs/architecture/policy-languages.md"
+      ],
+      "example_paths": [
+        "examples/policies/README.md"
+      ],
+      "validation_commands": [
+        "make test"
+      ],
+      "claim_terms": [
+        "CEL",
+        "Rego",
+        "Cedar"
+      ]
     },
     {
       "id": "release-artifact-verification",
       "category": "release",
       "surface": "Checksums, SBOM, Cosign bundles, VEX, provenance, and reproducible binaries",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/publishing",
-      "source_paths": ["Makefile", ".github/workflows/release.yml", "scripts/release/verify_cosign.sh", "scripts/release/build-evidence-bundle.sh"],
-      "example_paths": ["docs/PUBLISHING.md", "release/README.md"],
-      "validation_commands": ["make release-binaries-reproducible", "make verify-cosign"],
-      "claim_terms": ["SBOM", "Cosign", "reproducible"]
+      "public_doc_slug": "publishing",
+      "source_paths": [
+        "Makefile",
+        ".github/workflows/release.yml",
+        "scripts/release/verify_cosign.sh",
+        "scripts/release/build-evidence-bundle.sh"
+      ],
+      "example_paths": [
+        "docs/PUBLISHING.md",
+        "release/README.md"
+      ],
+      "validation_commands": [
+        "make release-binaries-reproducible",
+        "make verify-cosign"
+      ],
+      "claim_terms": [
+        "SBOM",
+        "Cosign",
+        "reproducible"
+      ]
     },
     {
       "id": "troubleshooting-runtime",
       "category": "troubleshooting-class",
       "surface": "Runtime, proxy, verification, MCP, sandbox, and release troubleshooting",
       "status": "supported",
-      "public_doc_slug": "helm-ai-kernel/troubleshooting",
-      "source_paths": ["docs/TROUBLESHOOTING.md", "core/cmd/helm-ai-kernel/doctor_cmd.go", "core/cmd/helm-ai-kernel/receipts_cmd.go"],
-      "example_paths": ["docs/QUICKSTART.md"],
-      "validation_commands": ["make build", "make test"],
-      "claim_terms": ["troubleshooting", "helm-ai-kernel doctor", "receipts"]
+      "public_doc_slug": "troubleshooting",
+      "source_paths": [
+        "docs/TROUBLESHOOTING.md",
+        "core/cmd/helm-ai-kernel/doctor_cmd.go",
+        "core/cmd/helm-ai-kernel/receipts_cmd.go"
+      ],
+      "example_paths": [
+        "docs/QUICKSTART.md"
+      ],
+      "validation_commands": [
+        "make build",
+        "make test"
+      ],
+      "claim_terms": [
+        "troubleshooting",
+        "helm-ai-kernel doctor",
+        "receipts"
+      ]
     }
   ]
 }

--- a/docs/governance/cncf-application.md
+++ b/docs/governance/cncf-application.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/governance/cncf-application`
+- Public route: `governance/cncf-application`
 - Source document: `helm-ai-kernel/docs/governance/cncf-application.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -10,7 +10,7 @@
   },
   "documents": [
     {
-      "slug": "helm-ai-kernel",
+      "slug": "index",
       "title": "HELM AI Kernel",
       "section": "helm-ai-kernel",
       "source_path": "docs/index.md",
@@ -19,7 +19,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/quickstart",
+      "slug": "quickstart",
       "title": "Quickstart",
       "section": "start-here",
       "source_path": "docs/QUICKSTART.md",
@@ -28,7 +28,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/developer-journey",
+      "slug": "developer-journey",
       "title": "Developer Journey",
       "section": "start-here",
       "source_path": "docs/DEVELOPER_JOURNEY.md",
@@ -37,7 +37,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/community",
+      "slug": "community",
       "title": "Community",
       "section": "start-here",
       "source_path": "COMMUNITY.md",
@@ -46,7 +46,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/ecosystem",
+      "slug": "ecosystem",
       "title": "Ecosystem",
       "section": "start-here",
       "source_path": "docs/ECOSYSTEM.md",
@@ -55,7 +55,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/oss-traction",
+      "slug": "oss-traction",
       "title": "HELM AI Kernel OSS Traction Plan",
       "section": "start-here",
       "source_path": "docs/TRACTION.md",
@@ -64,7 +64,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/use-cases/mcp-execution-firewall",
+      "slug": "use-cases/mcp-execution-firewall",
       "title": "MCP Tool Quarantine",
       "section": "use-cases",
       "source_path": "docs/use-cases/mcp-execution-firewall.md",
@@ -73,7 +73,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/use-cases/ai-agent-security",
+      "slug": "use-cases/ai-agent-security",
       "title": "AI Agent Security",
       "section": "use-cases",
       "source_path": "docs/use-cases/ai-agent-security.md",
@@ -82,7 +82,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/use-cases/openai-compatible-ai-gateway-policy",
+      "slug": "use-cases/openai-compatible-ai-gateway-policy",
       "title": "OpenAI-Compatible Execution Boundary",
       "section": "use-cases",
       "source_path": "docs/use-cases/openai-compatible-ai-gateway-policy.md",
@@ -91,7 +91,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/use-cases/llm-audit-receipts",
+      "slug": "use-cases/llm-audit-receipts",
       "title": "Signed Receipts for AI Agent Actions",
       "section": "use-cases",
       "source_path": "docs/use-cases/llm-audit-receipts.md",
@@ -100,7 +100,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/use-cases/agent-tool-call-governance",
+      "slug": "use-cases/agent-tool-call-governance",
       "title": "AI Agent Side-Effect Governance",
       "section": "use-cases",
       "source_path": "docs/use-cases/agent-tool-call-governance.md",
@@ -109,7 +109,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/posts/why-ai-agents-need-an-execution-firewall",
+      "slug": "posts/why-ai-agents-need-an-execution-firewall",
       "title": "Why AI Agents Need an Execution Firewall",
       "section": "posts",
       "source_path": "docs/posts/why-ai-agents-need-an-execution-firewall.md",
@@ -118,7 +118,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/posts/mcp-quarantine-before-tool-dispatch",
+      "slug": "posts/mcp-quarantine-before-tool-dispatch",
       "title": "MCP Quarantine Before Tool Dispatch",
       "section": "posts",
       "source_path": "docs/posts/mcp-quarantine-before-tool-dispatch.md",
@@ -127,7 +127,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/posts/receipts-beat-logs-for-agent-audit-trails",
+      "slug": "posts/receipts-beat-logs-for-agent-audit-trails",
       "title": "Receipts Beat Logs for Agent Audit Trails",
       "section": "posts",
       "source_path": "docs/posts/receipts-beat-logs-for-agent-audit-trails.md",
@@ -136,7 +136,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/posts/how-to-fail-closed-on-agent-tool-calls",
+      "slug": "posts/how-to-fail-closed-on-agent-tool-calls",
       "title": "How To Fail Closed on Agent Tool Calls",
       "section": "posts",
       "source_path": "docs/posts/how-to-fail-closed-on-agent-tool-calls.md",
@@ -145,7 +145,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/architecture",
+      "slug": "architecture",
       "title": "Architecture",
       "section": "start-here",
       "source_path": "docs/ARCHITECTURE.md",
@@ -154,7 +154,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/architecture/canonical-diagrams",
+      "slug": "architecture/canonical-diagrams",
       "title": "Canonical Diagrams",
       "section": "architecture",
       "source_path": "docs/architecture/canonical-diagrams.md",
@@ -163,7 +163,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/conformance",
+      "slug": "conformance",
       "title": "Conformance",
       "section": "start-here",
       "source_path": "docs/CONFORMANCE.md",
@@ -172,7 +172,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad",
+      "slug": "launchpad",
       "title": "Launchpad",
       "section": "start-here",
       "source_path": "docs/LAUNCHPAD.md",
@@ -181,7 +181,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad/conformance",
+      "slug": "launchpad/conformance",
       "title": "Launchpad Conformance",
       "section": "start-here",
       "source_path": "docs/launchpad/CONFORMANCE.md",
@@ -190,7 +190,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad/clean-install-ga",
+      "slug": "launchpad/clean-install-ga",
       "title": "Launchpad Clean Install GA",
       "section": "start-here",
       "source_path": "docs/launchpad/CLEAN_INSTALL_GA.md",
@@ -199,7 +199,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad/apps/openclaw",
+      "slug": "launchpad/apps/openclaw",
       "title": "OpenClaw on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/OPENCLAW.md",
@@ -208,7 +208,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad/apps/hermes",
+      "slug": "launchpad/apps/hermes",
       "title": "Hermes on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/HERMES.md",
@@ -217,7 +217,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad/apps/opencode",
+      "slug": "launchpad/apps/opencode",
       "title": "OpenCode on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/OPENCODE.md",
@@ -226,7 +226,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad/apps/kilocode",
+      "slug": "launchpad/apps/kilocode",
       "title": "Kilo Code on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/KILOCODE.md",
@@ -235,7 +235,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/skills/flow-catalog",
+      "slug": "skills/flow-catalog",
       "title": "Skill Packs Flow Catalog",
       "section": "interfaces",
       "source_path": "docs/skills/FLOW_CATALOG.md",
@@ -244,7 +244,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/launchpad/flow-catalog",
+      "slug": "launchpad/flow-catalog",
       "title": "Launchpad Flow Catalog",
       "section": "interfaces",
       "source_path": "docs/launchpad/FLOW_CATALOG.md",
@@ -253,7 +253,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/verification",
+      "slug": "verification",
       "title": "Verification",
       "section": "start-here",
       "source_path": "docs/VERIFICATION.md",
@@ -262,7 +262,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/compatibility",
+      "slug": "compatibility",
       "title": "Compatibility",
       "section": "start-here",
       "source_path": "docs/COMPATIBILITY.md",
@@ -271,7 +271,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/publishing",
+      "slug": "publishing",
       "title": "Publishing",
       "section": "start-here",
       "source_path": "docs/PUBLISHING.md",
@@ -280,7 +280,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/changelog",
+      "slug": "changelog",
       "title": "HELM AI Kernel Changelog",
       "section": "helm-ai-kernel",
       "source_path": "CHANGELOG.md",
@@ -289,7 +289,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/execution-security-model",
+      "slug": "execution-security-model",
       "title": "Execution Security Model",
       "section": "interfaces",
       "source_path": "docs/EXECUTION_SECURITY_MODEL.md",
@@ -298,7 +298,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/owasp-mcp-threat-mapping",
+      "slug": "owasp-mcp-threat-mapping",
       "title": "OWASP MCP Threat Mapping",
       "section": "interfaces",
       "source_path": "docs/OWASP_MCP_THREAT_MAPPING.md",
@@ -307,7 +307,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/sdks",
+      "slug": "sdks",
       "title": "SDK Index",
       "section": "interfaces",
       "source_path": "docs/sdks/00_INDEX.md",
@@ -316,7 +316,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/benchmarks",
+      "slug": "benchmarks",
       "title": "Benchmarks",
       "section": "supporting-material",
       "source_path": "docs/BENCHMARKS.md",
@@ -325,7 +325,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/troubleshooting",
+      "slug": "troubleshooting",
       "title": "Troubleshooting",
       "section": "supporting-material",
       "source_path": "docs/TROUBLESHOOTING.md",
@@ -334,7 +334,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/integrations/openai-compatible-proxy",
+      "slug": "integrations/openai-compatible-proxy",
       "title": "OpenAI-Compatible Proxy Integration",
       "section": "integrations",
       "source_path": "docs/INTEGRATIONS/openai_baseurl.md",
@@ -343,7 +343,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/integrations/mcp",
+      "slug": "integrations/mcp",
       "title": "MCP Integration",
       "section": "integrations",
       "source_path": "docs/INTEGRATIONS/mcp.md",
@@ -352,7 +352,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/integrations/codebase-memory-mcp",
+      "slug": "integrations/codebase-memory-mcp",
       "title": "Codebase Memory MCP Integration",
       "section": "integrations",
       "source_path": "docs/INTEGRATIONS/codebase_memory_mcp.md",
@@ -361,7 +361,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/integrations/microsoft-agent-governance-toolkit",
+      "slug": "integrations/microsoft-agent-governance-toolkit",
       "title": "Microsoft Agent Governance Toolkit Coexistence",
       "section": "integrations",
       "source_path": "docs/INTEGRATIONS/microsoft_agent_governance_toolkit.md",
@@ -370,7 +370,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/security/owasp-agentic-top10-mapping",
+      "slug": "security/owasp-agentic-top10-mapping",
       "title": "OWASP Agentic Top 10 Mapping",
       "section": "security",
       "source_path": "docs/security/owasp-agentic-top10-coverage.md",
@@ -379,7 +379,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/security/prompt-injection-watchlist-2026-04",
+      "slug": "security/prompt-injection-watchlist-2026-04",
       "title": "Prompt Injection Watchlist - April 2026",
       "section": "security",
       "source_path": "docs/security/prompt-injection-watchlist-2026-04.md",
@@ -388,7 +388,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/compliance/nist-ai-agent-critical-infrastructure",
+      "slug": "compliance/nist-ai-agent-critical-infrastructure",
       "title": "NIST AI Agent Critical Infrastructure Alignment",
       "section": "compliance",
       "source_path": "docs/compliance/nist-ai-agent-critical-infrastructure.md",
@@ -397,7 +397,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/compliance/eu-ai-act-high-risk-pack",
+      "slug": "compliance/eu-ai-act-high-risk-pack",
       "title": "EU AI Act High-Risk Pack",
       "section": "compliance",
       "source_path": "docs/compliance/eu-ai-act-high-risk-pack.md",
@@ -406,7 +406,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/compliance/nist-ai-rmf-iso-42001-crosswalk",
+      "slug": "compliance/nist-ai-rmf-iso-42001-crosswalk",
       "title": "NIST AI RMF to ISO 42001 Crosswalk",
       "section": "compliance",
       "source_path": "docs/compliance/nist-ai-rmf-iso-42001-crosswalk.md",
@@ -415,7 +415,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/source-map",
+      "slug": "source-map",
       "title": "Developer Surface Map",
       "section": "helm-ai-kernel",
       "source_path": "docs/DEVELOPER_SURFACE_MAP.md",
@@ -424,7 +424,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/kernel-scope",
+      "slug": "kernel-scope",
       "title": "Kernel Scope",
       "section": "helm-ai-kernel",
       "source_path": "docs/KERNEL_SCOPE.md",
@@ -433,7 +433,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/deployment-and-examples",
+      "slug": "deployment-and-examples",
       "title": "Deployment and Examples",
       "section": "deployment",
       "source_path": "docs/DEPLOYMENT_AND_EXAMPLES.md",
@@ -442,7 +442,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/examples",
+      "slug": "examples",
       "title": "HELM AI Kernel Examples Matrix",
       "section": "deployment",
       "source_path": "docs/EXAMPLES.md",
@@ -451,7 +451,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/deployment/kubernetes",
+      "slug": "deployment/kubernetes",
       "title": "Kubernetes Deployment",
       "section": "deployment",
       "source_path": "docs/KUBERNETES_DEPLOYMENT.md",
@@ -460,7 +460,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/reference/cli",
+      "slug": "reference/cli",
       "title": "HELM AI Kernel CLI Reference",
       "section": "reference",
       "source_path": "docs/reference/cli.md",
@@ -469,7 +469,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/reference/http-api",
+      "slug": "reference/http-api",
       "title": "HELM AI Kernel HTTP API Reference",
       "section": "reference",
       "source_path": "docs/reference/http-api.md",
@@ -478,7 +478,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/reference/execution-boundary",
+      "slug": "reference/execution-boundary",
       "title": "Execution Boundary Reference",
       "section": "reference",
       "source_path": "docs/reference/execution-boundary.md",
@@ -487,7 +487,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/reference/json-schemas",
+      "slug": "reference/json-schemas",
       "title": "HELM AI Kernel JSON Schema Reference",
       "section": "reference",
       "source_path": "docs/reference/json-schemas.md",
@@ -496,7 +496,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/reference/protocols-and-schemas",
+      "slug": "reference/protocols-and-schemas",
       "title": "Protocols and Schemas",
       "section": "reference",
       "source_path": "docs/REFERENCE_PROTOCOLS.md",
@@ -505,7 +505,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/architecture/cognitive-firewall",
+      "slug": "architecture/cognitive-firewall",
       "title": "Cognitive Firewall Pattern",
       "section": "architecture",
       "source_path": "docs/architecture/cognitive-firewall.md",
@@ -514,7 +514,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/architecture/eidas-qtsp",
+      "slug": "architecture/eidas-qtsp",
       "title": "eIDAS QTSP Anchoring",
       "section": "architecture",
       "source_path": "docs/architecture/eidas-qtsp.md",
@@ -523,7 +523,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/architecture/policy-languages",
+      "slug": "architecture/policy-languages",
       "title": "Policy Languages",
       "section": "architecture",
       "source_path": "docs/architecture/policy-languages.md",
@@ -532,7 +532,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/security/clawguard-taint-tracking",
+      "slug": "security/clawguard-taint-tracking",
       "title": "ClawGuard Taint Tracking",
       "section": "security",
       "source_path": "docs/security/clawguard-taint-tracking.md",
@@ -541,7 +541,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/security/session-risk-memory",
+      "slug": "security/session-risk-memory",
       "title": "Session Risk Memory",
       "section": "security",
       "source_path": "docs/security/session-risk-memory.md",
@@ -550,7 +550,7 @@
       "sensitivity": "public"
     },
     {
-      "slug": "helm-ai-kernel/security/release-security",
+      "slug": "security/release-security",
       "title": "Release and Security Evidence",
       "section": "security",
       "source_path": "docs/RELEASE_SECURITY.md",

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -14,7 +14,7 @@
       "title": "HELM AI Kernel",
       "section": "helm-ai-kernel",
       "source_path": "docs/index.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel",
+      "docs_origin_hint": "helm.docs.mindburn.org",
       "access": "public",
       "sensitivity": "public"
     },
@@ -32,7 +32,7 @@
       "title": "Developer Journey",
       "section": "start-here",
       "source_path": "docs/DEVELOPER_JOURNEY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/developer-journey",
+      "docs_origin_hint": "helm.docs.mindburn.org/developer-journey",
       "access": "public",
       "sensitivity": "public"
     },
@@ -41,7 +41,7 @@
       "title": "Community",
       "section": "start-here",
       "source_path": "COMMUNITY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/community",
+      "docs_origin_hint": "helm.docs.mindburn.org/community",
       "access": "public",
       "sensitivity": "public"
     },
@@ -50,7 +50,7 @@
       "title": "Ecosystem",
       "section": "start-here",
       "source_path": "docs/ECOSYSTEM.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/ecosystem",
+      "docs_origin_hint": "helm.docs.mindburn.org/ecosystem",
       "access": "public",
       "sensitivity": "public"
     },
@@ -59,7 +59,7 @@
       "title": "HELM AI Kernel OSS Traction Plan",
       "section": "start-here",
       "source_path": "docs/TRACTION.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/oss-traction",
+      "docs_origin_hint": "helm.docs.mindburn.org/oss-traction",
       "access": "public",
       "sensitivity": "public"
     },
@@ -68,7 +68,7 @@
       "title": "MCP Tool Quarantine",
       "section": "use-cases",
       "source_path": "docs/use-cases/mcp-execution-firewall.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/mcp-execution-firewall",
+      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/mcp-execution-firewall",
       "access": "public",
       "sensitivity": "public"
     },
@@ -77,7 +77,7 @@
       "title": "AI Agent Security",
       "section": "use-cases",
       "source_path": "docs/use-cases/ai-agent-security.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/ai-agent-security",
+      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/ai-agent-security",
       "access": "public",
       "sensitivity": "public"
     },
@@ -86,7 +86,7 @@
       "title": "OpenAI-Compatible Execution Boundary",
       "section": "use-cases",
       "source_path": "docs/use-cases/openai-compatible-ai-gateway-policy.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/openai-compatible-ai-gateway-policy",
+      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/openai-compatible-ai-gateway-policy",
       "access": "public",
       "sensitivity": "public"
     },
@@ -95,7 +95,7 @@
       "title": "Signed Receipts for AI Agent Actions",
       "section": "use-cases",
       "source_path": "docs/use-cases/llm-audit-receipts.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/llm-audit-receipts",
+      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/llm-audit-receipts",
       "access": "public",
       "sensitivity": "public"
     },
@@ -104,7 +104,7 @@
       "title": "AI Agent Side-Effect Governance",
       "section": "use-cases",
       "source_path": "docs/use-cases/agent-tool-call-governance.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/use-cases/agent-tool-call-governance",
+      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/agent-tool-call-governance",
       "access": "public",
       "sensitivity": "public"
     },
@@ -113,7 +113,7 @@
       "title": "Why AI Agents Need an Execution Firewall",
       "section": "posts",
       "source_path": "docs/posts/why-ai-agents-need-an-execution-firewall.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/posts/why-ai-agents-need-an-execution-firewall",
+      "docs_origin_hint": "helm.docs.mindburn.org/posts/why-ai-agents-need-an-execution-firewall",
       "access": "public",
       "sensitivity": "public"
     },
@@ -122,7 +122,7 @@
       "title": "MCP Quarantine Before Tool Dispatch",
       "section": "posts",
       "source_path": "docs/posts/mcp-quarantine-before-tool-dispatch.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/posts/mcp-quarantine-before-tool-dispatch",
+      "docs_origin_hint": "helm.docs.mindburn.org/posts/mcp-quarantine-before-tool-dispatch",
       "access": "public",
       "sensitivity": "public"
     },
@@ -131,7 +131,7 @@
       "title": "Receipts Beat Logs for Agent Audit Trails",
       "section": "posts",
       "source_path": "docs/posts/receipts-beat-logs-for-agent-audit-trails.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/posts/receipts-beat-logs-for-agent-audit-trails",
+      "docs_origin_hint": "helm.docs.mindburn.org/posts/receipts-beat-logs-for-agent-audit-trails",
       "access": "public",
       "sensitivity": "public"
     },
@@ -140,7 +140,7 @@
       "title": "How To Fail Closed on Agent Tool Calls",
       "section": "posts",
       "source_path": "docs/posts/how-to-fail-closed-on-agent-tool-calls.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/posts/how-to-fail-closed-on-agent-tool-calls",
+      "docs_origin_hint": "helm.docs.mindburn.org/posts/how-to-fail-closed-on-agent-tool-calls",
       "access": "public",
       "sensitivity": "public"
     },
@@ -158,7 +158,7 @@
       "title": "Canonical Diagrams",
       "section": "architecture",
       "source_path": "docs/architecture/canonical-diagrams.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/architecture/canonical-diagrams",
+      "docs_origin_hint": "helm.docs.mindburn.org/architecture/canonical-diagrams",
       "access": "public",
       "sensitivity": "public"
     },
@@ -176,7 +176,7 @@
       "title": "Launchpad",
       "section": "start-here",
       "source_path": "docs/LAUNCHPAD.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad",
       "access": "public",
       "sensitivity": "public"
     },
@@ -185,7 +185,7 @@
       "title": "Launchpad Conformance",
       "section": "start-here",
       "source_path": "docs/launchpad/CONFORMANCE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad/conformance",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/conformance",
       "access": "public",
       "sensitivity": "public"
     },
@@ -194,7 +194,7 @@
       "title": "Launchpad Clean Install GA",
       "section": "start-here",
       "source_path": "docs/launchpad/CLEAN_INSTALL_GA.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad/clean-install-ga",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/clean-install-ga",
       "access": "public",
       "sensitivity": "public"
     },
@@ -203,7 +203,7 @@
       "title": "OpenClaw on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/OPENCLAW.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad/apps/openclaw",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/openclaw",
       "access": "public",
       "sensitivity": "public"
     },
@@ -212,7 +212,7 @@
       "title": "Hermes on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/HERMES.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad/apps/hermes",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/hermes",
       "access": "public",
       "sensitivity": "public"
     },
@@ -221,7 +221,7 @@
       "title": "OpenCode on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/OPENCODE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad/apps/opencode",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/opencode",
       "access": "public",
       "sensitivity": "public"
     },
@@ -230,7 +230,7 @@
       "title": "Kilo Code on HELM",
       "section": "start-here",
       "source_path": "docs/launchpad/apps/KILOCODE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad/apps/kilocode",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/kilocode",
       "access": "public",
       "sensitivity": "public"
     },
@@ -239,7 +239,7 @@
       "title": "Skill Packs Flow Catalog",
       "section": "interfaces",
       "source_path": "docs/skills/FLOW_CATALOG.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/skills/flow-catalog",
+      "docs_origin_hint": "helm.docs.mindburn.org/skills/flow-catalog",
       "access": "public",
       "sensitivity": "public"
     },
@@ -248,7 +248,7 @@
       "title": "Launchpad Flow Catalog",
       "section": "interfaces",
       "source_path": "docs/launchpad/FLOW_CATALOG.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/launchpad/flow-catalog",
+      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/flow-catalog",
       "access": "public",
       "sensitivity": "public"
     },
@@ -284,7 +284,7 @@
       "title": "HELM AI Kernel Changelog",
       "section": "helm-ai-kernel",
       "source_path": "CHANGELOG.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/changelog",
+      "docs_origin_hint": "helm.docs.mindburn.org/changelog",
       "access": "public",
       "sensitivity": "public"
     },
@@ -419,7 +419,7 @@
       "title": "Developer Surface Map",
       "section": "helm-ai-kernel",
       "source_path": "docs/DEVELOPER_SURFACE_MAP.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/source-map",
+      "docs_origin_hint": "helm.docs.mindburn.org/source-map",
       "access": "public",
       "sensitivity": "public"
     },
@@ -428,7 +428,7 @@
       "title": "Kernel Scope",
       "section": "helm-ai-kernel",
       "source_path": "docs/KERNEL_SCOPE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/kernel-scope",
+      "docs_origin_hint": "helm.docs.mindburn.org/kernel-scope",
       "access": "public",
       "sensitivity": "public"
     },
@@ -437,7 +437,7 @@
       "title": "Deployment and Examples",
       "section": "deployment",
       "source_path": "docs/DEPLOYMENT_AND_EXAMPLES.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/deployment-and-examples",
+      "docs_origin_hint": "helm.docs.mindburn.org/deployment-and-examples",
       "access": "public",
       "sensitivity": "public"
     },
@@ -446,7 +446,7 @@
       "title": "HELM AI Kernel Examples Matrix",
       "section": "deployment",
       "source_path": "docs/EXAMPLES.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/examples",
+      "docs_origin_hint": "helm.docs.mindburn.org/examples",
       "access": "public",
       "sensitivity": "public"
     },
@@ -455,7 +455,7 @@
       "title": "Kubernetes Deployment",
       "section": "deployment",
       "source_path": "docs/KUBERNETES_DEPLOYMENT.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/deployment/kubernetes",
+      "docs_origin_hint": "helm.docs.mindburn.org/deployment/kubernetes",
       "access": "public",
       "sensitivity": "public"
     },
@@ -464,7 +464,7 @@
       "title": "HELM AI Kernel CLI Reference",
       "section": "reference",
       "source_path": "docs/reference/cli.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/reference/cli",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/cli",
       "access": "public",
       "sensitivity": "public"
     },
@@ -473,7 +473,7 @@
       "title": "HELM AI Kernel HTTP API Reference",
       "section": "reference",
       "source_path": "docs/reference/http-api.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/reference/http-api",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/http-api",
       "access": "public",
       "sensitivity": "public"
     },
@@ -482,7 +482,7 @@
       "title": "Execution Boundary Reference",
       "section": "reference",
       "source_path": "docs/reference/execution-boundary.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/reference/execution-boundary",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/execution-boundary",
       "access": "public",
       "sensitivity": "public"
     },
@@ -491,7 +491,7 @@
       "title": "HELM AI Kernel JSON Schema Reference",
       "section": "reference",
       "source_path": "docs/reference/json-schemas.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/reference/json-schemas",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/json-schemas",
       "access": "public",
       "sensitivity": "public"
     },
@@ -500,7 +500,7 @@
       "title": "Protocols and Schemas",
       "section": "reference",
       "source_path": "docs/REFERENCE_PROTOCOLS.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/reference/protocols-and-schemas",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/protocols-and-schemas",
       "access": "public",
       "sensitivity": "public"
     },
@@ -509,7 +509,7 @@
       "title": "Cognitive Firewall Pattern",
       "section": "architecture",
       "source_path": "docs/architecture/cognitive-firewall.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/architecture/cognitive-firewall",
+      "docs_origin_hint": "helm.docs.mindburn.org/architecture/cognitive-firewall",
       "access": "public",
       "sensitivity": "public"
     },
@@ -518,7 +518,7 @@
       "title": "eIDAS QTSP Anchoring",
       "section": "architecture",
       "source_path": "docs/architecture/eidas-qtsp.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/architecture/eidas-qtsp",
+      "docs_origin_hint": "helm.docs.mindburn.org/architecture/eidas-qtsp",
       "access": "public",
       "sensitivity": "public"
     },
@@ -527,7 +527,7 @@
       "title": "Policy Languages",
       "section": "architecture",
       "source_path": "docs/architecture/policy-languages.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/architecture/policy-languages",
+      "docs_origin_hint": "helm.docs.mindburn.org/architecture/policy-languages",
       "access": "public",
       "sensitivity": "public"
     },
@@ -536,7 +536,7 @@
       "title": "ClawGuard Taint Tracking",
       "section": "security",
       "source_path": "docs/security/clawguard-taint-tracking.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/security/clawguard-taint-tracking",
+      "docs_origin_hint": "helm.docs.mindburn.org/security/clawguard-taint-tracking",
       "access": "public",
       "sensitivity": "public"
     },
@@ -545,7 +545,7 @@
       "title": "Session Risk Memory",
       "section": "security",
       "source_path": "docs/security/session-risk-memory.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/security/session-risk-memory",
+      "docs_origin_hint": "helm.docs.mindburn.org/security/session-risk-memory",
       "access": "public",
       "sensitivity": "public"
     },
@@ -554,7 +554,7 @@
       "title": "Release and Security Evidence",
       "section": "security",
       "source_path": "docs/RELEASE_SECURITY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/helm-ai-kernel/security/release-security",
+      "docs_origin_hint": "helm.docs.mindburn.org/security/release-security",
       "access": "public",
       "sensitivity": "public"
     }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -17,7 +17,7 @@ After this page you should know the supported top-level command families, the so
 
 ## Source Truth
 
-This page is generated from the active CLI implementation and must stay aligned with [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel), [`core/cmd/README.md`](../../core/cmd/README.md), the command tests in [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel), and the public manifest row for `helm-ai-kernel/reference/cli`.
+This page is generated from the active CLI implementation and must stay aligned with [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel), [`core/cmd/README.md`](../../core/cmd/README.md), the command tests in [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel), and the public manifest row for `reference/cli`.
 
 ## Runtime Map
 

--- a/docs/security/clawguard-taint-tracking.md
+++ b/docs/security/clawguard-taint-tracking.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/security/clawguard-taint-tracking`
+- Public route: `security/clawguard-taint-tracking`
 - Source document: `helm-ai-kernel/docs/security/clawguard-taint-tracking.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/security/owasp-agentic-top10-coverage.md
+++ b/docs/security/owasp-agentic-top10-coverage.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/security/owasp-agentic-top10-mapping`
+- Public route: `security/owasp-agentic-top10-mapping`
 - Source document: `helm-ai-kernel/docs/security/owasp-agentic-top10-coverage.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/security/prompt-injection-watchlist-2026-04.md
+++ b/docs/security/prompt-injection-watchlist-2026-04.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/security/prompt-injection-watchlist-2026-04`
+- Public route: `security/prompt-injection-watchlist-2026-04`
 - Source document: `helm-ai-kernel/docs/security/prompt-injection-watchlist-2026-04.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/security/session-risk-memory.md
+++ b/docs/security/session-risk-memory.md
@@ -15,7 +15,7 @@ After this page you should know what this surface is for, which source files own
 
 ## Source Truth
 
-- Public route: `helm-ai-kernel/security/session-risk-memory`
+- Public route: `security/session-risk-memory`
 - Source document: `helm-ai-kernel/docs/security/session-risk-memory.md`
 - Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
 - Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`

--- a/docs/source-inventory.manifest.json
+++ b/docs/source-inventory.manifest.json
@@ -48,10 +48,10 @@
       ],
       "owner_doc_path": "README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel",
-        "helm-ai-kernel/source-map",
-        "helm-ai-kernel/security/release-security",
-        "helm-ai-kernel/changelog"
+        "index",
+        "source-map",
+        "security/release-security",
+        "changelog"
       ],
       "rationale": "Top-level tracked files define install, release, contribution, governance, and security behavior without masking runtime trees behind a repository-wide wildcard.",
       "validation_commands": [
@@ -75,8 +75,8 @@
       ],
       "owner_doc_path": ".github/SURFACE.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/source-map",
-        "helm-ai-kernel/security/release-security"
+        "source-map",
+        "security/release-security"
       ],
       "rationale": "CI and tooling are externally relevant as validation gates and release evidence, but individual workflow files remain source-owned.",
       "validation_commands": [
@@ -95,8 +95,8 @@
       ],
       "owner_doc_path": "api/openapi/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/reference/http-api",
-        "helm-ai-kernel/reference/execution-boundary"
+        "reference/http-api",
+        "reference/execution-boundary"
       ],
       "rationale": "The OpenAPI contract is a direct public reference surface and must stay tied to route parity tests and the HTTP API page.",
       "validation_commands": [
@@ -128,19 +128,19 @@
       ],
       "owner_doc_path": "protocols/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/reference/protocols-and-schemas",
-        "helm-ai-kernel/reference/json-schemas",
-        "helm-ai-kernel/conformance",
-        "helm-ai-kernel/reference/execution-boundary",
-        "helm-ai-kernel/launchpad",
-        "helm-ai-kernel/launchpad/conformance",
-        "helm-ai-kernel/launchpad/clean-install-ga",
-        "helm-ai-kernel/launchpad/apps/openclaw",
-        "helm-ai-kernel/launchpad/apps/hermes",
-        "helm-ai-kernel/launchpad/apps/opencode",
-        "helm-ai-kernel/launchpad/apps/kilocode",
-        "helm-ai-kernel/launchpad/flow-catalog",
-        "helm-ai-kernel/skills/flow-catalog"
+        "reference/protocols-and-schemas",
+        "reference/json-schemas",
+        "conformance",
+        "reference/execution-boundary",
+        "launchpad",
+        "launchpad/conformance",
+        "launchpad/clean-install-ga",
+        "launchpad/apps/openclaw",
+        "launchpad/apps/hermes",
+        "launchpad/apps/opencode",
+        "launchpad/apps/kilocode",
+        "launchpad/flow-catalog",
+        "skills/flow-catalog"
       ],
       "rationale": "Protocol and schema truth must be public and agent-readable, with detailed source ownership kept in protocol README files.",
       "validation_commands": [
@@ -164,9 +164,9 @@
       ],
       "owner_doc_path": "core/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/reference/cli",
-        "helm-ai-kernel/architecture",
-        "helm-ai-kernel/benchmarks"
+        "reference/cli",
+        "architecture",
+        "benchmarks"
       ],
       "rationale": "Core build and benchmark files are runtime evidence, but they are not allowed to stand in for command, API, or package source ownership.",
       "validation_commands": [
@@ -185,9 +185,9 @@
       ],
       "owner_doc_path": "core/cmd/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/reference/cli",
-        "helm-ai-kernel/developer-journey",
-        "helm-ai-kernel/troubleshooting"
+        "reference/cli",
+        "developer-journey",
+        "troubleshooting"
       ],
       "rationale": "The CLI is a first-class public runtime surface; flags and subcommands must be source-linked to the CLI reference rather than hidden behind core/**.",
       "validation_commands": [
@@ -233,8 +233,8 @@
       ],
       "owner_doc_path": "core/cmd/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/reference/http-api",
-        "helm-ai-kernel/reference/execution-boundary"
+        "reference/http-api",
+        "reference/execution-boundary"
       ],
       "rationale": "HTTP route behavior is enforceable at file-level granularity through the route registry, auth wrapper, handler files, and OpenAPI/SDK contract checks.",
       "validation_commands": [
@@ -263,11 +263,11 @@
       ],
       "owner_doc_path": "core/pkg/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/reference/execution-boundary",
-        "helm-ai-kernel/reference/http-api",
-        "helm-ai-kernel/conformance",
-        "helm-ai-kernel/verification",
-        "helm-ai-kernel/integrations/mcp"
+        "reference/execution-boundary",
+        "reference/http-api",
+        "conformance",
+        "verification",
+        "integrations/mcp"
       ],
       "rationale": "Boundary behavior is the highest-value OSS runtime reference surface and must remain directly linked to package families, HTTP routes, CLI commands, receipt schemas, and conformance vectors.",
       "validation_commands": [
@@ -305,10 +305,10 @@
       ],
       "owner_doc_path": "core/pkg/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/architecture",
-        "helm-ai-kernel/execution-security-model",
-        "helm-ai-kernel/reference/execution-boundary",
-        "helm-ai-kernel/reference/protocols-and-schemas"
+        "architecture",
+        "execution-security-model",
+        "reference/execution-boundary",
+        "reference/protocols-and-schemas"
       ],
       "rationale": "Kernel and policy packages back public runtime guarantees, but public docs should describe supported behavior through architecture, execution-boundary, and protocol references.",
       "validation_commands": [
@@ -362,8 +362,8 @@
       ],
       "owner_doc_path": "core/pkg/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/architecture",
-        "helm-ai-kernel/source-map"
+        "architecture",
+        "source-map"
       ],
       "rationale": "Remaining runtime libraries stay documented through owner docs and architecture/source-map pages without diluting the direct CLI/API/boundary rows.",
       "validation_commands": [
@@ -389,14 +389,14 @@
       ],
       "owner_doc_path": "examples/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/developer-journey",
-        "helm-ai-kernel/deployment-and-examples",
-        "helm-ai-kernel/examples",
-        "helm-ai-kernel/deployment/kubernetes",
-        "helm-ai-kernel/sdks",
-        "helm-ai-kernel/integrations/openai-compatible-proxy",
-        "helm-ai-kernel/integrations/codebase-memory-mcp",
-        "helm-ai-kernel/integrations/mcp"
+        "developer-journey",
+        "deployment-and-examples",
+        "examples",
+        "deployment/kubernetes",
+        "sdks",
+        "integrations/openai-compatible-proxy",
+        "integrations/codebase-memory-mcp",
+        "integrations/mcp"
       ],
       "rationale": "Developers need install, SDK, framework, and deployment paths from the public docs, with examples and package docs as executable proof.",
       "validation_commands": [
@@ -416,9 +416,9 @@
       ],
       "owner_doc_path": "adapters/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/developer-journey",
-        "helm-ai-kernel/deployment-and-examples",
-        "helm-ai-kernel/source-map"
+        "developer-journey",
+        "deployment-and-examples",
+        "source-map"
       ],
       "rationale": "Adapter code is integration proof material for external runtimes and must remain classified without promoting every adapter as a first-class runtime surface.",
       "validation_commands": [
@@ -455,11 +455,11 @@
       ],
       "owner_doc_path": "tests/conformance/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/conformance",
-        "helm-ai-kernel/verification",
-        "helm-ai-kernel/benchmarks",
-        "helm-ai-kernel/publishing",
-        "helm-ai-kernel/security/release-security"
+        "conformance",
+        "verification",
+        "benchmarks",
+        "publishing",
+        "security/release-security"
       ],
       "rationale": "Evidence and conformance material is public proof material; generated artifacts are linked through verification and publishing docs rather than duplicated.",
       "validation_commands": [
@@ -478,8 +478,8 @@
       ],
       "owner_doc_path": "docs/skills/FLOW_CATALOG.md",
       "public_doc_slugs": [
-        "helm-ai-kernel/skills/flow-catalog",
-        "helm-ai-kernel/compatibility"
+        "skills/flow-catalog",
+        "compatibility"
       ],
       "rationale": "Skill packs are source-backed procedural guidance. Public docs expose the flow catalog and authority boundary while registry internals remain source-owned.",
       "validation_commands": [
@@ -498,36 +498,36 @@
       ],
       "owner_doc_path": "docs/README.md",
       "public_doc_slugs": [
-        "helm-ai-kernel",
-        "helm-ai-kernel/community",
-        "helm-ai-kernel/ecosystem",
-        "helm-ai-kernel/oss-traction",
-        "helm-ai-kernel/source-map",
-        "helm-ai-kernel/quickstart",
-        "helm-ai-kernel/compatibility",
-        "helm-ai-kernel/use-cases/mcp-execution-firewall",
-        "helm-ai-kernel/use-cases/ai-agent-security",
-        "helm-ai-kernel/use-cases/openai-compatible-ai-gateway-policy",
-        "helm-ai-kernel/use-cases/llm-audit-receipts",
-        "helm-ai-kernel/use-cases/agent-tool-call-governance",
-        "helm-ai-kernel/posts/why-ai-agents-need-an-execution-firewall",
-        "helm-ai-kernel/posts/mcp-quarantine-before-tool-dispatch",
-        "helm-ai-kernel/posts/receipts-beat-logs-for-agent-audit-trails",
-        "helm-ai-kernel/posts/how-to-fail-closed-on-agent-tool-calls",
-        "helm-ai-kernel/owasp-mcp-threat-mapping",
-        "helm-ai-kernel/integrations/microsoft-agent-governance-toolkit",
-        "helm-ai-kernel/security/owasp-agentic-top10-mapping",
-        "helm-ai-kernel/security/prompt-injection-watchlist-2026-04",
-        "helm-ai-kernel/compliance/nist-ai-agent-critical-infrastructure",
-        "helm-ai-kernel/compliance/eu-ai-act-high-risk-pack",
-        "helm-ai-kernel/compliance/nist-ai-rmf-iso-42001-crosswalk",
-        "helm-ai-kernel/kernel-scope",
-        "helm-ai-kernel/architecture/cognitive-firewall",
-        "helm-ai-kernel/architecture/eidas-qtsp",
-        "helm-ai-kernel/architecture/policy-languages",
-        "helm-ai-kernel/security/clawguard-taint-tracking",
-        "helm-ai-kernel/security/session-risk-memory",
-        "helm-ai-kernel/architecture/canonical-diagrams"
+        "index",
+        "community",
+        "ecosystem",
+        "oss-traction",
+        "source-map",
+        "quickstart",
+        "compatibility",
+        "use-cases/mcp-execution-firewall",
+        "use-cases/ai-agent-security",
+        "use-cases/openai-compatible-ai-gateway-policy",
+        "use-cases/llm-audit-receipts",
+        "use-cases/agent-tool-call-governance",
+        "posts/why-ai-agents-need-an-execution-firewall",
+        "posts/mcp-quarantine-before-tool-dispatch",
+        "posts/receipts-beat-logs-for-agent-audit-trails",
+        "posts/how-to-fail-closed-on-agent-tool-calls",
+        "owasp-mcp-threat-mapping",
+        "integrations/microsoft-agent-governance-toolkit",
+        "security/owasp-agentic-top10-mapping",
+        "security/prompt-injection-watchlist-2026-04",
+        "compliance/nist-ai-agent-critical-infrastructure",
+        "compliance/eu-ai-act-high-risk-pack",
+        "compliance/nist-ai-rmf-iso-42001-crosswalk",
+        "kernel-scope",
+        "architecture/cognitive-firewall",
+        "architecture/eidas-qtsp",
+        "architecture/policy-languages",
+        "security/clawguard-taint-tracking",
+        "security/session-risk-memory",
+        "architecture/canonical-diagrams"
       ],
       "rationale": "Docs files are source material for the public site and are checked through manifest, LLM, search, and source-inventory gates.",
       "validation_commands": [

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -633,8 +633,8 @@
     {
       "id": "docs-site-developer-journey",
       "kind": "http_contains",
-      "url": "https://helm.docs.mindburn.org/helm-ai-kernel/developer-journey",
-      "human_url": "https://helm.docs.mindburn.org/helm-ai-kernel/developer-journey",
+      "url": "https://helm.docs.mindburn.org/developer-journey",
+      "human_url": "https://helm.docs.mindburn.org/developer-journey",
       "contains": [
         "io.github.mindburnlabs:helm-sdk:{version}",
         "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}",
@@ -650,8 +650,8 @@
     {
       "id": "docs-site-sdk-index",
       "kind": "http_contains",
-      "url": "https://helm.docs.mindburn.org/helm-ai-kernel/sdks",
-      "human_url": "https://helm.docs.mindburn.org/helm-ai-kernel/sdks",
+      "url": "https://helm.docs.mindburn.org/sdks",
+      "human_url": "https://helm.docs.mindburn.org/sdks",
       "contains": [
         "io.github.mindburnlabs:helm-sdk:{version}",
         "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}",
@@ -669,8 +669,8 @@
     {
       "id": "docs-site-examples",
       "kind": "http_contains",
-      "url": "https://helm.docs.mindburn.org/helm-ai-kernel/examples",
-      "human_url": "https://helm.docs.mindburn.org/helm-ai-kernel/examples",
+      "url": "https://helm.docs.mindburn.org/examples",
+      "human_url": "https://helm.docs.mindburn.org/examples",
       "contains": [
         "io.github.mindburnlabs:helm-sdk:{version}"
       ],

--- a/scripts/check_documentation_truth.py
+++ b/scripts/check_documentation_truth.py
@@ -45,9 +45,9 @@ KERNEL_SCOPE_SPEC_ONLY_PATHS = (
 
 FORBIDDEN_SOURCE_INVENTORY_PATTERNS = {'*', 'core/**', 'api/**'}
 REQUIRED_RUNTIME_REFERENCE_SLUGS = {
-    'helm-ai-kernel/reference/cli',
-    'helm-ai-kernel/reference/http-api',
-    'helm-ai-kernel/reference/execution-boundary',
+    'reference/cli',
+    'reference/http-api',
+    'reference/execution-boundary',
 }
 CANONICAL_REPO_RENAMES = {
     'helm' + '-oss': 'helm-ai-kernel',
@@ -184,7 +184,7 @@ def validate_source_inventory(failures: list[str], public_slugs: set[str]) -> No
         public_doc_slugs = [str(slug).strip() for slug in family.get('public_doc_slugs') or [] if str(slug).strip()]
         inventory_slugs.update(public_doc_slugs)
         for slug in public_doc_slugs:
-            if (slug == 'oss' or slug.startswith('helm-ai-kernel/')) and slug not in public_slugs:
+            if slug not in public_slugs:
                 failures.append(f'docs/source-inventory.manifest.json:{family_id} public_doc_slug is missing from public docs manifest: {slug}')
 
         if patterns and not any(matches_inventory_family(file_path, family) for file_path in tracked):


### PR DESCRIPTION
## Summary
- Removes `/helm-ai-kernel` from GitHub-facing docs links in repo metadata, issue-template config, docs manifest, and version-surface files.
- Points GitHub-facing docs URLs at `https://helm.docs.mindburn.org/`.

## Validation
- `rg -n --fixed-strings 'helm.docs.mindburn.org/helm-ai-kernel' .bestpractices.json .github/ISSUE_TEMPLATE/config.yml docs/TRACTION.md docs/public-docs.manifest.json release/version-surfaces.yaml` returned no matches.
- `python3 -m json.tool .bestpractices.json` and `python3 -m json.tool docs/public-docs.manifest.json` passed.
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/ISSUE_TEMPLATE/config.yml release/version-surfaces.yaml` passed.
- `git diff --check origin/main...HEAD` passed.
- `gh repo view Mindburn-Labs/helm-ai-kernel --json homepageUrl --jq .homepageUrl` returned `https://helm.docs.mindburn.org/`.
- Docs smoke returned HTTP 200 for `/`, `/quickstart`, `/developer-journey`, `/sdks`, and `/examples` using a browser user agent.