### PR TITLE
Add observe receipt projection to risk scan

### DIFF
--- a/core/cmd/helm-ai-kernel/scan_cmd.go
+++ b/core/cmd/helm-ai-kernel/scan_cmd.go
@@ -34,6 +34,7 @@ func runScanCmd(args []string, stdout, stderr io.Writer) int {
 
 	var (
 		rootPath     string
+		receiptsPath string
 		cohort       string
 		saltFile     string
 		envelopePath string
@@ -44,6 +45,7 @@ func runScanCmd(args []string, stdout, stderr io.Writer) int {
 		previews     scanPreviewFlags
 	)
 	cmd.StringVar(&rootPath, "path", ".", "Directory to scan")
+	cmd.StringVar(&receiptsPath, "from-receipts", "", "Project workstation observe/decision receipts from this directory")
 	cmd.StringVar(&cohort, "cohort", string(riskenvelope.CohortUnknown), "Cohort bucket: unknown|1-10repos|11-50repos|51-200repos|201plusrepos")
 	cmd.StringVar(&saltFile, "salt-file", "", "Local-only pseudonym salt file (default: user config dir)")
 	cmd.StringVar(&envelopePath, "risk-envelope", "", "Write anonymized RiskEnvelope JSON")
@@ -72,13 +74,23 @@ func runScanCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "Error loading scan salt: %v\n", err)
 		return 2
 	}
-	envelope, err := riskscan.Scan(rootPath, riskscan.BuildOptions{
+	opts := riskscan.BuildOptions{
 		Salt:   salt,
 		Cohort: riskenvelope.CohortBucket(cohort),
 		Now:    time.Now().UTC(),
-	})
+	}
+	var envelope riskenvelope.RiskEnvelope
+	if strings.TrimSpace(receiptsPath) != "" {
+		envelope, err = riskscan.ScanReceipts(receiptsPath, opts)
+	} else {
+		envelope, err = riskscan.Scan(rootPath, opts)
+	}
 	if err != nil {
-		fmt.Fprintf(stderr, "Error scanning %q: %v\n", rootPath, err)
+		target := rootPath
+		if strings.TrimSpace(receiptsPath) != "" {
+			target = receiptsPath
+		}
+		fmt.Fprintf(stderr, "Error scanning %q: %v\n", target, err)
 		return 2
 	}
 	body, err := riskscan.EnvelopeJSON(envelope)

--- a/core/cmd/helm-ai-kernel/scan_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/scan_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,7 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/riskenvelope"
 )
 
@@ -105,6 +108,31 @@ func TestScanCommandUploadSendsPrintedBody(t *testing.T) {
 	}
 }
 
+func TestScanCommandFromReceiptsWritesEnvelope(t *testing.T) {
+	receipts := scanReceiptFixtureRoot(t)
+	out := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"helm-ai-kernel", "scan",
+		"--from-receipts", receipts,
+		"--salt-file", filepath.Join(out, "salt.hex"),
+		"--risk-envelope", filepath.Join(out, "risk.json"),
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("scan receipts code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	riskJSON, err := os.ReadFile(filepath.Join(out, "risk.json"))
+	if err != nil {
+		t.Fatalf("read risk envelope: %v", err)
+	}
+	if !bytes.Contains(riskJSON, []byte(`"DIRECT_DISPATCH_SEEN"`)) {
+		t.Fatalf("receipt-derived risk missing from envelope: %s", riskJSON)
+	}
+	if bytes.Contains(riskJSON, []byte("customer/private-game")) || bytes.Contains(riskJSON, []byte("curl https://private.example")) {
+		t.Fatalf("risk envelope leaked raw receipt data: %s", riskJSON)
+	}
+}
+
 func scanFixtureRoot(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
@@ -120,6 +148,37 @@ func scanFixtureRoot(t *testing.T) string {
 	}
 	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"permissionMode":"acceptEdits","project":"customer/private-game"}`), 0o644); err != nil {
 		t.Fatalf("write settings: %v", err)
+	}
+	return root
+}
+
+func scanReceiptFixtureRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	receipt := contracts.WorkstationPolicyDecisionReceipt{
+		ReceiptVersion: "workstation_policy_decision.v1",
+		DecisionID:     "decision-network",
+		Request: contracts.WorkstationDecisionRequest{
+			RequestID:    "network-1",
+			RunID:        "run-private-game",
+			AgentSurface: "codex",
+			ToolID:       "curl",
+			Action:       "curl https://private.example/customer/private-game",
+			EffectType:   contracts.EffectTypeWorkstationNetworkEgress,
+			EffectMode:   contracts.WorkstationEffectModeObserve,
+			Target:       "customer/private-game",
+			OccurredAt:   time.Unix(0, 0).UTC(),
+		},
+		Verdict:      contracts.WorkstationVerdictAllow,
+		ObservedOnly: true,
+		CreatedAt:    time.Unix(0, 0).UTC(),
+	}
+	data, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "decision.json"), append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("write receipt: %v", err)
 	}
 	return root
 }

--- a/core/pkg/riskscan/receipts.go
+++ b/core/pkg/riskscan/receipts.go
@@ -1,0 +1,429 @@
+package riskscan
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/riskenvelope"
+)
+
+type receiptProjectionInput struct {
+	Source       string
+	ReceiptID    string
+	AgentSurface string
+	EffectID     string
+	EffectType   string
+	EffectMode   string
+	Verdict      string
+	ObservedOnly bool
+}
+
+type receiptSourceSummary struct {
+	AgentRunReceipts int            `json:"agent_run_receipts"`
+	DecisionReceipts int            `json:"decision_receipts"`
+	Actions          int            `json:"actions"`
+	DeniedActions    int            `json:"denied_actions"`
+	ObservedOnly     int            `json:"observed_only"`
+	ByEffectType     map[string]int `json:"by_effect_type"`
+	ByToolClass      map[string]int `json:"by_tool_class"`
+	ByRiskCode       map[string]int `json:"by_risk_code"`
+}
+
+// ScanReceipts projects workstation observe/decision receipts into the same
+// anonymized RiskEnvelope shape as Scan. It never exports raw receipt fields.
+func ScanReceipts(root string, opts BuildOptions) (riskenvelope.RiskEnvelope, error) {
+	if opts.Now.IsZero() {
+		opts.Now = time.Now().UTC()
+	}
+	events, summary, surface, err := collectReceiptProjectionInputs(root)
+	if err != nil {
+		return riskenvelope.RiskEnvelope{}, err
+	}
+	for _, event := range events {
+		tool, risk := receiptToolAndRisk(event.EffectType)
+		summary.ByToolClass[string(tool)]++
+		summary.ByRiskCode[string(risk)]++
+	}
+	sourceHash, err := riskenvelope.CanonicalSHA256Ref(summary)
+	if err != nil {
+		return riskenvelope.RiskEnvelope{}, err
+	}
+	envelopeID, err := riskenvelope.EnvelopeID(opts.Salt, sourceHash)
+	if err != nil {
+		return riskenvelope.RiskEnvelope{}, err
+	}
+	findings, err := projectReceiptFindings(events, opts.Salt)
+	if err != nil {
+		return riskenvelope.RiskEnvelope{}, err
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Severity != findings[j].Severity {
+			return findings[i].Severity > findings[j].Severity
+		}
+		if findings[i].RiskCode != findings[j].RiskCode {
+			return findings[i].RiskCode < findings[j].RiskCode
+		}
+		return findings[i].ResourceID < findings[j].ResourceID
+	})
+	mode := riskenvelope.PermissionModeUnknown
+	if summary.ObservedOnly > 0 {
+		mode = riskenvelope.PermissionModeAsk
+	}
+	if summary.Actions > summary.DeniedActions && hasOperateEvent(events) {
+		mode = riskenvelope.PermissionModeAcceptEdits
+	}
+	envelope := riskenvelope.RiskEnvelope{
+		SchemaVersion:  riskenvelope.SchemaVersion,
+		EnvelopeID:     envelopeID,
+		CohortBucket:   opts.Cohort,
+		SourcePackHash: sourceHash,
+		Findings:       findings,
+		Posture: riskenvelope.PostureProbe{
+			AgentSurface:           surface,
+			PermissionMode:         mode,
+			ManagedSettingsPresent: false,
+			MCPServerCount:         0,
+			OAuthScopeBuckets:      []riskenvelope.OAuthScopeBucketCount{},
+			IAMGrantBuckets:        []riskenvelope.IAMGrantBucketCount{},
+			StaticConfigFilesRead:  0,
+			MetadataAPICalls:       0,
+			SuppressedFindingCount: 0,
+			KAnonymityFloor:        0,
+		},
+		Privacy:     riskenvelope.PrivacyNonCollection{},
+		GeneratedAt: opts.Now.UTC(),
+	}
+	sealed, err := riskenvelope.Seal(envelope)
+	if err != nil {
+		return riskenvelope.RiskEnvelope{}, err
+	}
+	if err := sealed.Validate(); err != nil {
+		return riskenvelope.RiskEnvelope{}, err
+	}
+	return sealed, nil
+}
+
+func collectReceiptProjectionInputs(root string) ([]receiptProjectionInput, receiptSourceSummary, riskenvelope.AgentSurface, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, err
+	}
+	summary := receiptSourceSummary{
+		ByEffectType: map[string]int{},
+		ByToolClass:  map[string]int{},
+		ByRiskCode:   map[string]int{},
+	}
+	var events []receiptProjectionInput
+	surface := riskenvelope.AgentSurfaceUnknown
+	err = filepath.WalkDir(absRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry == nil {
+			return nil
+		}
+		if entry.IsDir() {
+			if shouldSkipDir(entry.Name()) && path != absRoot {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".json" && ext != ".ndjson" {
+			return nil
+		}
+		fileEvents, fileSummary, fileSurface, err := parseReceiptFile(path)
+		if err != nil {
+			return err
+		}
+		events = append(events, fileEvents...)
+		summary.AgentRunReceipts += fileSummary.AgentRunReceipts
+		summary.DecisionReceipts += fileSummary.DecisionReceipts
+		summary.Actions += fileSummary.Actions
+		summary.DeniedActions += fileSummary.DeniedActions
+		summary.ObservedOnly += fileSummary.ObservedOnly
+		for k, v := range fileSummary.ByEffectType {
+			summary.ByEffectType[k] += v
+		}
+		if surface == riskenvelope.AgentSurfaceUnknown && fileSurface != riskenvelope.AgentSurfaceUnknown {
+			surface = fileSurface
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, err
+	}
+	if len(events) == 0 {
+		return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, fmt.Errorf("no supported receipt events found in %s", root)
+	}
+	return events, summary, surface, nil
+}
+
+func parseReceiptFile(path string) ([]receiptProjectionInput, receiptSourceSummary, riskenvelope.AgentSurface, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, err
+	}
+	if strings.EqualFold(filepath.Ext(path), ".ndjson") {
+		return parseReceiptNDJSON(data)
+	}
+	events, summary, surface, ok, err := parseReceiptJSON(data)
+	if err != nil {
+		return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, fmt.Errorf("%s: %w", path, err)
+	}
+	if !ok {
+		return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, nil
+	}
+	return events, summary, surface, nil
+}
+
+func parseReceiptNDJSON(data []byte) ([]receiptProjectionInput, receiptSourceSummary, riskenvelope.AgentSurface, error) {
+	summary := receiptSourceSummary{ByEffectType: map[string]int{}, ByToolClass: map[string]int{}, ByRiskCode: map[string]int{}}
+	var events []receiptProjectionInput
+	surface := riskenvelope.AgentSurfaceUnknown
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		lineEvents, lineSummary, lineSurface, ok, err := parseReceiptJSON(line)
+		if err != nil {
+			return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, err
+		}
+		if !ok {
+			continue
+		}
+		events = append(events, lineEvents...)
+		mergeReceiptSummary(&summary, lineSummary)
+		if surface == riskenvelope.AgentSurfaceUnknown && lineSurface != riskenvelope.AgentSurfaceUnknown {
+			surface = lineSurface
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, receiptSourceSummary{}, riskenvelope.AgentSurfaceUnknown, err
+	}
+	return events, summary, surface, nil
+}
+
+func parseReceiptJSON(data []byte) ([]receiptProjectionInput, receiptSourceSummary, riskenvelope.AgentSurface, bool, error) {
+	summary := receiptSourceSummary{ByEffectType: map[string]int{}, ByToolClass: map[string]int{}, ByRiskCode: map[string]int{}}
+	var header map[string]json.RawMessage
+	if err := json.Unmarshal(data, &header); err != nil {
+		return nil, summary, riskenvelope.AgentSurfaceUnknown, false, err
+	}
+	if raw, ok := header["receipt"]; ok {
+		return parseReceiptJSON(raw)
+	}
+	var version string
+	_ = json.Unmarshal(header["receipt_version"], &version)
+	if version == contracts.AgentRunReceiptVersion {
+		var receipt contracts.AgentRunReceipt
+		if err := json.Unmarshal(data, &receipt); err != nil {
+			return nil, summary, riskenvelope.AgentSurfaceUnknown, false, err
+		}
+		events := eventsFromAgentRunReceipt(receipt)
+		summary.AgentRunReceipts = 1
+		accumulateReceiptEvents(&summary, events)
+		return events, summary, normalizeReceiptSurface(receipt.AgentSurface), true, nil
+	}
+	if _, ok := header["decision_id"]; ok {
+		var receipt contracts.WorkstationPolicyDecisionReceipt
+		if err := json.Unmarshal(data, &receipt); err != nil {
+			return nil, summary, riskenvelope.AgentSurfaceUnknown, false, err
+		}
+		if strings.TrimSpace(receipt.DecisionID) == "" {
+			return nil, summary, riskenvelope.AgentSurfaceUnknown, false, nil
+		}
+		event := eventFromDecisionReceipt(receipt)
+		events := []receiptProjectionInput{event}
+		summary.DecisionReceipts = 1
+		accumulateReceiptEvents(&summary, events)
+		return events, summary, normalizeReceiptSurface(receipt.Request.AgentSurface), true, nil
+	}
+	return nil, summary, riskenvelope.AgentSurfaceUnknown, false, nil
+}
+
+func eventsFromAgentRunReceipt(receipt contracts.AgentRunReceipt) []receiptProjectionInput {
+	events := make([]receiptProjectionInput, 0, len(receipt.ToolActions)+len(receipt.DeniedEffects))
+	for _, action := range receipt.ToolActions {
+		events = append(events, receiptProjectionInput{
+			Source:       "agent_run_receipt",
+			ReceiptID:    receipt.ReceiptID,
+			AgentSurface: receipt.AgentSurface,
+			EffectID:     action.ActionID,
+			EffectType:   action.EffectType,
+			EffectMode:   action.EffectMode,
+			Verdict:      action.Verdict,
+			ObservedOnly: strings.EqualFold(action.EffectMode, contracts.WorkstationEffectModeObserve),
+		})
+	}
+	for _, denied := range receipt.DeniedEffects {
+		events = append(events, receiptProjectionInput{
+			Source:       "agent_run_receipt",
+			ReceiptID:    receipt.ReceiptID,
+			AgentSurface: receipt.AgentSurface,
+			EffectID:     denied.EffectID,
+			EffectType:   denied.EffectType,
+			Verdict:      contracts.WorkstationVerdictDeny,
+		})
+	}
+	return events
+}
+
+func eventFromDecisionReceipt(receipt contracts.WorkstationPolicyDecisionReceipt) receiptProjectionInput {
+	return receiptProjectionInput{
+		Source:       "policy_decision_receipt",
+		ReceiptID:    receipt.DecisionID,
+		AgentSurface: receipt.Request.AgentSurface,
+		EffectID:     receipt.Request.RequestID,
+		EffectType:   receipt.Request.EffectType,
+		EffectMode:   receipt.Request.EffectMode,
+		Verdict:      receipt.Verdict,
+		ObservedOnly: receipt.ObservedOnly,
+	}
+}
+
+func accumulateReceiptEvents(summary *receiptSourceSummary, events []receiptProjectionInput) {
+	for _, event := range events {
+		summary.Actions++
+		if strings.EqualFold(event.Verdict, contracts.WorkstationVerdictDeny) {
+			summary.DeniedActions++
+		}
+		if event.ObservedOnly || strings.EqualFold(event.EffectMode, contracts.WorkstationEffectModeObserve) {
+			summary.ObservedOnly++
+		}
+		summary.ByEffectType[event.EffectType]++
+	}
+}
+
+func mergeReceiptSummary(dst *receiptSourceSummary, src receiptSourceSummary) {
+	dst.AgentRunReceipts += src.AgentRunReceipts
+	dst.DecisionReceipts += src.DecisionReceipts
+	dst.Actions += src.Actions
+	dst.DeniedActions += src.DeniedActions
+	dst.ObservedOnly += src.ObservedOnly
+	for k, v := range src.ByEffectType {
+		dst.ByEffectType[k] += v
+	}
+}
+
+func projectReceiptFindings(events []receiptProjectionInput, salt []byte) ([]riskenvelope.EnvelopeFinding, error) {
+	findings := make([]riskenvelope.EnvelopeFinding, 0, len(events))
+	for i, event := range events {
+		tool, risk := receiptToolAndRisk(event.EffectType)
+		direct := true
+		secretReadable := tool == riskenvelope.ToolClassSecretRead && !strings.EqualFold(event.Verdict, contracts.WorkstationVerdictDeny)
+		resourceID, err := riskenvelope.Pseudonym(salt, fmt.Sprintf("receipt:%s:%s:%s:%s:%d", event.Source, event.ReceiptID, event.EffectID, event.EffectType, i))
+		if err != nil {
+			return nil, err
+		}
+		evidence := riskenvelope.EnvelopeEvidence{
+			AgentTool:          tool,
+			PermissionMode:     permissionModeFromReceiptEvent(event),
+			DirectDispatchSeen: &direct,
+		}
+		if tool == riskenvelope.ToolClassSecretRead {
+			evidence.SecretValueAccessible = &secretReadable
+		}
+		findings = append(findings, riskenvelope.EnvelopeFinding{
+			ResourceID:   resourceID,
+			ResourceType: resourceTypeForTool(tool),
+			RiskCode:     risk,
+			Severity:     receiptSeverity(event, tool),
+			Evidence:     evidence,
+		})
+	}
+	return findings, nil
+}
+
+func receiptToolAndRisk(effectType string) (riskenvelope.ToolClass, riskenvelope.RiskCode) {
+	switch effectType {
+	case contracts.EffectTypeWorkstationMCPToolCall:
+		return riskenvelope.ToolClassMCPWrite, riskenvelope.RiskMCPWriteScopeWithoutApproval
+	case contracts.EffectTypeWorkstationShellCommand:
+		return riskenvelope.ToolClassShellOperate, riskenvelope.RiskBroadShellAllow
+	case contracts.EffectTypeWorkstationNetworkEgress:
+		return riskenvelope.ToolClassNetworkEgress, riskenvelope.RiskDirectDispatchSeen
+	case contracts.EffectTypeWorkstationDeployPublish:
+		return riskenvelope.ToolClassDeployPublish, riskenvelope.RiskAgentWriteWithoutEnvApproval
+	case contracts.EffectTypeWorkstationSecretRead:
+		return riskenvelope.ToolClassSecretRead, riskenvelope.RiskSecretClassAgentReadable
+	case contracts.EffectTypeWorkstationPaymentInitiate:
+		return riskenvelope.ToolClassPaymentInitiate, riskenvelope.RiskDirectDispatchSeen
+	case contracts.EffectTypeWorkstationFileWrite, contracts.EffectTypeWorkstationFileDraft:
+		return riskenvelope.ToolClassGitWrite, riskenvelope.RiskAgentWriteWithoutEnvApproval
+	default:
+		return riskenvelope.ToolClassUnknown, riskenvelope.RiskDirectDispatchSeen
+	}
+}
+
+func resourceTypeForTool(tool riskenvelope.ToolClass) riskenvelope.ResourceType {
+	switch tool {
+	case riskenvelope.ToolClassMCPWrite, riskenvelope.ToolClassMCPRead:
+		return riskenvelope.ResourceMCPServer
+	case riskenvelope.ToolClassSecretRead:
+		return riskenvelope.ResourceSecretClass
+	case riskenvelope.ToolClassDeployPublish:
+		return riskenvelope.ResourceEnvironment
+	default:
+		return riskenvelope.ResourcePermissionProfile
+	}
+}
+
+func receiptSeverity(event receiptProjectionInput, tool riskenvelope.ToolClass) riskenvelope.Severity {
+	if strings.EqualFold(event.Verdict, contracts.WorkstationVerdictDeny) {
+		return riskenvelope.SeverityInfo
+	}
+	switch tool {
+	case riskenvelope.ToolClassSecretRead, riskenvelope.ToolClassPaymentInitiate, riskenvelope.ToolClassDeployPublish, riskenvelope.ToolClassShellOperate:
+		return riskenvelope.SeverityHigh
+	default:
+		if event.ObservedOnly || strings.EqualFold(event.EffectMode, contracts.WorkstationEffectModeObserve) {
+			return riskenvelope.SeverityMedium
+		}
+		return riskenvelope.SeverityLow
+	}
+}
+
+func permissionModeFromReceiptEvent(event receiptProjectionInput) riskenvelope.PermissionMode {
+	switch strings.ToLower(strings.TrimSpace(event.EffectMode)) {
+	case contracts.WorkstationEffectModeOperate:
+		return riskenvelope.PermissionModeAcceptEdits
+	case contracts.WorkstationEffectModeDraft, contracts.WorkstationEffectModeObserve:
+		return riskenvelope.PermissionModeAsk
+	default:
+		return riskenvelope.PermissionModeUnknown
+	}
+}
+
+func hasOperateEvent(events []receiptProjectionInput) bool {
+	for _, event := range events {
+		if strings.EqualFold(event.EffectMode, contracts.WorkstationEffectModeOperate) && !strings.EqualFold(event.Verdict, contracts.WorkstationVerdictDeny) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeReceiptSurface(value string) riskenvelope.AgentSurface {
+	v := strings.ToLower(strings.TrimSpace(value))
+	switch {
+	case strings.Contains(v, "claude"):
+		return riskenvelope.AgentSurfaceClaudeCode
+	case strings.Contains(v, "codex"):
+		return riskenvelope.AgentSurfaceCodex
+	case strings.Contains(v, "github"):
+		return riskenvelope.AgentSurfaceGitHubActions
+	case strings.Contains(v, "mcp"):
+		return riskenvelope.AgentSurfaceMCP
+	default:
+		return riskenvelope.AgentSurfaceUnknown
+	}
+}

--- a/core/pkg/riskscan/scan_test.go
+++ b/core/pkg/riskscan/scan_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/riskenvelope"
 )
 
@@ -152,6 +154,75 @@ func TestUploadEnvelopeSendsExactBody(t *testing.T) {
 	}
 }
 
+func TestScanReceiptsProjectsObservedTrafficWithoutRawLeakage(t *testing.T) {
+	root := receiptFixtureRoot(t)
+	envelope, err := ScanReceipts(root, BuildOptions{
+		Salt:   testSalt,
+		Cohort: riskenvelope.CohortRepos11To50,
+		Now:    fixedTime(),
+	})
+	if err != nil {
+		t.Fatalf("scan receipts: %v", err)
+	}
+	if err := envelope.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if envelope.Posture.StaticConfigFilesRead != 0 {
+		t.Fatalf("static config files read = %d, want 0", envelope.Posture.StaticConfigFilesRead)
+	}
+	if envelope.Posture.AgentSurface != riskenvelope.AgentSurfaceClaudeCode {
+		t.Fatalf("agent surface = %s, want claude_code", envelope.Posture.AgentSurface)
+	}
+	if envelope.Posture.PermissionMode != riskenvelope.PermissionModeAcceptEdits {
+		t.Fatalf("permission mode = %s, want accept_edits", envelope.Posture.PermissionMode)
+	}
+	wantRisks := map[riskenvelope.RiskCode]bool{
+		riskenvelope.RiskBroadShellAllow:              false,
+		riskenvelope.RiskMCPWriteScopeWithoutApproval: false,
+		riskenvelope.RiskSecretClassAgentReadable:     false,
+	}
+	for _, finding := range envelope.Findings {
+		if _, ok := wantRisks[finding.RiskCode]; ok {
+			wantRisks[finding.RiskCode] = true
+		}
+	}
+	for risk, seen := range wantRisks {
+		if !seen {
+			t.Fatalf("missing receipt risk %s in %#v", risk, envelope.Findings)
+		}
+	}
+
+	body, err := EnvelopeJSON(envelope)
+	if err != nil {
+		t.Fatalf("envelope json: %v", err)
+	}
+	md, err := RenderMarkdown(envelope)
+	if err != nil {
+		t.Fatalf("markdown: %v", err)
+	}
+	html, err := RenderHTML(envelope)
+	if err != nil {
+		t.Fatalf("html: %v", err)
+	}
+	for _, raw := range []string{
+		"/Users/customer/private-game",
+		"customer/private-game",
+		"kubectl apply -f prod.yaml",
+		"prod-cluster-token",
+		"sk-12345678901234567890123456789012",
+	} {
+		for name, payload := range map[string][]byte{
+			"envelope": body,
+			"markdown": md,
+			"html":     html,
+		} {
+			if bytes.Contains(payload, []byte(raw)) {
+				t.Fatalf("%s leaked raw receipt input %q", name, raw)
+			}
+		}
+	}
+}
+
 func fixtureRoot(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
@@ -169,6 +240,89 @@ func fixtureRoot(t *testing.T) string {
 		t.Fatalf("write claude settings: %v", err)
 	}
 	return root
+}
+
+func receiptFixtureRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	created := time.Date(2026, 6, 30, 15, 0, 0, 0, time.UTC)
+	receipt := contracts.AgentRunReceipt{
+		ReceiptVersion: contracts.AgentRunReceiptVersion,
+		ReceiptID:      "receipt-private-game",
+		RunID:          "run-private-game",
+		Goal:           "deploy customer/private-game to prod with prod-cluster-token",
+		Workspace: contracts.AgentRunWorkspace{
+			WorkspaceID: "workspace-private-game",
+			Path:        "/Users/customer/private-game",
+			Repository:  "customer/private-game",
+		},
+		AgentSurface: "claude-code",
+		ToolActions: []contracts.AgentToolAction{
+			{
+				ActionID:   "shell-1",
+				ToolID:     "bash",
+				Action:     "kubectl apply -f prod.yaml",
+				EffectType: contracts.EffectTypeWorkstationShellCommand,
+				EffectMode: contracts.WorkstationEffectModeOperate,
+				Status:     "ok",
+				Verdict:    contracts.WorkstationVerdictAllow,
+				Target:     "prod-cluster-token",
+				OccurredAt: created,
+				Metadata:   map[string]string{"command": "kubectl apply -f prod.yaml"},
+			},
+			{
+				ActionID:   "mcp-1",
+				ToolID:     "private-mcp",
+				Action:     "write",
+				EffectType: contracts.EffectTypeWorkstationMCPToolCall,
+				EffectMode: contracts.WorkstationEffectModeObserve,
+				Status:     "ok",
+				Verdict:    contracts.WorkstationVerdictAllow,
+				Target:     "customer/private-game",
+				OccurredAt: created,
+			},
+		},
+		CreatedAt: created,
+	}
+	writeJSON(t, filepath.Join(root, "agent.json"), receipt)
+
+	decision := contracts.WorkstationPolicyDecisionReceipt{
+		ReceiptVersion: "workstation_policy_decision.v1",
+		DecisionID:     "decision-secret",
+		Request: contracts.WorkstationDecisionRequest{
+			RequestID:    "secret-1",
+			RunID:        "run-private-game",
+			AgentSurface: "claude-code",
+			ToolID:       "env",
+			Action:       "read",
+			EffectType:   contracts.EffectTypeWorkstationSecretRead,
+			EffectMode:   contracts.WorkstationEffectModeObserve,
+			Target:       "sk-12345678901234567890123456789012",
+			OccurredAt:   created,
+		},
+		Verdict:      contracts.WorkstationVerdictAllow,
+		ObservedOnly: true,
+		CreatedAt:    created,
+	}
+	data, err := json.Marshal(decision)
+	if err != nil {
+		t.Fatalf("marshal decision: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "decisions.ndjson"), append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("write ndjson: %v", err)
+	}
+	return root
+}
+
+func writeJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
 }
 
 func fixedTime() time.Time {


### PR DESCRIPTION
## Summary
- add `helm-ai-kernel scan --from-receipts <dir>` to project workstation observe/decision receipts into the same anonymized RiskEnvelope shape as static scan
- parse plain JSON and NDJSON receipt inputs without exporting raw paths, repo names, command bodies, targets, metadata, prompts, or secret-looking values
- reuse existing RiskCode/Severity/ToolClass vocabulary for observed shell, MCP, network, deploy, secret, payment, and file effects

## Privacy boundary
- source_pack_hash is derived from receipt counts/classes only
- resource IDs are local-salt HMAC pseudonyms
- previews and upload body are still generated only from the RiskEnvelope
- no runtime dispatch/enforce behavior is added

## Validation
- `env -u GOROOT -u GOBIN /usr/local/go/bin/go test ./pkg/riskenvelope ./pkg/riskscan ./pkg/shadow ./cmd/helm-ai-kernel`
- `git diff --check`
- `env -u GOROOT -u GOBIN PATH="/usr/local/go/bin:/Users/ivan/.elan/bin:/Users/ivan/.antigravity/antigravity/bin:/Users/ivan/.opencode/bin:/Users/ivan/.lmstudio/bin:/Users/ivan/.krew/bin:/Users/ivan/.local/share/mise/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/ivan/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/go/bin:/Users/ivan/.codex/tmp/arg0/codex-arg0hvI9Ku:/Users/ivan/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/ivan/.antigravity-ide/antigravity-ide/bin:/Users/ivan/.raindrop/bin:/Users/ivan/.bun/bin:/Users/ivan/.antigravity/antigravity/bin:/Users/ivan/.local/share/mise/installs/node/22.19.0/bin:/Users/ivan/.local/share/mise/installs/python/3.12.11/bin:/Users/ivan/.local/share/mise/installs/python/3.13.7/bin:/Users/ivan/.local/share/mise/installs/ruby/3.3.9/bin:/Users/ivan/.local/share/mise/installs/java/temurin-21.0.8+9.0.LTS/bin:/Users/ivan/.local/share/mise/installs/go/1.22.12/bin:/Users/ivan/.cargo/bin:/Users/ivan/.local/share/mise/installs/bun/1.2.21/bin:/Users/ivan/.local/share/mise/installs/deno/2.4.5/bin:/Users/ivan/.local/share/mise/installs/deno/2.4.5/.deno/bin:/Users/ivan/.local/share/mise/installs/npm-google-gemini-cli/0.29.0/bin:/Users/ivan/.elan/bin:/Users/ivan/.opencode/bin:/Users/ivan/.lmstudio/bin:/Users/ivan/.krew/bin:/Users/ivan/.local/share/mise/shims:/opt/homebrew/share/android-commandlinetools/platform-tools:/opt/homebrew/share/android-commandlinetools/build-tools/34.0.0:/Applications/Codex.app/Contents/Resources:/opt/homebrew/share/android-commandlinetools/platform-tools:/opt/homebrew/share/android-commandlinetools/build-tools/34.0.0" make verify-boundary`

Stacked on PR #449 / branch `risk-envelope-v1`.