### PR TITLE
Publish risk scan docs route

### DIFF
--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -433,6 +433,15 @@
       "sensitivity": "public"
     },
     {
+      "slug": "reference/agent-risk-scan",
+      "title": "Agent Risk Scan",
+      "section": "reference",
+      "source_path": "docs/reference/agent-risk-scan.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/agent-risk-scan",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "reference/http-api",
       "title": "HELM AI Kernel HTTP API Reference",
       "section": "reference",


### PR DESCRIPTION
## Summary
- add the new Agent Risk Scan reference page to the public docs manifest
- preserves source-owned docs publication authority for helm.docs.mindburn.org generation

## Validation
- make verify-boundary
- make docs-coverage docs-truth
- git diff --check

## Context
Follow-up to #449 so app-helm-docs can publish /reference/agent-risk-scan from the merged source doc.