### PR TITLE
Tighten public docs proof boundaries

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -6,13 +6,14 @@
 - HELM normative status: Canonical HELM AI Kernel under UCS v1.3.
 - Current status: Active implementation with Go server, guardian evaluation, receipt storage/verification paths, API contracts, Dockerfile, Helm chart, tests, and docs.
 - Implemented capabilities: Guardian decision evaluation, API/server wiring, receipt persistence and verification primitives, external host evidence ingestion/verification/correlation, deployment assets, conformance/test scaffolding.
-- Not implemented: No Console source code in this repo; no hosted Enterprise automation production claim; no claim of full L2/L3 conformance; no production customer deployment claim; no eBPF, seccomp, TPM, TEE, or packet-blocking enforcement claim unless a tested code path proves it.
+- Not implemented: No Console source code in this repo; no hosted Enterprise automation production claim; no named buyer production rollout claim; no L4 conformance claim; no eBPF, seccomp, TPM, hardware enclave, or packet-blocking enforcement claim unless a tested code path proves it.
 - Public claims: HELM AI Kernel is the fail-closed execution firewall for AI agents; dangerous actions must be denied or escalated before dispatch; receipts can be verified and tampering must fail; HELM can consume and correlate external host/network evidence without claiming host-level enforcement.
 - Claim evidence: `core/cmd/helm-ai-kernel`, `core/pkg/guardian`, `core/pkg/receipt`, `core/pkg/evidence/externalhost`, `core/pkg/correlation/hostaction`, `core/pkg/verifier/externalreceipt`, `api/openapi`, `Dockerfile`, `charts/helm-ai-kernel`, `README.md`.
 - Tests that prove each claim: `go test ./...`, API contract checks, demo receipt smoke tests after API routes are enabled.
 - Docs that mention each claim: `README.md`, `docs/`, `examples/`, deployment/runbook docs.
+- Conformance boundary: Public CLI proof supports `L1` and `L2` level shortcuts. `L3` is source/test conformance coverage until a public CLI/API proof path is wired and tested. Higher levels are not public claims in this repo.
 - Stale claims removed: Any unsupported hosted Enterprise automation, entitlement-enforcement, or production-conformance claim must remain absent until smoke-tested.
-- Remaining gaps: Publish release tag/version after final local gates pass.
+- Remaining gaps: Keep release/version claims tied to published GitHub release assets and docs gates.
 - Verification commands: `make test` if available, `go test ./...`, API contract checks, Docker/Helm chart smoke commands from runbooks.
-- Last audited date: 2026-05-06.
+- Last audited date: 2026-07-01.
 - Owner: Mindburn Labs.

--- a/docs/CLAIM_BOUNDARIES.md
+++ b/docs/CLAIM_BOUNDARIES.md
@@ -1,0 +1,53 @@
+---
+title: Claim Boundaries
+last_reviewed: 2026-07-01
+---
+
+# Claim Boundaries
+
+HELM AI Kernel is public OSS. It is safe to describe the local kernel,
+CLI/API, receipts, verification, MCP boundary checks, workstation hook receipts,
+and local onboarding proof path when the claim points to source, tests, or a
+published release asset.
+
+## Public Claims
+
+- HELM AI Kernel is a fail-closed execution firewall for AI agents.
+- Dangerous or unapproved selected effects can be denied before dispatch when
+  they pass through a HELM adapter, wrapper, hook, or API route.
+- Decisions produce signed receipts that can be verified offline.
+- EvidencePacks and release assets can be checked from local material without a
+  hosted service.
+- The public conformance proof path supports `L1` and `L2` CLI shortcuts.
+- The OpenAI-compatible proxy and MCP authorization routes are local boundary
+  surfaces, not claims of model-provider control.
+
+## Not Public Claims
+
+- No hosted Enterprise automation production deployment is claimed by this repo.
+- No named buyer rollout, buyer certification, or compliance certification is
+  claimed by this repo.
+- No public paid signup or paid production account activation is claimed here.
+- No full operating-system, browser, IDE, eBPF, seccomp, TPM, hardware enclave,
+  packet blocking, or proprietary hosted-agent control is claimed unless a
+  tested source path proves the specific effect crossed HELM.
+- No `L4` conformance claim is public. `L3` remains source/test coverage until
+  a public proof path is wired and tested.
+
+## Source Truth
+
+- `CLAIMS.md`
+- `docs/QUICKSTART.md`
+- `docs/CONFORMANCE.md`
+- `docs/reference/http-api.md`
+- `core/cmd/helm-ai-kernel`
+- `core/pkg/conformance`
+- `api/openapi/helm.openapi.yaml`
+
+## Validation
+
+```bash
+python3 scripts/check_documentation_truth.py
+go test ./core/cmd/helm-ai-kernel -run TestConformLevelAliasesSeedBaselineEvidence -count=1
+go test ./core/pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_Top10' -count=1
+```

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -1,6 +1,6 @@
 ---
 title: Conformance
-last_reviewed: 2026-05-05
+last_reviewed: 2026-07-01
 ---
 
 # Conformance
@@ -39,7 +39,7 @@ flowchart TD
     subgraph Ingestion["1. Ingestion & Context Plane"]
         Page["Conformance"]
         C["Profile Material"]
-        D["What L1 and L2 Mean in This Repo"]
+        D["Conformance Status Matrix"]
     end
 
     subgraph Execution["3. Execution & Verdict Plane"]
@@ -70,17 +70,19 @@ HELM keeps a retained conformance profile under `tests/conformance/profile-v1/`.
 ./bin/helm-ai-kernel conform vectors --json
 ```
 
-The public API exposes the same negative gates at
-`GET /api/v1/conformance/negative` and `GET /api/v1/conformance/vectors`.
-Reports can be created and read through `POST /api/v1/conformance/run`,
-`GET /api/v1/conformance/reports`, and
-`GET /api/v1/conformance/reports/{report_id}`.
+Use the CLI commands above as the public proof path. `L1` and `L2` are the
+only public level shortcuts accepted by `helm-ai-kernel conform --level`.
 
-## Run the Conformance Test Suite
+The public API exposes negative vectors at
+`GET /api/v1/conformance/negative`. Runtime conformance report routes are
+admin/runtime status surfaces, not public conformance proof, until they are
+backed by the same engine and tests as the CLI.
+
+## Run the Maintained Conformance Tests
 
 ```bash
-cd tests/conformance
-go test ./...
+go test ./core/cmd/helm-ai-kernel -run TestConformLevelAliasesSeedBaselineEvidence -count=1
+go test ./core/pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_Top10' -count=1
 ```
 
 ## Profile Material
@@ -91,12 +93,21 @@ The profile directory contains:
 - `profile_test.go` for profile assertions
 - `README.md` for the human-readable profile summary
 
-## What L1 and L2 Mean in This Repo
+## Conformance Status Matrix
 
-- `L1` covers core structural correctness such as canonicalization, schema handling, receipt shape, offline verification, and checkpoint roots.
-- `L2` adds MCP execution-firewall behavior: quarantine, tool-list/call consistency, OAuth resource and scope checks, schema pinning, direct-bypass denial, and deny-path receipt emission.
-- `L3` covers sandbox grants, ReBAC snapshots, approval ceremonies, budget ceilings, stale tuple/model mismatch denial, and backend outage denial.
-- `L4` covers non-authoritative telemetry/coexistence exports, evidence envelope wrappers, framework middleware, and checkpoint inclusion verification.
+- `L1` is implemented as a public CLI shortcut. It covers the baseline OSS
+  proof path: canonical inputs, schema handling, receipt shape, offline
+  verification, and checkpoint roots.
+- `L2` is implemented as a public CLI shortcut. It adds the MCP
+  execution-firewall gates: quarantine, tool-list/call consistency, OAuth
+  resource and scope checks, schema pinning, direct-bypass denial, and deny-path
+  receipt emission.
+- `L3` exists as source/test conformance coverage, not as a public
+  `--level L3` shortcut. Treat it as maintainer-facing until the CLI and public
+  docs publish an engine-backed proof path.
+- Higher levels are not a public claim in this repo. Do not publish them as
+  supported conformance until the level constants, CLI wiring, fixtures, and
+  tests all exist.
 
 The exact checks are defined by the code and checklist in `tests/conformance/`, not by this page.
 

--- a/docs/PUBLICATION_POLICY.md
+++ b/docs/PUBLICATION_POLICY.md
@@ -1,0 +1,60 @@
+---
+title: Publication Policy
+last_reviewed: 2026-07-01
+---
+
+# Publication Policy
+
+The kernel repository can contain more public-safe source documents than the
+live docs site publishes. The live site should stay small and proof-oriented.
+
+## Route Authority
+
+- `docs/public-docs.manifest.json` marks source documents that are eligible for
+  public use.
+- The docs app publication policy chooses the smaller live route set.
+- The deployed `route-manifest.json` is the route truth for the live host.
+- Unknown routes, private prefixes, and customer or Enterprise-only paths must
+  return non-200 responses at the edge.
+
+## Live Public Shape
+
+The public site should lead with:
+
+- local quickstart proof;
+- what HELM is and is not claiming;
+- integrations for MCP and OpenAI-compatible traffic;
+- offline receipt and EvidencePack verification;
+- a compact API/reference surface for local proof operations;
+- support and troubleshooting.
+
+Generated API pages are fail-closed. They should be published only for local
+proof and core boundary operations. Console diagnostics, identity, billing,
+trust-key mutation, Enterprise, customer, internal, secret, and deployment
+runbook surfaces stay out of the live public route set.
+
+## Denied Prefixes
+
+The public host must not publish these prefixes:
+
+```text
+/customer
+/internal
+/helm-ai-enterprise
+/enterprise
+/trust
+/product
+/operations
+/backend
+/platform
+```
+
+## Validation
+
+```bash
+python3 scripts/check_documentation_truth.py
+HELM_KERNEL_REPO_PATH=/path/to/helm-ai-kernel npm run ci
+HELM_DOCS_URL=https://helm.docs.mindburn.org
+curl -i "$HELM_DOCS_URL/customer/test"
+curl -i "$HELM_DOCS_URL/no-such-route"
+```

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -84,12 +84,35 @@ artifacts only; approvals remain explicit.
 
 Keep the Kernel terminal open, then ask the local agent to perform a tool action
 that the starter policy denies. The expected result is a blocked action and a
-signed decision receipt.
+signed decision receipt. A known local fixture denies the shell target
+`rm -rf /tmp/helm-risky-cleanup` before dispatch and records
+`OPERATE_PERMISSIONS_EMPTY`.
+
+Expected hook shape:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "HELM denied shell operation: OPERATE_PERMISSIONS_EMPTY (receipt: ~/.helm-ai-kernel/receipts/hooks/wpd_<decision>.json)"
+  }
+}
+```
 
 Verify the receipt offline:
 
 ```bash
-helm-ai-kernel workstation verify-decision --receipt ~/.helm-ai-kernel/receipts/hooks/<decision>.json
+helm-ai-kernel workstation verify-decision --receipt ~/.helm-ai-kernel/receipts/hooks/wpd_<decision>.json
+```
+
+Expected verification fields:
+
+```text
+verdict:   DENY
+reason:    OPERATE_PERMISSIONS_EMPTY
+effect:    WORKSTATION_SHELL_COMMAND
+signature: true
 ```
 
 Run the headless API proof path when you do not want to modify a local client:

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -113,6 +113,11 @@ The `v0.5.18` release is complete only when it attaches these primary assets:
 primary asset, including `SHA256SUMS.txt`, with a matching
 `*.cosign.bundle`.
 
+If a release also attaches `helm-console-web-*` bundle artifacts, treat them as
+release packaging evidence only. They do not imply that Console source code,
+hosted Enterprise availability, or customer production access is published from
+this kernel repo.
+
 ## EvidencePack Contents
 
 An EvidencePack is the portable verification bundle for a HELM-governed run or

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -28,6 +28,33 @@
       "sensitivity": "public"
     },
     {
+      "slug": "guides/protect-local-coding-agents",
+      "title": "Protect Local Coding Agents",
+      "section": "start-here",
+      "source_path": "docs/quickstart/workstation-governance.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/guides/protect-local-coding-agents",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "claim-boundaries",
+      "title": "Claim Boundaries",
+      "section": "supporting-material",
+      "source_path": "docs/CLAIM_BOUNDARIES.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/claim-boundaries",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "publication-policy",
+      "title": "Publication Policy",
+      "section": "supporting-material",
+      "source_path": "docs/PUBLICATION_POLICY.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/publication-policy",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "developer-journey",
       "title": "Developer Journey",
       "section": "start-here",

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -1,6 +1,55 @@
-# Workstation Governance Quickstart
+# Protect Local Coding Agents
 
-This quickstart shows the local workstation adapter path for Codex or Claude Code-style runs. It uses manifest artifacts and wrapper decisions; it does not require private vendor APIs.
+This guide shows the local HELM path for Codex or Claude Code-style runs. It
+uses local client setup, hook decisions, manifest artifacts, and wrapper
+receipts. It does not require private vendor APIs, a hosted account, or a model
+provider key.
+
+HELM is not a competing coding agent. It governs selected effects around a
+local agent workflow and leaves an offline-verifiable receipt trail.
+
+## Install a local hook
+
+Inspect the writes first:
+
+```bash
+helm-ai-kernel setup codex --dry-run --json
+helm-ai-kernel setup claude-code --dry-run --json
+```
+
+Install the local integration:
+
+```bash
+helm-ai-kernel setup codex --yes
+helm-ai-kernel setup claude-code --yes
+```
+
+Setup writes draft policy and quarantine artifacts. It does not approve tools
+or grant operate permissions.
+
+## Prove a denied action
+
+Ask the local agent to perform an action the starter policy denies. The
+reference transcript denies the shell target `rm -rf /tmp/helm-risky-cleanup`
+before dispatch and writes a signed workstation policy decision receipt.
+
+Verify the receipt:
+
+```bash
+helm-ai-kernel workstation verify-decision --receipt ~/.helm-ai-kernel/receipts/hooks/wpd_<decision>.json
+```
+
+Expected fields:
+
+```text
+verdict:   DENY
+reason:    OPERATE_PERMISSIONS_EMPTY
+effect:    WORKSTATION_SHELL_COMMAND
+signature: true
+```
+
+Use the imported-artifact flow below when you want to test workstation
+receipts without modifying local client configuration.
 
 ## Import a run
 

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -1,6 +1,6 @@
 ---
 title: HELM AI Kernel HTTP API Reference
-last_reviewed: 2026-05-05
+last_reviewed: 2026-07-01
 ---
 
 # HELM AI Kernel HTTP API Reference
@@ -78,11 +78,16 @@ The OpenAPI security blocks describe the external contract. `route_auth.go` is t
 | Local onboarding proof | `GET /api/v1/onboarding/state`, `POST /api/v1/onboarding/run-step`, `GET /api/v1/onboarding/export` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go) |
 | Evidence | `POST /api/v1/evidence/export`, `POST /api/v1/evidence/verify` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go) |
 | Boundary | `GET /api/v1/boundary/status`, `GET /api/v1/boundary/capabilities`, `GET /api/v1/boundary/records`, `GET /api/v1/boundary/records/{record_id}`, `POST /api/v1/boundary/records/{record_id}/verify` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`core/pkg/boundary`](../../core/pkg/boundary) |
-| Conformance | `POST /api/v1/conformance/run`, `GET /api/v1/conformance/reports`, `GET /api/v1/conformance/reports/{report_id}`, `GET /api/v1/conformance/vectors`, `GET /api/v1/conformance/negative` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`conform.go`](../../core/cmd/helm-ai-kernel/conform.go) |
+| Conformance | `GET /api/v1/conformance/negative` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`conform.go`](../../core/cmd/helm-ai-kernel/conform.go) |
 | MCP transport and guarded tools | `GET|POST /mcp`, `GET /mcp/v1/capabilities`, `POST /mcp/v1/execute` | [`mcp_runtime.go`](../../core/cmd/helm-ai-kernel/mcp_runtime.go), [`mcp_cmd.go`](../../core/cmd/helm-ai-kernel/mcp_cmd.go) |
 | MCP registry and authorization | `GET /api/v1/mcp/registry`, `POST /api/v1/mcp/scan`, `POST /api/v1/mcp/authorize-call` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`mcp_boundary_cmd.go`](../../core/cmd/helm-ai-kernel/mcp_boundary_cmd.go) |
 
 The public docs site publishes only the route families above. Other runtime routes are implementation, protected, customer-preview, or maintainer-facing surfaces until the public docs policy, source evidence, and route-manifest gates explicitly add them.
+
+Use `helm-ai-kernel conform --level L1 --json`,
+`helm-ai-kernel conform --level L2 --json`, and the maintained conformance
+tests as the public proof path. Runtime conformance run/report endpoints are
+not public proof until they are engine-backed and covered by the same tests.
 
 `helm-ai-kernel server` runs API routes on `HELM_PORT` or `8080` by default. Its health server is separate and uses `HELM_HEALTH_PORT` or `8081` by default; `helm-ai-kernel serve` keeps the local policy boundary default at `127.0.0.1:7714`.
 


### PR DESCRIPTION
## Summary
- clarify public conformance proof as L1/L2 CLI plus negative vectors only
- add claim-boundaries and publication-policy source pages
- merge local coding-agent protection into one concrete guide and Quickstart deny proof
- mark release console bundles as packaging evidence, not Console availability

## Validation
- python3 scripts/check_documentation_truth.py
- go test ./core/cmd/helm-ai-kernel -run TestConformLevelAliasesSeedBaselineEvidence -count=1
- go test ./core/pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_Top10' -count=1
- app-helm-docs npm run ci using HELM_KERNEL_REPO_PATH pointing at this worktree