### PR TITLE
docs: restore version drift guard anchors

### DIFF
--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -60,6 +60,15 @@ Java SDK consumers can use the current Maven coordinate:
 </dependency>
 ```
 
+Current source release target: `v0.5.18`.
+Release assets are attached at
+`https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.18`,
+including `v0.5.18.openvex.json` and `v0.5.18.json`.
+
+Go SDK consumers can pin
+`github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.18`; the source subdir tag
+is `sdk/go/v0.5.18`.
+
 ## Local Boundary
 
 ```bash

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -92,6 +92,9 @@ helm-ai-kernel workstation verify-decision \
 The verifier exits `0` only when the decision receipt hash and Ed25519 signature
 verify. Tampered receipts return a non-zero exit.
 
+Use the `v0.5.18` release `evidence-pack.tar` when verifying release-bundle
+evidence instead of local quickstart receipts.
+
 ## 5. Run The Headless Local Proof
 
 Use this when you want the local Kernel API proof path without changing an


### PR DESCRIPTION
## Summary
- restores release-version anchor strings removed from Developer Journey and Quickstart
- keeps the public docs source-truth wording local/release-target scoped
- unblocks `make quality-pr` for downstream PRs after #447

## Validation
- `make version-drift docs-truth`
- `git diff --check`

## Controlled-GA note
This is a narrow gate repair after #447. It does not add a production, GA, hosted, certified, or checkout claim.
