### PR TITLE
Center public docs on approval contract

### DIFF
--- a/core/cmd/helm-ai-kernel/autoconfigure_phases.go
+++ b/core/cmd/helm-ai-kernel/autoconfigure_phases.go
@@ -115,6 +115,8 @@ func runBlastRadius(ctx context.Context, inv AutoconfigureInventory) (BlastRadiu
 		ServerID:          simApprovedServer,
 		ApproverID:        "sim-harness",
 		ApprovalReceiptID: "sim-approval-fixture",
+		Reason:            "simulation fixture",
+		ToolNames:         []string{simApprovedTool},
 	}); err != nil {
 		return report, nil, fmt.Errorf("approve fixture: %w", err)
 	}

--- a/core/cmd/helm-ai-kernel/boundary_surface_cmd.go
+++ b/core/cmd/helm-ai-kernel/boundary_surface_cmd.go
@@ -8,6 +8,8 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,6 +34,37 @@ func writeSurfaceJSON(w io.Writer, value any) int {
 	enc.SetIndent("", "  ")
 	_ = enc.Encode(value)
 	return 0
+}
+
+func writeLocalMCPReceipt(id, kind string, value any) string {
+	path := localMCPReceiptPath(id)
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return ""
+	}
+	payload := map[string]any{
+		"schema_version": "helm.mcp.local_receipt/v1",
+		"kind":           kind,
+		"receipt_id":     sanitizeReceiptPart(id),
+		"created_at":     time.Now().UTC().Format(time.RFC3339),
+		"record":         value,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return ""
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o600); err != nil {
+		return ""
+	}
+	return path
+}
+
+func localMCPReceiptPath(id string) string {
+	id = sanitizeReceiptPart(id)
+	if id == "" {
+		id = "unknown"
+	}
+	return filepath.Join(normalizedDataDir(""), "receipts", "mcp", id+".json")
 }
 
 func runBoundarySurfaceCmd(args []string, stdout, stderr io.Writer) int {
@@ -769,6 +802,52 @@ func runMCPGet(args []string, stdout, stderr io.Writer) int {
 	return 1
 }
 
+func runMCPPending(args []string, stdout, stderr io.Writer) int {
+	cmd := flag.NewFlagSet("mcp pending", flag.ContinueOnError)
+	cmd.SetOutput(stderr)
+	jsonOutput := cmd.Bool("json", false, "Output as JSON")
+	if err := cmd.Parse(args); err != nil {
+		return 2
+	}
+	var pending []mcppkg.ServerQuarantineRecord
+	for _, record := range newLocalSurfaceRegistry().ListMCPServers() {
+		if record.State != mcppkg.QuarantineApproved {
+			pending = append(pending, record)
+		}
+	}
+	if *jsonOutput {
+		return writeSurfaceJSON(stdout, pending)
+	}
+	for _, record := range pending {
+		fmt.Fprintf(stdout, "%s  state=%s reason=%s\n", record.ServerID, record.State, record.Reason)
+	}
+	return 0
+}
+
+func runMCPReceipts(args []string, stdout, stderr io.Writer) int {
+	cmd := flag.NewFlagSet("mcp receipts", flag.ContinueOnError)
+	cmd.SetOutput(stderr)
+	jsonOutput := cmd.Bool("json", false, "Output as JSON")
+	limit := cmd.Int("limit", 50, "Maximum records to return")
+	if err := cmd.Parse(args); err != nil {
+		return 2
+	}
+	records := newLocalSurfaceRegistry().ListRecords(contracts.BoundarySearchRequest{Limit: *limit})
+	var mcpRecords []contracts.ExecutionBoundaryRecord
+	for _, record := range records {
+		if record.MCPServerID != "" {
+			mcpRecords = append(mcpRecords, record)
+		}
+	}
+	if *jsonOutput {
+		return writeSurfaceJSON(stdout, mcpRecords)
+	}
+	for _, record := range mcpRecords {
+		fmt.Fprintf(stdout, "%s  %s  reason=%s receipt=%s\n", record.RecordID, record.Verdict, record.ReasonCode, record.DecisionReceiptPath)
+	}
+	return 0
+}
+
 func runMCPRevoke(args []string, stdout, stderr io.Writer) int {
 	cmd := flag.NewFlagSet("mcp revoke", flag.ContinueOnError)
 	cmd.SetOutput(stderr)
@@ -782,6 +861,10 @@ func runMCPRevoke(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Error: --server-id is required")
 		return 2
 	}
+	if strings.TrimSpace(*reason) == "" {
+		fmt.Fprintln(stderr, "Error: --reason is required")
+		return 2
+	}
 	surfaces := newLocalSurfaceRegistry()
 	registry := mcppkg.NewQuarantineRegistry()
 	hydrateMCPQuarantine(context.Background(), registry, surfaces.ListMCPServers())
@@ -793,6 +876,7 @@ func runMCPRevoke(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 2
 	}
+	record.RevocationReceiptPath = writeLocalMCPReceipt("rcp_mcp_revoke_"+record.ServerID, "revocation", record)
 	if _, err := surfaces.PutMCPServer(record); err != nil {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 1
@@ -908,6 +992,7 @@ func runMCPAuthorizeCall(args []string, stdout, stderr io.Writer) int {
 	toolSchemaJSON := cmd.String("tool-schema-json", "", "JSON Schema for a discovered server-local tool")
 	outputSchemaJSON := cmd.String("output-schema-json", "", "Output JSON Schema for a discovered server-local tool")
 	oauthResource := cmd.String("oauth-resource", "https://helm.local/mcp", "OAuth resource indicator")
+	effect := cmd.String("effect", "read", "Tool effect: read or side_effect")
 	approved := cmd.Bool("approved", false, "Seed an approved local server before authorization")
 	receiptID := cmd.String("receipt-id", "", "Receipt id to bind")
 	jsonOutput := cmd.Bool("json", false, "Output as JSON")
@@ -951,7 +1036,17 @@ func runMCPAuthorizeCall(args []string, stdout, stderr io.Writer) int {
 		_, _ = quarantine.Discover(context.Background(), mcppkg.DiscoverServerRequest{ServerID: *serverID, ToolNames: []string{*toolName}})
 	}
 	if *approved {
-		record, _ := quarantine.Approve(context.Background(), mcppkg.ApprovalDecision{ServerID: *serverID, ApproverID: "user:local-admin", ApprovalReceiptID: "receipt-local-mcp-approval"})
+		now := time.Now().UTC()
+		record, _ := quarantine.Approve(context.Background(), mcppkg.ApprovalDecision{
+			ServerID:          *serverID,
+			ApproverID:        "user:local-admin",
+			ApprovalReceiptID: "receipt-local-mcp-approval",
+			ApprovedAt:        now,
+			ExpiresAt:         now.Add(15 * time.Minute),
+			Reason:            "local authorize-call test approval",
+			ToolNames:         []string{*toolName},
+			Effects:           []string{*effect},
+		})
 		_, _ = surfaces.PutMCPServer(record)
 	}
 	firewall := mcppkg.NewExecutionFirewall(catalog, quarantine, "local-cli")
@@ -959,6 +1054,7 @@ func runMCPAuthorizeCall(args []string, stdout, stderr io.Writer) int {
 	record, err := firewall.AuthorizeToolCall(context.Background(), mcppkg.ToolCallAuthorization{
 		ServerID:         *serverID,
 		ToolName:         *toolName,
+		Effect:           *effect,
 		ArgsHash:         *argsHash,
 		GrantedScopes:    splitCSV(*scopes),
 		PinnedSchemaHash: *pinnedSchema,
@@ -969,9 +1065,21 @@ func runMCPAuthorizeCall(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 2
 	}
-	if _, err := surfaces.PutRecord(record); err != nil {
+	if record.Verdict == contracts.VerdictEscalate {
+		record.DecisionReceiptPath = localMCPReceiptPath(record.RecordID)
+		if record.ReasonCode == contracts.ReasonApprovalRequired {
+			record.ApprovalCommand = mcpApprovalCommand(*serverID, *toolName, *effect)
+		}
+	}
+	sealed, err := surfaces.PutRecord(record)
+	if err != nil {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 1
+	}
+	record = sealed
+	if record.Verdict == contracts.VerdictEscalate {
+		record.DecisionReceiptPath = writeLocalMCPReceipt(record.RecordID, "decision", record)
+		_, _ = surfaces.PutRecord(record)
 	}
 	exitCode := 0
 	if record.Verdict != contracts.VerdictAllow {
@@ -981,8 +1089,61 @@ func runMCPAuthorizeCall(args []string, stdout, stderr io.Writer) int {
 		_ = writeSurfaceJSON(stdout, record)
 		return exitCode
 	}
+	if record.Verdict == contracts.VerdictEscalate {
+		fmt.Fprintln(stdout, "HELM ESCALATE")
+		fmt.Fprintf(stdout, "decision: %s\n", record.RecordID)
+		fmt.Fprintf(stdout, "reason: %s\n", mcpEscalationReason(record))
+		fmt.Fprintf(stdout, "receipt: %s\n", record.DecisionReceiptPath)
+		if record.ApprovalCommand != "" {
+			fmt.Fprintln(stdout, "approve:")
+			fmt.Fprintf(stdout, "  %s\n", record.ApprovalCommand)
+		}
+		return exitCode
+	}
 	fmt.Fprintf(stdout, "MCP authorization verdict=%s reason=%s record=%s\n", record.Verdict, record.ReasonCode, record.RecordID)
 	return exitCode
+}
+
+func mcpApprovalCommand(serverID, toolName, effect string) string {
+	parts := []string{
+		"helm-ai-kernel mcp approve",
+		"--server-id " + shellToken(serverID),
+		"--tools " + shellDoubleQuote(toolName),
+		"--ttl 15m",
+		"--reason " + shellQuote("read-only repo inspection for local dev"),
+	}
+	if effect != "" && effect != "read" {
+		parts = append(parts[:3], append([]string{"--effects " + shellToken(effect)}, parts[3:]...)...)
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellToken(value string) string {
+	if value == "" || strings.ContainsAny(value, " \t\n'\"\\$&|;()<>*?[]{}!") {
+		return shellQuote(value)
+	}
+	return value
+}
+
+func shellDoubleQuote(value string) string {
+	escaped := strings.ReplaceAll(value, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	escaped = strings.ReplaceAll(escaped, `$`, `\$`)
+	escaped = strings.ReplaceAll(escaped, "`", "\\`")
+	return `"` + escaped + `"`
+}
+
+func mcpEscalationReason(record contracts.ExecutionBoundaryRecord) string {
+	if record.ReasonCode == contracts.ReasonApprovalRequired {
+		return "unknown MCP server requires approval"
+	}
+	if record.ReasonCode == contracts.ReasonSchemaViolation {
+		return "MCP tool schema requires approval or pinning"
+	}
+	if record.ReasonCode != "" {
+		return string(record.ReasonCode)
+	}
+	return "MCP action requires approval"
 }
 
 func runSandboxProfiles(args []string, stdout, stderr io.Writer) int {

--- a/core/cmd/helm-ai-kernel/contract_routes.go
+++ b/core/cmd/helm-ai-kernel/contract_routes.go
@@ -724,10 +724,12 @@ func registerContractRoutes(mux *http.ServeMux, svc *Services) {
 			return
 		}
 		var req struct {
-			ServerID          string `json:"server_id"`
-			ApproverID        string `json:"approver_id"`
-			ApprovalReceiptID string `json:"approval_receipt_id"`
-			Reason            string `json:"reason"`
+			ServerID          string   `json:"server_id"`
+			ApproverID        string   `json:"approver_id"`
+			ApprovalReceiptID string   `json:"approval_receipt_id"`
+			Reason            string   `json:"reason"`
+			ToolNames         []string `json:"tool_names"`
+			Effects           []string `json:"effects"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			api.WriteBadRequest(w, "Invalid MCP approval request")
@@ -739,6 +741,8 @@ func registerContractRoutes(mux *http.ServeMux, svc *Services) {
 			ApprovalReceiptID: req.ApprovalReceiptID,
 			ApprovedAt:        time.Now().UTC(),
 			Reason:            req.Reason,
+			ToolNames:         req.ToolNames,
+			Effects:           req.Effects,
 		})
 		if err != nil {
 			api.WriteBadRequest(w, err.Error())
@@ -773,9 +777,11 @@ func registerContractRoutes(mux *http.ServeMux, svc *Services) {
 			writeContractJSON(w, http.StatusOK, record)
 		case action == "approve" && r.Method == http.MethodPost:
 			var req struct {
-				ApproverID        string `json:"approver_id"`
-				ApprovalReceiptID string `json:"approval_receipt_id"`
-				Reason            string `json:"reason"`
+				ApproverID        string   `json:"approver_id"`
+				ApprovalReceiptID string   `json:"approval_receipt_id"`
+				Reason            string   `json:"reason"`
+				ToolNames         []string `json:"tool_names"`
+				Effects           []string `json:"effects"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				api.WriteBadRequest(w, "Invalid MCP approval request")
@@ -787,6 +793,8 @@ func registerContractRoutes(mux *http.ServeMux, svc *Services) {
 				ApprovalReceiptID: req.ApprovalReceiptID,
 				ApprovedAt:        time.Now().UTC(),
 				Reason:            req.Reason,
+				ToolNames:         req.ToolNames,
+				Effects:           req.Effects,
 			})
 			if err != nil {
 				api.WriteBadRequest(w, err.Error())
@@ -1362,6 +1370,8 @@ func hydrateMCPQuarantine(ctx context.Context, registry *mcppkg.QuarantineRegist
 					ApprovedAt:        record.ApprovedAt,
 					ExpiresAt:         record.ExpiresAt,
 					Reason:            record.Reason,
+					ToolNames:         record.ApprovedToolNames,
+					Effects:           record.ApprovedEffects,
 				})
 			}
 		case mcppkg.QuarantineRevoked:

--- a/core/cmd/helm-ai-kernel/contract_routes_test.go
+++ b/core/cmd/helm-ai-kernel/contract_routes_test.go
@@ -128,7 +128,7 @@ func TestBoundaryContractRoutesExposeNewControlSurfaces(t *testing.T) {
 		t.Fatalf("discover status=%d body=%s", discoverRec.Code, discoverRec.Body.String())
 	}
 
-	approveReq := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/registry/approve", strings.NewReader(`{"server_id":"srv-1","approver_id":"user:alice","approval_receipt_id":"approval-r1"}`))
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/registry/approve", strings.NewReader(`{"server_id":"srv-1","approver_id":"user:alice","approval_receipt_id":"approval-r1","reason":"reviewed","tool_names":["local.echo"]}`))
 	authorizeTestRequest(approveReq)
 	approveRec := httptest.NewRecorder()
 	mux.ServeHTTP(approveRec, approveReq)
@@ -218,7 +218,7 @@ func TestMCPAuthorizeCallAPIFailClosedAndPinnedAllow(t *testing.T) {
 		t.Fatalf("discover status=%d body=%s", discoverRec.Code, discoverRec.Body.String())
 	}
 
-	approveReq := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/registry/api-fixture/approve", strings.NewReader(`{"approver_id":"user:alice","approval_receipt_id":"approval-r1"}`))
+	approveReq := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/registry/api-fixture/approve", strings.NewReader(`{"approver_id":"user:alice","approval_receipt_id":"approval-r1","reason":"reviewed","tool_names":["local.echo"]}`))
 	authorizeTestRequest(approveReq)
 	approveRec := httptest.NewRecorder()
 	mux.ServeHTTP(approveRec, approveReq)

--- a/core/cmd/helm-ai-kernel/execution_boundary_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/execution_boundary_cmd_test.go
@@ -68,6 +68,8 @@ func TestRunMCPApproveJSON(t *testing.T) {
 		"--server-id", "srv-1",
 		"--approver", "user:alice",
 		"--receipt-id", "approval-r1",
+		"--tools", "file_read",
+		"--reason", "test approval",
 		"--json",
 	}, &stdout, &stderr)
 	if code != 0 {
@@ -82,6 +84,19 @@ func TestRunMCPApproveJSON(t *testing.T) {
 	}
 	if record["approval_receipt_id"] != "approval-r1" {
 		t.Fatalf("approval receipt = %v", record["approval_receipt_id"])
+	}
+}
+
+func TestRunMCPApproveRejectsUnsafeScopes(t *testing.T) {
+	for _, args := range [][]string{
+		{"--server-id", "srv-wildcard", "--tools", "*", "--reason", "too broad"},
+		{"--server-id", "srv-write", "--tools", "deploy", "--effects", "side_effect", "--ttl", "1h", "--reason", "too long"},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := runMCPApprove(args, &stdout, &stderr)
+		if code != 2 {
+			t.Fatalf("args %v exit code = %d stdout=%s stderr=%s", args, code, stdout.String(), stderr.String())
+		}
 	}
 }
 
@@ -152,7 +167,7 @@ func TestRunBoundaryStatusJSON(t *testing.T) {
 	}
 }
 
-func TestRunMCPAuthorizeCallDenyJSON(t *testing.T) {
+func TestRunMCPAuthorizeCallEscalateJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runMCPAuthorizeCall([]string{
 		"--server-id", "srv-1",
@@ -166,15 +181,45 @@ func TestRunMCPAuthorizeCallDenyJSON(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
 		t.Fatalf("parse json: %v\n%s", err, stdout.String())
 	}
-	if record["verdict"] != "DENY" {
+	if record["verdict"] != "ESCALATE" {
 		t.Fatalf("verdict = %v", record["verdict"])
+	}
+	if record["approval_command"] == "" {
+		t.Fatal("approval_command missing")
+	}
+	if record["decision_receipt_path"] == "" {
+		t.Fatal("decision_receipt_path missing")
 	}
 	if record["record_hash"] == "" {
 		t.Fatal("record_hash missing")
 	}
 }
 
-func TestRunMCPAuthorizeCallUnknownToolDenyJSON(t *testing.T) {
+func TestRunMCPAuthorizeCallEscalateHumanMessage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runMCPAuthorizeCall([]string{
+		"--server-id", "shell-mcp-server",
+		"--tool-name", "pwd",
+	}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit code = %d stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"HELM ESCALATE",
+		"decision: mcp-boundary-",
+		"reason: unknown MCP server requires approval",
+		"receipt:",
+		"approve:",
+		"helm-ai-kernel mcp approve --server-id shell-mcp-server --tools \"pwd\" --ttl 15m --reason 'read-only repo inspection for local dev'",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunMCPAuthorizeCallUnknownToolEscalateJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runMCPAuthorizeCall([]string{
 		"--server-id", "srv-cli-unknown-tool",
@@ -189,12 +234,12 @@ func TestRunMCPAuthorizeCallUnknownToolDenyJSON(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
 		t.Fatalf("parse json: %v\n%s", err, stdout.String())
 	}
-	if record["verdict"] != "DENY" {
+	if record["verdict"] != "ESCALATE" {
 		t.Fatalf("verdict = %v", record["verdict"])
 	}
 }
 
-func TestRunMCPAuthorizeCallMissingSchemaPinDenyJSON(t *testing.T) {
+func TestRunMCPAuthorizeCallMissingSchemaPinEscalateJSON(t *testing.T) {
 	schema := map[string]any{
 		"type": "object",
 		"properties": map[string]any{
@@ -218,7 +263,7 @@ func TestRunMCPAuthorizeCallMissingSchemaPinDenyJSON(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &record); err != nil {
 		t.Fatalf("parse json: %v\n%s", err, stdout.String())
 	}
-	if record["verdict"] != "DENY" {
+	if record["verdict"] != "ESCALATE" {
 		t.Fatalf("verdict = %v", record["verdict"])
 	}
 }

--- a/core/cmd/helm-ai-kernel/mcp_boundary_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_boundary_cmd.go
@@ -86,6 +86,7 @@ func runMCPApprove(args []string, stdout, stderr io.Writer) int {
 		receiptID  string
 		risk       string
 		tools      string
+		effects    string
 		ttl        string
 		reason     string
 		jsonOutput bool
@@ -95,7 +96,8 @@ func runMCPApprove(args []string, stdout, stderr io.Writer) int {
 	cmd.StringVar(&receiptID, "receipt-id", "", "Approval ceremony receipt id")
 	cmd.StringVar(&risk, "risk", "unknown", "Risk label: unknown, low, medium, high, critical")
 	cmd.StringVar(&tools, "tools", "", "Comma-separated tools approved by this scoped grant")
-	cmd.StringVar(&ttl, "ttl", "1h", "Approval TTL")
+	cmd.StringVar(&effects, "effects", "read", "Comma-separated effects approved by this scoped grant")
+	cmd.StringVar(&ttl, "ttl", "15m", "Approval TTL")
 	cmd.StringVar(&reason, "reason", "", "Human approval reason")
 	cmd.BoolVar(&jsonOutput, "json", false, "Output approval record as JSON")
 	if err := cmd.Parse(args); err != nil {
@@ -104,7 +106,13 @@ func runMCPApprove(args []string, stdout, stderr io.Writer) int {
 	if serverID == "" && cmd.NArg() > 0 {
 		serverID = cmd.Arg(0)
 	}
-	legacyApproval := tools == "" && reason == "" && receiptID != ""
+	toolNames := splitCSV(tools)
+	effectNames := splitCSV(effects)
+	duration, err := scopedApprovalTTL(ttl, effectNames)
+	if err != nil {
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 2
+	}
 	if receiptID == "" && serverID != "" {
 		receiptID = "rcp_mcp_approval_" + sanitizeReceiptPart(serverID+"_"+tools)
 	}
@@ -112,15 +120,17 @@ func runMCPApprove(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Error: server id is required")
 		return 2
 	}
-	if !legacyApproval && (tools == "" || reason == "") {
+	if len(toolNames) == 0 || strings.TrimSpace(reason) == "" {
 		fmt.Fprintln(stderr, "Error: --tools and --reason are required for scoped MCP approval")
 		return 2
 	}
 
+	now := time.Now().UTC()
 	registry := mcppkg.NewQuarantineRegistry()
 	if _, err := registry.Discover(context.Background(), mcppkg.DiscoverServerRequest{
-		ServerID: serverID,
-		Risk:     mcppkg.ServerRisk(risk),
+		ServerID:  serverID,
+		ToolNames: toolNames,
+		Risk:      mcppkg.ServerRisk(risk),
 	}); err != nil {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 2
@@ -129,12 +139,17 @@ func runMCPApprove(args []string, stdout, stderr io.Writer) int {
 		ServerID:          serverID,
 		ApproverID:        approver,
 		ApprovalReceiptID: receiptID,
-		ApprovedAt:        time.Now().UTC(),
+		ApprovedAt:        now,
+		ExpiresAt:         now.Add(duration),
+		Reason:            strings.TrimSpace(reason),
+		ToolNames:         toolNames,
+		Effects:           effectNames,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 2
 	}
+	record.ApprovalReceiptPath = writeLocalMCPReceipt(record.ApprovalReceiptID, "approval", record)
 	if _, err := newLocalSurfaceRegistry().PutMCPServer(record); err != nil {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 1
@@ -143,26 +158,36 @@ func runMCPApprove(args []string, stdout, stderr io.Writer) int {
 	if jsonOutput {
 		enc := json.NewEncoder(stdout)
 		enc.SetIndent("", "  ")
-		if legacyApproval {
-			_ = enc.Encode(record)
-			return 0
-		}
-		_ = enc.Encode(map[string]any{
-			"record":                record,
-			"tools":                 strings.Split(tools, ","),
-			"ttl":                   ttl,
-			"reason":                reason,
-			"revocation_semantics":  "revocable by quarantine reset, TTL expiry, or policy epoch change",
-			"side_effects_allowed":  true,
-			"raw_secret_disclosure": false,
-		})
+		_ = enc.Encode(record)
 		return 0
 	}
 	fmt.Fprintf(stdout, "Approved MCP server %s with receipt %s\n", record.ServerID, record.ApprovalReceiptID)
-	fmt.Fprintf(stdout, "Tools: %s\n", tools)
+	fmt.Fprintf(stdout, "Tools: %s\n", strings.Join(record.ApprovedToolNames, ","))
+	fmt.Fprintf(stdout, "Effects: %s\n", strings.Join(record.ApprovedEffects, ","))
 	fmt.Fprintf(stdout, "TTL: %s\n", ttl)
-	fmt.Fprintf(stdout, "Reason: %s\n", reason)
+	fmt.Fprintf(stdout, "Reason: %s\n", record.Reason)
 	return 0
+}
+
+func scopedApprovalTTL(value string, effects []string) (time.Duration, error) {
+	if strings.TrimSpace(value) == "" {
+		value = "15m"
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return 0, fmt.Errorf("--ttl must be a positive Go duration such as 15m")
+	}
+	max := 24 * time.Hour
+	for _, effect := range effects {
+		switch strings.ToLower(strings.TrimSpace(effect)) {
+		case "write", "deploy", "network", "payment", "side_effect":
+			max = 15 * time.Minute
+		}
+	}
+	if duration > max {
+		return 0, fmt.Errorf("--ttl exceeds maximum %s for this approval scope", max)
+	}
+	return duration, nil
 }
 
 func runMCPQuarantine(args []string, stdout, stderr io.Writer) int {

--- a/core/cmd/helm-ai-kernel/mcp_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_cmd.go
@@ -24,7 +24,7 @@ import (
 //	2 = config error
 func runMCPCmd(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "Usage: helm-ai-kernel mcp <serve|install|pack|print-config|scan|wrap|proof|list|get|quarantine|approve|revoke|auth-profile|authorize-call> [flags]")
+		fmt.Fprintln(stderr, "Usage: helm-ai-kernel mcp <serve|install|pack|print-config|scan|wrap|proof|list|get|pending|receipts|quarantine|approve|revoke|auth-profile|authorize-call> [flags]")
 		fmt.Fprintln(stderr, "")
 		fmt.Fprintln(stderr, "Subcommands:")
 		fmt.Fprintln(stderr, "  serve         Start the HELM MCP server (stdio or remote HTTP)")
@@ -36,6 +36,8 @@ func runMCPCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "  proof         Emit a no-dispatch MCP quarantine proof EvidencePack")
 		fmt.Fprintln(stderr, "  list          List local MCP registry records")
 		fmt.Fprintln(stderr, "  get           Get one MCP registry record")
+		fmt.Fprintln(stderr, "  pending       List MCP servers awaiting local approval")
+		fmt.Fprintln(stderr, "  receipts      List local MCP decision receipts")
 		fmt.Fprintln(stderr, "  quarantine    List Launchpad MCP threat reviews and quarantined tools")
 		fmt.Fprintln(stderr, "  approve       Create a receipt-backed MCP server approval record")
 		fmt.Fprintln(stderr, "  revoke        Revoke a local MCP server approval")
@@ -63,6 +65,10 @@ func runMCPCmd(args []string, stdout, stderr io.Writer) int {
 		return runMCPList(args[1:], stdout, stderr)
 	case "get":
 		return runMCPGet(args[1:], stdout, stderr)
+	case "pending":
+		return runMCPPending(args[1:], stdout, stderr)
+	case "receipts":
+		return runMCPReceipts(args[1:], stdout, stderr)
 	case "quarantine":
 		return runMCPQuarantine(args[1:], stdout, stderr)
 	case "approve":
@@ -74,7 +80,7 @@ func runMCPCmd(args []string, stdout, stderr io.Writer) int {
 	case "authorize-call":
 		return runMCPAuthorizeCall(args[1:], stdout, stderr)
 	case "--help", "-h":
-		fmt.Fprintln(stdout, "Usage: helm-ai-kernel mcp <serve|install|pack|print-config|scan|wrap|proof|list|get|quarantine|approve|revoke|auth-profile|authorize-call> [flags]")
+		fmt.Fprintln(stdout, "Usage: helm-ai-kernel mcp <serve|install|pack|print-config|scan|wrap|proof|list|get|pending|receipts|quarantine|approve|revoke|auth-profile|authorize-call> [flags]")
 		fmt.Fprintln(stdout, "")
 		fmt.Fprintln(stdout, "Subcommands:")
 		fmt.Fprintln(stdout, "  serve         Start the HELM MCP server (stdio or remote HTTP)")
@@ -86,6 +92,8 @@ func runMCPCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "  proof         Emit a no-dispatch MCP quarantine proof EvidencePack")
 		fmt.Fprintln(stdout, "  list          List local MCP registry records")
 		fmt.Fprintln(stdout, "  get           Get one MCP registry record")
+		fmt.Fprintln(stdout, "  pending       List MCP servers awaiting local approval")
+		fmt.Fprintln(stdout, "  receipts      List local MCP decision receipts")
 		fmt.Fprintln(stdout, "  quarantine    List Launchpad MCP threat reviews and quarantined tools")
 		fmt.Fprintln(stdout, "  approve       Create a receipt-backed MCP server approval record")
 		fmt.Fprintln(stdout, "  revoke        Revoke a local MCP server approval")

--- a/core/pkg/contracts/execution_boundary.go
+++ b/core/pkg/contracts/execution_boundary.go
@@ -95,24 +95,27 @@ const EnforcementModeShadow = "shadow"
 // policy, MCP auth, sandbox grants, relationship snapshots, and allow/deny
 // decisions before an actuator can dispatch.
 type ExecutionBoundaryRecord struct {
-	RecordID           string     `json:"record_id"`
-	Verdict            Verdict    `json:"verdict"`
-	ReasonCode         ReasonCode `json:"reason_code,omitempty"`
-	ToolName           string     `json:"tool_name,omitempty"`
-	ArgsHash           string     `json:"args_hash,omitempty"`
-	PolicyEpoch        string     `json:"policy_epoch"`
-	MCPServerID        string     `json:"mcp_server_id,omitempty"`
-	OAuthResource      string     `json:"oauth_resource,omitempty"`
-	OAuthScopes        []string   `json:"oauth_scopes,omitempty"`
-	SandboxGrantHash   string     `json:"sandbox_grant_hash,omitempty"`
-	AuthzSnapshotHash  string     `json:"authz_snapshot_hash,omitempty"`
-	ReceiptID          string     `json:"receipt_id,omitempty"`
-	ApprovalReceiptID  string     `json:"approval_receipt_id,omitempty"`
-	DirectDispatchSeen bool       `json:"direct_dispatch_seen,omitempty"`
-	EnforcementMode    string     `json:"enforcement_mode,omitempty"`
-	ObserveGrantID     string     `json:"observe_grant_id,omitempty"`
-	CreatedAt          time.Time  `json:"created_at"`
-	RecordHash         string     `json:"record_hash,omitempty"`
+	RecordID            string     `json:"record_id"`
+	Verdict             Verdict    `json:"verdict"`
+	ReasonCode          ReasonCode `json:"reason_code,omitempty"`
+	ToolName            string     `json:"tool_name,omitempty"`
+	ToolEffect          string     `json:"tool_effect,omitempty"`
+	ArgsHash            string     `json:"args_hash,omitempty"`
+	PolicyEpoch         string     `json:"policy_epoch"`
+	MCPServerID         string     `json:"mcp_server_id,omitempty"`
+	OAuthResource       string     `json:"oauth_resource,omitempty"`
+	OAuthScopes         []string   `json:"oauth_scopes,omitempty"`
+	SandboxGrantHash    string     `json:"sandbox_grant_hash,omitempty"`
+	AuthzSnapshotHash   string     `json:"authz_snapshot_hash,omitempty"`
+	ReceiptID           string     `json:"receipt_id,omitempty"`
+	DecisionReceiptPath string     `json:"decision_receipt_path,omitempty"`
+	ApprovalCommand     string     `json:"approval_command,omitempty"`
+	ApprovalReceiptID   string     `json:"approval_receipt_id,omitempty"`
+	DirectDispatchSeen  bool       `json:"direct_dispatch_seen,omitempty"`
+	EnforcementMode     string     `json:"enforcement_mode,omitempty"`
+	ObserveGrantID      string     `json:"observe_grant_id,omitempty"`
+	CreatedAt           time.Time  `json:"created_at"`
+	RecordHash          string     `json:"record_hash,omitempty"`
 }
 
 // EvidenceEnvelopeManifest records a non-authoritative export wrapper over a

--- a/core/pkg/mcp/aegis_overhead_bench_test.go
+++ b/core/pkg/mcp/aegis_overhead_bench_test.go
@@ -29,7 +29,7 @@ func benchFirewall(b *testing.B) (*ExecutionFirewall, context.Context) {
 	if _, err := registry.Discover(ctx, DiscoverServerRequest{ServerID: "srv-bench"}); err != nil {
 		b.Fatalf("discover: %v", err)
 	}
-	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-bench", ApproverID: "user:bench", ApprovalReceiptID: "approval-bench"}); err != nil {
+	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-bench", ApproverID: "user:bench", ApprovalReceiptID: "approval-bench", Reason: "benchmark fixture", ToolNames: []string{"crm.read"}}); err != nil {
 		b.Fatalf("approve: %v", err)
 	}
 	if err := catalog.Register(ctx, ToolRef{Name: "crm.read", ServerID: "srv-bench", RequiredScopes: []string{"crm.read"}, Schema: map[string]any{"type": "object"}}); err != nil {

--- a/core/pkg/mcp/counterfactual_receipt_test.go
+++ b/core/pkg/mcp/counterfactual_receipt_test.go
@@ -29,8 +29,8 @@ func TestObserveModeEmitsCounterfactualReceipt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	if record.Verdict != contracts.VerdictDeny {
-		t.Fatalf("verdict = %s, want DENY", record.Verdict)
+	if record.Verdict != contracts.VerdictEscalate {
+		t.Fatalf("verdict = %s, want ESCALATE", record.Verdict)
 	}
 
 	cf, err := firewall.CounterfactualReceiptFor(record)
@@ -40,8 +40,8 @@ func TestObserveModeEmitsCounterfactualReceipt(t *testing.T) {
 	if cf.Enforcement != contracts.EnforcementCounterfactual {
 		t.Fatalf("enforcement = %q, want counterfactual", cf.Enforcement)
 	}
-	if cf.WouldHaveVerdict != contracts.VerdictDeny {
-		t.Fatalf("would-have verdict = %q, want DENY", cf.WouldHaveVerdict)
+	if cf.WouldHaveVerdict != contracts.VerdictEscalate {
+		t.Fatalf("would-have verdict = %q, want ESCALATE", cf.WouldHaveVerdict)
 	}
 	if cf.ReasonCode != record.ReasonCode {
 		t.Fatalf("reason code = %q, want %q", cf.ReasonCode, record.ReasonCode)

--- a/core/pkg/mcp/execution_firewall_test.go
+++ b/core/pkg/mcp/execution_firewall_test.go
@@ -29,6 +29,8 @@ func TestExecutionFirewallFiltersToolsByQuarantineAndScope(t *testing.T) {
 		ServerID:          "srv-1",
 		ApproverID:        "user:alice",
 		ApprovalReceiptID: "approval-r1",
+		Reason:            "reviewed",
+		ToolNames:         []string{"read", "write"},
 	}); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
@@ -41,7 +43,7 @@ func TestExecutionFirewallFiltersToolsByQuarantineAndScope(t *testing.T) {
 	}
 }
 
-func TestExecutionFirewallDeniesUnknownToolBeforeDispatch(t *testing.T) {
+func TestExecutionFirewallEscalatesUnknownToolBeforeDispatch(t *testing.T) {
 	ctx := context.Background()
 	firewall := approvedFirewall(t)
 	record, err := firewall.AuthorizeToolCall(ctx, ToolCallAuthorization{
@@ -52,8 +54,8 @@ func TestExecutionFirewallDeniesUnknownToolBeforeDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	if record.Verdict != contracts.VerdictDeny {
-		t.Fatalf("verdict = %s, want DENY", record.Verdict)
+	if record.Verdict != contracts.VerdictEscalate {
+		t.Fatalf("verdict = %s, want ESCALATE", record.Verdict)
 	}
 	if record.ReasonCode != contracts.ReasonSchemaViolation {
 		t.Fatalf("reason = %s, want schema violation", record.ReasonCode)
@@ -63,7 +65,7 @@ func TestExecutionFirewallDeniesUnknownToolBeforeDispatch(t *testing.T) {
 	}
 }
 
-func TestExecutionFirewallDeniesUnknownServerBeforeDispatch(t *testing.T) {
+func TestExecutionFirewallEscalatesUnknownServerBeforeDispatch(t *testing.T) {
 	ctx := context.Background()
 	catalog := NewToolCatalog()
 	tool := ToolRef{Name: "local.echo", ServerID: "srv-unknown", Schema: map[string]any{"type": "object"}}
@@ -85,8 +87,8 @@ func TestExecutionFirewallDeniesUnknownServerBeforeDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	if record.Verdict != contracts.VerdictDeny {
-		t.Fatalf("verdict = %s, want DENY", record.Verdict)
+	if record.Verdict != contracts.VerdictEscalate {
+		t.Fatalf("verdict = %s, want ESCALATE", record.Verdict)
 	}
 	if record.ReasonCode != contracts.ReasonApprovalRequired {
 		t.Fatalf("reason = %s, want approval required", record.ReasonCode)
@@ -140,8 +142,8 @@ func TestExecutionFirewallDeniesMissingSchemaPin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	if record.Verdict != contracts.VerdictDeny || record.ReasonCode != contracts.ReasonSchemaViolation {
-		t.Fatalf("expected missing pin denial, got %s/%s", record.Verdict, record.ReasonCode)
+	if record.Verdict != contracts.VerdictEscalate || record.ReasonCode != contracts.ReasonSchemaViolation {
+		t.Fatalf("expected missing pin escalation, got %s/%s", record.Verdict, record.ReasonCode)
 	}
 }
 
@@ -234,6 +236,8 @@ func approvedFirewall(t *testing.T) *ExecutionFirewall {
 		ServerID:          "srv-1",
 		ApproverID:        "user:alice",
 		ApprovalReceiptID: "approval-r1",
+		Reason:            "reviewed",
+		ToolNames:         []string{"read", "write", "local.echo", "missing"},
 	}); err != nil {
 		t.Fatalf("approve: %v", err)
 	}

--- a/core/pkg/mcp/firewall.go
+++ b/core/pkg/mcp/firewall.go
@@ -43,6 +43,7 @@ func (g *ObserveGrant) Active(now time.Time) bool {
 type ToolCallAuthorization struct {
 	ServerID         string
 	ToolName         string
+	Effect           string
 	ArgsHash         string
 	GrantedScopes    []string
 	PinnedSchemaHash string
@@ -86,9 +87,14 @@ func (f *ExecutionFirewall) FilterVisibleTools(ctx context.Context, serverID str
 }
 
 func (f *ExecutionFirewall) AuthorizeToolCall(ctx context.Context, req ToolCallAuthorization) (contracts.ExecutionBoundaryRecord, error) {
+	effect := req.Effect
+	if effect == "" {
+		effect = "read"
+	}
 	record := contracts.ExecutionBoundaryRecord{
 		RecordID:      fmt.Sprintf("mcp-boundary-%d", f.now().UnixNano()),
 		ToolName:      req.ToolName,
+		ToolEffect:    effect,
 		ArgsHash:      req.ArgsHash,
 		PolicyEpoch:   f.PolicyEpoch,
 		MCPServerID:   req.ServerID,
@@ -102,7 +108,19 @@ func (f *ExecutionFirewall) AuthorizeToolCall(ctx context.Context, req ToolCallA
 		record.ObserveGrantID = f.Observe.GrantID
 	}
 
-	if err := f.Quarantine.RequireApproved(ctx, req.ServerID, f.now()); err != nil {
+	now := f.now()
+	if err := f.Quarantine.RequireApproved(ctx, req.ServerID, now); err != nil {
+		record.Verdict = contracts.VerdictEscalate
+		record.ReasonCode = contracts.ReasonApprovalRequired
+		if existing, ok := f.Quarantine.Get(ctx, req.ServerID); ok {
+			if existing.State == QuarantineRevoked || existing.State == QuarantineExpired || (!existing.ExpiresAt.IsZero() && now.After(existing.ExpiresAt)) {
+				record.Verdict = contracts.VerdictDeny
+				record.ReasonCode = contracts.ReasonApprovalTimeout
+			}
+		}
+		return record.Seal()
+	}
+	if err := f.Quarantine.RequireApprovedTool(ctx, req.ServerID, req.ToolName, effect, now); err != nil {
 		record.Verdict = contracts.VerdictDeny
 		record.ReasonCode = contracts.ReasonApprovalRequired
 		return record.Seal()
@@ -110,7 +128,7 @@ func (f *ExecutionFirewall) AuthorizeToolCall(ctx context.Context, req ToolCallA
 
 	tool, ok := f.Catalog.Lookup(req.ToolName)
 	if !ok || (tool.ServerID != "" && tool.ServerID != req.ServerID) {
-		record.Verdict = contracts.VerdictDeny
+		record.Verdict = contracts.VerdictEscalate
 		record.ReasonCode = contracts.ReasonSchemaViolation
 		return record.Seal()
 	}
@@ -128,7 +146,7 @@ func (f *ExecutionFirewall) AuthorizeToolCall(ctx context.Context, req ToolCallA
 		return record.Seal()
 	}
 	if f.RequirePinnedSchema && req.PinnedSchemaHash == "" {
-		record.Verdict = contracts.VerdictDeny
+		record.Verdict = contracts.VerdictEscalate
 		record.ReasonCode = contracts.ReasonSchemaViolation
 		return record.Seal()
 	}

--- a/core/pkg/mcp/mcp_2026_07_28_authz_vectors_test.go
+++ b/core/pkg/mcp/mcp_2026_07_28_authz_vectors_test.go
@@ -103,7 +103,13 @@ func TestMCP20260728AuthorizationSEPVectors(t *testing.T) {
 	if _, err := registry.Discover(ctx, DiscoverServerRequest{ServerID: "srv-rc"}); err != nil {
 		t.Fatalf("discover: %v", err)
 	}
-	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-rc", ApproverID: "user:reviewer", ApprovalReceiptID: "approval-rc"}); err != nil {
+	approvedTools := make([]string, 0)
+	for _, vector := range file.Vectors {
+		if vector.Kind == "tool_call" {
+			approvedTools = append(approvedTools, "rc."+vector.ID)
+		}
+	}
+	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-rc", ApproverID: "user:reviewer", ApprovalReceiptID: "approval-rc", Reason: "authz vector fixture", ToolNames: approvedTools}); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
 

--- a/core/pkg/mcp/observe_mode_test.go
+++ b/core/pkg/mcp/observe_mode_test.go
@@ -25,8 +25,8 @@ func TestObserveGrantLabelsRecordAndPermitsShadowDispatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("authorize: %v", err)
 	}
-	if record.Verdict != contracts.VerdictDeny {
-		t.Fatalf("verdict = %s, want DENY (shadow mode must not change verdicts)", record.Verdict)
+	if record.Verdict != contracts.VerdictEscalate {
+		t.Fatalf("verdict = %s, want ESCALATE (shadow mode must not change verdicts)", record.Verdict)
 	}
 	if record.EnforcementMode != contracts.EnforcementModeShadow {
 		t.Fatalf("enforcement mode = %q, want shadow", record.EnforcementMode)
@@ -38,7 +38,7 @@ func TestObserveGrantLabelsRecordAndPermitsShadowDispatch(t *testing.T) {
 		t.Fatal("shadow records must still be sealed")
 	}
 	if !ShouldDispatch(record) {
-		t.Fatal("labeled shadow DENY record should permit dispatch")
+		t.Fatal("labeled shadow ESCALATE record should permit dispatch")
 	}
 }
 
@@ -63,7 +63,7 @@ func TestExpiredObserveGrantRestoresEnforcement(t *testing.T) {
 		t.Fatalf("enforcement mode = %q, want empty after expiry", record.EnforcementMode)
 	}
 	if ShouldDispatch(record) {
-		t.Fatal("expired grant must not permit DENY dispatch")
+		t.Fatal("expired grant must not permit ESCALATE dispatch")
 	}
 }
 

--- a/core/pkg/mcp/pcas_propagation_proof_test.go
+++ b/core/pkg/mcp/pcas_propagation_proof_test.go
@@ -122,7 +122,7 @@ func TestPCASPropagatedScopeEnforcedAtDispatchWithEvidence(t *testing.T) {
 	if _, err := registry.Discover(ctx, DiscoverServerRequest{ServerID: "srv-pcas"}); err != nil {
 		t.Fatalf("discover: %v", err)
 	}
-	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-pcas", ApproverID: "user:root", ApprovalReceiptID: "approval-pcas"}); err != nil {
+	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-pcas", ApproverID: "user:root", ApprovalReceiptID: "approval-pcas", Reason: "pcas fixture", ToolNames: []string{"crm.read", "crm.export"}}); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
 	for _, tool := range []ToolRef{
@@ -179,7 +179,7 @@ func TestPCASAggregationInferenceGapIsDocumentedBehavior(t *testing.T) {
 	if _, err := registry.Discover(ctx, DiscoverServerRequest{ServerID: "srv-pcas"}); err != nil {
 		t.Fatalf("discover: %v", err)
 	}
-	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-pcas", ApproverID: "user:root", ApprovalReceiptID: "approval-pcas"}); err != nil {
+	if _, err := registry.Approve(ctx, ApprovalDecision{ServerID: "srv-pcas", ApproverID: "user:root", ApprovalReceiptID: "approval-pcas", Reason: "pcas fixture", ToolNames: []string{"directory.lookup"}}); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
 	if err := catalog.Register(ctx, ToolRef{Name: "directory.lookup", ServerID: "srv-pcas", RequiredScopes: []string{"dir.read"}, Schema: map[string]any{"type": "object"}}); err != nil {

--- a/core/pkg/mcp/quarantine.go
+++ b/core/pkg/mcp/quarantine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -32,20 +33,24 @@ const (
 // server. Unknown servers are not executable until an approval ceremony emits a
 // receipt and the registry transitions the record to approved.
 type ServerQuarantineRecord struct {
-	ServerID          string          `json:"server_id"`
-	Name              string          `json:"name,omitempty"`
-	Transport         string          `json:"transport,omitempty"`
-	Endpoint          string          `json:"endpoint,omitempty"`
-	ToolNames         []string        `json:"tool_names,omitempty"`
-	Risk              ServerRisk      `json:"risk"`
-	State             QuarantineState `json:"state"`
-	DiscoveredAt      time.Time       `json:"discovered_at"`
-	ApprovedAt        time.Time       `json:"approved_at,omitempty"`
-	ApprovedBy        string          `json:"approved_by,omitempty"`
-	ApprovalReceiptID string          `json:"approval_receipt_id,omitempty"`
-	RevokedAt         time.Time       `json:"revoked_at,omitempty"`
-	ExpiresAt         time.Time       `json:"expires_at,omitempty"`
-	Reason            string          `json:"reason,omitempty"`
+	ServerID              string          `json:"server_id"`
+	Name                  string          `json:"name,omitempty"`
+	Transport             string          `json:"transport,omitempty"`
+	Endpoint              string          `json:"endpoint,omitempty"`
+	ToolNames             []string        `json:"tool_names,omitempty"`
+	ApprovedToolNames     []string        `json:"approved_tool_names,omitempty"`
+	ApprovedEffects       []string        `json:"approved_effects,omitempty"`
+	Risk                  ServerRisk      `json:"risk"`
+	State                 QuarantineState `json:"state"`
+	DiscoveredAt          time.Time       `json:"discovered_at"`
+	ApprovedAt            time.Time       `json:"approved_at,omitempty"`
+	ApprovedBy            string          `json:"approved_by,omitempty"`
+	ApprovalReceiptID     string          `json:"approval_receipt_id,omitempty"`
+	ApprovalReceiptPath   string          `json:"approval_receipt_path,omitempty"`
+	RevokedAt             time.Time       `json:"revoked_at,omitempty"`
+	RevocationReceiptPath string          `json:"revocation_receipt_path,omitempty"`
+	ExpiresAt             time.Time       `json:"expires_at,omitempty"`
+	Reason                string          `json:"reason,omitempty"`
 }
 
 type DiscoverServerRequest struct {
@@ -67,6 +72,8 @@ type ApprovalDecision struct {
 	ApprovedAt        time.Time
 	ExpiresAt         time.Time
 	Reason            string
+	ToolNames         []string
+	Effects           []string
 }
 
 type QuarantineRegistry struct {
@@ -133,6 +140,20 @@ func (r *QuarantineRegistry) Approve(ctx context.Context, decision ApprovalDecis
 	if decision.ApprovalReceiptID == "" {
 		return ServerQuarantineRecord{}, fmt.Errorf("approval receipt id is required")
 	}
+	tools, err := normalizeApprovalScope(decision.ToolNames, "tool")
+	if err != nil {
+		return ServerQuarantineRecord{}, err
+	}
+	effects, err := normalizeApprovalScope(decision.Effects, "effect")
+	if err != nil {
+		return ServerQuarantineRecord{}, err
+	}
+	if len(effects) == 0 {
+		effects = []string{"read"}
+	}
+	if decision.Reason == "" {
+		return ServerQuarantineRecord{}, fmt.Errorf("approval reason is required")
+	}
 	now := decision.ApprovedAt
 	if now.IsZero() {
 		now = time.Now().UTC()
@@ -153,6 +174,8 @@ func (r *QuarantineRegistry) Approve(ctx context.Context, decision ApprovalDecis
 	record.ApprovalReceiptID = decision.ApprovalReceiptID
 	record.ExpiresAt = decision.ExpiresAt
 	record.Reason = decision.Reason
+	record.ApprovedToolNames = tools
+	record.ApprovedEffects = effects
 	r.records[decision.ServerID] = record
 	return record, nil
 }
@@ -198,6 +221,10 @@ func (r *QuarantineRegistry) List(ctx context.Context) []ServerQuarantineRecord 
 }
 
 func (r *QuarantineRegistry) RequireApproved(ctx context.Context, serverID string, now time.Time) error {
+	return r.RequireApprovedTool(ctx, serverID, "", "", now)
+}
+
+func (r *QuarantineRegistry) RequireApprovedTool(ctx context.Context, serverID, toolName, effect string, now time.Time) error {
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -216,5 +243,44 @@ func (r *QuarantineRegistry) RequireApproved(ctx context.Context, serverID strin
 	if record.State != QuarantineApproved {
 		return fmt.Errorf("server %q is %s", serverID, record.State)
 	}
+	if toolName != "" && !scopeAllows(record.ApprovedToolNames, toolName) {
+		return fmt.Errorf("server %q approval does not include tool %q", serverID, toolName)
+	}
+	if effect != "" && !scopeAllows(record.ApprovedEffects, effect) {
+		return fmt.Errorf("server %q approval does not include effect %q", serverID, effect)
+	}
 	return nil
+}
+
+func normalizeApprovalScope(values []string, label string) ([]string, error) {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if value == "*" {
+			return nil, fmt.Errorf("%s wildcard approval is not allowed", label)
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	if label == "tool" && len(out) == 0 {
+		return nil, fmt.Errorf("approval tools are required")
+	}
+	return out, nil
+}
+
+func scopeAllows(allowed []string, value string) bool {
+	for _, item := range allowed {
+		if item == value {
+			return true
+		}
+	}
+	return false
 }

--- a/core/pkg/mcp/quarantine_test.go
+++ b/core/pkg/mcp/quarantine_test.go
@@ -34,6 +34,8 @@ func TestQuarantineRegistryApprovalRequiresReceipt(t *testing.T) {
 	_, err := registry.Approve(context.Background(), ApprovalDecision{
 		ServerID:   "srv-1",
 		ApproverID: "user:alice",
+		Reason:     "reviewed",
+		ToolNames:  []string{"read_file"},
 	})
 	if err == nil {
 		t.Fatal("approval without receipt should fail")
@@ -52,6 +54,9 @@ func TestQuarantineRegistryApprovedServerPassesUntilExpiry(t *testing.T) {
 		ApprovalReceiptID: "approval-r1",
 		ApprovedAt:        now,
 		ExpiresAt:         now.Add(time.Hour),
+		Reason:            "reviewed",
+		ToolNames:         []string{"read_file"},
+		Effects:           []string{"read"},
 	})
 	if err != nil {
 		t.Fatalf("approve: %v", err)
@@ -61,6 +66,12 @@ func TestQuarantineRegistryApprovedServerPassesUntilExpiry(t *testing.T) {
 	}
 	if err := registry.RequireApproved(context.Background(), "srv-1", now.Add(time.Minute)); err != nil {
 		t.Fatalf("approved server denied: %v", err)
+	}
+	if err := registry.RequireApprovedTool(context.Background(), "srv-1", "read_file", "read", now.Add(time.Minute)); err != nil {
+		t.Fatalf("approved tool denied: %v", err)
+	}
+	if err := registry.RequireApprovedTool(context.Background(), "srv-1", "write_file", "read", now.Add(time.Minute)); err == nil {
+		t.Fatal("unapproved tool should fail closed")
 	}
 	if err := registry.RequireApproved(context.Background(), "srv-1", now.Add(2*time.Hour)); err == nil {
 		t.Fatal("expired approval should fail closed")
@@ -83,6 +94,8 @@ func TestQuarantineRegistryRevokedServerDenied(t *testing.T) {
 		ServerID:          "srv-1",
 		ApproverID:        "user:alice",
 		ApprovalReceiptID: "approval-r1",
+		Reason:            "reviewed",
+		ToolNames:         []string{"read_file"},
 	}); err != nil {
 		t.Fatalf("approve: %v", err)
 	}
@@ -158,6 +171,7 @@ func TestQuarantineRegistryLifecycleEdges(t *testing.T) {
 		ApprovalReceiptID: "receipt-a",
 		ApprovedAt:        now,
 		Reason:            "reviewed",
+		ToolNames:         []string{"read"},
 	})
 	if err != nil {
 		t.Fatalf("approve srv-a: %v", err)
@@ -200,6 +214,8 @@ func TestQuarantineRegistryLifecycleEdges(t *testing.T) {
 		ServerID:          "srv-b",
 		ApproverID:        "user:alice",
 		ApprovalReceiptID: "receipt-b",
+		Reason:            "reviewed",
+		ToolNames:         []string{"read"},
 	}); err == nil {
 		t.Fatal("revoked server should not be approvable")
 	}

--- a/docs/CLAIM_BOUNDARIES.md
+++ b/docs/CLAIM_BOUNDARIES.md
@@ -5,49 +5,38 @@ last_reviewed: 2026-07-01
 
 # Claim Boundaries
 
-HELM AI Kernel is public OSS. It is safe to describe the local kernel,
-CLI/API, receipts, verification, MCP boundary checks, workstation hook receipts,
-and local onboarding proof path when the claim points to source, tests, or a
-published release asset.
+HELM AI Kernel is public OSS. The public docs may describe the local kernel,
+CLI/API, receipts, verification, MCP boundary checks, workstation hook
+receipts, and local proof path when those claims are backed by source, tests,
+or release artifacts.
 
 ## Public Claims
 
 - HELM AI Kernel is a fail-closed execution firewall for AI agents.
-- Dangerous or unapproved selected effects can be denied before dispatch when
-  they pass through a HELM adapter, wrapper, hook, or API route.
-- Decisions produce signed receipts that can be verified offline.
-- EvidencePacks and release assets can be checked from local material without a
-  hosted service.
+- Selected effects can be denied before dispatch when they pass through a HELM
+  adapter, wrapper, hook, proxy, or API route.
+- Unknown or unapproved MCP paths can escalate into local scoped approval.
+- Decisions, approvals, and revocations write local receipts.
+- EvidencePacks can be checked from local material without trusting a hosted
+  service.
 - The public conformance proof path supports `L1` and `L2` CLI shortcuts.
-- The OpenAI-compatible proxy and MCP authorization routes are local boundary
-  surfaces, not claims of model-provider control.
 
 ## Not Public Claims
 
-- No hosted Enterprise automation production deployment is claimed by this repo.
-- No named buyer rollout, buyer certification, or compliance certification is
-  claimed by this repo.
-- No public paid signup or paid production account activation is claimed here.
+- No hosted Enterprise deployment is claimed by this repo.
+- No named buyer rollout is claimed by this repo.
+- No public paid signup or paid account activation is claimed here.
 - No full operating-system, browser, IDE, eBPF, seccomp, TPM, hardware enclave,
   packet blocking, or proprietary hosted-agent control is claimed unless a
-  tested source path proves the specific effect crossed HELM.
+  tested path proves the specific effect crossed HELM.
 - No `L4` conformance claim is public. `L3` remains source/test coverage until
   a public proof path is wired and tested.
 
-## Source Truth
-
-- `CLAIMS.md`
-- `docs/QUICKSTART.md`
-- `docs/CONFORMANCE.md`
-- `docs/reference/http-api.md`
-- `core/cmd/helm-ai-kernel`
-- `core/pkg/conformance`
-- `api/openapi/helm.openapi.yaml`
-
-## Validation
+## Local Checks
 
 ```bash
 python3 scripts/check_documentation_truth.py
-go test ./core/cmd/helm-ai-kernel -run TestConformLevelAliasesSeedBaselineEvidence -count=1
-go test ./core/pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_Top10' -count=1
+cd core
+go test ./cmd/helm-ai-kernel -run TestConformLevelAliasesSeedBaselineEvidence -count=1
+go test ./pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_Top10' -count=1
 ```

--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -5,114 +5,46 @@ last_reviewed: 2026-07-01
 
 # Conformance
 
-## Audience
+Conformance is the runnable check that HELM behaves like the public Kernel
+contract says it behaves.
 
-Policy/runtime implementers and maintainers validating behavior with conformance packs and fixture replay.
+## Run The Public Levels
 
-## Outcome
+```bash
+helm-ai-kernel conform --level L1 --json
+helm-ai-kernel conform --level L2 --json
+helm-ai-kernel conform negative --json
+helm-ai-kernel conform vectors --json
+```
 
-After this page you should know what this surface is for, which source files own the behavior, which public route or adjacent page to use next, and which validation command to run before changing the claim.
+`L1` covers the local proof path: canonical inputs, receipt shape, offline
+verification, and checkpoint roots.
 
-## Source Truth
+`L2` adds the MCP execution firewall: quarantine, tool-list/call consistency,
+schema pinning, direct-bypass denial, scoped approvals, revocation, expiry, and
+receipt emission.
 
-- Public route: `conformance`
-- Source document: `helm-ai-kernel/docs/CONFORMANCE.md`
-- Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
-- Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
-- Validation: `make docs-coverage`, `make docs-truth`, and `npm run coverage:inventory` from `docs-platform`
+Higher levels are not public shortcuts in the Kernel docs. Treat any `L3` or
+`L4` material as source/test coverage until a public command and test-backed
+proof path exists.
 
-Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the inventory manifest points to code, schemas, tests, examples, or an owner doc that proves the claim.
+## Maintainer Test Targets
 
-## Troubleshooting
+```bash
+cd core
+go test ./cmd/helm-ai-kernel -run TestConformLevelAliasesSeedBaselineEvidence -count=1
+go test ./pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_Top10' -count=1
+```
 
-| Symptom | First check |
+## Interpreting Failures
+
+| Failure area | First check |
 | --- | --- |
-| Published output is stale or incomplete | Run `npm run helm-public:accuracy` in `docs-platform`, then check the source path and public manifest row for this page. |
-| A claim needs implementation backing | Check the Source Truth files above and update the implementation, manifest, source inventory, or page in the same change. |
+| Canonicalization | Input JSON shape and sorted keys |
+| Receipts | Decision id, verdict, reason code, and signature material |
+| MCP boundary | Server id, tool list, schema pin, approval scope, and effect |
+| Revocation or expiry | Approval receipt, revocation receipt, and TTL |
+| EvidencePack | Indexed file hashes and receipt bytes |
 
-## Diagram
-
-This scheme maps the main sections of Conformance in reading order.
-
-```mermaid
-flowchart TD
-    subgraph Ingestion["1. Ingestion & Context Plane"]
-        Page["Conformance"]
-        C["Profile Material"]
-        D["Conformance Status Matrix"]
-    end
-
-    subgraph Execution["3. Execution & Verdict Plane"]
-        A["Run the Kernel Conformance Command"]
-        B["Run the Conformance Test Suite"]
-    end
-
-    %% Operational Flow Edges
-    Page --> A
-    A --> B
-    B --> C
-    C --> D
-
-    %% Premium Styling Rules
-    style A fill:#3182ce,stroke:#2b6cb0,stroke-width:2px,color:#fff
-    style B fill:#3182ce,stroke:#2b6cb0,stroke-width:2px,color:#fff
-```
-
-
-HELM keeps a retained conformance profile under `tests/conformance/profile-v1/`. The profile describes the minimum checks an implementation must pass to match the public OSS kernel behavior documented in this repository.
-
-## Run the Kernel Conformance Command
-
-```bash
-./bin/helm-ai-kernel conform --level L1 --json
-./bin/helm-ai-kernel conform --level L2 --json
-./bin/helm-ai-kernel conform negative --json
-./bin/helm-ai-kernel conform vectors --json
-```
-
-Use the CLI commands above as the public proof path. `L1` and `L2` are the
-only public level shortcuts accepted by `helm-ai-kernel conform --level`.
-
-The public API exposes negative vectors at
-`GET /api/v1/conformance/negative`. Runtime conformance report routes are
-admin/runtime status surfaces, not public conformance proof, until they are
-backed by the same engine and tests as the CLI.
-
-## Run the Maintained Conformance Tests
-
-```bash
-go test ./core/cmd/helm-ai-kernel -run TestConformLevelAliasesSeedBaselineEvidence -count=1
-go test ./core/pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_Top10' -count=1
-```
-
-## Profile Material
-
-The profile directory contains:
-
-- `checklist.yaml` for the machine-readable checklist
-- `profile_test.go` for profile assertions
-- `README.md` for the human-readable profile summary
-
-## Conformance Status Matrix
-
-- `L1` is implemented as a public CLI shortcut. It covers the baseline OSS
-  proof path: canonical inputs, schema handling, receipt shape, offline
-  verification, and checkpoint roots.
-- `L2` is implemented as a public CLI shortcut. It adds the MCP
-  execution-firewall gates: quarantine, tool-list/call consistency, OAuth
-  resource and scope checks, schema pinning, direct-bypass denial, and deny-path
-  receipt emission.
-- `L3` exists as source/test conformance coverage, not as a public
-  `--level L3` shortcut. Treat it as maintainer-facing until the CLI and public
-  docs publish an engine-backed proof path.
-- Higher levels are not a public claim in this repo. Do not publish them as
-  supported conformance until the level constants, CLI wiring, fixtures, and
-  tests all exist.
-
-The exact checks are defined by the code and checklist in `tests/conformance/`, not by this page.
-
-<!-- docs-depth-final-pass -->
-
-## Conformance Completion Path
-
-A conformance page is complete only when it tells a maintainer how to run the profile, how to interpret a failure, and which fixture owns the expected behavior. Keep profiles explicit: runtime decision, receipt canonicalization, verifier replay, policy denial, MCP boundary, and OpenAI-compatible proxy behavior are different surfaces. When adding a profile, add a fixture, a golden expected output, a negative case, and a short compatibility note. Public users should be able to run the command from a clean checkout, compare output to the documented profile, and decide whether a failure is a local environment issue, a schema drift, or an implementation regression.
+Conformance is local proof. It does not claim provider certification, hosted
+deployment status, or broad platform control.

--- a/docs/HOW_HELM_WORKS.md
+++ b/docs/HOW_HELM_WORKS.md
@@ -5,45 +5,54 @@ last_reviewed: 2026-07-01
 
 # How HELM Works
 
-HELM sits between an agent proposal and a real side effect. The public proof
-path is local: load a policy, evaluate a proposed action, return `ALLOW`,
-`DENY`, or `ESCALATE`, and write evidence that can be verified offline.
+HELM is a local execution firewall for AI agents. A client, hook, wrapper, MCP
+adapter, or OpenAI-compatible proxy sends a proposed action to HELM before the
+action runs.
 
-## Boundary
+```text
+agent/tool requests action
+-> HELM evaluates before dispatch
+-> ALLOW: action runs
+-> DENY: action is blocked
+-> ESCALATE: action is blocked and a decision receipt is written
+```
 
-The boundary is the checkpoint before dispatch. A client, hook, wrapper, MCP
-adapter, or OpenAI-compatible proxy sends the proposed action to HELM before
-the action runs.
+## Verdicts
 
-## Policy
+`ALLOW` means the proposed action matched the active policy and any required
+approval scope.
 
-Policies decide whether the action may proceed. Unknown, untrusted, or
-unapproved paths fail closed: they deny or escalate instead of silently
-continuing.
+`DENY` means the action is unsafe, mismatched, expired, revoked, outside scope,
+or policy-forbidden.
+
+`ESCALATE` means a developer can safely resolve the block with an exact local
+approval. HELM writes a receipt and returns a short approval hint. It never
+continues the original action silently.
+
+## Approvals
+
+Approvals are local-first and narrow:
+
+- exact server id
+- exact tool list
+- explicit effect scope
+- required reason
+- TTL-bound
+- receipt-backed
+- revocable
+
+Read-only is the default effect. Write, deploy, network, and payment effects
+must be approved explicitly and use a shorter TTL.
 
 ## Receipts
 
-Each governed decision records a signed receipt. Receipts let a reviewer check
-what was evaluated, which verdict was returned, and whether the record was
-tampered with.
+Decision, approval, and revocation receipts live under
+`~/.helm-ai-kernel/receipts/`. They are the public proof surface: inspect them,
+export them, or include them in an EvidencePack for offline verification.
 
-## EvidencePacks
+## Boundaries
 
-EvidencePacks bundle receipt and proof material for offline verification. They
-are evidence containers, not regulatory certifications or buyer rollout claims.
-
-## What This Does Not Claim
-
-HELM controls actions that cross a HELM adapter, hook, wrapper, proxy, or API
-route. The public Kernel docs do not claim operating-system-wide enforcement,
-hosted Enterprise automation, or provider-level model control.
-
-## Evidence
-
-- `docs/QUICKSTART.md`
-- `docs/CONFORMANCE.md`
-- `docs/VERIFICATION.md`
-- `docs/reference/execution-boundary.md`
-- `docs/reference/http-api.md`
-- `core/cmd/helm-ai-kernel`
-- `api/openapi/helm.openapi.yaml`
+HELM governs effects that cross a HELM adapter, hook, wrapper, proxy, or API
+route. The public Kernel docs do not claim full operating-system control,
+hosted Enterprise automation, provider-level model control, or buyer rollout
+status.

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -1,22 +1,21 @@
 ---
-title: MCP Integration
-last_reviewed: 2026-06-29
+title: MCP
+last_reviewed: 2026-07-01
 ---
 
-# MCP Integration
+# MCP
 
-Route MCP tool calls through HELM so unknown servers, unknown tools, and
-unpinned schemas are quarantined before dispatch.
+Use HELM as a pre-dispatch firewall for MCP tool calls.
 
-## Quick Setup
-
-Start the local boundary:
-
-```bash
-helm-ai-kernel serve --policy ./release.high_risk.v3.toml
+```text
+tools/list -> visible tools are filtered
+tools/call -> HELM evaluates before dispatch
+ALLOW -> call upstream
+DENY -> block
+ESCALATE -> block, write receipt, show scoped approval command
 ```
 
-Wrap an upstream shell MCP server:
+## Wrap A Server
 
 ```bash
 helm-ai-kernel mcp wrap \
@@ -26,82 +25,88 @@ helm-ai-kernel mcp wrap \
   --json
 ```
 
-Print configuration for a client:
+Print or install client config:
 
 ```bash
 helm-ai-kernel mcp print-config --client codex
-```
-
-Claude Code has a direct installer:
-
-```bash
 helm-ai-kernel mcp install --client claude-code
 ```
 
-## Run The Maintained Demo
+## Authorize Before Dispatch
 
 ```bash
-./scripts/launch/demo-mcp.sh
+helm-ai-kernel mcp authorize-call \
+  --server-id shell-mcp-server \
+  --tool-name pwd
 ```
 
-The demo checks that unknown servers, unknown tools, and missing schema pins
-return `DENY` or `ESCALATE`; they do not dispatch to the fixture server.
+An unknown or unapproved server returns `ESCALATE`:
 
-## Receipt Inspection
+```text
+HELM ESCALATE
+decision: mcp-boundary-...
+reason: unknown MCP server requires approval
+receipt: ~/.helm-ai-kernel/receipts/mcp/...
+approve:
+  helm-ai-kernel mcp approve --server-id shell-mcp-server \
+    --tools "pwd" \
+    --ttl 15m \
+    --reason 'read-only repo inspection for local dev'
+```
+
+The action is not dispatched. Approval never resumes it automatically.
+
+## Approve A Narrow Scope
 
 ```bash
-helm-ai-kernel receipts tail --agent mcp-demo-agent --server http://127.0.0.1:7714
+helm-ai-kernel mcp approve \
+  --server-id shell-mcp-server \
+  --tools "pwd,ls,cat" \
+  --ttl 15m \
+  --reason "read-only repo inspection for local dev"
 ```
 
-Use the receipt ID or decision ID in support reports. Do not include provider
-keys, private prompts, or production tenant data.
+Approvals are local, receipt-backed, TTL-bound, and revocable. HELM rejects
+wildcard tool approvals and overlong side-effect approvals.
 
-## Policy Fixture
+For side-effect tools, approve the effect explicitly:
 
-The minimal shell fixture is
-`examples/launch/policies/shell_mcp_server_boundary.json`.
+```bash
+helm-ai-kernel mcp approve \
+  --server-id deploy-tools \
+  --tools deploy.preview \
+  --effects side_effect \
+  --ttl 15m \
+  --reason "preview deploy for local validation"
+```
 
-| Command class | Verdict | Reason |
-| --- | --- | --- |
-| `ls` | `ALLOW` | Read-only directory listing |
-| `pwd` | `ALLOW` | Read-only current-directory inspection |
-| `cat <path>` | `ALLOW` | Read-only file inspection |
-| `git status` | `ALLOW` | Read-only worktree status |
-| `rm -rf` and equivalent recursive force delete patterns | `DENY` | Destructive deletion |
-| `dd`, `mkfs`, and raw-device write patterns | `DENY` | Disk or filesystem destruction |
-| `git clean -f`, `git clean -fd`, `git clean -fdx`, `git clean --force` | `DENY` | Destructive worktree cleanup |
+## Revoke
 
-## OAuth Mode
+```bash
+helm-ai-kernel mcp revoke \
+  --server-id shell-mcp-server \
+  --reason "inspection finished"
+```
 
-`helm-ai-kernel mcp serve --auth oauth` supports production JWKS validation and
-the dev-only `HELM_OAUTH_BEARER_TOKEN` fallback.
+Revoked and expired grants fail closed on the next evaluation.
 
-| Variable | Purpose |
-| --- | --- |
-| `HELM_OAUTH_JWKS_URL` | JWKS endpoint used to verify bearer-token signatures |
-| `HELM_OAUTH_ISSUER` | Required `iss` claim |
-| `HELM_OAUTH_AUDIENCE` | Required `aud` claim |
-| `HELM_OAUTH_RESOURCE` | Required RFC 8707 resource indicator; defaults to `<base-url>/mcp` |
-| `HELM_OAUTH_SCOPES` | Scopes required before gateway entry |
+## Inspect
 
-Tool definitions can declare `required_scopes`. HELM surfaces them as
-`requiredScopes` in `tools/list` and enforces them again at execution time.
+```bash
+helm-ai-kernel mcp pending --json
+helm-ai-kernel mcp receipts --json
+helm-ai-kernel mcp get --server-id shell-mcp-server --json
+```
 
-## Debug
+Run the no-dispatch proof:
 
-| Symptom | First check |
-| --- | --- |
-| Client cannot see the MCP server | Re-run `helm-ai-kernel mcp print-config --client <client>` and compare the installed config. |
-| Tool is stuck quarantined | Inspect the server ID, schema hash, and approval receipt. |
-| Receipts are missing | Confirm the boundary is running on `127.0.0.1:7714` and tail receipts for the expected agent ID. |
-| OAuth calls fail | Check issuer, audience, resource, scopes, and token expiry. |
+```bash
+helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
+```
 
-## Source Truth
+## What Still Blocks
 
-- `core/cmd/helm-ai-kernel/mcp_cmd.go`
-- `core/cmd/helm-ai-kernel/mcp_runtime.go`
-- `core/cmd/helm-ai-kernel/mcp_boundary_cmd.go`
-- `core/cmd/helm-ai-kernel/receipt_routes.go`
-- `scripts/launch/demo-mcp.sh`
-- `examples/launch/policies/shell_mcp_server_boundary.json`
-- `docs/use-cases/mcp-execution-firewall.md`
+HELM denies mismatched scopes, expired or revoked approvals, schema drift,
+side-effect scope mismatch, and policy-forbidden actions. Missing approval or
+unknown tool/server state escalates only when a developer can resolve it with a
+local scoped approval or schema review.

--- a/docs/INTEGRATIONS/openai_baseurl.md
+++ b/docs/INTEGRATIONS/openai_baseurl.md
@@ -1,45 +1,67 @@
 ---
-title: OpenAI-Compatible Proxy Integration
-last_reviewed: 2026-06-29
+title: OpenAI Proxy
+last_reviewed: 2026-07-01
 ---
 
-# OpenAI-Compatible Proxy Integration
+# OpenAI Proxy
 
-Use this path when an app already speaks the OpenAI chat-completions API and
-you want requests to cross a local HELM boundary before reaching an upstream.
+Use the OpenAI-compatible proxy when an app already speaks the OpenAI API shape
+and can set a custom base URL. HELM stays local, evaluates requests before they
+reach the upstream, and writes receipts for allowed, denied, or escalated
+decisions.
 
-## Quick Setup
+## Start Locally
 
-Start the HELM boundary:
+Build the CLI:
 
 ```bash
-helm-ai-kernel serve --policy ./release.high_risk.v3.toml
+make build
 ```
 
-Start a mock upstream and the proxy:
+Start the local HELM boundary:
+
+```bash
+./bin/helm-ai-kernel serve --policy ./release.high_risk.v3.toml
+```
+
+Start a local mock upstream and proxy:
 
 ```bash
 python3 scripts/launch/mock-openai-upstream.py --port 19090
-helm-ai-kernel proxy \
+
+./bin/helm-ai-kernel proxy \
   --upstream http://127.0.0.1:19090/v1 \
   --port 9090 \
   --receipts-dir ./helm-receipts
 ```
 
-Point the client at:
+Point OpenAI-shaped clients at:
 
 ```text
 http://127.0.0.1:9090/v1
 ```
 
-## Environment Setup
+## Configure A Client
+
+Environment-only setup:
 
 ```bash
 export OPENAI_BASE_URL=http://127.0.0.1:9090/v1
 export OPENAI_API_KEY=local-dev-key
 ```
 
-## cURL Request
+Python client example:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://127.0.0.1:9090/v1",
+    api_key="local-dev-key",
+)
+```
+
+Raw request:
 
 ```bash
 curl -sS http://127.0.0.1:9090/v1/chat/completions \
@@ -48,71 +70,30 @@ curl -sS http://127.0.0.1:9090/v1/chat/completions \
   -d '{"model":"helm-local-mock","messages":[{"role":"user","content":"hello through HELM"}]}'
 ```
 
-## OpenAI Agents SDK
+## Prove The Boundary
 
-```python
-from openai import AsyncOpenAI
-from agents import Agent, Runner, set_default_openai_api, set_default_openai_client
+The response should include HELM metadata when the client exposes headers:
 
-set_default_openai_client(
-    AsyncOpenAI(base_url="http://127.0.0.1:9090/v1", api_key="local-dev-key"),
-    use_for_tracing=False,
-)
-set_default_openai_api("chat_completions")
+| Header | Meaning |
+| --- | --- |
+| `X-Helm-Decision-ID` | Decision emitted by HELM |
+| `X-Helm-Receipt-ID` | Receipt for the governed request |
+| `X-Helm-Reason-Code` | Reason context |
+| `X-Helm-Status` | Boundary status |
 
-agent = Agent(name="governed", instructions="Route tool effects through HELM.")
-result = await Runner.run(agent, "summarize the current task")
-```
-
-## Verify Denial Behavior
-
-The mock upstream has a deny fixture. Request model `helm-local-tool-fixture`
-and the proxy must stop the response before executable `tool_calls` reach the
-caller.
+If a client hides headers, inspect the local receipt stream:
 
 ```bash
-curl -sS -D headers.txt -o denied.json -w '%{http_code}\n' \
-  http://127.0.0.1:9090/v1/chat/completions \
-  -H 'content-type: application/json' \
-  -H 'authorization: Bearer local-dev-key' \
-  -d '{"model":"helm-local-tool-fixture","messages":[{"role":"user","content":"call a denied tool"}]}'
+./bin/helm-ai-kernel receipts tail \
+  --agent <agent-id> \
+  --server http://127.0.0.1:7714
 ```
 
-Expected result:
-
-- HTTP status is `403`.
-- `X-Helm-Status` is `DENIED`.
-- `X-Helm-Receipt-ID` is present.
-- `denied.json` contains a HELM error body and no executable `tool_calls`.
-
-Run the maintained proof:
+Run the maintained local proof:
 
 ```bash
 ./scripts/launch/demo-openai-proxy.sh
 ```
 
-## Receipt Headers
-
-| Header | Meaning |
-| --- | --- |
-| `X-Helm-Decision-ID` | Decision identifier emitted by the HELM boundary |
-| `X-Helm-Receipt-ID` | Receipt identifier for the governed request |
-| `X-Helm-Reason-Code` | ALLOW, DENY, or ESCALATE reason context |
-| `X-Helm-Output-Hash` | Hash of the governed output |
-| `X-Helm-Status` | Governance status for the proxied response |
-| `X-Helm-Correlation-ID` | Trace and receipt correlation value |
-
-Some clients hide response headers. In that case, inspect the receipt stream or
-use a HELM SDK path that exposes receipt metadata.
-
-## Source Truth
-
-- `core/cmd/helm-ai-kernel/proxy_cmd.go`
-- `core/cmd/helm-ai-kernel/server_cmd.go`
-- `core/cmd/helm-ai-kernel/serve_policy.go`
-- `core/cmd/helm-ai-kernel/receipt_routes.go`
-- `scripts/launch/demo-openai-proxy.sh`
-- `scripts/launch/mock-openai-upstream.py`
-- `examples/python_openai_baseurl/`
-- `examples/ts_openai_baseurl/`
-- `examples/js_openai_baseurl/`
+The proxy is a local request boundary. A successful model response is not proof
+that the request crossed HELM unless a receipt or response metadata proves it.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -5,23 +5,18 @@ last_reviewed: 2026-07-01
 
 # Quickstart
 
-Install HELM AI Kernel, protect a local coding agent, and verify the signed
-receipt for a blocked action. This path is local-first: no hosted account, live
-model key, production credential, Docker daemon, or private endpoint is required
-for the first proof.
+Run HELM locally and prove the boundary before connecting it to a real agent.
+No account, hosted service, model key, or private endpoint is required.
 
-## 1. Install HELM
-
-Published macOS CLI:
+## Install
 
 ```bash
 brew tap mindburn-labs/tap
-brew trust mindburn-labs/tap
 brew install helm-ai-kernel
 helm-ai-kernel --version
 ```
 
-Source build:
+From source:
 
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
@@ -30,16 +25,84 @@ make build
 ./bin/helm-ai-kernel --version
 ```
 
-Use `./bin/helm-ai-kernel` for source builds and `helm-ai-kernel` for installed
-CLI examples.
-
-## 2. Protect Codex Or Claude Code
-
-For Codex:
+## Prove The Boundary
 
 ```bash
-helm-ai-kernel setup codex --yes
+helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
 ```
+
+Expected shape:
+
+```json
+{
+  "schema_version": "helm.mcp.proof/v1",
+  "offline_verified": true,
+  "scenarios": [
+    { "verdict": "ESCALATE", "dispatched": false },
+    { "verdict": "DENY", "dispatched": false }
+  ]
+}
+```
+
+Verify the generated EvidencePack offline:
+
+```bash
+helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/<run-id> --profile dev-local --json
+```
+
+Use the `v0.5.18` release `evidence-pack.tar` from the GitHub release for
+release verification instead of a local proof bundle.
+
+## See An Escalation
+
+Ask HELM to authorize a local MCP action before dispatch:
+
+```bash
+helm-ai-kernel mcp authorize-call \
+  --server-id shell-mcp-server \
+  --tool-name pwd
+```
+
+Expected client message:
+
+```text
+HELM ESCALATE
+decision: mcp-boundary-...
+reason: unknown MCP server requires approval
+receipt: ~/.helm-ai-kernel/receipts/mcp/...
+approve:
+  helm-ai-kernel mcp approve --server-id shell-mcp-server \
+    --tools "pwd" \
+    --ttl 15m \
+    --reason 'read-only repo inspection for local dev'
+```
+
+Nothing runs on `ESCALATE`. The developer either approves the exact scope or
+does nothing.
+
+Approve a narrow read-only grant:
+
+```bash
+helm-ai-kernel mcp approve \
+  --server-id shell-mcp-server \
+  --tools "pwd,ls,cat" \
+  --ttl 15m \
+  --reason "read-only repo inspection for local dev"
+```
+
+Then rerun the original action. HELM evaluates again against the approval,
+schema, policy, and effect scope. Approval does not silently resume the blocked
+action.
+
+Revoke the grant:
+
+```bash
+helm-ai-kernel mcp revoke \
+  --server-id shell-mcp-server \
+  --reason "inspection finished"
+```
+
+## Connect A Local Agent
 
 For Claude Code:
 
@@ -47,99 +110,28 @@ For Claude Code:
 helm-ai-kernel setup claude-code --yes
 ```
 
-The setup command defaults to user scope and `~/.helm-ai-kernel`. Project scope
-is explicit:
+For Codex:
 
 ```bash
-helm-ai-kernel setup codex --scope project --yes
+helm-ai-kernel setup codex --yes
 ```
 
-Inspect before writing:
+Preview writes first:
 
 ```bash
 helm-ai-kernel setup codex --dry-run --json
 ```
 
-Check or remove the integration:
-
-```bash
-helm-ai-kernel setup status codex
-helm-ai-kernel setup remove codex --yes
-```
-
-Setup writes draft policy and quarantine artifacts only. It does not approve
+Setup writes local config and draft policy artifacts. It does not approve
 detected tools.
 
-## 3. Trigger A Denial
-
-Use the protected client and attempt a high-risk tool action such as destructive
-shell cleanup. HELM should deny or escalate instead of silently dispatching the
-effect.
-
-Hook denials write signed workstation decision receipts under:
-
-```text
-~/.helm-ai-kernel/receipts/hooks/
-```
-
-## 4. Verify The Receipt
+## Inspect
 
 ```bash
-helm-ai-kernel workstation verify-decision \
-  --receipt ~/.helm-ai-kernel/receipts/hooks/<decision>.json
+helm-ai-kernel mcp pending --json
+helm-ai-kernel mcp receipts --json
+helm-ai-kernel boundary records --verdict ESCALATE --json
 ```
 
-The verifier exits `0` only when the decision receipt hash and Ed25519 signature
-verify. Tampered receipts return a non-zero exit.
-
-Use the `v0.5.18` release `evidence-pack.tar` when verifying release-bundle
-evidence instead of local quickstart receipts.
-
-## 5. Run The Headless Local Proof
-
-Use this when you want the local Kernel API proof path without changing an
-agent client config:
-
-```bash
-helm-ai-kernel quickstart
-```
-
-Machine-readable startup state:
-
-```bash
-helm-ai-kernel quickstart --json
-```
-
-Useful flags:
-
-| Flag | Purpose |
-| --- | --- |
-| `--addr 127.0.0.1` | Loopback bind address. Non-loopback binds are rejected. |
-| `--port 7714` | Local Kernel port. |
-| `--data-dir <dir>` | SQLite, keys, policy, receipts, and EvidencePack location. |
-| `--reset` | Remove the quickstart data directory before initialization. |
-| `--profile claude|codex|mcp|openai-compatible` | Label the onboarding path. |
-| `--dry-run --json` | Prepare startup state without serving. |
-
-## Next Steps
-
-- [Agent Risk Scan](reference/agent-risk-scan.md)
-- [Codex integration](INTEGRATIONS/codex.md)
-- [Claude Code integration](INTEGRATIONS/claude-code.md)
-- [MCP integration](INTEGRATIONS/mcp.md)
-- [OpenAI-compatible proxy](INTEGRATIONS/openai_baseurl.md)
-- [Verification](VERIFICATION.md)
-- [Troubleshooting](TROUBLESHOOTING.md)
-
-## Source Truth
-
-- `core/cmd/helm-ai-kernel/setup_cmd.go`
-- `core/cmd/helm-ai-kernel/hook_cmd.go`
-- `core/cmd/helm-ai-kernel/quickstart_cmd.go`
-- `core/cmd/helm-ai-kernel/local_first_run_routes.go`
-- `core/cmd/helm-ai-kernel/workstation_m3_cmd.go`
-- `core/cmd/helm-ai-kernel/receipts_cmd.go`
-- `core/cmd/helm-ai-kernel/verify_cmd.go`
-- `api/openapi/helm.openapi.yaml`
-- `scripts/launch/demo-mcp.sh`
-- `scripts/launch/demo-openai-proxy.sh`
+Keep private prompts, provider keys, private endpoints, and unredacted receipts
+out of public issues.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,249 +1,107 @@
 ---
-title: TROUBLESHOOTING
-last_reviewed: 2026-05-05
+title: Troubleshooting
+last_reviewed: 2026-07-01
 ---
 
 # Troubleshooting
 
-## Audience
-
-Operators and contributors diagnosing local HELM AI Kernel startup, proxy, Console, receipt, and verification failures.
-
-## Outcome
-
-After this page you should know what this surface is for, which source files own the behavior, which public route or adjacent page to use next, and which validation command to run before changing the claim.
-
-## Source Truth
-
-- Public route: `troubleshooting`
-- Source document: `helm-ai-kernel/docs/TROUBLESHOOTING.md`
-- Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
-- Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
-- Validation: `make docs-coverage`, `make docs-truth`, and `npm run coverage:inventory` from `docs-platform`
-
-Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the inventory manifest points to code, schemas, tests, examples, or an owner doc that proves the claim.
-
-## Troubleshooting
-
-| Symptom | First check |
-| --- | --- |
-| Published output is stale or incomplete | Run `npm run helm-public:accuracy` in `docs-platform`, then check the source path and public manifest row for this page. |
-| A claim needs implementation backing | Check the Source Truth files above and update the implementation, manifest, source inventory, or page in the same change. |
-
-## Diagram
-
-This scheme maps the main sections of Troubleshooting in reading order.
-
-```mermaid
-flowchart TD
-    subgraph Ingestion["1. Ingestion & Context Plane"]
-        Page["Troubleshooting"]
-        A["First Diagnostic"]
-        B["Auth Errors"]
-        D["Timeouts"]
-        E["Conformance Failures"]
-    end
-
-    subgraph Execution["3. Execution & Verdict Plane"]
-        C["Egress / Network"]
-    end
-
-    %% Operational Flow Edges
-    Page --> A
-    A --> B
-    B --> C
-    C --> D
-    D --> E
-
-    %% Premium Styling Rules
-    style C fill:#3182ce,stroke:#2b6cb0,stroke-width:2px,color:#fff
-```
-
-
-Common issues and solutions for HELM.
-
----
-
-## First Diagnostic
-
-Run `helm-ai-kernel doctor --json` before deeper debugging when the CLI is installed but the runtime path is unclear. The doctor command checks local initialization, trust material, data directories, and common environment mistakes.
+Start with the local diagnostic:
 
 ```bash
 helm-ai-kernel doctor --json
 ```
 
----
+## No HELM Server
 
-## Auth Errors
-
-### `HELM_UNREACHABLE` in adapters
-
-The adapter cannot reach the HELM server.
+Check the local boundary:
 
 ```bash
-# Check HELM is running
 curl http://127.0.0.1:7714/healthz
-
-# Check the URL in your adapter config
 export HELM_URL=http://127.0.0.1:7714
 ```
 
-`helm-ai-kernel server` still defaults to `127.0.0.1:8080`. The public quickstart uses `helm-ai-kernel quickstart`, which defaults to `127.0.0.1:7714`.
-The separate `helm-ai-kernel server` health endpoint uses `HELM_HEALTH_PORT` or `8081`;
-`helm-ai-kernel health` checks that health endpoint, not the main API port.
+`helm-ai-kernel serve --policy` is the quickstart boundary. `helm-ai-kernel
+server` is the broader local API server and may use a different port.
 
-### `401 Unauthorized` from proxy
+## Unexpected DENY
 
-```bash
-# Set your upstream API key
-helm-ai-kernel proxy --upstream https://your-upstream.example/v1 --api-key $OPENAI_API_KEY
-
-# Or via environment
-export OPENAI_API_KEY=sk-...
-helm-ai-kernel proxy --upstream https://your-upstream.example/v1
-```
-
-For release smoke or customer-data-free debugging, use the local fixture instead:
+Read the receipt first:
 
 ```bash
-python3 scripts/launch/mock-openai-upstream.py --port 19090
-helm-ai-kernel proxy --upstream http://127.0.0.1:19090/v1
+helm-ai-kernel boundary records --json
+helm-ai-kernel mcp receipts --json
 ```
 
----
+Common causes:
 
-## Egress / Network
+- revoked approval
+- expired approval
+- unapproved tool
+- effect mismatch
+- schema drift
+- policy-forbidden action
 
-### Sandbox exec fails with "PREFLIGHT_DENIED"
+A definitive `DENY` should not be retried as if it were a network error.
 
-The sandbox provider's egress policy is too restrictive or the provider is not configured.
+## Unexpected ESCALATE
+
+Inspect pending escalations:
 
 ```bash
-# Check preflight details
-helm-ai-kernel sandbox exec --provider e2b --json -- echo test | jq .preflight
-
-# Ensure provider credentials
-export E2B_API_KEY=your-key
+helm-ai-kernel mcp pending --json
 ```
 
-### MCP server unreachable over HTTP/SSE
+`ESCALATE` means HELM blocked the action and wrote a receipt. Approve only the
+exact server, tool, effect, TTL, and reason you intend to allow, then rerun the
+original action.
 
 ```bash
-# Start with explicit transport
-helm-ai-kernel mcp serve --transport http --port 9100
-
-# Check firewall allows the port
-curl http://localhost:9100/mcp
+helm-ai-kernel mcp approve \
+  --server-id shell-mcp-server \
+  --tools "pwd,ls,cat" \
+  --ttl 15m \
+  --reason "read-only repo inspection for local dev"
 ```
 
----
+## Approval Did Not Work
 
-## Timeouts
-
-### Proxy request timeout
+Check scope:
 
 ```bash
-# Increase wallclock limit (default: 120s)
-helm-ai-kernel proxy --upstream http://127.0.0.1:19090/v1 --max-wallclock 300s
+helm-ai-kernel mcp receipts --json
 ```
 
-### Sandbox execution timeout
+Approvals do not resume a blocked action. They only affect the next evaluation.
+If the original action uses a different server, tool, schema, or effect, HELM
+must keep blocking it.
+
+## Proxy Has No Receipts
+
+Confirm the app is using HELM as the base URL:
 
 ```bash
-# Increase timeout (default: 30s)
-helm-ai-kernel sandbox exec --provider opensandbox --timeout 60s -- long-running-command
+export OPENAI_BASE_URL=http://127.0.0.1:9090/v1
 ```
 
----
-
-## Conformance Failures
-
-### `G0_JCS_CANONICALIZATION` fails
-
-JCS canonicalization requires valid JSON. Check your tool arguments:
+Then inspect receipts:
 
 ```bash
-echo '{"b":2,"a":1}' | jq -S .   # sorted keys
+helm-ai-kernel receipts tail \
+  --agent <agent-id> \
+  --server http://127.0.0.1:7714
 ```
 
-### `G1_PROOFGRAPH` fails
+A successful upstream response is not proof that the request crossed HELM.
 
-ProofGraph requires at least one receipt in the evidence directory:
+## Conformance Failure
+
+Run the public levels:
 
 ```bash
-ls data/evidence/   # Should contain .json receipt files
+helm-ai-kernel conform --level L1 --json
+helm-ai-kernel conform --level L2 --json
+helm-ai-kernel conform negative --json
 ```
 
-### `G2A_EVIDENCE_PACK` fails
-
-EvidencePack requires deterministic tar with epoch mtime:
-
-```bash
-# Export with HELM (ensures determinism)
-helm-ai-kernel export --evidence ./data/evidence --out evidence.tar
-
-# Verify
-helm-ai-kernel verify evidence.tar
-```
-
-### `helm-ai-kernel verify --online` fails but offline verification passes
-
-`--online` requires a reachable public proof API and matching ledger metadata in the pack.
-
-```bash
-export HELM_LEDGER_URL=https://mindburn.org/api/proof/verify
-helm-ai-kernel verify evidence.tar --online
-```
-
-If the pack has no public anchor, use offline verification or regenerate the pack from a release asset with public proof metadata.
-
-### `helm-ai-kernel receipts tail` does not print events
-
-Confirm the local boundary is running and that receipts are being emitted for the same agent id:
-
-```bash
-helm-ai-kernel serve --policy ./release.high_risk.v3.toml
-helm-ai-kernel receipts tail --agent agent.helm.demo --server http://127.0.0.1:7714
-```
-
-### release smoke fails locally
-
-Run `make release-smoke` from the repository root and inspect the first failing
-phase: reproducible binaries, SBOM JSON, OpenVEX JSON, or optional Cosign
-bundle verification. The command writes generated evidence under ignored
-release/build artifact paths, so rerun after fixing the source failure. Missing
-Cosign bundles are informational in local smoke runs unless
-`REQUIRE_COSIGN_BUNDLES=1` is set.
-
-### release asset staging fails in CI
-
-Run the same tag-shaped command locally:
-
-```bash
-GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v<version> RELEASE_ASSETS_DIR="$(mktemp -d)" make release-assets
-```
-
-If the failure reports a missing exact OpenVEX document, run `make vex` with the
-same tag-derived version. If it fails while verifying `evidence-pack.tar`, check
-that `helm-ai-kernel export --audit` preserved every file referenced by
-`00_INDEX.json`.
-
-### Kubernetes Helm validation uses the HELM AI Kernel CLI
-
-The local `helm` binary in this repository may be the HELM AI Kernel CLI, not the
-Kubernetes Helm v3 binary. Set `KUBE_HELM_CMD` to a Kubernetes Helm v3 binary or
-run `make helm-chart-smoke`, which uses the pinned containerized chart runner
-when needed.
-
----
-
-## Common Errors
-
-| Error                   | Cause                     | Fix                              |
-| ----------------------- | ------------------------- | -------------------------------- |
-| `DENY_TOOL_NOT_FOUND`   | Unknown tool URN          | Register tool in policy manifest |
-| `DENY_SCHEMA_MISMATCH`  | Args don't match schema   | Check tool argument types        |
-| `PROXY_ITERATION_LIMIT` | Too many tool call rounds | Increase `--max-iterations`      |
-| `PROXY_WALLCLOCK_LIMIT` | Session too long          | Increase `--max-wallclock`       |
-| `HELM_UNREACHABLE`      | Server down or wrong URL  | Check `helm-ai-kernel health`              |
-| `ESCALATE`              | Human approval or more evidence needed | Stop dispatch and complete the required approval/evidence path |
+If `L2` fails, inspect MCP quarantine state, schema pins, approval scope,
+revocation, expiry, and receipt emission.

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,144 +1,46 @@
 ---
-title: Verification
-last_reviewed: 2026-06-12
+title: Receipts
+last_reviewed: 2026-07-01
 ---
 
-# Verification
+# Receipts
 
-Verification proves a HELM AI Kernel EvidencePack, boundary record, release artifact, or optional signature bundle from source-owned material instead of prose.
+Every governed action should leave a local record. For public HELM, that record
+is the proof path: show what was proposed, what HELM decided, why it decided
+that, and where the receipt was written.
 
-## Audience
+## What Gets Written
 
-This page is for release consumers, security reviewers, and integration owners who need to verify HELM AI Kernel outputs without trusting a hosted service or marketing claim.
+For MCP and boundary decisions, HELM records:
 
-## Outcome
+- `decision_id`
+- verdict: `ALLOW`, `DENY`, or `ESCALATE`
+- reason code
+- server id, tool name, and effect scope when available
+- receipt path
+- approval hint for resolvable escalations
+- policy epoch and record hash
 
-You should be able to run local offline verification, distinguish release metadata from cryptographic evidence, and identify which release assets have enough material to verify before you execute or redistribute them.
+Approvals and revocations also write receipts. A later evaluation must fail
+closed when an approval is expired, revoked, or outside its server, tool, or
+effect scope.
 
-## Source Truth
+## Inspect Local Receipts
 
-- Public route: `verification`
-- Source document: `helm-ai-kernel/docs/VERIFICATION.md`
-- Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
-- Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
-- Validation: `make docs-coverage`, `make docs-truth`, and `npm run coverage:inventory` from `docs-platform`
-
-Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the inventory manifest points to code, schemas, tests, examples, or an owner doc that proves the claim.
-
-## Troubleshooting
-
-| Symptom | First check |
-| --- | --- |
-| Published output is stale or incomplete | Run `npm run helm-public:accuracy` in `docs-platform`, then check the source path and public manifest row for this page. |
-| A claim needs implementation backing | Check the Source Truth files above and update the implementation, manifest, source inventory, or page in the same change. |
-
-## Diagram
-
-This scheme maps the main sections of Verification in reading order.
-
-```mermaid
-flowchart TD
-    subgraph Execution["3. Execution & Verdict Plane"]
-        E["Run the Maintained Validation Targets"]
-    end
-
-    subgraph Ledger["4. Tamper-Evident Ledger Plane"]
-        Page["Verification"]
-        A["Offline Verification"]
-        B["Online Proof Check"]
-        C["Export and Verify"]
-        D["Release Asset Verification"]
-        F["Optional Cosign / VEX Verification"]
-    end
-
-    %% Operational Flow Edges
-    Page --> A
-    A --> B
-    B --> C
-    C --> D
-    D --> F
-    F --> E
-
-    %% Premium Styling Rules
-    style Page fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style A fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style B fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style C fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style D fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style F fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style E fill:#3182ce,stroke:#2b6cb0,stroke-width:2px,color:#fff
+```bash
+helm-ai-kernel mcp receipts --json
+helm-ai-kernel mcp pending --json
+helm-ai-kernel boundary records --json
 ```
 
+For a single workstation receipt:
 
-The verification path is local-first. `helm-ai-kernel verify <evidence-pack.tar|dir>`
-performs offline checks by default; `--online` is optional and only runs after
-offline checks pass.
+```bash
+helm-ai-kernel workstation verify-decision \
+  --receipt ~/.helm-ai-kernel/receipts/hooks/wpd_<decision>.json
+```
 
-Current source release target: `v0.5.18`:
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.18>. The
-release is complete only when the page attaches platform binaries,
-`SHA256SUMS.txt`, `sbom.json`, `v0.5.18.openvex.json`,
-`release-attestation.json`, `evidence-pack.tar`,
-`release.high_risk.v3.toml`, `sample-policy-material.tar`,
-`helm-ai-kernel-launchpad-data.tar`, `helm-ai-kernel.mcpb`,
-`helm-ai-kernel.rb`, `v0.5.18.json`, `version-status.json`, and matching
-`*.cosign.bundle` files for each primary asset.
-
-There is no public GitHub Release object for `v0.4.1`; use `v0.4.0` as the
-actual baseline when auditing the `v0.5.0` delta.
-
-## v0.5.18 Asset Contract
-
-The `v0.5.18` release is complete only when it attaches these primary assets:
-
-- `helm-ai-kernel-darwin-amd64`
-- `helm-ai-kernel-darwin-arm64`
-- `helm-ai-kernel-linux-amd64`
-- `helm-ai-kernel-linux-arm64`
-- `helm-ai-kernel-windows-amd64.exe`
-- `SHA256SUMS.txt`
-- `sbom.json`
-- `v0.5.18.openvex.json`
-- `release-attestation.json`
-- `evidence-pack.tar`
-- `release.high_risk.v3.toml`
-- `sample-policy-material.tar`
-- `helm-ai-kernel-launchpad-data.tar`
-- `helm-ai-kernel.mcpb`
-- `helm-ai-kernel.rb`
-
-`sample-policy-material.tar` must include both
-`release.high_risk.v3.toml` and
-`reference_packs/eu_ai_act_high_risk.v1.json`. The release workflow signs each
-primary asset, including `SHA256SUMS.txt`, with a matching
-`*.cosign.bundle`.
-
-If a release also attaches `helm-console-web-*` bundle artifacts, treat them as
-release packaging evidence only. They do not imply that Console source code,
-hosted Enterprise availability, or customer production access is published from
-this kernel repo.
-
-## EvidencePack Contents
-
-An EvidencePack is the portable verification bundle for a HELM-governed run or
-release path. A complete pack includes the indexed records needed to verify the
-decision chain without trusting the process that produced it:
-
-- prompts or request metadata when the surface records them for the run;
-- MCP tool calls, OpenAI-compatible proxy requests, policy decisions, and
-  outcomes that crossed the HELM boundary;
-- receipt bytes, receipt IDs, decision IDs, output hashes, and reason codes;
-- ProofGraph or boundary record roots that bind the decision path;
-- signature material and native seal metadata when the pack has been sealed;
-- optional external anchor and storage receipts for customer or
-  high-assurance profiles.
-
-The verifier checks the archive or directory shape, the indexed file hashes,
-the receipt material, root hashes, and available signatures. A demo receipt is
-not automatically a complete EvidencePack; use a pack produced by export,
-LaunchKit, release artifacts, or an operator-controlled evidence workflow.
-
-## Offline Verification
+For an EvidencePack:
 
 ```bash
 helm-ai-kernel verify evidence-pack.tar
@@ -150,243 +52,49 @@ Compatibility form:
 helm-ai-kernel verify --bundle evidence-pack.tar
 ```
 
-Successful compact output includes the envelope id, signature count, anchor state, and sealed timestamp when those fields are embedded in the pack. If no anchor is embedded, the CLI reports `anchor offline`; it does not invent an anchor.
+Offline verification is the default. If a pack has no public anchor, HELM
+reports that directly; it does not invent one.
 
-Native EvidencePack seals live at
-`07_ATTESTATIONS/evidence_pack.sig`. The old `00_SEAL.json` plan is not a
-customer-facing verification contract. Customer and high-assurance profiles
-must verify the native seal signature, a trusted external signer key, an
-external Rekor or RFC3161 anchor receipt, and an S3 Object Lock storage receipt
-with active COMPLIANCE retention:
+## Read A Decision
 
-```bash
-helm-ai-kernel trust init --config helm/helm.yaml \
-  --profile customer \
-  --signer kms \
-  --anchor rekor \
-  --store s3 \
-  --object-lock
+Start with these fields:
 
-helm-ai-kernel verify --bundle evidence-pack.tar \
-  --profile customer \
-  --storage-receipt evidence-pack.tar.storage.json
-```
-
-The storage receipt must identify the bucket, key, object version, object hash,
-retention mode, and `retain_until` timestamp. When verification runs against a
-tar archive, the verifier compares the receipt object hash with the local
-archive bytes.
-
-## Receipt Tail Output
-
-Use `receipts tail` while an integration is running to prove the request crossed
-the HELM boundary:
-
-```bash
-helm-ai-kernel receipts tail --agent agent.demo.exec --server http://127.0.0.1:7714
-```
-
-The command prints durable receipt events for the selected agent. In compact
-output, the fields to read first are:
-
-| Field | What it tells the operator |
+| Field | Meaning |
 | --- | --- |
-| `receipt_id` | The durable receipt to cite in an issue, audit note, or EvidencePack |
-| `decision_id` | The policy decision that produced the receipt |
-| `verdict` or `status` | `ALLOW`, `DENY`, `ESCALATE`, or proxy status such as `DENIED` |
-| `reason_code` | Why the boundary allowed, denied, or escalated the effect |
-| `output_hash` | The hash that binds the governed result or denial body |
-| `signature` | Receipt-level signature material; absence means the event is not audit-ready |
+| `decision_id` | The decision to cite when debugging or rerunning |
+| `verdict` | `ALLOW`, `DENY`, or `ESCALATE` |
+| `reason_code` | Why the boundary returned that verdict |
+| `receipt_path` | Local file written for the decision |
+| `approval_command` | Scoped command to run when the verdict is `ESCALATE` |
+| `record_hash` | Tamper-evidence handle for the boundary record |
 
-For a denied shell or proxy tool-call test, the receipt should show a deny
-status/reason and the effect should not be dispatched. That receipt is the
-operator-facing handle that later appears inside the EvidencePack.
+An `ESCALATE` receipt is not permission to continue. Approve the exact scope,
+then rerun the original action so HELM evaluates it again.
 
-The CLI requires `--agent`; use the HTTP list route when a local unfiltered
-view is more useful during a quickstart:
+## Export Evidence
 
-```bash
-curl 'http://127.0.0.1:7714/api/v1/receipts?limit=20'
-```
-
-## EvidencePack Verify Output
-
-Use offline verification for archives:
+Use an EvidencePack when you need to move proof material between machines or
+review it later:
 
 ```bash
+helm-ai-kernel evidence export \
+  --receipts ~/.helm-ai-kernel/receipts \
+  --out evidence-pack.tar
+
 helm-ai-kernel verify evidence-pack.tar
 ```
 
-The command succeeds only after the verifier has checked the archive/index
-shape, content hashes, required receipt material, root hash, and available
-signatures. A passing dev-local pack may report `anchor offline`; that means no
-external timestamp/transparency anchor was embedded, not that verification was
-skipped. Customer/high-assurance packs should additionally report a trusted seal
-signer, external anchor, and storage receipt verification when those inputs are
-provided.
+EvidencePacks are portable proof bundles. They are not compliance
+certifications, hosted availability claims, or buyer rollout evidence.
 
-## Online Proof Check
+## Release Evidence
 
-```bash
-helm-ai-kernel verify evidence-pack.tar --online
-```
+Current source release target: `v0.5.18`.
 
-`--online` posts envelope/root metadata to `HELM_LEDGER_URL` or `https://mindburn.org/api/proof/verify`. Public proof verification is additive and must never use fixture-backed positive proof.
+The `v0.5.18` release is complete when the GitHub release and local verification
+artifacts agree:
 
-## Export and Verify
-
-```bash
-helm-ai-kernel export --evidence ./data/evidence --out evidence.tar
-helm-ai-kernel verify evidence.tar
-```
-
-Audit exports preserve every file listed by `00_INDEX.json`, including
-top-level sidecars such as `01_SCORE.json.sha256`. Verification fails when an
-indexed file is missing or the exported archive contains an unexpected
-canonical top-level entry.
-
-## Local Tamper-Failure Demo
-
-The launch proof demo exercises the public verification path without external
-network calls:
-
-```bash
-./scripts/launch/demo-proof.sh
-```
-
-The script starts a localhost HELM boundary, creates a signed `DENY` receipt
-for the dangerous shell fixture, verifies the receipt through `/api/demo/verify`,
-then flips the verdict through `/api/demo/tamper`. The original receipt must
-verify, and the tamper attempt must fail signature and ProofGraph hash checks.
-
-## Boundary Records, Checkpoints, and Envelopes
-
-The execution-boundary verifier checks HELM-native records first. External envelopes are wrappers over HELM roots, not independent authority.
-
-```bash
-helm-ai-kernel boundary records --json
-helm-ai-kernel boundary checkpoint --create --receipt-count 1 --json
-helm-ai-kernel boundary verify boundary-record-bootstrap --json
-helm-ai-kernel evidence envelope create --envelope dsse --native-hash sha256:evidence --manifest-id demo --json
-helm-ai-kernel evidence envelope verify --manifest-id demo --json
-```
-
-For API-backed verification, use:
-
-```text
-POST /api/v1/boundary/records/{record_id}/verify
-POST /api/v1/evidence/envelopes/{manifest_id}/verify
-POST /api/v1/evidence/verify
-POST /api/v1/replay/verify
-```
-
-## Release Asset Verification
-
-Download the binary and `SHA256SUMS.txt` from the same GitHub release, then
-check the digest before executing the binary:
-
-```bash
-shasum -a 256 -c SHA256SUMS.txt --ignore-missing
-```
-
-Inspect the release metadata and SBOM:
-
-```bash
-jq . release-attestation.json
-jq . sbom.json
-```
-
-`release-attestation.json` in `v0.4.0` is release metadata. Treat it as
-descriptive unless a release also provides a cryptographically verifiable
-provenance predicate and a documented verifier command.
-
-Verify the bundled offline evidence pack:
-
-```bash
-helm-ai-kernel verify evidence-pack.tar
-```
-
-The release staging path runs the same offline verification before publishing
-release checksums. If this step fails, the release must be treated as incomplete
-and the exported EvidencePack must be repaired before attaching assets.
-
-For `v0.5.10`, this command passes without network access. The verifier
-accepts both the legacy `receipts/` layout and the canonical
-`02_PROOFGRAPH/receipts/` layout.
-
-For `v0.4.0`, the included EvidencePack also verifies offline and reports
-`anchor offline`, but that release does not attach OpenVEX or Cosign bundles.
-
-## Cosign Artifact Verification When Bundles Are Attached
-
-> [!NOTE]
-> Early draft/development releases before the `v0.5.9` release target did not
-> complete the current Cosign OIDC and SLSA provenance release contract. As a
-> result, those legacy assets must not be treated as having associated
-> `*.cosign.bundle` or provenance files unless those files are attached to the
-> release. A completed `v0.5.9` or later public release must ship the matching
-> signature bundles and attestation metadata described here.
-
-Cosign verification requires a matching `*.cosign.bundle` file attached to the
-release. When a release includes those files, verify a downloaded binary blob
-with the bundled signature:
-
-```bash
-cosign verify-blob \
-  --bundle helm-ai-kernel-linux-amd64.cosign.bundle \
-  --certificate-identity-regexp "https://github.com/Mindburn-Labs/helm-ai-kernel" \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  helm-ai-kernel-linux-amd64
-```
-
-Verify the published container image when one is published for the release:
-
-```bash
-cosign verify \
-  --certificate-identity-regexp "Mindburn-Labs/helm-ai-kernel" \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/mindburn-labs/helm-ai-kernel:<version>
-```
-
-Verify every artifact in a downloaded release directory in one command when the
-directory contains matching `*.cosign.bundle` files:
-
-```bash
-bash scripts/release/verify_cosign.sh ./downloaded-release/
-```
-
-The script walks the directory, finds every `*.cosign.bundle`, and runs
-`cosign verify-blob` against the matching artifact. A run with zero bundle
-files proves no signature coverage; check that bundles exist before treating
-Cosign as part of the release evidence. The `make verify-cosign` target runs
-the same script against `dist/`. If the release has no bundle assets, use
-checksum, SBOM, release metadata, offline EvidencePack, and reproducible-build
-verification instead.
-
-### VEX Consumption When A VEX File Is Attached
-
-The repository retains OpenVEX policy source under `release/vex/`. When a
-release attaches an OpenVEX file next to the SBOM, filter scanner output
-through the published VEX statements:
-
-```bash
-vexctl filter --vex release/vex/v<version>.openvex.json sbom.json
-```
-
-CVEs marked `not_affected` in the VEX are removed from the scan output;
-`under_investigation` and `affected` entries pass through unchanged so
-the scanner can still surface them.
-
-## Run the Maintained Validation Targets
-
-```bash
-make test
-make test-platform
-make test-all
-make crucible
-make launch-smoke
-make sdk-openapi-check
-make sdk-examples-smoke
-make launch-ready
-make release-smoke
-```
+- release: `https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.18`
+- v0.5.18 Asset Contract
+- `v0.5.18.openvex.json`
+- `v0.5.18.json`

--- a/docs/architecture/policy-languages.md
+++ b/docs/architecture/policy-languages.md
@@ -1,189 +1,72 @@
 ---
-title: Policy Languages — CEL, Rego, Cedar
-last_reviewed: 2026-05-05
+title: Write Policies
+last_reviewed: 2026-07-01
 ---
 
-# Policy Languages — CEL, Rego, Cedar
+# Write Policies
 
-## Audience
+Policies decide whether a proposed action becomes `ALLOW`, `DENY`, or
+`ESCALATE`. Public HELM supports CEL, Rego, and Cedar inputs through one
+normalized decision boundary.
 
-Policy authors and runtime maintainers comparing supported policy-language inputs with current enforcement behavior.
+## Choose A Language
 
-## Outcome
+| Use case | Start with |
+| --- | --- |
+| Small attribute rules | CEL |
+| Existing OPA/Rego practice | Rego |
+| Entity and role relationships | Cedar |
 
-After this page you should know what this surface is for, which source files own the behavior, which public route or adjacent page to use next, and which validation command to run before changing the claim.
+All three paths must produce the same kind of verdict envelope.
 
-## Source Truth
-
-- Public route: `architecture/policy-languages`
-- Source document: `helm-ai-kernel/docs/architecture/policy-languages.md`
-- Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
-- Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
-- Validation: `make docs-coverage`, `make docs-truth`, and `npm run coverage:inventory` from `docs-platform`
-
-Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the inventory manifest points to code, schemas, tests, examples, or an owner doc that proves the claim.
-
-helm-ai-kernel accepts policy sources written in three languages and routes
-them through one enforcement boundary. The kernel never branches on
-language at decision time; only the multi-language registry in
-[`core/pkg/policybundles/registry.go`](../../core/pkg/policybundles/registry.go)
-does, and only at compile/load.
-
-## CEL — historical baseline
-
-[Common Expression Language](https://github.com/google/cel-spec). Single
-expression returning a verdict envelope. Carried via the existing
-`core/pkg/celcheck/` and `core/pkg/policybundles/builtin.go` pipeline.
-
-- Inputs: `request.action`, `request.principal.roles`, `request.context`.
-- Strengths: fastest evaluation, smallest dependency footprint, best
-  fit for attribute-mostly rules.
-- Weaknesses: limited control flow; nested ternaries get unwieldy.
-- Example: [`examples/policies/cel/example.cel`](../../examples/policies/cel/example.cel).
-
-## OPA / Rego — procurement standard
-
-[Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) via
-[`core/pkg/policybundles/rego/`](../../core/pkg/policybundles/rego/).
-
-- Inputs: top-level `input` document.
-- Strengths: rich set semantics, partial evaluation, mature ecosystem.
-- Determinism guard:
-  [`core/pkg/policybundles/rego/capabilities.json`](../../core/pkg/policybundles/rego/capabilities.json)
-  forbids `http.send`, `time.now_ns`, `rand.intn`, and
-  `crypto.x509.parse_certificates`.
-- Example: [`examples/policies/rego/example.rego`](../../examples/policies/rego/example.rego).
-
-## Cedar — entity-shape model
-
-[Cedar](https://docs.cedarpolicy.com) via
-[`core/pkg/policybundles/cedar/`](../../core/pkg/policybundles/cedar/).
-
-- Inputs: principal/action/resource as `EntityUID` (`Type::"id"`); an
-  optional entities document declares parent chains for the `in`
-  operator.
-- Strengths: explicit entity types, native role/group reasoning, AWS
-  Verified Permissions interop.
-- Example:
-  [`examples/policies/cedar/example.cedar`](../../examples/policies/cedar/example.cedar)
-  with companion entities at
-  [`examples/policies/cedar/entities.json`](../../examples/policies/cedar/entities.json).
-
-## Side-by-side: same logical rule
-
-*Anyone may view; only admins may delete; default deny.*
+## CEL
 
 ```cel
 request.action == "view"
   ? {"verdict": "ALLOW"}
-  : (request.action == "delete" && ("admin" in request.principal.roles)
-       ? {"verdict": "ALLOW"}
-       : {"verdict": "DENY"})
+  : {"verdict": "DENY"}
 ```
+
+CEL is the smallest path for attribute checks. Keep rules direct; avoid nested
+policy logic that is hard to review.
+
+## Rego
 
 ```rego
 package helm.policy
 import rego.v1
 
 default decision := {"verdict": "DENY"}
-decision := {"verdict": "ALLOW"} if { input.action == "view" }
 decision := {"verdict": "ALLOW"} if {
-  input.action == "delete"
-  "admin" in input.principal.roles
+  input.action == "view"
 }
 ```
 
+Rego is useful when your team already uses OPA or set-based rules. HELM uses a
+restricted capability set for deterministic evaluation.
+
+## Cedar
+
 ```cedar
 permit(principal, action == Action::"view", resource);
-permit(principal, action == Action::"delete", resource)
-when { principal in Role::"admin" };
 ```
 
-A regression test under `tests/conformance/policy-langs/` (Workstream
-F1) will assert byte-identical decisions across all three on a
-50-policy reference suite.
+Cedar is useful for entity-shaped authorization where principals, actions, and
+resources have explicit types.
 
-## Edge-case behavior
+## Determinism Rules
 
-| Edge case | CEL | Rego | Cedar |
-| --- | --- | --- | --- |
-| Negation of undefined | undefined propagates | `not` is well-defined | requires explicit guards |
-| Set membership on missing list | error / `false` | empty set | `in` returns `false` |
-| Numeric overflow | int64 wraps | bignum-correct | int64 wraps |
-| Role / group reasoning | flat `in roles` | set semantics + virtual docs | parent-chain via entities |
-| Time predicates | `request.now()` injected | `time.now_ns` forbidden; use `input.now` | supply `context.now` |
-| Recursion | not allowed | partial-eval supported | not allowed |
+Policy evaluation does not read the network, filesystem, environment, random
+numbers, or system clock directly. The kernel injects request data and time so
+the same input can be verified later.
 
-## Non-determinism rules (uniform)
+## Build And Test
 
-Across all three languages, helm-ai-kernel enforces:
-
-- No network I/O during evaluation.
-- No random number generation.
-- No system clock reads; the kernel injects `now`.
-- No filesystem reads.
-- No environment-variable reads.
-
-Rego uses OPA's capabilities file. CEL uses the curated function set in
-`core/pkg/celcheck/`. Cedar's spec excludes these operations natively.
-
-## Choose your lane
-
-| You want | Pick |
-| --- | --- |
-| Smallest footprint, fastest eval, attribute-mostly rules | **CEL** |
-| Procurement-team-already-on-OPA, rich set semantics | **Rego** |
-| Entity-rich auth, AWS Verified Permissions interop | **Cedar** |
-
-Bundle manifests carry `language: cel | rego | cedar`. The kernel loads
-+ dispatches via
-[`core/pkg/policybundles/registry.go`](../../core/pkg/policybundles/registry.go).
-The `helm-ai-kernel bundle build` subcommand auto-detects from file extension when
-`--language` is omitted.
-
-## See also
-
-- [`core/pkg/policybundles/registry.go`](../../core/pkg/policybundles/registry.go) — language dispatch
-- [Conformance Profile v1](../CONFORMANCE.md) — required behavior across implementations
-- [Verification](../VERIFICATION.md) — verifying a built bundle's hash
-
-## Troubleshooting
-
-| Symptom | First check |
-| --- | --- |
-| Published output is stale or incomplete | Run `npm run helm-public:accuracy` in `docs-platform`, then check the source path and public manifest row for this page. |
-| A claim needs implementation backing | Check the Source Truth files above and update the implementation, manifest, source inventory, or page in the same change. |
-
-## Diagram
-
-```mermaid
-flowchart TD
-    subgraph Ingestion["1. Ingestion & Context Plane"]
-        cel["CEL"]
-        rego["Rego"]
-        cedar["Cedar"]
-    end
-
-    subgraph Evaluation["2. Evaluation & Policy Plane"]
-        input["Canonical policy input"]
-        decision["Normalized decision"]
-    end
-
-    subgraph Ledger["4. Tamper-Evident Ledger Plane"]
-        receipt["Signed receipt"]
-    end
-
-    %% Operational Flow Edges
-    input --> cel
-    input --> rego
-    input --> cedar
-    cel --> decision
-    rego --> decision
-    cedar --> decision
-    decision --> receipt
-
-    %% Premium Styling Rules
-    style input fill:#2d3748,stroke:#4a5568,stroke-width:2px,color:#fff
-    style decision fill:#2d3748,stroke:#4a5568,stroke-width:2px,color:#fff
-    style receipt fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
+```bash
+helm-ai-kernel bundle build --policy ./policy.cel --out ./policy.bundle
+helm-ai-kernel evaluate --bundle ./policy.bundle --input ./request.json
+helm-ai-kernel conform --level L1 --json
 ```
+
+Use `DENY` for unsafe or mismatched actions. Use `ESCALATE` only when a
+developer can resolve the block with a local scoped approval.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,93 +1,47 @@
 ---
-title: HELM AI Kernel
+title: HELM documentation
 last_reviewed: 2026-07-01
 ---
 
-# HELM AI Kernel
+# HELM documentation
 
-HELM is a local execution firewall for AI agents. Start with a denied-action
-proof, then choose an integration or reference path. A governed action returns
-`ALLOW`, `DENY`, or `ESCALATE` and leaves signed evidence that can be verified
-later.
+Block unsafe AI-agent actions before they run.
+
+HELM sits between an agent and a tool call:
+
+```text
+agent/tool requests action
+-> HELM evaluates before dispatch
+-> ALLOW: action runs
+-> DENY: action is blocked
+-> ESCALATE: action is blocked and a decision receipt is written
+```
+
+Run the local proof:
+
+```bash
+helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
+```
+
+The proof writes a local EvidencePack with no dispatched side effects. It
+includes quarantined MCP servers, schema drift, missing approval receipts, and
+replay attempts.
 
 ## Start
 
-| Goal | Start here |
-| --- | --- |
-| Protect a local coding agent | [Quickstart](QUICKSTART.md) |
-| Understand the local proof path | [How HELM works](HOW_HELM_WORKS.md) |
-| Scan an agent before enforcement | [Agent Risk Scan](reference/agent-risk-scan.md) |
-| Install the CLI | [Installation](DEVELOPER_JOURNEY.md#install) |
-| Call the HTTP API | [API introduction](reference/http-api.md) |
-| Use an SDK | [SDKs](sdks/00_INDEX.md) |
-| Route MCP tools | [MCP integration](INTEGRATIONS/mcp.md) |
-| Use an OpenAI-compatible base URL | [OpenAI-compatible proxy](INTEGRATIONS/openai_baseurl.md) |
+- [Quickstart](QUICKSTART.md)
+- [Protect local coding agents](quickstart/workstation-governance.md)
+- [OpenAI proxy](INTEGRATIONS/openai_baseurl.md)
+- [MCP](INTEGRATIONS/mcp.md)
 
-## First Command
+## Verify
 
-```bash
-helm-ai-kernel setup codex --yes
-```
-
-For Claude Code:
-
-```bash
-helm-ai-kernel setup claude-code --yes
-```
-
-Both commands keep the proof local. They write draft policy material, configure
-the supported client integration, start the local Kernel path, and leave signed
-receipts for blocked actions.
-
-## Main Paths
-
-- [Quickstart](QUICKSTART.md) - first local denial and receipt verification.
-- [Agent Risk Scan](reference/agent-risk-scan.md) - local-first scan,
-  anonymized risk envelope, and EvidencePack path.
-- [Developer journey](DEVELOPER_JOURNEY.md) - choose the next path after the
-  first proof.
-- [Claude Code](INTEGRATIONS/claude-code.md) - one-command setup, status,
-  remove, and receipt verification.
-- [Codex](INTEGRATIONS/codex.md) - user or project-scoped setup for Codex.
-- [MCP tools](INTEGRATIONS/mcp.md) - wrap, quarantine, approve, and inspect MCP
-  tool calls.
-- [OpenAI-compatible proxy](INTEGRATIONS/openai_baseurl.md) - keep an
-  OpenAI-shaped client while moving enforcement into HELM.
-- [Verification](VERIFICATION.md) - verify receipts and EvidencePacks offline.
-- [Troubleshooting](TROUBLESHOOTING.md) - diagnose setup, ports, receipts, and
-  policy behavior.
-
-## Capabilities
-
-| Capability | What to read |
-| --- | --- |
-| Fail-closed execution | [Execution security model](EXECUTION_SECURITY_MODEL.md) |
-| MCP quarantine | [MCP tool quarantine](use-cases/mcp-execution-firewall.md) |
-| Signed receipts | [Signed receipts](capabilities/signed-receipts.md) |
-| EvidencePack verification | [EvidencePack verification](capabilities/evidencepack-verification.md) |
-| Agent Risk Scan | [Agent Risk Scan](reference/agent-risk-scan.md) |
-| Policy bundles | [Policy bundles](capabilities/policy-bundles.md) |
-| OpenAI-compatible proxy | [Proxy integration](INTEGRATIONS/openai_baseurl.md) |
+- [Receipts and EvidencePacks](VERIFICATION.md)
+- [Conformance](CONFORMANCE.md)
+- [Troubleshooting](TROUBLESHOOTING.md)
 
 ## Reference
 
-- [CLI reference](reference/cli.md)
-- [HTTP API reference](reference/http-api.md)
+- [CLI](reference/cli.md)
+- [HTTP API](reference/http-api.md)
 - [SDKs](sdks/00_INDEX.md)
-- [JSON schemas](reference/json-schemas.md)
-- [Protocols and schemas](reference/protocols-and-schemas.md)
-- [Compatibility](COMPATIBILITY.md)
-- [Publishing](PUBLISHING.md)
-
-## Public Boundary
-
-The public docs describe HELM AI Kernel only. They do not claim hosted
-Enterprise availability, buyer rollout, regulatory certification, paid account
-activation, or broad operating-system control.
-
-## Source Truth
-
-This site is built from source-owned docs in this repository. Runtime behavior
-is owned by `core/`, `api/openapi/helm.openapi.yaml`, SDK README files,
-examples, and verification tests. If a public claim cannot be tied to those
-sources, remove it or qualify it.

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "repo": "helm-ai-kernel",
   "local_repo_path": "helm-ai-kernel",
-  "display_name": "HELM AI Kernel",
+  "display_name": "HELM AI Kernel Public Docs",
   "docs_origin": {
     "canonical_host": "helm.docs.mindburn.org",
     "source_repo": "Mindburn-Labs/helm-ai-kernel",
@@ -11,8 +11,8 @@
   "documents": [
     {
       "slug": "index",
-      "title": "HELM AI Kernel",
-      "section": "helm-ai-kernel",
+      "title": "HELM documentation",
+      "section": "guide",
       "source_path": "docs/index.md",
       "docs_origin_hint": "helm.docs.mindburn.org",
       "access": "public",
@@ -21,18 +21,108 @@
     {
       "slug": "quickstart",
       "title": "Quickstart",
-      "section": "start-here",
+      "section": "guide",
       "source_path": "docs/QUICKSTART.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
+      "docs_origin_hint": "helm.docs.mindburn.org/quickstart",
       "access": "public",
       "sensitivity": "public"
     },
     {
       "slug": "guides/protect-local-coding-agents",
       "title": "Protect Local Coding Agents",
-      "section": "start-here",
+      "section": "guide",
       "source_path": "docs/quickstart/workstation-governance.md",
       "docs_origin_hint": "helm.docs.mindburn.org/guides/protect-local-coding-agents",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "how-helm-works",
+      "title": "How HELM Works",
+      "section": "guide",
+      "source_path": "docs/HOW_HELM_WORKS.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/how-helm-works",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "integrations/openai-compatible-proxy",
+      "title": "OpenAI Proxy",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/openai_baseurl.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/openai-compatible-proxy",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "integrations/mcp",
+      "title": "MCP",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/mcp.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/mcp",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "guides/write-policies",
+      "title": "Write Policies",
+      "section": "guide",
+      "source_path": "docs/architecture/policy-languages.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/guides/write-policies",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "verification",
+      "title": "Receipts",
+      "section": "verify",
+      "source_path": "docs/VERIFICATION.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/verification",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "conformance",
+      "title": "Conformance",
+      "section": "verify",
+      "source_path": "docs/CONFORMANCE.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/conformance",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "troubleshooting",
+      "title": "Troubleshooting",
+      "section": "verify",
+      "source_path": "docs/TROUBLESHOOTING.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/troubleshooting",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "reference/cli",
+      "title": "CLI",
+      "section": "reference",
+      "source_path": "docs/reference/cli.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/cli",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "reference/http-api",
+      "title": "HTTP API",
+      "section": "reference",
+      "source_path": "docs/reference/http-api.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/http-api",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "sdks",
+      "title": "SDKs",
+      "section": "reference",
+      "source_path": "docs/sdks/00_INDEX.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/sdks",
       "access": "public",
       "sensitivity": "public"
     },
@@ -51,618 +141,6 @@
       "section": "supporting-material",
       "source_path": "docs/PUBLICATION_POLICY.md",
       "docs_origin_hint": "helm.docs.mindburn.org/publication-policy",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "how-helm-works",
-      "title": "How HELM Works",
-      "section": "concepts",
-      "source_path": "docs/HOW_HELM_WORKS.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/how-helm-works",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "developer-journey",
-      "title": "Developer Journey",
-      "section": "start-here",
-      "source_path": "docs/DEVELOPER_JOURNEY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/developer-journey",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "guides/govern-mcp-tools",
-      "title": "Govern MCP Tools",
-      "section": "guides",
-      "source_path": "docs/guides/govern-mcp-tools.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/guides/govern-mcp-tools",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "guides/use-openai-compatible-proxy",
-      "title": "Use The OpenAI-Compatible Proxy",
-      "section": "guides",
-      "source_path": "docs/guides/use-openai-compatible-proxy.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/guides/use-openai-compatible-proxy",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "guides/export-verify-evidencepacks",
-      "title": "Export And Verify EvidencePacks",
-      "section": "guides",
-      "source_path": "docs/guides/export-verify-evidencepacks.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/guides/export-verify-evidencepacks",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "capabilities/signed-receipts",
-      "title": "Signed Receipts",
-      "section": "capabilities",
-      "source_path": "docs/capabilities/signed-receipts.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/capabilities/signed-receipts",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "capabilities/evidencepack-verification",
-      "title": "EvidencePack Verification",
-      "section": "capabilities",
-      "source_path": "docs/capabilities/evidencepack-verification.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/capabilities/evidencepack-verification",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "capabilities/policy-bundles",
-      "title": "Policy Bundles",
-      "section": "capabilities",
-      "source_path": "docs/capabilities/policy-bundles.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/capabilities/policy-bundles",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "community",
-      "title": "Community",
-      "section": "start-here",
-      "source_path": "COMMUNITY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/community",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "ecosystem",
-      "title": "Ecosystem",
-      "section": "start-here",
-      "source_path": "docs/ECOSYSTEM.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/ecosystem",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "use-cases/mcp-execution-firewall",
-      "title": "MCP Tool Quarantine",
-      "section": "use-cases",
-      "source_path": "docs/use-cases/mcp-execution-firewall.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/mcp-execution-firewall",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "use-cases/ai-agent-security",
-      "title": "AI Agent Security",
-      "section": "use-cases",
-      "source_path": "docs/use-cases/ai-agent-security.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/ai-agent-security",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "use-cases/openai-compatible-ai-gateway-policy",
-      "title": "OpenAI-Compatible Execution Boundary",
-      "section": "use-cases",
-      "source_path": "docs/use-cases/openai-compatible-ai-gateway-policy.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/openai-compatible-ai-gateway-policy",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "use-cases/llm-audit-receipts",
-      "title": "Signed Receipts for AI Agent Actions",
-      "section": "use-cases",
-      "source_path": "docs/use-cases/llm-audit-receipts.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/llm-audit-receipts",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "use-cases/agent-tool-call-governance",
-      "title": "AI Agent Side-Effect Governance",
-      "section": "use-cases",
-      "source_path": "docs/use-cases/agent-tool-call-governance.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/use-cases/agent-tool-call-governance",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "posts/why-ai-agents-need-an-execution-firewall",
-      "title": "Why AI Agents Need an Execution Firewall",
-      "section": "posts",
-      "source_path": "docs/posts/why-ai-agents-need-an-execution-firewall.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/posts/why-ai-agents-need-an-execution-firewall",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "posts/mcp-quarantine-before-tool-dispatch",
-      "title": "MCP Quarantine Before Tool Dispatch",
-      "section": "posts",
-      "source_path": "docs/posts/mcp-quarantine-before-tool-dispatch.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/posts/mcp-quarantine-before-tool-dispatch",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "posts/receipts-beat-logs-for-agent-audit-trails",
-      "title": "Receipts Beat Logs for Agent Audit Trails",
-      "section": "posts",
-      "source_path": "docs/posts/receipts-beat-logs-for-agent-audit-trails.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/posts/receipts-beat-logs-for-agent-audit-trails",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "posts/how-to-fail-closed-on-agent-tool-calls",
-      "title": "How To Fail Closed on Agent Tool Calls",
-      "section": "posts",
-      "source_path": "docs/posts/how-to-fail-closed-on-agent-tool-calls.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/posts/how-to-fail-closed-on-agent-tool-calls",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "architecture",
-      "title": "Architecture",
-      "section": "start-here",
-      "source_path": "docs/ARCHITECTURE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "architecture/canonical-diagrams",
-      "title": "Canonical Diagrams",
-      "section": "architecture",
-      "source_path": "docs/architecture/canonical-diagrams.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/architecture/canonical-diagrams",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "conformance",
-      "title": "Conformance",
-      "section": "start-here",
-      "source_path": "docs/CONFORMANCE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "launchpad",
-      "title": "Launchpad",
-      "section": "start-here",
-      "source_path": "docs/LAUNCHPAD.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/launchpad",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "launchpad/apps/openclaw",
-      "title": "OpenClaw on HELM",
-      "section": "start-here",
-      "source_path": "docs/launchpad/apps/OPENCLAW.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/openclaw",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "launchpad/apps/hermes",
-      "title": "Hermes on HELM",
-      "section": "start-here",
-      "source_path": "docs/launchpad/apps/HERMES.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/hermes",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "launchpad/apps/opencode",
-      "title": "OpenCode on HELM",
-      "section": "start-here",
-      "source_path": "docs/launchpad/apps/OPENCODE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/opencode",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "launchpad/apps/kilocode",
-      "title": "Kilo Code on HELM",
-      "section": "start-here",
-      "source_path": "docs/launchpad/apps/KILOCODE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/apps/kilocode",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "skills/flow-catalog",
-      "title": "Skill Packs Flow Catalog",
-      "section": "interfaces",
-      "source_path": "docs/skills/FLOW_CATALOG.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/skills/flow-catalog",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "launchpad/flow-catalog",
-      "title": "Launchpad Flow Catalog",
-      "section": "interfaces",
-      "source_path": "docs/launchpad/FLOW_CATALOG.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/launchpad/flow-catalog",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "verification",
-      "title": "Verification",
-      "section": "start-here",
-      "source_path": "docs/VERIFICATION.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "compatibility",
-      "title": "Compatibility",
-      "section": "start-here",
-      "source_path": "docs/COMPATIBILITY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "publishing",
-      "title": "Publishing",
-      "section": "start-here",
-      "source_path": "docs/PUBLISHING.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "changelog",
-      "title": "HELM AI Kernel Changelog",
-      "section": "helm-ai-kernel",
-      "source_path": "CHANGELOG.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/changelog",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "execution-security-model",
-      "title": "Execution Security Model",
-      "section": "interfaces",
-      "source_path": "docs/EXECUTION_SECURITY_MODEL.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "owasp-mcp-threat-mapping",
-      "title": "OWASP MCP Threat Mapping",
-      "section": "interfaces",
-      "source_path": "docs/OWASP_MCP_THREAT_MAPPING.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "sdks",
-      "title": "SDK Index",
-      "section": "interfaces",
-      "source_path": "docs/sdks/00_INDEX.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "troubleshooting",
-      "title": "Troubleshooting",
-      "section": "supporting-material",
-      "source_path": "docs/TROUBLESHOOTING.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/openai-compatible-proxy",
-      "title": "OpenAI-Compatible Proxy Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/openai_baseurl.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/claude-code",
-      "title": "Claude Code Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/claude-code.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/integrations/claude-code",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/codex",
-      "title": "Codex Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/codex.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/integrations/codex",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/cursor",
-      "title": "Cursor Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/cursor.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/integrations/cursor",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/vscode",
-      "title": "VS Code Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/vscode.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/integrations/vscode",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/windsurf",
-      "title": "Windsurf Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/windsurf.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/integrations/windsurf",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/mcp",
-      "title": "MCP Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/mcp.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/codebase-memory-mcp",
-      "title": "Codebase Memory MCP Integration",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/codebase_memory_mcp.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "integrations/microsoft-agent-governance-toolkit",
-      "title": "Microsoft Agent Governance Toolkit Coexistence",
-      "section": "integrations",
-      "source_path": "docs/INTEGRATIONS/microsoft_agent_governance_toolkit.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "security/owasp-agentic-top10-mapping",
-      "title": "OWASP Agentic Top 10 Mapping",
-      "section": "security",
-      "source_path": "docs/security/owasp-agentic-top10-coverage.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "security/prompt-injection-watchlist-2026-04",
-      "title": "Prompt Injection Watchlist - April 2026",
-      "section": "security",
-      "source_path": "docs/security/prompt-injection-watchlist-2026-04.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "compliance/nist-ai-agent-critical-infrastructure",
-      "title": "NIST AI Agent Critical Infrastructure Alignment",
-      "section": "compliance",
-      "source_path": "docs/compliance/nist-ai-agent-critical-infrastructure.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "compliance/eu-ai-act-high-risk-pack",
-      "title": "EU AI Act High-Risk Pack",
-      "section": "compliance",
-      "source_path": "docs/compliance/eu-ai-act-high-risk-pack.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "compliance/nist-ai-rmf-iso-42001-crosswalk",
-      "title": "NIST AI RMF to ISO 42001 Crosswalk",
-      "section": "compliance",
-      "source_path": "docs/compliance/nist-ai-rmf-iso-42001-crosswalk.md",
-      "docs_origin_hint": "helm.docs.mindburn.org",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "source-map",
-      "title": "Developer Surface Map",
-      "section": "helm-ai-kernel",
-      "source_path": "docs/DEVELOPER_SURFACE_MAP.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/source-map",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "kernel-scope",
-      "title": "Kernel Scope",
-      "section": "helm-ai-kernel",
-      "source_path": "docs/KERNEL_SCOPE.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/kernel-scope",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "deployment-and-examples",
-      "title": "Deployment and Examples",
-      "section": "deployment",
-      "source_path": "docs/DEPLOYMENT_AND_EXAMPLES.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/deployment-and-examples",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "examples",
-      "title": "HELM AI Kernel Examples Matrix",
-      "section": "deployment",
-      "source_path": "docs/EXAMPLES.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/examples",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "deployment/kubernetes",
-      "title": "Kubernetes Deployment",
-      "section": "deployment",
-      "source_path": "docs/KUBERNETES_DEPLOYMENT.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/deployment/kubernetes",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "reference/cli",
-      "title": "HELM AI Kernel CLI Reference",
-      "section": "reference",
-      "source_path": "docs/reference/cli.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/reference/cli",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "reference/agent-risk-scan",
-      "title": "Agent Risk Scan",
-      "section": "reference",
-      "source_path": "docs/reference/agent-risk-scan.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/reference/agent-risk-scan",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "reference/http-api",
-      "title": "HELM AI Kernel HTTP API Reference",
-      "section": "reference",
-      "source_path": "docs/reference/http-api.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/reference/http-api",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "reference/execution-boundary",
-      "title": "Execution Boundary Reference",
-      "section": "reference",
-      "source_path": "docs/reference/execution-boundary.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/reference/execution-boundary",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "reference/json-schemas",
-      "title": "HELM AI Kernel JSON Schema Reference",
-      "section": "reference",
-      "source_path": "docs/reference/json-schemas.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/reference/json-schemas",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "reference/protocols-and-schemas",
-      "title": "Protocols and Schemas",
-      "section": "reference",
-      "source_path": "docs/REFERENCE_PROTOCOLS.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/reference/protocols-and-schemas",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "architecture/cognitive-firewall",
-      "title": "Cognitive Firewall Pattern",
-      "section": "architecture",
-      "source_path": "docs/architecture/cognitive-firewall.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/architecture/cognitive-firewall",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "architecture/eidas-qtsp",
-      "title": "eIDAS QTSP Anchoring",
-      "section": "architecture",
-      "source_path": "docs/architecture/eidas-qtsp.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/architecture/eidas-qtsp",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "architecture/policy-languages",
-      "title": "Policy Languages",
-      "section": "architecture",
-      "source_path": "docs/architecture/policy-languages.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/architecture/policy-languages",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "security/clawguard-taint-tracking",
-      "title": "ClawGuard Taint Tracking",
-      "section": "security",
-      "source_path": "docs/security/clawguard-taint-tracking.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/security/clawguard-taint-tracking",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "security/session-risk-memory",
-      "title": "Session Risk Memory",
-      "section": "security",
-      "source_path": "docs/security/session-risk-memory.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/security/session-risk-memory",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "security/release-security",
-      "title": "Release and Security Evidence",
-      "section": "security",
-      "source_path": "docs/RELEASE_SECURITY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/security/release-security",
       "access": "public",
       "sensitivity": "public"
     }

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -1,14 +1,13 @@
 # Protect Local Coding Agents
 
-This guide shows the local HELM path for Codex or Claude Code-style runs. It
-uses local client setup, hook decisions, manifest artifacts, and wrapper
-receipts. It does not require private vendor APIs, a hosted account, or a model
-provider key.
+HELM can sit around Codex, Claude Code, and similar local agent workflows. The
+goal is narrow: selected effects cross a HELM boundary before dispatch, and
+each decision leaves a local receipt.
 
-HELM is not a competing coding agent. It governs selected effects around a
-local agent workflow and leaves an offline-verifiable receipt trail.
+HELM is not a competing coding agent. It evaluates the actions your agent wants
+to take.
 
-## Install a local hook
+## Install A Local Hook
 
 Inspect the writes first:
 
@@ -25,103 +24,84 @@ helm-ai-kernel setup claude-code --yes
 ```
 
 Setup writes draft policy and quarantine artifacts. It does not approve tools
-or grant operate permissions.
+or grant broad operating permissions.
 
-## Prove a denied action
+## Prove A Denial
 
-Ask the local agent to perform an action the starter policy denies. The
-reference transcript denies the shell target `rm -rf /tmp/helm-risky-cleanup`
-before dispatch and writes a signed workstation policy decision receipt.
+Ask the local agent to attempt an action the starter policy denies, such as a
+risky shell cleanup. HELM should block before dispatch and write a receipt.
 
 Verify the receipt:
 
 ```bash
-helm-ai-kernel workstation verify-decision --receipt ~/.helm-ai-kernel/receipts/hooks/wpd_<decision>.json
+helm-ai-kernel workstation verify-decision \
+  --receipt ~/.helm-ai-kernel/receipts/hooks/wpd_<decision>.json
 ```
 
 Expected fields:
 
 ```text
-verdict:   DENY
-reason:    OPERATE_PERMISSIONS_EMPTY
-effect:    WORKSTATION_SHELL_COMMAND
+verdict: DENY
+reason: OPERATE_PERMISSIONS_EMPTY
+effect: WORKSTATION_SHELL_COMMAND
 signature: true
 ```
 
-Use the imported-artifact flow below when you want to test workstation
-receipts without modifying local client configuration.
+## Prove An Escalation
 
-## Import a run
-
-```bash
-cd helm-ai-kernel/core
-go run ./cmd/helm-ai-kernel workstation import \
-  --artifacts ../fixtures/workstation/allowed-draft \
-  --out /tmp/helm-workstation-run.json
-```
-
-View the receipt without reading raw chat history:
+For MCP-backed local tools, unknown servers and missing scoped approvals should
+pause as `ESCALATE`:
 
 ```bash
-go run ./cmd/helm-ai-kernel workstation view \
-  --receipt /tmp/helm-workstation-run.json
+helm-ai-kernel mcp authorize-call \
+  --server-id shell-mcp-server \
+  --tool-name pwd
 ```
 
-## Enforce a selected effect
+Expected output:
 
-Network egress fails closed under `workstation.observe_draft.v1` because the default allowlist is empty:
+```text
+HELM ESCALATE
+decision: dec_...
+reason: unknown MCP server requires approval
+receipt: ~/.helm-ai-kernel/receipts/...
+approve:
+  helm-ai-kernel mcp approve --server-id shell-mcp-server \
+    --tools "pwd" \
+    --ttl 15m \
+    --reason "read-only repo inspection for local dev"
+```
+
+Approve the exact scope only when it is safe:
 
 ```bash
-go run ./cmd/helm-ai-kernel workstation enforce \
-  --class network \
-  --target https://forbidden.example \
-  --out /tmp/helm-workstation-network-deny.json
+helm-ai-kernel mcp approve \
+  --server-id shell-mcp-server \
+  --tools "pwd,ls,cat" \
+  --ttl 15m \
+  --reason "read-only repo inspection for local dev"
 ```
 
-The command exits `126` and writes a signed policy decision receipt. Draft workspace edits remain separately allowed:
+Then rerun the original action. Approval never resumes it automatically.
+
+## Revoke Access
 
 ```bash
-go run ./cmd/helm-ai-kernel workstation decide \
-  --class file \
-  --target docs/example.md \
-  --out /tmp/helm-workstation-draft-allow.json
+helm-ai-kernel mcp revoke \
+  --server-id shell-mcp-server \
+  --reason "repo inspection finished"
 ```
 
-## Operator views
+The next evaluation must fail closed when the approval is revoked, expired, or
+outside its server, tool, or effect scope.
+
+## Inspect Receipts
 
 ```bash
-go run ./cmd/helm-ai-kernel workstation denied --input /tmp/helm-workstation-network-deny.json
-go run ./cmd/helm-ai-kernel workstation memory --input ../fixtures/workstation/reference/receipts
-go run ./cmd/helm-ai-kernel workstation loops --input ../fixtures/workstation/reference/receipts
+helm-ai-kernel mcp pending --json
+helm-ai-kernel mcp receipts --json
+helm-ai-kernel boundary records --json
 ```
 
-## Agent scope audit
-
-Generate one audit report across MCP tools, filesystem, network, memory, secrets, deploys, payments, loops, and shell:
-
-```bash
-go run ./cmd/helm-ai-kernel audit scope \
-  --input ../fixtures/workstation/reference/receipts \
-  --json
-
-go run ./cmd/helm-ai-kernel audit scope \
-  --input /tmp/helm-workstation-run.json,/tmp/helm-workstation-network-deny.json \
-  --out /tmp/helm-scope-audit \
-  --evidence-pack
-```
-
-The report is receipt-scoped. It never claims full desktop, browser, OS, or proprietary hosted-agent control.
-
-## EvidencePack and certification
-
-```bash
-go run ./cmd/helm-ai-kernel workstation evidence \
-  --receipt /tmp/helm-workstation-run.json \
-  --out /tmp/helm-workstation-evidencepack
-
-go run ./cmd/helm-ai-kernel workstation certify \
-  --fixtures ../fixtures/workstation \
-  --mode high-risk-effect-capable
-```
-
-Expected result: deterministic import, signed receipts, denied operate effects, memory effects with TTL/sensitivity, recurring loops with schedule/max runtime/tool scope/expiration, and a sample EvidencePack that can be inspected offline.
+The report is receipt-scoped. It does not claim full desktop, browser, OS, or
+hosted-agent control.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,170 +1,85 @@
 ---
-title: HELM AI Kernel CLI Reference
-last_reviewed: 2026-06-30
+title: CLI
+last_reviewed: 2026-07-01
 ---
 
-# HELM AI Kernel CLI Reference
+# CLI
 
-The `helm-ai-kernel` binary is wired in [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel). Command registration is centralized in [`registry.go`](../../core/cmd/helm-ai-kernel/registry.go), with startup handling in [`main.go`](../../core/cmd/helm-ai-kernel/main.go) and `helm-ai-kernel serve` flag parsing in [`server_cmd.go`](../../core/cmd/helm-ai-kernel/server_cmd.go).
+Use `helm-ai-kernel` to run the local proof path, connect agent clients, and
+inspect receipts.
 
-## Audience
-
-Use this page if you run the HELM AI Kernel binary, copy CLI snippets into automation, or update command docs after changing `core/cmd/helm-ai-kernel`.
-
-## Outcome
-
-After this page you should know the supported top-level command families, the source file that owns each command, the flag contracts that public docs may claim, and the tests that must pass after command changes.
-
-## Source Truth
-
-This page is generated from the active CLI implementation and must stay aligned with [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel), [`core/cmd/README.md`](../../core/cmd/README.md), the command tests in [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel), and the public manifest row for `reference/cli`.
-
-## Runtime Map
-
-```mermaid
-flowchart TD
-    subgraph Ingestion["1. Ingestion & Context Plane"]
-        User["operator or client"]
-        CLI["helm-ai-kernel command"]
-        Registry["command registry"]
-        Server["serve / server"]
-        Proxy["proxy"]
-        API["HTTP API"]
-        Upstream["OpenAI-compatible upstream"]
-        State["boundary surface registry"]
-    end
-
-    subgraph Execution["3. Execution & Verdict Plane"]
-        Boundary["boundary / mcp"]
-    end
-
-    subgraph Ledger["4. Tamper-Evident Ledger Plane"]
-        Evidence["receipts / evidence / verify"]
-        Pack["EvidencePack or receipt stream"]
-    end
-
-    %% Operational Flow Edges
-    User --> CLI
-    CLI --> Registry
-    Registry --> Server
-    Registry --> Proxy
-    Registry --> Boundary
-    Registry --> Evidence
-    Server --> API
-    Proxy --> Upstream
-    Boundary --> State
-    Evidence --> Pack
-
-    %% Premium Styling Rules
-    style Boundary fill:#3182ce,stroke:#2b6cb0,stroke-width:2px,color:#fff
-    style Evidence fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style Pack fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-```
-
-
-## Primary Commands
-
-| Command | Purpose | Source truth |
-| --- | --- | --- |
-| `helm up <app>` / `helm-ai-kernel up <app>` | Run a supported local AppSpec through environment preflight, supply-chain checks, policy/CPI compile, MCP quarantine, receipts, EvidencePack export, offline verify command, and CLI inspection command. | [`up_cmd.go`](../../core/cmd/helm-ai-kernel/up_cmd.go), [`core/pkg/launchkit`](../../core/pkg/launchkit) |
-| `helm-ai-kernel serve` | Start the local execution boundary from a policy file. | [`server_cmd.go`](../../core/cmd/helm-ai-kernel/server_cmd.go), [`serve_policy.go`](../../core/cmd/helm-ai-kernel/serve_policy.go) |
-| `helm-ai-kernel server` | Start the default Guardian API and proxy services. | [`main.go`](../../core/cmd/helm-ai-kernel/main.go), [`subsystems.go`](../../core/cmd/helm-ai-kernel/subsystems.go) |
-| `helm-ai-kernel proxy` | Run the OpenAI-compatible governance proxy. | [`proxy_cmd.go`](../../core/cmd/helm-ai-kernel/proxy_cmd.go) |
-| `helm-ai-kernel setup <claude-code\|codex>` | Install local MCP and PreToolUse hook integration for Claude Code or Codex, write autoconfigure draft artifacts, and start the local headless proof path. | [`setup_cmd.go`](../../core/cmd/helm-ai-kernel/setup_cmd.go), [`hook_cmd.go`](../../core/cmd/helm-ai-kernel/hook_cmd.go), [`quickstart_cmd.go`](../../core/cmd/helm-ai-kernel/quickstart_cmd.go) |
-| `helm-ai-kernel scan` | Run a local anonymized AI-agent risk scan, render previews, write a scan evidence pack, optionally upload only the RiskEnvelope, or project workstation receipts with `--from-receipts`. | [`scan_cmd.go`](../../core/cmd/helm-ai-kernel/scan_cmd.go), [`core/pkg/riskscan`](../../core/pkg/riskscan), [`Agent Risk Scan`](agent-risk-scan.md) |
-| `helm-ai-kernel receipts tail` | Tail durable receipt events for a specific agent. | [`receipts_cmd.go`](../../core/cmd/helm-ai-kernel/receipts_cmd.go), [`receipt_routes.go`](../../core/cmd/helm-ai-kernel/receipt_routes.go) |
-| `helm-ai-kernel evidence` | Export evidence envelopes over native EvidencePacks. | [`evidence_cmd.go`](../../core/cmd/helm-ai-kernel/evidence_cmd.go), [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go) |
-| `helm-ai-kernel export` | Export an EvidencePack from local evidence material. | [`export_cmd.go`](../../core/cmd/helm-ai-kernel/export_cmd.go), [`export_pack.go`](../../core/cmd/helm-ai-kernel/export_pack.go) |
-| `helm-ai-kernel export aat` | Export audit entries as an IETF draft-sharif-agent-audit-trail (AAT) conformant JSON Lines hash chain (`--in`, `--agent-id`, optional `--sign-key`), or verify an existing chain (`--verify`). | [`export_aat_cmd.go`](../../core/cmd/helm-ai-kernel/export_aat_cmd.go), [`core/pkg/audit`](../../core/pkg/audit) |
-| `helm-ai-kernel verify` | Verify an EvidencePack directory or archive offline, with optional online proof checks. Use `--entry <path> --proof <file>` for privacy-preserving single-entry verification — confirm one manifest entry belongs to a pack via a Merkle inclusion path without possessing the other entries (see `evidence prove-entry` and evidence-pack-v1.md Section 14). | [`verify_cmd.go`](../../core/cmd/helm-ai-kernel/verify_cmd.go), [`verify_entry_cmd.go`](../../core/cmd/helm-ai-kernel/verify_entry_cmd.go), [`core/pkg/verifier`](../../core/pkg/verifier) |
-| `helm-ai-kernel bundle` | List, inspect, verify, or build policy bundles. | [`bundle_cmd.go`](../../core/cmd/helm-ai-kernel/bundle_cmd.go), [`core/pkg/policybundles`](../../core/pkg/policybundles) |
-| `helm-ai-kernel conform` | Run conformance gates and list negative boundary vectors. | [`conform.go`](../../core/cmd/helm-ai-kernel/conform.go), [`core/pkg/conformance`](../../core/pkg/conformance) |
-| `helm-ai-kernel mcp` | Serve, package, scan, quarantine, approve, and authorize MCP surfaces. | [`mcp_cmd.go`](../../core/cmd/helm-ai-kernel/mcp_cmd.go), [`mcp_boundary_cmd.go`](../../core/cmd/helm-ai-kernel/mcp_boundary_cmd.go), [`mcp_runtime.go`](../../core/cmd/helm-ai-kernel/mcp_runtime.go) |
-| `helm-ai-kernel hook pre-tool` | Local client hook handler. It reads Claude Code or Codex PreToolUse JSON on stdin, emits hook denial JSON for selected high-risk effects, and writes signed workstation policy decision receipts. | [`hook_cmd.go`](../../core/cmd/helm-ai-kernel/hook_cmd.go), [`workstation_m3_cmd.go`](../../core/cmd/helm-ai-kernel/workstation_m3_cmd.go) |
-| `helm-ai-kernel boundary` | Inspect execution-boundary status, capabilities, records, verification, and checkpoints. | [`boundary_surface_cmd.go`](../../core/cmd/helm-ai-kernel/boundary_surface_cmd.go), [`core/pkg/boundary`](../../core/pkg/boundary) |
-| `helm-ai-kernel policy` | Work with local policy tests used by the public proof path. | [`policy_cmd.go`](../../core/cmd/helm-ai-kernel/policy_cmd.go) |
-| `helm-ai-kernel test` | Run local HELM smoke checks exposed by the CLI. | [`test_cmd.go`](../../core/cmd/helm-ai-kernel/test_cmd.go) |
-| `helm-ai-kernel workstation verify-decision` | Verify a signed workstation policy decision receipt, including hook DENY receipts. | [`workstation_m3_cmd.go`](../../core/cmd/helm-ai-kernel/workstation_m3_cmd.go), [`core/pkg/workstation`](../../core/pkg/workstation) |
-| `helm-ai-kernel doctor`, `helm-ai-kernel init`, `helm-ai-kernel onboard`, `helm-ai-kernel demo` | Initialize, diagnose, and run local demonstration flows. | [`doctor_cmd.go`](../../core/cmd/helm-ai-kernel/doctor_cmd.go), [`doctor_init_trust.go`](../../core/cmd/helm-ai-kernel/doctor_init_trust.go), [`onboard_cmd.go`](../../core/cmd/helm-ai-kernel/onboard_cmd.go), [`demo_cmd.go`](../../core/cmd/helm-ai-kernel/demo_cmd.go) |
-| `helm-ai-kernel health`, `helm-ai-kernel version`, `helm-ai-kernel help` | Global utility commands for local health checks, version reporting, and usage output. | [`main.go`](../../core/cmd/helm-ai-kernel/main.go), [`registry.go`](../../core/cmd/helm-ai-kernel/registry.go) |
-
-Auxiliary binaries under `core/cmd/bootstrap`, `core/cmd/channel_gateway`, `core/cmd/pack_verify`, `core/cmd/skill_lint`, and `core/cmd/skill_pack` are source-owned helpers. They are not top-level `helm-ai-kernel` subcommands unless wired through `core/cmd/helm-ai-kernel`.
-
-This table documents the public proof-path `helm-ai-kernel` command families and global utility commands. Additional registered commands remain source-owned until the public docs policy and evidence gates explicitly add them.
-
-## Key Flag Contracts
-
-| Command | Contract |
-| --- | --- |
-| `helm up <app>` | Defaults to `--target local --mode auto`; accepts `--target local|cloud|cloud:helm|cloud:aws|cloud:kubernetes`, `--demo`, `--verify-only`, `--live`, `--resume <run_id>`, `--yes`, and `--json`. `--verify-only` never starts runtime. `--live` never falls back to demo. Cloud targets escalate before paid resources unless provider auth and explicit approval are present. |
-| `helm-ai-kernel setup <claude-code\|codex>` | Defaults to user scope and `~/.helm-ai-kernel`; accepts `--scope user|project`, `--yes`, `--dry-run`, `--json`, and `--data-dir`. `--dry-run` writes nothing. Non-dry-run setup requires `--yes`. The JSON summary includes target, binary path, client config path, hook config path, data dir, Kernel URL, scan grade, draft policy path, and uninstall command. |
-| `helm-ai-kernel setup status <target>` / `setup remove <target>` | `status` checks for the HELM MCP and hook entries. `remove` requires `--yes` unless `--dry-run`; it removes the HELM hook entry and the local MCP entry for the selected target/scope. |
-| `helm-ai-kernel scan` | Defaults to `--path .` and `--cohort unknown`. `--risk-envelope` writes anonymized JSON. Repeatable `--preview` accepts `.md` and `.html`. `--evidence-pack` writes an anonymized tar containing only envelope, schema validation, privacy manifest, source-pack hash, and previews. `--from-receipts <dir>` switches input to workstation receipt projection. `--upload` requires `--upload-url`; without `--yes`, upload is not sent. |
-| `helm-ai-kernel hook pre-tool` | Requires `--client claude-code|codex`; reads hook JSON from stdin. Safe calls emit no output and grant no approval. Denied calls emit client-compatible `hookSpecificOutput.permissionDecision=deny` and write a signed decision receipt under `<data-dir>/receipts/hooks/`. |
-| `helm-ai-kernel workstation verify-decision` | Requires `--receipt <file>` or a single positional receipt path. Returns exit `0` only when the workstation policy decision receipt hash and configured receipt signature verify. Tampered receipts return exit `1` and print `signature: false`. |
-| `helm-ai-kernel serve --policy <path>` | `--policy` is required. Optional flags are `--addr`, `--port`, `--data-dir`, and `--json`. If the policy does not override bind or port, `serve` uses `127.0.0.1:7714`. |
-| `helm-ai-kernel server` | Starts without `--policy` and defaults to `127.0.0.1:8080` unless flags, env, or config override it. `HELM_BIND_ADDR` overrides the bind address when no explicit flag is set. `HELM_PORT` overrides the API port when no explicit flag is set. The separate health server uses `HELM_HEALTH_PORT` and defaults to `8081`. |
-| `helm-ai-kernel proxy` | Defaults to `--upstream https://api.openai.com/v1`, `--port 9090`, and `--receipts-dir ./helm-receipts`. `--websocket` is explicitly unsupported in the OSS proxy runtime. |
-| `helm-ai-kernel health` | Checks `http://localhost:$HELM_HEALTH_PORT/healthz`; if `HELM_HEALTH_PORT` is unset, it checks `http://localhost:8081/healthz`. |
-| `helm-ai-kernel receipts tail` | Requires `--agent <id>`. `--server` defaults from `HELM_URL` or `http://127.0.0.1:7714`. |
-| `helm-ai-kernel bundle build` | Takes the policy source as the positional argument: `helm-ai-kernel bundle build [--language=cel|rego|cedar] [--entities=path] <source>`. There is no `--policy` flag for this subcommand. |
-| `helm-ai-kernel bundle verify` | Requires `--file <bundle.yaml>` and `--hash <expected-hash>`. |
-| `helm-ai-kernel verify` | Accepts a positional EvidencePack path or `--bundle`. `--online` only adds public proof-ledger verification after offline checks pass. Passing `--entry`/`--proof` switches to single-entry inclusion-proof verification (offline, no network, no sibling entries required). |
-| `helm-ai-kernel evidence prove-entry` | Requires `--manifest <manifest.json>` and `--entry <path>`; writes a self-contained inclusion proof to `--out` (default stdout) for redacted single-entry verification. |
-| `helm-ai-kernel boundary` | Uses `status`, `capabilities`, `records`, `get`, `verify`, and `checkpoint` subcommands. |
-
-## Receipt And Verification Output
-
-`helm-ai-kernel receipts tail --agent <id>` is the live operator view over
-durable boundary events. The command is useful when proving that Claude, Cursor,
-LangGraph, or a custom runtime crossed HELM instead of calling a tool or model
-endpoint directly.
-
-Read the output as:
-
-| Output field | Meaning |
-| --- | --- |
-| `receipt_id` | Stable handle for the governed request; cite this in issues, reviews, and EvidencePacks |
-| `decision_id` | Policy decision that produced the receipt |
-| `verdict` / `status` | Boundary result such as `ALLOW`, `DENY`, `ESCALATE`, `APPROVED`, or `DENIED` |
-| `reason_code` | Machine-readable reason for the decision |
-| `effect_id` | Proposed or denied side effect when the runtime records one |
-| `output_hash` | Hash of the governed response, denial body, or completion |
-| `signature` | Receipt signature material; required before treating the event as audit evidence |
-
-`helm-ai-kernel verify evidence-pack.tar` is the offline archive verifier. A
-successful run means the verifier accepted the archive/index shape, checked the
-indexed content hashes, found required receipt/proof material, and verified the
-available seal/signature material. If the output says `anchor offline`, no
-external anchor was embedded; the local pack can still pass hash and signature
-checks, but customer/high-assurance review should add the trusted signer,
-external anchor, and storage receipt inputs.
-
-## Boundary And API References
-
-- [HTTP API Reference](http-api.md) covers the route registry, auth classes, OpenAPI contract, and local API behavior.
-- [Execution Boundary Reference](execution-boundary.md) covers boundary records, checkpoints, fail-closed cases, and native evidence authority.
-
-## Validation
-
-Run CLI-focused validation after changing command flags or public examples:
+## First Proof
 
 ```bash
-cd core
-go test ./cmd/helm-ai-kernel -count=1
+helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
+helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/<run-id> --profile dev-local --json
 ```
 
-Then run the documentation gates from the repository root:
+## Local Agent Setup
 
 ```bash
-make docs-coverage
-make docs-truth
+helm-ai-kernel setup claude-code --yes
+helm-ai-kernel setup codex --yes
+helm-ai-kernel setup codex --dry-run --json
 ```
 
-## Troubleshooting
+Setup writes local client configuration and draft policy artifacts. It does not
+approve tools.
 
-| Symptom | First check |
+## MCP Approval Loop
+
+| Command | Purpose |
 | --- | --- |
-| A command snippet fails with an unknown flag | Compare the snippet with `core/cmd/helm-ai-kernel/*_cmd.go`; for example, `helm-ai-kernel bundle build` takes the policy source positionally, not through `--policy`. |
-| A helper binary appears in public docs as a `helm-ai-kernel` subcommand | Keep helper binaries source-owned unless they are registered in `core/cmd/helm-ai-kernel/registry.go`. |
-| CLI docs and tests disagree | Update the source command, the command test, and this reference in the same change. |
+| `helm-ai-kernel mcp authorize-call --server-id <id> --tool-name <tool>` | Evaluate one MCP tool call before dispatch. |
+| `helm-ai-kernel mcp approve --server-id <id> --tools <csv> --ttl 15m --reason <text>` | Approve an exact local server/tool scope. |
+| `helm-ai-kernel mcp approve --server-id <id> --tools <csv> --effects side_effect --ttl 15m --reason <text>` | Approve a side-effect tool scope. |
+| `helm-ai-kernel mcp revoke --server-id <id> --reason <text>` | Revoke a local approval. |
+| `helm-ai-kernel mcp pending --json` | List servers or tools still awaiting approval. |
+| `helm-ai-kernel mcp receipts --json` | List local MCP boundary records. |
+| `helm-ai-kernel mcp get --server-id <id> --json` | Inspect one MCP server record. |
+
+Approval rules:
+
+- `--server-id`, `--tools`, `--ttl`, and `--reason` are required.
+- `--effects` defaults to read-only.
+- Wildcard tools are rejected.
+- Default TTL is `15m`; max TTL is `24h`.
+- Side-effect approvals max out at `15m`.
+- Approval never resumes a blocked action. Rerun the original action.
+
+## Boundary Inspection
+
+```bash
+helm-ai-kernel boundary status --json
+helm-ai-kernel boundary records --verdict ESCALATE --json
+helm-ai-kernel boundary verify --record-id <record-id> --json
+```
+
+## Receipts
+
+```bash
+helm-ai-kernel receipts tail --agent <agent-id>
+helm-ai-kernel workstation verify-decision --receipt <receipt.json>
+```
+
+`ALLOW`, `DENY`, and `ESCALATE` records include a reason code. `DENY` and
+`ESCALATE` do not dispatch in enforce mode.
+
+## OpenAI-Compatible Proxy
+
+```bash
+helm-ai-kernel proxy \
+  --upstream https://api.openai.com/v1 \
+  --port 9090 \
+  --receipts-dir ./helm-receipts
+```
+
+Point an OpenAI-compatible client at `http://127.0.0.1:9090/v1`.
+
+## Help
+
+```bash
+helm-ai-kernel help
+helm-ai-kernel mcp --help
+helm-ai-kernel verify --help
+```

--- a/docs/reference/http-api.md
+++ b/docs/reference/http-api.md
@@ -1,116 +1,76 @@
 ---
-title: HELM AI Kernel HTTP API Reference
+title: HTTP API
 last_reviewed: 2026-07-01
 ---
 
-# HELM AI Kernel HTTP API Reference
+# HTTP API
 
-The public HTTP contract is anchored in [`api/openapi/helm.openapi.yaml`](../../api/openapi/helm.openapi.yaml). Runtime route ownership is mirrored in [`core/cmd/helm-ai-kernel/route_registry.go`](../../core/cmd/helm-ai-kernel/route_registry.go), enforced by [`route_auth.go`](../../core/cmd/helm-ai-kernel/route_auth.go), and wired into the local server through [`subsystems.go`](../../core/cmd/helm-ai-kernel/subsystems.go), [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`receipt_routes.go`](../../core/cmd/helm-ai-kernel/receipt_routes.go), and [`console_routes.go`](../../core/cmd/helm-ai-kernel/console_routes.go).
+The public HTTP surface is for local proof, boundary evaluation, receipts,
+evidence export, conformance checks, MCP authorization, and the
+OpenAI-compatible proxy.
 
-## Audience
+Use the CLI first. Use HTTP when you need a local client or generated types.
 
-Use this page if you call HELM AI Kernel over HTTP, generate a client from OpenAPI, configure auth headers, or debug route drift between the runtime and public docs.
+## Base URLs
 
-## Outcome
-
-After this page you should know each public route family, its auth class, the source file that owns it, and the tests that catch route/OpenAPI drift.
-
-## Source Truth
-
-This page is source-backed by [`api/openapi/helm.openapi.yaml`](../../api/openapi/helm.openapi.yaml), [`core/cmd/helm-ai-kernel/route_registry.go`](../../core/cmd/helm-ai-kernel/route_registry.go), [`core/cmd/helm-ai-kernel/route_auth.go`](../../core/cmd/helm-ai-kernel/route_auth.go), [`core/cmd/helm-ai-kernel/contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`core/cmd/helm-ai-kernel/receipt_routes.go`](../../core/cmd/helm-ai-kernel/receipt_routes.go), [`core/cmd/helm-ai-kernel/console_routes.go`](../../core/cmd/helm-ai-kernel/console_routes.go), and route parity tests under [`core/cmd/helm-ai-kernel`](../../core/cmd/helm-ai-kernel).
-
-## Contract Flow
-
-```mermaid
-flowchart TD
-    subgraph Ingestion["1. Ingestion & Context Plane"]
-        OpenAPI["api/openapi/helm.openapi.yaml"]
-        Auth["route_auth.go"]
-        Mux["serve/server mux"]
-    end
-
-    subgraph Execution["3. Execution & Verdict Plane"]
-        Registry["RuntimeRouteSpecs"]
-    end
-
-    subgraph Ledger["4. Tamper-Evident Ledger Plane"]
-        Handlers["contract, receipt, console, subsystem handlers"]
-        Stores["receipts, boundary registry, services"]
-        Response["JSON, SSE, or EvidencePack bytes"]
-    end
-
-    %% Operational Flow Edges
-    OpenAPI --> Registry
-    Registry --> Auth
-    Auth --> Mux
-    Mux --> Handlers
-    Handlers --> Stores
-    Stores --> Response
-
-    %% Premium Styling Rules
-    style Registry fill:#3182ce,stroke:#2b6cb0,stroke-width:2px,color:#fff
-    style Handlers fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style Stores fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style Response fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-```
-
-
-## Runtime Auth Classes
-
-| Class | Runtime behavior |
+| Surface | Base URL |
 | --- | --- |
-| `public` | No runtime admin credential required by `protectRuntimeHandler`. |
-| `tenant_scoped` | Requires `Authorization: Bearer $HELM_ADMIN_API_KEY`. Effective tenant/principal come from `HELM_RUNTIME_TENANT_ID` and `HELM_RUNTIME_PRINCIPAL_ID` (defaulting to `default` and the system admin principal). Optional `X-Helm-Tenant-ID`, `tenant_id`, and `X-Helm-Principal-ID` values must match the server-bound identity or the request is rejected. |
-| `admin` / `authenticated` | Requires `Authorization: Bearer $HELM_ADMIN_API_KEY`. |
-| `service_internal` | Requires `Authorization: Bearer $HELM_SERVICE_API_KEY`; used for service-to-service kernel approval. |
-
-The OpenAPI security blocks describe the external contract. `route_auth.go` is the runtime source for local OSS enforcement.
+| Local boundary | `http://127.0.0.1:7714` |
+| Local API server | `http://127.0.0.1:8080` |
+| OpenAI-compatible proxy | `http://127.0.0.1:9090/v1` |
 
 ## Public Route Families
 
-| Family | Methods and paths | Source truth |
-| --- | --- | --- |
-| Health | `GET /api/health` | [`demo_routes.go`](../../core/cmd/helm-ai-kernel/demo_routes.go), [`route_registry.go`](../../core/cmd/helm-ai-kernel/route_registry.go) |
-| Local proof demo | `POST /api/demo/run`, `POST /api/demo/verify`, `POST /api/demo/tamper` | [`demo_routes.go`](../../core/cmd/helm-ai-kernel/demo_routes.go) |
-| OpenAI-compatible boundary | `POST /v1/chat/completions` | [`subsystems.go`](../../core/cmd/helm-ai-kernel/subsystems.go), [`core/pkg/api/openai_proxy.go`](../../core/pkg/api/openai_proxy.go), [`proxy_cmd.go`](../../core/cmd/helm-ai-kernel/proxy_cmd.go) |
-| Evaluation | `POST /api/v1/evaluate` | [`route_registry.go`](../../core/cmd/helm-ai-kernel/route_registry.go), [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go) |
-| Receipts | `GET /api/v1/receipts`, `GET /api/v1/receipts/tail`, `GET /api/v1/receipts/{receipt_id}` | [`receipt_routes.go`](../../core/cmd/helm-ai-kernel/receipt_routes.go) |
-| Local onboarding proof | `GET /api/v1/onboarding/state`, `POST /api/v1/onboarding/run-step`, `GET /api/v1/onboarding/export` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go) |
-| Evidence | `POST /api/v1/evidence/export`, `POST /api/v1/evidence/verify` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go) |
-| Boundary | `GET /api/v1/boundary/status`, `GET /api/v1/boundary/capabilities`, `GET /api/v1/boundary/records`, `GET /api/v1/boundary/records/{record_id}`, `POST /api/v1/boundary/records/{record_id}/verify` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`core/pkg/boundary`](../../core/pkg/boundary) |
-| Conformance | `GET /api/v1/conformance/negative` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`conform.go`](../../core/cmd/helm-ai-kernel/conform.go) |
-| MCP transport and guarded tools | `GET|POST /mcp`, `GET /mcp/v1/capabilities`, `POST /mcp/v1/execute` | [`mcp_runtime.go`](../../core/cmd/helm-ai-kernel/mcp_runtime.go), [`mcp_cmd.go`](../../core/cmd/helm-ai-kernel/mcp_cmd.go) |
-| MCP registry and authorization | `GET /api/v1/mcp/registry`, `POST /api/v1/mcp/scan`, `POST /api/v1/mcp/authorize-call` | [`contract_routes.go`](../../core/cmd/helm-ai-kernel/contract_routes.go), [`mcp_boundary_cmd.go`](../../core/cmd/helm-ai-kernel/mcp_boundary_cmd.go) |
+| Family | Routes |
+| --- | --- |
+| Health | `GET /api/health` |
+| Demo proof | `POST /api/demo/run`, `POST /api/demo/verify`, `POST /api/demo/tamper` |
+| Evaluate | `POST /api/v1/evaluate` |
+| Receipts | `GET /api/v1/receipts`, `GET /api/v1/receipts/tail`, `GET /api/v1/receipts/{receipt_id}` |
+| Evidence | `POST /api/v1/evidence/export`, `POST /api/v1/evidence/verify` |
+| Boundary | `GET /api/v1/boundary/status` |
+| Conformance | `GET /api/v1/conformance/negative` |
+| MCP approvals | `GET /api/v1/mcp/registry`, `POST /api/v1/mcp/scan`, `POST /api/v1/mcp/authorize-call` |
+| OpenAI proxy | `POST /v1/chat/completions` |
 
-The public docs site publishes only the route families above. Other runtime routes are implementation, protected, customer-preview, or maintainer-facing surfaces until the public docs policy, source evidence, and route-manifest gates explicitly add them.
+Protected runtime, identity, trust-key mutation, billing, console diagnostics,
+direct MCP execution, onboarding, and unpublished operations are not part of the
+public docs surface.
 
-Use `helm-ai-kernel conform --level L1 --json`,
-`helm-ai-kernel conform --level L2 --json`, and the maintained conformance
-tests as the public proof path. Runtime conformance run/report endpoints are
-not public proof until they are engine-backed and covered by the same tests.
+## Auth Classes
 
-`helm-ai-kernel server` runs API routes on `HELM_PORT` or `8080` by default. Its health server is separate and uses `HELM_HEALTH_PORT` or `8081` by default; `helm-ai-kernel serve` keeps the local policy boundary default at `127.0.0.1:7714`.
+| Class | Behavior |
+| --- | --- |
+| `public` | No runtime admin credential required |
+| `tenant_scoped` | Requires `Authorization: Bearer $HELM_ADMIN_API_KEY` and matching tenant/principal context |
+| `admin` / `authenticated` | Requires `Authorization: Bearer $HELM_ADMIN_API_KEY` |
+| `service_internal` | Requires `Authorization: Bearer $HELM_SERVICE_API_KEY` |
 
-## Request And Response Notes
+## Receipt Headers
 
-- JSON routes return HELM error envelopes through [`core/pkg/api/apierror.go`](../../core/pkg/api/apierror.go).
-- `GET /api/v1/receipts/tail` is an SSE stream. The HTTP route can stream without an `agent` query; the CLI wrapper `helm-ai-kernel receipts tail` requires `--agent`.
-- `POST /api/v1/evidence/export` returns EvidencePack bytes and sets `X-Helm-Evidence-Hash`.
-- Boundary and evidence verification endpoints are offline-first. Online ledger checks are additive and never replace native receipts or EvidencePack roots.
+Some routes return HELM decision metadata:
 
-## Validation
+| Header | Meaning |
+| --- | --- |
+| `X-Helm-Decision-ID` | Boundary decision id |
+| `X-Helm-Receipt-ID` | Receipt id |
+| `X-Helm-Reason-Code` | Reason code |
+| `X-Helm-Status` | Boundary status |
+| `X-Helm-Output-Hash` | Hash binding governed output |
+
+If a client hides headers, inspect receipts through the CLI or receipt routes.
+
+## OpenAPI
+
+Generate clients from:
+
+```text
+api/openapi/helm.openapi.yaml
+```
+
+Validate route drift locally:
 
 ```bash
 cd core
 go test ./cmd/helm-ai-kernel -run 'Test.*Route|Test.*OpenAPI|Test.*Receipt|Test.*Boundary' -count=1
-cd ..
-make docs-truth
 ```
-
-## Troubleshooting
-
-| Symptom | First check |
-| --- | --- |
-| `401` or `403` on a protected route | Confirm `Authorization`, `HELM_ADMIN_API_KEY`, `HELM_SERVICE_API_KEY`, and that tenant/principal headers match `HELM_RUNTIME_TENANT_ID` / `HELM_RUNTIME_PRINCIPAL_ID` for tenant-scoped routes. |
-| A route appears in OpenAPI but not runtime | Compare `api/openapi/helm.openapi.yaml` with `core/cmd/helm-ai-kernel/route_registry.go` and run the route parity tests. |
-| SSE receipt tail does not stream | Verify the runtime was started with receipt storage enabled; add an `agent` query only when you want to filter the stream. |

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -1,145 +1,45 @@
 ---
-title: SDK Index
-last_reviewed: 2026-05-19
+title: SDKs
+last_reviewed: 2026-07-01
 ---
 
-# SDK Index
+# SDKs
 
-HELM AI Kernel retains typed SDK surfaces for developers who want clients over the HTTP API instead of raw requests. Package publication status must be proven separately from source availability.
+Use an SDK when you want typed access to the local HELM HTTP API. Use the
+OpenAI-compatible proxy when an existing app can set `base_url` or `baseURL`.
 
-## Audience
+## Local Base URLs
 
-This page is for developers who need a typed client for the HELM AI Kernel HTTP API and reviewers auditing whether a language SDK is source-only, locally buildable, or published under a verified package identity.
+| Surface | Base URL |
+| --- | --- |
+| HELM boundary | `http://127.0.0.1:7714` |
+| API server | `http://127.0.0.1:8080` |
+| OpenAI proxy | `http://127.0.0.1:9090/v1` |
 
-## Outcome
+## Clients In This Repository
 
-You should leave with the current SDK matrix, local validation command for each language, and the right base URL for direct HELM boundary calls versus the OpenAI-compatible proxy.
+| Language | Source | Local check |
+| --- | --- | --- |
+| Python | `sdk/python/` | `make test-sdk-py` |
+| TypeScript / JavaScript | `sdk/ts/` | `make test-sdk-ts` |
+| Go | `sdk/go/` | `cd sdk/go && go test ./...` |
+| Rust | `sdk/rust/` | `make test-sdk-rust` |
+| Java | `sdk/java/` | `make test-sdk-java` |
 
-```mermaid
-flowchart TD
-    subgraph Ingestion["1. Ingestion & Context Plane"]
-        OpenAPI["OpenAPI contract"]
-        SDKs["Python SDK / TypeScript / Go SDK / Rust SDK / Java"]
-        Boundary["HELM HTTP boundary"]
-    end
+Registry package availability can differ from source availability. Verify the
+target package registry before publishing pinned install instructions.
+Use `version-status.json` or `make version-drift-published` before making a
+pinned package claim.
 
-    subgraph Ledger["4. Tamper-Evident Ledger Plane"]
-        Receipts["signed receipts"]
-        Verify["offline verification"]
-    end
+Current source identity includes the Java coordinate
+`io.github.mindburnlabs:helm-sdk:0.5.18`; verify registry availability before
+presenting it as an install path.
 
-    %% Operational Flow Edges
-    OpenAPI --> SDKs
-    SDKs --> Boundary
-    Boundary --> Receipts
-    Receipts --> Verify
+Source version claims are tied to the repository `VERSION` (`0.5.18` for this release). Current source package coordinates include:
 
-    %% Premium Styling Rules
-    style Receipts fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-    style Verify fill:#2f855a,stroke:#276749,stroke-width:2px,color:#fff
-```
-
-
-## Source Truth
-
-- `api/openapi/helm.openapi.yaml`
-- `sdk/go/`
-- `sdk/python/`
-- `sdk/ts/`
-- `sdk/rust/`
-- `sdk/java/`
-- `examples/go_client/`
-- `examples/java_client/`
-- `examples/rust_client/`
-- `examples/python_openai_baseurl/`
-- `examples/ts_openai_baseurl/`
-- `examples/js_openai_baseurl/`
-- `docs/developer-coverage.manifest.json`
-
-SDK documentation should separate three facts: source exists, local tests pass,
-and a package is published under a public registry identity. Source availability
-is proven by this repository. Local behavior is proven by the validation command
-listed in the matrix. Registry publication must be verified independently before
-docs claim that an install command fetches a released package. This prevents the
-SDK docs from turning generated clients or local examples into unsupported
-distribution promises.
-
-## SDK Matrix
-
-| Language | Public package status | Source | Validation |
-| --- | --- | --- | --- |
-| Python SDK | Package name `helm-sdk`; source manifest follows the repository `VERSION` (`0.5.18` for this release). Verify `version-status.json` or `make version-drift-published` before publishing pinned install claims. | `sdk/python/helm_sdk/client.py` | `make test-sdk-py` |
-| TypeScript | Package name `@mindburn/helm-ai-kernel`; source manifest follows the repository `VERSION` (`0.5.18` for this release). Verify `version-status.json` or `make version-drift-published` before publishing pinned install claims. | `sdk/ts/src/client.ts` | `make test-sdk-ts` |
-| JavaScript | Uses `@mindburn/helm-ai-kernel` or raw HTTP/fetch | `sdk/ts/src/client.ts`, `examples/js_openai_baseurl/` | `make test-sdk-ts` |
-| Go SDK | Module path `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.18`; released by the subdirectory tag `sdk/go/v0.5.18` | `sdk/go/client/client.go` | `cd sdk/go && go test ./...` |
-| Rust SDK | Package name `helm-sdk`; source manifest follows the repository `VERSION` (`0.5.18` for this release). Verify `version-status.json` or `make version-drift-published` before publishing pinned install claims. | `sdk/rust/src/client.rs` | `make test-sdk-rust` |
-| Java SDK | Maven Central coordinate `io.github.mindburnlabs:helm-sdk:0.5.18`; verified by remote Maven resolution and repo1 artifacts. | `sdk/java/pom.xml` | `make test-sdk-java` |
-
-Use `http://127.0.0.1:7714` for the local `helm-ai-kernel serve --policy` quickstart, `http://localhost:8080` for `helm-ai-kernel server` or the current Docker Compose mapping, and `http://localhost:9090/v1` only for the OpenAI-compatible proxy.
-
-## Python
-
-```bash
-pip install helm-sdk
-cd sdk/python
-python -m pip install '.[dev]'
-pytest -v --tb=short
-```
-
-```python
-from helm_sdk import HelmApiError, HelmClient, ChatCompletionRequest, ChatMessage
-
-client = HelmClient(base_url="http://127.0.0.1:7714")
-```
-
-## TypeScript / JavaScript
-
-```bash
-npm install @mindburn/helm-ai-kernel
-cd sdk/ts
-npm ci
-npm test -- --run
-npm run build
-```
-
-```ts
-import { HelmApiError, HelmClient } from "@mindburn/helm-ai-kernel";
-
-const client = new HelmClient({ baseUrl: "http://127.0.0.1:7714" });
-```
-
-Use the OpenAI-compatible proxy instead of the SDK when an existing OpenAI-style client can set `base_url` or `baseURL`.
-
-## Go
-
-```bash
-go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.18
-cd sdk/go
-go test ./...
-```
-
-```go
-client := helm.New("http://127.0.0.1:7714")
-```
-
-## Rust
-
-```bash
-cargo add helm-sdk
-```
-
-```bash
-cd sdk/rust
-cargo test
-```
-
-```rust
-let client = HelmClient::new("http://127.0.0.1:7714");
-```
-
-## Java
-
-Use the verified Maven Central coordinate:
+- Go module: `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.18`
+- Go subdirectory tag: `sdk/go/v0.5.18`
+- Java dependency:
 
 ```xml
 <dependency>
@@ -149,35 +49,48 @@ Use the verified Maven Central coordinate:
 </dependency>
 ```
 
-Use a local Maven build when editing this repository:
+## Python
 
-```bash
-cd sdk/java
-mvn -q test
+```python
+from helm_sdk import HelmClient
+
+client = HelmClient(base_url="http://127.0.0.1:7714")
 ```
+
+## TypeScript
+
+```ts
+import { HelmClient } from "@mindburn/helm-ai-kernel";
+
+const client = new HelmClient({ baseUrl: "http://127.0.0.1:7714" });
+```
+
+## Go
+
+```go
+client := helm.New("http://127.0.0.1:7714")
+```
+
+## Rust
+
+```rust
+let client = HelmClient::new("http://127.0.0.1:7714");
+```
+
+## Java
 
 ```java
 HelmClient client = new HelmClient("http://127.0.0.1:7714");
 ```
 
-## Agent Framework Helpers
+## Client Behavior
 
-The TypeScript SDK includes adapter helpers for LangGraph, CrewAI, OpenAI Agents SDK, PydanticAI, and LlamaIndex tool-call events. The helpers normalize framework events into a HELM governance request and submit it through `chatCompletionsWithReceipt`, preserving the kernel receipt returned in `X-Helm-*` headers.
-
-```bash
-make test-sdk-ts
-```
-
-These helpers do not add vendor framework packages as HELM dependencies and do not claim vendor certification.
-
-## Troubleshooting
-
-| Condition | Developer behavior |
+| Condition | Do this |
 | --- | --- |
-| policy denial | treat as a final authorization result and surface the reason code |
-| network failure | retry only when no HELM decision was returned |
-| malformed request | fix the request shape against the OpenAPI types |
-| missing receipt metadata | verify the app is calling the HELM boundary |
-| SDK drift | rerun generated-type checks and update code plus docs together |
+| `ALLOW` | Continue with the governed result |
+| `DENY` | Stop and show the reason code |
+| `ESCALATE` | Show the approval hint; do not continue automatically |
+| Missing receipt | Confirm the app called HELM instead of the upstream directly |
 
-If registry state and source manifests disagree, treat the repository source as buildable code and do not publish an install claim until the registry package can be verified independently.
+SDK helpers do not add vendor framework certification or hosted availability
+claims. They are local clients for the Kernel boundary.

--- a/docs/source-inventory.manifest.json
+++ b/docs/source-inventory.manifest.json
@@ -49,9 +49,9 @@
       "owner_doc_path": "README.md",
       "public_doc_slugs": [
         "index",
-        "source-map",
-        "security/release-security",
-        "changelog"
+        "reference/cli",
+        "verification",
+        "publication-policy"
       ],
       "rationale": "Top-level tracked files define install, release, contribution, governance, and security behavior without masking runtime trees behind a repository-wide wildcard.",
       "validation_commands": [
@@ -75,8 +75,8 @@
       ],
       "owner_doc_path": ".github/SURFACE.md",
       "public_doc_slugs": [
-        "source-map",
-        "security/release-security"
+        "reference/cli",
+        "publication-policy"
       ],
       "rationale": "CI and tooling are externally relevant as validation gates and release evidence, but individual workflow files remain source-owned.",
       "validation_commands": [
@@ -96,7 +96,7 @@
       "owner_doc_path": "api/openapi/README.md",
       "public_doc_slugs": [
         "reference/http-api",
-        "reference/execution-boundary"
+        "how-helm-works"
       ],
       "rationale": "The OpenAPI contract is a direct public reference surface and must stay tied to route parity tests and the HTTP API page.",
       "validation_commands": [
@@ -128,17 +128,10 @@
       ],
       "owner_doc_path": "protocols/README.md",
       "public_doc_slugs": [
-        "reference/protocols-and-schemas",
-        "reference/json-schemas",
+        "reference/http-api",
         "conformance",
-        "reference/execution-boundary",
-        "launchpad",
-        "launchpad/apps/openclaw",
-        "launchpad/apps/hermes",
-        "launchpad/apps/opencode",
-        "launchpad/apps/kilocode",
-        "launchpad/flow-catalog",
-        "skills/flow-catalog"
+        "verification",
+        "how-helm-works"
       ],
       "rationale": "Protocol and schema truth must be public and agent-readable, with detailed source ownership kept in protocol README files.",
       "validation_commands": [
@@ -163,7 +156,7 @@
       "owner_doc_path": "core/README.md",
       "public_doc_slugs": [
         "reference/cli",
-        "architecture"
+        "how-helm-works"
       ],
       "rationale": "Core build and benchmark files are runtime evidence, but they are not allowed to stand in for command, API, or package source ownership.",
       "validation_commands": [
@@ -183,7 +176,7 @@
       "owner_doc_path": "core/cmd/README.md",
       "public_doc_slugs": [
         "reference/cli",
-        "developer-journey",
+        "quickstart",
         "troubleshooting"
       ],
       "rationale": "The CLI is a first-class public runtime surface; flags and subcommands must be source-linked to the CLI reference rather than hidden behind core/**.",
@@ -231,7 +224,7 @@
       "owner_doc_path": "core/cmd/README.md",
       "public_doc_slugs": [
         "reference/http-api",
-        "reference/execution-boundary"
+        "how-helm-works"
       ],
       "rationale": "HTTP route behavior is enforceable at file-level granularity through the route registry, auth wrapper, handler files, and OpenAPI/SDK contract checks.",
       "validation_commands": [
@@ -260,7 +253,7 @@
       ],
       "owner_doc_path": "core/pkg/README.md",
       "public_doc_slugs": [
-        "reference/execution-boundary",
+        "how-helm-works",
         "reference/http-api",
         "conformance",
         "verification",
@@ -302,10 +295,9 @@
       ],
       "owner_doc_path": "core/pkg/README.md",
       "public_doc_slugs": [
-        "architecture",
-        "execution-security-model",
-        "reference/execution-boundary",
-        "reference/protocols-and-schemas"
+        "how-helm-works",
+        "guides/write-policies",
+        "reference/http-api"
       ],
       "rationale": "Kernel and policy packages back public runtime guarantees, but public docs should describe supported behavior through architecture, execution-boundary, and protocol references.",
       "validation_commands": [
@@ -359,8 +351,7 @@
       ],
       "owner_doc_path": "core/pkg/README.md",
       "public_doc_slugs": [
-        "architecture",
-        "source-map"
+        "how-helm-works"
       ],
       "rationale": "Remaining runtime libraries stay documented through owner docs and architecture/source-map pages without diluting the direct CLI/API/boundary rows.",
       "validation_commands": [
@@ -386,13 +377,9 @@
       ],
       "owner_doc_path": "examples/README.md",
       "public_doc_slugs": [
-        "developer-journey",
-        "deployment-and-examples",
-        "examples",
-        "deployment/kubernetes",
+        "quickstart",
         "sdks",
         "integrations/openai-compatible-proxy",
-        "integrations/codebase-memory-mcp",
         "integrations/mcp"
       ],
       "rationale": "Developers need install, SDK, framework, and deployment paths from the public docs, with examples and package docs as executable proof.",
@@ -413,9 +400,9 @@
       ],
       "owner_doc_path": "adapters/README.md",
       "public_doc_slugs": [
-        "developer-journey",
-        "deployment-and-examples",
-        "source-map"
+        "guides/protect-local-coding-agents",
+        "integrations/openai-compatible-proxy",
+        "integrations/mcp"
       ],
       "rationale": "Adapter code is integration proof material for external runtimes and must remain classified without promoting every adapter as a first-class runtime surface.",
       "validation_commands": [
@@ -453,9 +440,7 @@
       "owner_doc_path": "tests/conformance/README.md",
       "public_doc_slugs": [
         "conformance",
-        "verification",
-        "publishing",
-        "security/release-security"
+        "verification"
       ],
       "rationale": "Evidence and conformance material is public proof material; generated artifacts are linked through verification and publishing docs rather than duplicated.",
       "validation_commands": [
@@ -474,8 +459,7 @@
       ],
       "owner_doc_path": "docs/skills/FLOW_CATALOG.md",
       "public_doc_slugs": [
-        "skills/flow-catalog",
-        "compatibility"
+        "guides/write-policies"
       ],
       "rationale": "Skill packs are source-backed procedural guidance. Public docs expose the flow catalog and authority boundary while registry internals remain source-owned.",
       "validation_commands": [
@@ -495,34 +479,20 @@
       "owner_doc_path": "docs/README.md",
       "public_doc_slugs": [
         "index",
-        "community",
-        "ecosystem",
-        "source-map",
         "quickstart",
-        "compatibility",
-        "use-cases/mcp-execution-firewall",
-        "use-cases/ai-agent-security",
-        "use-cases/openai-compatible-ai-gateway-policy",
-        "use-cases/llm-audit-receipts",
-        "use-cases/agent-tool-call-governance",
-        "posts/why-ai-agents-need-an-execution-firewall",
-        "posts/mcp-quarantine-before-tool-dispatch",
-        "posts/receipts-beat-logs-for-agent-audit-trails",
-        "posts/how-to-fail-closed-on-agent-tool-calls",
-        "owasp-mcp-threat-mapping",
-        "integrations/microsoft-agent-governance-toolkit",
-        "security/owasp-agentic-top10-mapping",
-        "security/prompt-injection-watchlist-2026-04",
-        "compliance/nist-ai-agent-critical-infrastructure",
-        "compliance/eu-ai-act-high-risk-pack",
-        "compliance/nist-ai-rmf-iso-42001-crosswalk",
-        "kernel-scope",
-        "architecture/cognitive-firewall",
-        "architecture/eidas-qtsp",
-        "architecture/policy-languages",
-        "security/clawguard-taint-tracking",
-        "security/session-risk-memory",
-        "architecture/canonical-diagrams"
+        "guides/protect-local-coding-agents",
+        "how-helm-works",
+        "integrations/openai-compatible-proxy",
+        "integrations/mcp",
+        "guides/write-policies",
+        "verification",
+        "conformance",
+        "troubleshooting",
+        "reference/cli",
+        "reference/http-api",
+        "sdks",
+        "claim-boundaries",
+        "publication-policy"
       ],
       "rationale": "Docs files are source material for the public site and are checked through manifest, LLM, search, and source-inventory gates.",
       "validation_commands": [

--- a/scripts/check_documentation_truth.py
+++ b/scripts/check_documentation_truth.py
@@ -47,7 +47,7 @@ FORBIDDEN_SOURCE_INVENTORY_PATTERNS = {'*', 'core/**', 'api/**'}
 REQUIRED_RUNTIME_REFERENCE_SLUGS = {
     'reference/cli',
     'reference/http-api',
-    'reference/execution-boundary',
+    'how-helm-works',
 }
 CANONICAL_REPO_RENAMES = {
     'helm' + '-oss': 'helm-ai-kernel',

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-01T14:59:31Z
-# Commit: 1356d0b5e9f7eb3cbc0f99231362384b456f3909
+# Generated: 2026-07-01T16:52:36Z
+# Commit: d66452d3f3c6398e19cad4e5e9690f1478316ecf
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -191,7 +191,7 @@ e0ae0eb682c07e6b3930c057a22a476292ab270ef7f88d7ab24f095d83396451  core/pkg/contr
 d29fe1bb678b79cb4e7e1f7531396c71354389fa10fd4ce024fafe3196fb30c3  core/pkg/contracts/evidence_eu_ai_act_test.go
 b2f4075709b2d09edb2b245e5d8cd1097bbb63fdc4291c37522eb5b69ed6b507  core/pkg/contracts/evidence_pack_single_source_test.go
 4f436de6d176339bedbe736e71343e0df2e9403e7f7fb30124cf3d6f808cce75  core/pkg/contracts/evidence_security_finding_test.go
-b73247596b31e34f593de62e5a59a1d31887ab307572fed66e477298a5134f20  core/pkg/contracts/execution_boundary.go
+8b7a4da9bc25ce4493c098bd16a1194fcfef7e67b461b84507a3d4f2bc13b9f5  core/pkg/contracts/execution_boundary.go
 1dd110c768d83d94b4c9e1805911595a9acd0ed7ae9e20633a5866e0790ff483  core/pkg/contracts/execution_boundary_test.go
 18f026d4224115c4eba1c4d17f2cec94d3d1fe3a0ce24255e2c66d39917fb4b7  core/pkg/contracts/extended2_test.go
 5cc87c7e53683f74a29cb325a1eea166e2b44c69e65e0b8757e180849d6b4d7b  core/pkg/contracts/external_decision_receipt.go


### PR DESCRIPTION
## Summary
- implement local-first MCP approval contract: ESCALATE receipts, scoped approvals, TTL/effect checks, revoke receipts, pending/receipts CLI
- reduce public Kernel manifest to the compact proof surface
- rewrite retained public docs around ALLOW/DENY/ESCALATE, approvals, receipts, MCP, proxy, policies, conformance, and API boundaries

## Validation
- GOROOT=/usr/local/go /usr/local/go/bin/go test ./pkg/mcp
- GOROOT=/usr/local/go /usr/local/go/bin/go test ./cmd/helm-ai-kernel -run 'TestRunMCP|TestMCP|TestContract|TestRunBoundary'
- /usr/bin/python3 scripts/check_documentation_truth.py
- git diff --check