### PR TITLE
docs: keep publication policy machine output public-safe

### DIFF
--- a/docs/PUBLICATION_POLICY.md
+++ b/docs/PUBLICATION_POLICY.md
@@ -14,7 +14,7 @@ live docs site publishes. The live site should stay small and proof-oriented.
   public use.
 - The docs app publication policy chooses the smaller live route set.
 - The deployed `route-manifest.json` is the route truth for the live host.
-- Unknown routes, private prefixes, and customer or Enterprise-only paths must
+- Unknown routes, private namespaces, and non-Kernel product surfaces must
   return non-200 responses at the edge.
 
 ## Live Public Shape
@@ -30,24 +30,15 @@ The public site should lead with:
 
 Generated API pages are fail-closed. They should be published only for local
 proof and core boundary operations. Console diagnostics, identity, billing,
-trust-key mutation, Enterprise, customer, internal, secret, and deployment
-runbook surfaces stay out of the live public route set.
+trust-key mutation, private control-plane, secret, and deployment runbook
+surfaces stay out of the live public route set.
 
-## Denied Prefixes
+## Denied Namespaces
 
-The public host must not publish these prefixes:
-
-```text
-/customer
-/internal
-/helm-ai-enterprise
-/enterprise
-/trust
-/product
-/operations
-/backend
-/platform
-```
+The public host must not publish reserved account, private operations,
+control-plane, backend, product-console, or platform namespaces. The edge should
+return a non-200 response with a noindex robots header for those namespaces and
+for unknown routes.
 
 ## Validation
 
@@ -55,6 +46,6 @@ The public host must not publish these prefixes:
 python3 scripts/check_documentation_truth.py
 HELM_KERNEL_REPO_PATH=/path/to/helm-ai-kernel npm run ci
 HELM_DOCS_URL=https://helm.docs.mindburn.org
-curl -i "$HELM_DOCS_URL/customer/test"
+curl -i "$HELM_DOCS_URL/reserved-test"
 curl -i "$HELM_DOCS_URL/no-such-route"
 ```


### PR DESCRIPTION
## Summary
- remove exact restricted route strings from the public publication-policy source page
- keep the operational requirement that reserved/private namespaces and unknown routes fail closed with noindex
- prevents llms-full.txt from leaking customer/internal/Enterprise route terms after docs regeneration

## Validation
- /usr/bin/python3 scripts/check_documentation_truth.py
- make verify-boundary
- git diff --check