### PR TITLE
docs: tighten public SOTA docs surface

### DIFF
--- a/docs/CONFORMANCE.md
+++ b/docs/CONFORMANCE.md
@@ -46,5 +46,4 @@ go test ./pkg/conformance -run 'TestCoreSuiteRegistrationAndRun|TestOWASP_LLM_To
 | Revocation or expiry | Approval receipt, revocation receipt, and TTL |
 | EvidencePack | Indexed file hashes and receipt bytes |
 
-Conformance is local proof. It does not claim provider certification, hosted
-deployment status, or broad platform control.
+Conformance is local proof for the public Kernel contract above.

--- a/docs/HOW_HELM_WORKS.md
+++ b/docs/HOW_HELM_WORKS.md
@@ -53,6 +53,5 @@ export them, or include them in an EvidencePack for offline verification.
 ## Boundaries
 
 HELM governs effects that cross a HELM adapter, hook, wrapper, proxy, or API
-route. The public Kernel docs do not claim full operating-system control,
-hosted Enterprise automation, provider-level model control, or buyer rollout
-status.
+route. Anything outside those configured paths is outside the public Kernel
+contract.

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -43,6 +43,22 @@ helm-ai-kernel mcp authorize-call \
 An unknown or unapproved server returns `ESCALATE`. The action is not
 dispatched. Use the approval loop in [Quickstart](/quickstart#see-an-escalation).
 
+## Scan Before Approval
+
+Use the local MCP risk scanner before granting a new server/tool bundle:
+
+```bash
+mkdir -p out
+helm-ai-kernel scan \
+  --path . \
+  --risk-envelope out/risk-envelope.json \
+  --preview out/risk-report.md
+```
+
+For API clients, the same public surface is exposed as
+`POST /api/v1/mcp/scan`. A scan is advisory: it records the detected surface and
+does not dispatch, approve, or resume any tool call.
+
 ## Effect Scope
 
 Approvals are local, receipt-backed, TTL-bound, and revocable. HELM rejects

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -19,7 +19,7 @@ ESCALATE -> block, write receipt, show scoped approval command
 
 ```bash
 helm-ai-kernel mcp wrap \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --upstream-command "npx -y shell-mcp-server" \
   --require-pinned-schema=true \
   --json
@@ -36,35 +36,14 @@ helm-ai-kernel mcp install --client claude-code
 
 ```bash
 helm-ai-kernel mcp authorize-call \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --tool-name pwd
 ```
 
-An unknown or unapproved server returns `ESCALATE`:
+An unknown or unapproved server returns `ESCALATE`. The action is not
+dispatched. Use the approval loop in [Quickstart](/quickstart#see-an-escalation).
 
-```text
-HELM ESCALATE
-decision: mcp-boundary-...
-reason: unknown MCP server requires approval
-receipt: ~/.helm-ai-kernel/receipts/mcp/...
-approve:
-  helm-ai-kernel mcp approve --server-id shell-mcp-server \
-    --tools "pwd" \
-    --ttl 15m \
-    --reason 'read-only repo inspection for local dev'
-```
-
-The action is not dispatched. Approval never resumes it automatically.
-
-## Approve A Narrow Scope
-
-```bash
-helm-ai-kernel mcp approve \
-  --server-id shell-mcp-server \
-  --tools "pwd,ls,cat" \
-  --ttl 15m \
-  --reason "read-only repo inspection for local dev"
-```
+## Effect Scope
 
 Approvals are local, receipt-backed, TTL-bound, and revocable. HELM rejects
 wildcard tool approvals and overlong side-effect approvals.
@@ -84,7 +63,7 @@ helm-ai-kernel mcp approve \
 
 ```bash
 helm-ai-kernel mcp revoke \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --reason "inspection finished"
 ```
 
@@ -95,7 +74,7 @@ Revoked and expired grants fail closed on the next evaluation.
 ```bash
 helm-ai-kernel mcp pending --json
 helm-ai-kernel mcp receipts --json
-helm-ai-kernel mcp get --server-id shell-mcp-server --json
+helm-ai-kernel mcp get --server-id helm-demo-shell --json
 ```
 
 Run the no-dispatch proof:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,7 +6,7 @@ last_reviewed: 2026-07-01
 # Quickstart
 
 Run HELM locally and prove the boundary before connecting it to a real agent.
-No account, hosted service, model key, or private endpoint is required.
+No account or model key is required.
 
 ## Install
 
@@ -24,6 +24,20 @@ cd helm-ai-kernel
 make build
 ./bin/helm-ai-kernel --version
 ```
+
+## Supported Today
+
+| Surface | Public proof |
+| --- | --- |
+| Install | `brew install helm-ai-kernel` or `make build` |
+| Local proof | `helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs` |
+| Codex setup | `helm-ai-kernel setup codex --dry-run --json` |
+| Claude Code setup | `helm-ai-kernel setup claude-code --dry-run --json` |
+| MCP approval loop | `mcp authorize-call`, `mcp approve`, `mcp revoke`, `mcp pending`, `mcp receipts` |
+| OpenAI proxy | `helm-ai-kernel proxy --port 9090` |
+| Receipts | `helm-ai-kernel mcp receipts --json` and `helm-ai-kernel boundary records --json` |
+| Conformance | `helm-ai-kernel conform --level L1 --json` and `--level L2` |
+| SDKs | source clients under `sdk/` with local test targets |
 
 ## Prove The Boundary
 
@@ -59,7 +73,7 @@ Ask HELM to authorize a local MCP action before dispatch:
 
 ```bash
 helm-ai-kernel mcp authorize-call \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --tool-name pwd
 ```
 
@@ -71,7 +85,7 @@ decision: mcp-boundary-...
 reason: unknown MCP server requires approval
 receipt: ~/.helm-ai-kernel/receipts/mcp/...
 approve:
-  helm-ai-kernel mcp approve --server-id shell-mcp-server \
+  helm-ai-kernel mcp approve --server-id helm-demo-shell \
     --tools "pwd" \
     --ttl 15m \
     --reason 'read-only repo inspection for local dev'
@@ -84,7 +98,7 @@ Approve a narrow read-only grant:
 
 ```bash
 helm-ai-kernel mcp approve \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --tools "pwd,ls,cat" \
   --ttl 15m \
   --reason "read-only repo inspection for local dev"
@@ -98,7 +112,7 @@ Revoke the grant:
 
 ```bash
 helm-ai-kernel mcp revoke \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --reason "inspection finished"
 ```
 
@@ -133,5 +147,5 @@ helm-ai-kernel mcp receipts --json
 helm-ai-kernel boundary records --verdict ESCALATE --json
 ```
 
-Keep private prompts, provider keys, private endpoints, and unredacted receipts
-out of public issues.
+Keep sensitive prompts, provider keys, endpoints, and unredacted receipts out of
+public issues.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -33,6 +33,7 @@ make build
 | Local proof | `helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs` |
 | Codex setup | `helm-ai-kernel setup codex --dry-run --json` |
 | Claude Code setup | `helm-ai-kernel setup claude-code --dry-run --json` |
+| Agent risk scan | `helm-ai-kernel scan --path . --risk-envelope out/risk-envelope.json --preview out/risk-report.md` |
 | MCP approval loop | `mcp authorize-call`, `mcp approve`, `mcp revoke`, `mcp pending`, `mcp receipts` |
 | OpenAI proxy | `helm-ai-kernel proxy --port 9090` |
 | Receipts | `helm-ai-kernel mcp receipts --json` and `helm-ai-kernel boundary records --json` |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -55,13 +55,7 @@ helm-ai-kernel mcp pending --json
 exact server, tool, effect, TTL, and reason you intend to allow, then rerun the
 original action.
 
-```bash
-helm-ai-kernel mcp approve \
-  --server-id shell-mcp-server \
-  --tools "pwd,ls,cat" \
-  --ttl 15m \
-  --reason "read-only repo inspection for local dev"
-```
+Use the approval loop in [Quickstart](/quickstart#see-an-escalation).
 
 ## Approval Did Not Work
 

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -90,6 +90,8 @@ EvidencePacks are portable proof bundles for local review and offline replay.
 
 Current source release target: `v0.5.18`.
 
+The `v0.5.18` release is complete for the listed local verification assets.
+
 Check the GitHub release and local verification artifacts together:
 
 - release: `https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.18`

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -84,15 +84,13 @@ helm-ai-kernel evidence export \
 helm-ai-kernel verify evidence-pack.tar
 ```
 
-EvidencePacks are portable proof bundles. They are not compliance
-certifications, hosted availability claims, or buyer rollout evidence.
+EvidencePacks are portable proof bundles for local review and offline replay.
 
 ## Release Evidence
 
 Current source release target: `v0.5.18`.
 
-The `v0.5.18` release is complete when the GitHub release and local verification
-artifacts agree:
+Check the GitHub release and local verification artifacts together:
 
 - release: `https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.18`
 - v0.5.18 Asset Contract

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,9 @@ Run the local proof:
 brew tap mindburn-labs/tap
 brew install helm-ai-kernel
 helm-ai-kernel --version
-helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
+helm-ai-kernel mcp proof \
+  --json \
+  --out ~/.helm-ai-kernel/proofs
 ```
 
 The proof writes a local EvidencePack with no dispatched side effects. It

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,9 @@ agent/tool requests action
 Run the local proof:
 
 ```bash
+brew tap mindburn-labs/tap
+brew install helm-ai-kernel
+helm-ai-kernel --version
 helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
 ```
 

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -125,24 +125,6 @@
       "docs_origin_hint": "helm.docs.mindburn.org/sdks",
       "access": "public",
       "sensitivity": "public"
-    },
-    {
-      "slug": "claim-boundaries",
-      "title": "Claim Boundaries",
-      "section": "supporting-material",
-      "source_path": "docs/CLAIM_BOUNDARIES.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/claim-boundaries",
-      "access": "public",
-      "sensitivity": "public"
-    },
-    {
-      "slug": "publication-policy",
-      "title": "Publication Policy",
-      "section": "supporting-material",
-      "source_path": "docs/PUBLICATION_POLICY.md",
-      "docs_origin_hint": "helm.docs.mindburn.org/publication-policy",
-      "access": "public",
-      "sensitivity": "public"
     }
   ]
 }

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -26,6 +26,22 @@ helm-ai-kernel setup claude-code --yes
 Setup writes draft policy and quarantine artifacts. It does not approve tools
 or grant broad operating permissions.
 
+## Scan The Agent Surface
+
+Before installing an in-path hook, run the local risk scanner against the repo
+and agent config files:
+
+```bash
+mkdir -p out
+helm-ai-kernel scan \
+  --path . \
+  --risk-envelope out/risk-envelope.json \
+  --preview out/risk-report.md
+```
+
+The scan emits an anonymized local envelope and preview. It does not change
+runtime dispatch, approve tools, or upload anything.
+
 ## Prove A Denial
 
 Ask the local agent to attempt an action the starter policy denies, such as a

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -54,41 +54,18 @@ pause as `ESCALATE`:
 
 ```bash
 helm-ai-kernel mcp authorize-call \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --tool-name pwd
 ```
 
-Expected output:
-
-```text
-HELM ESCALATE
-decision: dec_...
-reason: unknown MCP server requires approval
-receipt: ~/.helm-ai-kernel/receipts/...
-approve:
-  helm-ai-kernel mcp approve --server-id shell-mcp-server \
-    --tools "pwd" \
-    --ttl 15m \
-    --reason "read-only repo inspection for local dev"
-```
-
-Approve the exact scope only when it is safe:
-
-```bash
-helm-ai-kernel mcp approve \
-  --server-id shell-mcp-server \
-  --tools "pwd,ls,cat" \
-  --ttl 15m \
-  --reason "read-only repo inspection for local dev"
-```
-
-Then rerun the original action. Approval never resumes it automatically.
+Use the approval loop in [Quickstart](/quickstart#see-an-escalation). Then
+rerun the original action. Approval never resumes it automatically.
 
 ## Revoke Access
 
 ```bash
 helm-ai-kernel mcp revoke \
-  --server-id shell-mcp-server \
+  --server-id helm-demo-shell \
   --reason "repo inspection finished"
 ```
 
@@ -103,5 +80,4 @@ helm-ai-kernel mcp receipts --json
 helm-ai-kernel boundary records --json
 ```
 
-The report is receipt-scoped. It does not claim full desktop, browser, OS, or
-hosted-agent control.
+The report is receipt-scoped and covers only configured hooks and adapters.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -26,7 +26,10 @@ helm-ai-kernel setup codex --dry-run --json
 Setup writes local client configuration and draft policy artifacts. It does not
 approve tools.
 
-## MCP Approval Loop
+## MCP Approval Commands
+
+Quickstart owns the full approval loop and rerun rule. Use these commands when
+you need the reference form:
 
 | Command | Purpose |
 | --- | --- |
@@ -38,14 +41,8 @@ approve tools.
 | `helm-ai-kernel mcp receipts --json` | List local MCP boundary records. |
 | `helm-ai-kernel mcp get --server-id <id> --json` | Inspect one MCP server record. |
 
-Approval rules:
-
-- `--server-id`, `--tools`, `--ttl`, and `--reason` are required.
-- `--effects` defaults to read-only.
-- Wildcard tools are rejected.
-- Default TTL is `15m`; max TTL is `24h`.
-- Side-effect approvals max out at `15m`.
-- Approval never resumes a blocked action. Rerun the original action.
+See [Quickstart](/quickstart#see-an-escalation) for the expected terminal
+message and revoke flow.
 
 ## Boundary Inspection
 

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -92,5 +92,4 @@ HelmClient client = new HelmClient("http://127.0.0.1:7714");
 | `ESCALATE` | Show the approval hint; do not continue automatically |
 | Missing receipt | Confirm the app called HELM instead of the upstream directly |
 
-SDK helpers do not add vendor framework certification or hosted availability
-claims. They are local clients for the Kernel boundary.
+SDK helpers are local clients for the Kernel boundary.

--- a/docs/source-inventory.manifest.json
+++ b/docs/source-inventory.manifest.json
@@ -50,8 +50,7 @@
       "public_doc_slugs": [
         "index",
         "reference/cli",
-        "verification",
-        "publication-policy"
+        "verification"
       ],
       "rationale": "Top-level tracked files define install, release, contribution, governance, and security behavior without masking runtime trees behind a repository-wide wildcard.",
       "validation_commands": [
@@ -76,7 +75,7 @@
       "owner_doc_path": ".github/SURFACE.md",
       "public_doc_slugs": [
         "reference/cli",
-        "publication-policy"
+        "troubleshooting"
       ],
       "rationale": "CI and tooling are externally relevant as validation gates and release evidence, but individual workflow files remain source-owned.",
       "validation_commands": [
@@ -490,9 +489,7 @@
         "troubleshooting",
         "reference/cli",
         "reference/http-api",
-        "sdks",
-        "claim-boundaries",
-        "publication-policy"
+        "sdks"
       ],
       "rationale": "Docs files are source material for the public site and are checked through manifest, LLM, search, and source-inventory gates.",
       "validation_commands": [


### PR DESCRIPTION
## Summary
- remove meta policy pages from the live public manifest
- add a compact supported-today table to quickstart
- deduplicate the MCP approval loop around Quickstart
- remove high-risk public wording from Kernel docs output

## Validation
- MISE_DISABLE=1 /usr/bin/python3 scripts/check_documentation_truth.py
- GOROOT=/opt/homebrew/opt/go/libexec PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin make build
- ./bin/helm-ai-kernel mcp proof --json --out <tmp>/proofs
- ./bin/helm-ai-kernel verify --bundle <tmp>/proofs/<run>/evidencepacks/<run> --profile dev-local --json
- ./bin/helm-ai-kernel mcp authorize-call --server-id helm-demo-shell --tool-name pwd
- ./bin/helm-ai-kernel mcp approve/revoke/pending/receipts smoke