### PR TITLE
Wire quantum crypto posture guard into quality gates

### DIFF
--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -15,6 +15,7 @@
         "verify-fixtures",
         "tcb-imports",
         "boundary-manifest",
+        "quantum-crypto-inventory",
         "python-sdk",
         "ts-sdk",
         "rust-sdk",
@@ -35,6 +36,7 @@
         "verify-fixtures",
         "tcb-imports",
         "boundary-manifest",
+        "quantum-crypto-inventory",
         "crucible",
         "go-race",
         "go-sdk",
@@ -66,6 +68,7 @@
         "verify-fixtures",
         "tcb-imports",
         "boundary-manifest",
+        "quantum-crypto-inventory",
         "crucible",
         "go-sdk",
         "python-sdk",
@@ -125,6 +128,7 @@
         "docker-smoke-hardening",
         "helm-smoke-hardening",
         "tla-tools-hardening",
+        "quantum-crypto-inventory",
         "secrets",
         "vuln-audit",
         "sbom",
@@ -318,6 +322,22 @@
         "protocols/**",
         "schemas/**",
         "tools/boundary/**"
+      ]
+    },
+    {
+      "id": "quantum-crypto-inventory",
+      "title": "Quantum crypto posture annotations",
+      "description": "quantum_posture: CI guard registration only; not a cryptographic control.",
+      "command": "make quantum-crypto-inventory",
+      "timeout_seconds": 120,
+      "paths": [
+        ".github/**",
+        "Makefile",
+        "core/**",
+        "deploy/**",
+        "protocols/**",
+        "scripts/**",
+        "sdk/**"
       ]
     },
     {

--- a/scripts/ci/quality.py
+++ b/scripts/ci/quality.py
@@ -24,6 +24,7 @@ EXPECTED_GATE_IDS = {
     "go-race",
     "tcb-imports",
     "boundary-manifest",
+    "quantum-crypto-inventory",
     "codegen-drift",
     "proto-breaking",
     "json-schemas",


### PR DESCRIPTION
## Summary
- add the existing quantum crypto posture annotation guard to PR, merge, release, and security quality profiles
- register the gate in the quality self-test expected gate set

## Validation
- /usr/bin/python3 scripts/ci/quality.py self-test
- make quantum-crypto-inventory PYTHON=/usr/bin/python3
- make quality-self-test QUALITY='/usr/bin/python3 scripts/ci/quality.py' PYTHON=/usr/bin/python3
- make quality-explain CHECK=quantum-crypto-inventory QUALITY='/usr/bin/python3 scripts/ci/quality.py' PYTHON=/usr/bin/python3
- git diff --check

Note: plain local python3/make validation in this fresh worktree was blocked by mise trust for this worktree's mise.toml; the commands above use system Python without changing user trust state.