### PR TITLE
docs: publish OpenClaw and Hermes integration coverage

### DIFF
--- a/docs/INTEGRATIONS/hermes.md
+++ b/docs/INTEGRATIONS/hermes.md
@@ -1,0 +1,56 @@
+---
+title: Hermes
+last_reviewed: 2026-07-01
+---
+
+# Hermes
+
+Use HELM as a pre-dispatch boundary for Hermes tool proposals.
+
+```text
+Hermes tool proposal
+-> fromHermesToolCall(...)
+-> HELM evaluate
+-> ALLOW: dispatch
+-> DENY or ESCALATE: block and write a receipt
+```
+
+## Adapter
+
+The supported adapter lives in `helm-agent-integrations`:
+
+```python
+from helm_tool_wrapper import from_hermes_tool_call, preflight_action
+
+intent = from_hermes_tool_call({
+    "tool_name": "terminal",
+    "arguments": {"command": "rm -rf ./secrets"},
+    "task_id": "local-task",
+})
+
+decision = preflight_action(
+    helm_url="http://127.0.0.1:7714",
+    action_urn=intent.action_urn,
+    input=intent.input,
+    metadata=intent.metadata,
+)
+```
+
+Dispatch the Hermes tool only when HELM returns `ALLOW`. For `DENY` or
+`ESCALATE`, keep the tool blocked and show the decision and receipt path.
+
+## Receipt Sample
+
+The integration repository includes a local sample for a destructive shell
+proposal that is denied before dispatch:
+
+```bash
+python3 scripts/generate_samples.py --check
+python3 scripts/verify_samples.py
+cat receipts/samples/hermes-dangerous-shell-deny.json
+```
+
+## Scope
+
+This page covers the Hermes tool-call boundary only. It does not claim upstream
+endorsement or a hosted Hermes runtime.

--- a/docs/INTEGRATIONS/openclaw.md
+++ b/docs/INTEGRATIONS/openclaw.md
@@ -1,0 +1,59 @@
+---
+title: OpenClaw
+last_reviewed: 2026-07-01
+---
+
+# OpenClaw
+
+Use HELM as a pre-dispatch boundary for OpenClaw-style skill calls.
+
+```text
+OpenClaw skill call
+-> fromOpenClawSkillCall(...)
+-> HELM evaluate
+-> ALLOW: dispatch
+-> DENY or ESCALATE: block and write a receipt
+```
+
+## Adapter
+
+The supported adapter lives in `helm-agent-integrations`:
+
+```ts
+import { fromOpenClawSkillCall, preflightAction } from "@mindburn/helm-tool-wrapper";
+
+const intent = fromOpenClawSkillCall({
+  skill: "gmail-send",
+  input: {
+    to: "ops@example.invalid",
+    subject: "Draft follow-up",
+  },
+  conversation_id: "local-session",
+});
+
+const decision = await preflightAction({
+  helmUrl: "http://127.0.0.1:7714",
+  actionUrn: intent.actionUrn,
+  input: intent.input,
+  metadata: intent.metadata,
+});
+```
+
+Dispatch the OpenClaw skill only when HELM returns `ALLOW`. For `DENY` or
+`ESCALATE`, show the decision and receipt path to the developer.
+
+## Receipt Sample
+
+The integration repository includes a local sample for an external send that
+escalates before dispatch:
+
+```bash
+python3 scripts/generate_samples.py --check
+python3 scripts/verify_samples.py
+cat receipts/samples/openclaw-email-escalate.json
+```
+
+## Scope
+
+This page covers the OpenClaw skill-call boundary only. It does not claim
+upstream endorsement or a hosted OpenClaw runtime.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -33,6 +33,7 @@ make build
 | Local proof | `helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs` |
 | Codex setup | `helm-ai-kernel setup codex --dry-run --json` |
 | Claude Code setup | `helm-ai-kernel setup claude-code --dry-run --json` |
+| OpenClaw / Hermes adapters | `helm-agent-integrations` wrapper helpers |
 | Agent risk scan | `helm-ai-kernel scan --path . --risk-envelope out/risk-envelope.json --preview out/risk-report.md` |
 | MCP approval loop | `mcp authorize-call`, `mcp approve`, `mcp revoke`, `mcp pending`, `mcp receipts` |
 | OpenAI proxy | `helm-ai-kernel proxy --port 9090` |

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -64,6 +64,24 @@
       "sensitivity": "public"
     },
     {
+      "slug": "integrations/openclaw",
+      "title": "OpenClaw",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/openclaw.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/openclaw",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "integrations/hermes",
+      "title": "Hermes",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/hermes.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/hermes",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "guides/write-policies",
       "title": "Write Policies",
       "section": "guide",

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -7,6 +7,14 @@ each decision leaves a local receipt.
 HELM is not a competing coding agent. It evaluates the actions your agent wants
 to take.
 
+## Agent Adapters
+
+Codex and Claude Code use local setup hooks. OpenClaw and Hermes use adapter
+helpers from `helm-agent-integrations`:
+
+- [OpenClaw](/integrations/openclaw) normalizes skill calls before dispatch.
+- [Hermes](/integrations/hermes) normalizes tool proposals before dispatch.
+
 ## Install A Local Hook
 
 Inspect the writes first:


### PR DESCRIPTION
## Summary\n- add public OpenClaw and Hermes integration pages backed by helm-agent-integrations adapters\n- link them from the local-agent coverage page and Quickstart supported surface\n- keep Launchpad/runtime claims out of public docs\n\n## Validation\n- MISE_DISABLE=1 /usr/bin/python3 scripts/check_documentation_truth.py\n- git diff --check\n- HELM_KERNEL_REPO_PATH=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-openclaw-hermes-public npm run ci (from app-helm-docs worktree)