### PR TITLE
docs: simplify kernel CLI first run

### DIFF
--- a/core/cmd/helm-ai-kernel/cli_support.go
+++ b/core/cmd/helm-ai-kernel/cli_support.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type cliSupportMatrix struct {
+	DirectSetup       []string `json:"direct_setup"`
+	ConfigPrint       []string `json:"config_print"`
+	Bundle            []string `json:"bundle"`
+	WrapperExamples   []string `json:"wrapper_examples"`
+	FrameworkAdapters []string `json:"framework_adapters"`
+}
+
+func supportMatrix() cliSupportMatrix {
+	return cliSupportMatrix{
+		DirectSetup:       []string{"claude-code", "codex"},
+		ConfigPrint:       []string{"cursor", "windsurf", "vscode"},
+		Bundle:            []string{"claude-desktop"},
+		WrapperExamples:   []string{"openclaw", "hermes", "mastra", "browser-use", "tinyfish", "e2b", "composio"},
+		FrameworkAdapters: []string{"LangGraph", "LangChain", "CrewAI", "OpenAI Agents SDK", "AutoGen/AG2", "Semantic Kernel", "PydanticAI", "LlamaIndex", "LiteLLM", "n8n", "Zapier", "raw MCP"},
+	}
+}
+
+func printFrontDoor(out io.Writer) {
+	fmt.Fprintf(out, "%sHELM AI Kernel%s %s (%s)\n\n", ColorBold, ColorReset, displayVersion(), displayCommit())
+	fmt.Fprintln(out, "Protect an agent:")
+	fmt.Fprintln(out, "  helm-ai-kernel setup claude-code --yes")
+	fmt.Fprintln(out, "  helm-ai-kernel setup codex --yes")
+	fmt.Fprintln(out, "  helm-ai-kernel setup --client cursor --print-config")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Check risk:")
+	fmt.Fprintln(out, "  helm-ai-kernel scan --path . --preview out.md")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "Verify:")
+	fmt.Fprintln(out, "  helm-ai-kernel receipts tail --agent <id>")
+	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "More:")
+	fmt.Fprintln(out, "  helm-ai-kernel help --all")
+}
+
+func printSupportMatrix(out io.Writer) {
+	matrix := supportMatrix()
+	fmt.Fprintln(out, "Supported clients and adapters:")
+	fmt.Fprintf(out, "  Direct setup:       %s\n", strings.Join(matrix.DirectSetup, ", "))
+	fmt.Fprintf(out, "  Config print:       %s\n", strings.Join(matrix.ConfigPrint, ", "))
+	fmt.Fprintf(out, "  Bundle:             %s\n", strings.Join(matrix.Bundle, ", "))
+	fmt.Fprintf(out, "  Wrapper examples:   %s\n", strings.Join(matrix.WrapperExamples, ", "))
+	fmt.Fprintf(out, "  Framework adapters: %s\n", strings.Join(matrix.FrameworkAdapters, ", "))
+}
+
+func writeSupportMatrixJSON(out io.Writer) int {
+	if err := json.NewEncoder(out).Encode(supportMatrix()); err != nil {
+		return 1
+	}
+	return 0
+}

--- a/core/cmd/helm-ai-kernel/doctor_init_trust.go
+++ b/core/cmd/helm-ai-kernel/doctor_init_trust.go
@@ -38,9 +38,9 @@ var initProfiles = map[string]initProfile{
 	"claude": {
 		Name:         "claude",
 		ProviderHint: "claude",
-		EnvTemplate:  "# Claude integrations are MCP-first.\n# Use `helm-ai-kernel mcp print-config --client claude-code` or `helm-ai-kernel mcp pack --client claude-desktop`.\n",
+		EnvTemplate:  "# Claude integrations are MCP-first.\n# Use `helm-ai-kernel setup claude-code --yes` or `helm-ai-kernel mcp pack --client claude-desktop`.\n",
 		NextSteps: []string{
-			"helm-ai-kernel mcp print-config --client claude-code",
+			"helm-ai-kernel setup claude-code --yes",
 			"helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb",
 		},
 	},

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -1,5 +1,8 @@
 package main
 
+// quantum_posture: CLI dispatch/front-door wiring only; cryptographic controls
+// live in core/pkg/crypto and related verifier packages.
+
 import (
 	"context"
 	"crypto/ed25519"
@@ -62,8 +65,7 @@ type serverOptions struct {
 // Run is the entrypoint for testing
 func Run(args []string, stdout, stderr io.Writer) int {
 	if len(args) < 2 {
-		// Default to server
-		startServer()
+		printFrontDoor(stdout)
 		return 0
 	}
 
@@ -103,8 +105,15 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "  MCP Bundle Schema:      1\n")
 		fmt.Fprintf(stdout, "  Build Time:             %s\n", displayBuildTime())
 		return 0
-	case "help", "--help", "-h":
-		printUsage(stdout)
+	case "help":
+		if len(args) > 2 && args[2] == "--all" {
+			printUsageAll(stdout)
+			return 0
+		}
+		printFrontDoor(stdout)
+		return 0
+	case "--help", "-h":
+		printFrontDoor(stdout)
 		return 0
 	default:
 		if args[1][0] == '-' {

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -47,7 +47,26 @@ func TestRun_Help(t *testing.T) {
 	exitCode := Run(args, &stdout, &stderr)
 
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout.String(), "helm-ai-kernel <command> [options]")
+	assert.Contains(t, stdout.String(), "Protect an agent:")
+	assert.Contains(t, stdout.String(), "helm-ai-kernel help --all")
+}
+
+func TestRunNoArgsPrintsFrontDoor(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"helm"}, &stdout, &stderr)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout.String(), "helm-ai-kernel setup claude-code --yes")
+	assert.Empty(t, stderr.String())
+}
+
+func TestRunHelpAllPrintsFullCommandList(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	exitCode := Run([]string{"helm", "help", "--all"}, &stdout, &stderr)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout.String(), "Usage: helm-ai-kernel <command> [options]")
+	assert.Contains(t, stdout.String(), "Commands:")
 }
 
 func TestRun_HelpOmitsRemovedUICommands(t *testing.T) {
@@ -62,6 +81,7 @@ func TestRun_HelpOmitsRemovedUICommands(t *testing.T) {
 
 	assert.Equal(t, 0, exitCode)
 	help := stdout.String()
+	assert.NotContains(t, help, "Launchpad")
 	removedCommands := []string{
 		"control" + "-" + "room",
 		"dash" + "board",

--- a/core/cmd/helm-ai-kernel/registry.go
+++ b/core/cmd/helm-ai-kernel/registry.go
@@ -36,6 +36,10 @@ func Dispatch(name string, args []string, stdout, stderr io.Writer) (int, bool) 
 }
 
 func printUsage(out io.Writer) {
+	printFrontDoor(out)
+}
+
+func printUsageAll(out io.Writer) {
 	fmt.Fprintf(out, "%sHELM AI Kernel%s: Canonical Execution Verifier (Version %s, Commit %s)\n\n", ColorBold, ColorReset, displayVersion(), displayCommit())
 	fmt.Fprintln(out, "Usage: helm-ai-kernel <command> [options]")
 	fmt.Fprintln(out, "\nCommands:")

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -59,8 +59,11 @@ func init() {
 
 func runSetupCmd(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		printSetupUsage(stderr)
-		return 2
+		printSetupUsage(stdout)
+		return 0
+	}
+	if strings.HasPrefix(args[0], "-") {
+		return runSetupFrontDoorFlags(args, stdout, stderr)
 	}
 	switch args[0] {
 	case "status":
@@ -73,6 +76,33 @@ func runSetupCmd(args []string, stdout, stderr io.Writer) int {
 	default:
 		return runSetupInstallCmd(args, stdout, stderr)
 	}
+}
+
+func runSetupFrontDoorFlags(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	client := fs.String("client", "", "Client to print config for")
+	printConfig := fs.Bool("print-config", false, "Print config for --client")
+	jsonOut := fs.Bool("json", false, "Print machine-readable support matrix")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "setup: unexpected argument %q\n", fs.Arg(0))
+		return 2
+	}
+	if *jsonOut {
+		return writeSupportMatrixJSON(stdout)
+	}
+	if *printConfig {
+		if *client == "" {
+			fmt.Fprintln(stderr, "setup: --print-config requires --client")
+			return 2
+		}
+		return runMCPPrintConfig([]string{"--client", *client}, stdout, stderr)
+	}
+	printSetupUsage(stdout)
+	return 0
 }
 
 func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
@@ -178,10 +208,22 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 }
 
 func printSetupUsage(w io.Writer) {
-	fmt.Fprintln(w, "Usage:")
-	fmt.Fprintln(w, "  helm-ai-kernel setup <claude-code|codex> [--scope user|project] [--yes] [--dry-run] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "Protect an agent:")
+	fmt.Fprintln(w, "  helm-ai-kernel setup claude-code --yes")
+	fmt.Fprintln(w, "  helm-ai-kernel setup codex --yes")
+	fmt.Fprintln(w, "  helm-ai-kernel setup --client cursor --print-config")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Inspect first:")
+	fmt.Fprintln(w, "  helm-ai-kernel setup claude-code --dry-run --json")
+	fmt.Fprintln(w, "  helm-ai-kernel setup --json")
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "Manage:")
 	fmt.Fprintln(w, "  helm-ai-kernel setup status <claude-code|codex> [--scope user|project] [--json] [--data-dir DIR]")
 	fmt.Fprintln(w, "  helm-ai-kernel setup remove <claude-code|codex> [--scope user|project] [--yes] [--dry-run] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "")
+	printSupportMatrix(w)
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "No config is written without --yes.")
 }
 
 func parseSetupInstallArgs(args []string, stderr io.Writer) (setupOptions, int) {

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -4,11 +4,111 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestSetupNoArgsPrintsChooser(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("setup no args exit = %d stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"helm-ai-kernel setup claude-code --yes",
+		"helm-ai-kernel setup codex --yes",
+		"helm-ai-kernel setup --client cursor --print-config",
+		"No config is written without --yes.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("setup chooser missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestSetupJSONSupportMatrix(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "--json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("setup --json exit = %d stderr = %s", code, stderr.String())
+	}
+	var matrix cliSupportMatrix
+	if err := json.Unmarshal(stdout.Bytes(), &matrix); err != nil {
+		t.Fatalf("support matrix JSON: %v\n%s", err, stdout.String())
+	}
+	for _, want := range []string{"claude-code", "codex"} {
+		if !containsSetupString(matrix.DirectSetup, want) {
+			t.Fatalf("direct setup missing %q: %#v", want, matrix.DirectSetup)
+		}
+	}
+	for _, want := range []string{"cursor", "windsurf", "vscode"} {
+		if !containsSetupString(matrix.ConfigPrint, want) {
+			t.Fatalf("config print missing %q: %#v", want, matrix.ConfigPrint)
+		}
+	}
+	for _, want := range []string{"openclaw", "hermes", "mastra", "browser-use", "tinyfish", "e2b", "composio"} {
+		if !containsSetupString(matrix.WrapperExamples, want) {
+			t.Fatalf("wrapper examples missing %q: %#v", want, matrix.WrapperExamples)
+		}
+	}
+	for _, want := range []string{"LangGraph", "LangChain", "CrewAI", "OpenAI Agents SDK", "AutoGen/AG2", "Semantic Kernel", "PydanticAI", "LlamaIndex", "LiteLLM", "n8n", "Zapier", "raw MCP"} {
+		if !containsSetupString(matrix.FrameworkAdapters, want) {
+			t.Fatalf("framework adapters missing %q: %#v", want, matrix.FrameworkAdapters)
+		}
+	}
+}
+
+func TestSetupPrintConfigDelegatesSupportedClients(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "--client", "cursor", "--print-config"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("setup print-config exit = %d stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "# Cursor MCP Configuration") {
+		t.Fatalf("cursor config missing:\n%s", stdout.String())
+	}
+}
+
+func TestPublicExamplesAvoidStaleCLIStrings(t *testing.T) {
+	root, err := filepath.Abs("../../..")
+	if err != nil {
+		t.Fatal(err)
+	}
+	banned := []string{
+		"mcp print-config --client " + "claude-code",
+		"127.0.0.1:" + "7715",
+	}
+	for _, dir := range []string{filepath.Join(root, "docs"), filepath.Join(root, "core", "cmd", "helm-ai-kernel"), filepath.Join(root, "sdk")} {
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return err
+			}
+			switch filepath.Ext(path) {
+			case ".go", ".md", ".json", ".toml":
+			default:
+				return nil
+			}
+			raw, readErr := os.ReadFile(path)
+			if readErr != nil {
+				return readErr
+			}
+			text := string(raw)
+			for _, term := range banned {
+				if strings.Contains(text, term) {
+					t.Fatalf("%s contains stale public CLI term %q", path, term)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
 
 func TestSetupDryRunJSONSummary(t *testing.T) {
 	tmp := t.TempDir()
@@ -188,4 +288,13 @@ func stubSetupSideEffects(t *testing.T) *setupStubState {
 		setupRunQuickstart = oldQuickstart
 	})
 	return state
+}
+
+func containsSetupString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/docs/INTEGRATIONS/agent-clients.md
+++ b/docs/INTEGRATIONS/agent-clients.md
@@ -1,0 +1,54 @@
+---
+title: Agent Clients
+last_reviewed: 2026-07-01
+---
+
+# Agent Clients
+
+Start with `setup`. It shows the supported clients without writing config.
+
+```bash
+helm-ai-kernel setup
+helm-ai-kernel setup --json
+```
+
+## Direct Setup
+
+| Client | Command |
+| --- | --- |
+| Claude Code | `helm-ai-kernel setup claude-code --yes` |
+| Codex | `helm-ai-kernel setup codex --yes` |
+
+Preview writes first:
+
+```bash
+helm-ai-kernel setup claude-code --dry-run --json
+helm-ai-kernel setup codex --dry-run --json
+```
+
+## Config Print
+
+| Client | Command |
+| --- | --- |
+| Cursor | `helm-ai-kernel setup --client cursor --print-config` |
+| Windsurf | `helm-ai-kernel setup --client windsurf --print-config` |
+| VS Code | `helm-ai-kernel setup --client vscode --print-config` |
+
+Claude Desktop uses a bundle:
+
+```bash
+helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb
+```
+
+## What HELM Does
+
+```text
+agent/tool requests action
+-> HELM evaluates before dispatch
+-> ALLOW: action runs
+-> DENY: action is blocked
+-> ESCALATE: action is blocked and a receipt is written
+```
+
+Setup writes local config and draft policy files only when `--yes` is present.
+It does not approve detected tools.

--- a/docs/INTEGRATIONS/claude-code.md
+++ b/docs/INTEGRATIONS/claude-code.md
@@ -52,10 +52,10 @@ helm-ai-kernel workstation verify-decision \
 
 ## MCP Configuration
 
-For lower-level MCP configuration, print the Claude Code config:
+For lower-level MCP configuration, install the Claude Code MCP server:
 
 ```bash
-helm-ai-kernel mcp print-config --client claude-code
+helm-ai-kernel mcp install --client claude-code
 ```
 
 Claude Desktop bundle output is separate:
@@ -64,7 +64,7 @@ Claude Desktop bundle output is separate:
 helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb
 ```
 
-## Source Truth
+## Implementation
 
 - `core/cmd/helm-ai-kernel/setup_cmd.go`
 - `core/cmd/helm-ai-kernel/hook_cmd.go`

--- a/docs/INTEGRATIONS/framework-adapters.md
+++ b/docs/INTEGRATIONS/framework-adapters.md
@@ -1,0 +1,51 @@
+---
+title: Framework Adapters
+last_reviewed: 2026-07-01
+---
+
+# Framework Adapters
+
+Use framework adapters when an agent framework already owns the tool-call hook
+and you need to normalize that proposed action before HELM evaluates it.
+
+## Supported Helpers
+
+| Framework | Helper |
+| --- | --- |
+| LangGraph | `fromLangGraphToolCall` |
+| LangChain | `fromLangChainToolCall` |
+| CrewAI | `fromCrewAITask` |
+| OpenAI Agents SDK | `fromOpenAIAgentsToolCall` |
+| AutoGen / AG2 | `fromAutoGenToolCall` |
+| Semantic Kernel | `fromSemanticKernelFunctionCall` |
+| PydanticAI | `fromPydanticAIToolCall` |
+| LlamaIndex | `fromLlamaIndexToolCall` |
+| LiteLLM | `fromLiteLLMToolCall` |
+| n8n | `fromN8NNodeExecution` |
+| Zapier-style webhook | `fromZapierWebhookCall` |
+| Raw MCP client | `fromRawMCPToolCall` |
+
+## Pattern
+
+```ts
+import { HelmClient, createAgentFrameworkAdapter, fromLangGraphToolCall } from "@mindburn/helm-ai-kernel";
+
+const helm = new HelmClient({ baseUrl: "http://127.0.0.1:7714" });
+const adapter = createAgentFrameworkAdapter(helm, {
+  model: "helm-governance",
+  metadata: { boundary: "local-dev" },
+});
+
+const result = await adapter.submit(
+  fromLangGraphToolCall({
+    id: "call-1",
+    name: "repo.read_file",
+    args: { path: "README.md" },
+  }),
+);
+
+console.log(result.governance.receiptId);
+```
+
+The adapter prepares the action for HELM. It does not execute the original
+tool.

--- a/docs/INTEGRATIONS/tool-runtime-adapters.md
+++ b/docs/INTEGRATIONS/tool-runtime-adapters.md
@@ -1,0 +1,48 @@
+---
+title: Tool Runtime Adapters
+last_reviewed: 2026-07-01
+---
+
+# Tool Runtime Adapters
+
+Use tool runtime adapters when the agent runtime proposes a concrete side
+effect and your wrapper must ask HELM before dispatch.
+
+## Supported Wrappers
+
+| Runtime | Helper |
+| --- | --- |
+| OpenClaw | `fromOpenClawSkillCall` |
+| Hermes | `fromHermesToolCall` |
+| Mastra | `fromMastraToolCall` |
+| Browser Use | `fromBrowserUseAction` |
+| TinyFish | `fromTinyFishSearch`, `fromTinyFishFetch`, `fromTinyFishBrowserSession`, `fromTinyFishAgentRun` |
+| E2B | `fromE2BExecution` |
+| Composio | `fromComposioAction` |
+
+## Pattern
+
+```ts
+import { preflightAction, fromOpenClawSkillCall } from "@mindburn/helm-tool-wrapper";
+
+const intent = fromOpenClawSkillCall({
+  skill: "gmail-send",
+  input: { to: "ops@example.invalid", subject: "Draft follow-up" },
+  conversation_id: "local-session",
+});
+
+const decision = await preflightAction({
+  helmUrl: "http://127.0.0.1:7714",
+  actionUrn: intent.actionUrn,
+  input: intent.input,
+  metadata: intent.metadata,
+});
+```
+
+Dispatch only when the verdict is `ALLOW`. For `DENY` or `ESCALATE`, keep the
+runtime blocked and show the receipt details to the developer.
+
+## Runtime Examples
+
+- [OpenClaw](openclaw.md)
+- [Hermes](hermes.md)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -30,10 +30,14 @@ make build
 | Surface | Public proof |
 | --- | --- |
 | Install | `brew install helm-ai-kernel` or `make build` |
+| CLI chooser | `helm-ai-kernel` or `helm-ai-kernel setup` |
 | Local proof | `helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs` |
 | Codex setup | `helm-ai-kernel setup codex --dry-run --json` |
 | Claude Code setup | `helm-ai-kernel setup claude-code --dry-run --json` |
-| OpenClaw / Hermes adapters | `helm-agent-integrations` wrapper helpers |
+| Cursor / Windsurf / VS Code config | `helm-ai-kernel setup --client cursor --print-config` |
+| OpenClaw / Hermes adapters | [tool runtime adapters](INTEGRATIONS/tool-runtime-adapters.md) |
+| Framework adapters | [framework adapters](INTEGRATIONS/framework-adapters.md) |
+| Skill Packs | `helm-ai-kernel skills search --json` |
 | Agent risk scan | `helm-ai-kernel scan --path . --risk-envelope out/risk-envelope.json --preview out/risk-report.md` |
 | MCP approval loop | `mcp authorize-call`, `mcp approve`, `mcp revoke`, `mcp pending`, `mcp receipts` |
 | OpenAI proxy | `helm-ai-kernel proxy --port 9090` |
@@ -120,6 +124,12 @@ helm-ai-kernel mcp revoke \
 
 ## Connect A Local Agent
 
+See the supported matrix:
+
+```bash
+helm-ai-kernel setup --json
+```
+
 For Claude Code:
 
 ```bash
@@ -136,6 +146,7 @@ Preview writes first:
 
 ```bash
 helm-ai-kernel setup codex --dry-run --json
+helm-ai-kernel setup --client cursor --print-config
 ```
 
 Setup writes local config and draft policy artifacts. It does not approve

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,36 +17,29 @@ agent/tool requests action
 -> ESCALATE: action is blocked and a decision receipt is written
 ```
 
-Run the local proof:
+Install and open the CLI front door:
 
 ```bash
 brew tap mindburn-labs/tap
 brew install helm-ai-kernel
-helm-ai-kernel --version
-helm-ai-kernel mcp proof \
-  --json \
-  --out ~/.helm-ai-kernel/proofs
+helm-ai-kernel
 ```
 
-The proof writes a local EvidencePack with no dispatched side effects. It
-includes quarantined MCP servers, schema drift, missing approval receipts, and
-replay attempts.
+Then choose one path.
 
 ## Start
 
 - [Quickstart](QUICKSTART.md)
 - [Protect local coding agents](quickstart/workstation-governance.md)
+- [Scan agent risk](reference/agent-risk-scan.md)
 - [OpenAI proxy](INTEGRATIONS/openai_baseurl.md)
+- [Verify receipts](VERIFICATION.md)
+
+## More
+
 - [MCP](INTEGRATIONS/mcp.md)
-
-## Verify
-
-- [Receipts and EvidencePacks](VERIFICATION.md)
 - [Conformance](CONFORMANCE.md)
 - [Troubleshooting](TROUBLESHOOTING.md)
-
-## Reference
-
 - [CLI](reference/cli.md)
 - [HTTP API](reference/http-api.md)
 - [SDKs](sdks/00_INDEX.md)

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -82,6 +82,33 @@
       "sensitivity": "public"
     },
     {
+      "slug": "integrations/agent-clients",
+      "title": "Agent Clients",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/agent-clients.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/agent-clients",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "integrations/framework-adapters",
+      "title": "Framework Adapters",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/framework-adapters.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/framework-adapters",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "integrations/tool-runtime-adapters",
+      "title": "Tool Runtime Adapters",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/tool-runtime-adapters.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/tool-runtime-adapters",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "guides/write-policies",
       "title": "Write Policies",
       "section": "guide",
@@ -123,6 +150,24 @@
       "section": "reference",
       "source_path": "docs/reference/cli.md",
       "docs_origin_hint": "helm.docs.mindburn.org/reference/cli",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "reference/agent-risk-scan",
+      "title": "Agent Risk Scan",
+      "section": "reference",
+      "source_path": "docs/reference/agent-risk-scan.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/agent-risk-scan",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "reference/skill-packs",
+      "title": "Skill Packs",
+      "section": "reference",
+      "source_path": "docs/reference/skill-packs.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/reference/skill-packs",
       "access": "public",
       "sensitivity": "public"
     },

--- a/docs/reference/agent-risk-scan.md
+++ b/docs/reference/agent-risk-scan.md
@@ -27,28 +27,19 @@ After running `scan`, you can show:
 - a local preview generated only from the envelope;
 - an evidence pack containing only anonymized scan artifacts.
 
-## Source Truth
-
-- CLI: [`core/cmd/helm-ai-kernel/scan_cmd.go`](../../core/cmd/helm-ai-kernel/scan_cmd.go)
-- Static projector: [`core/pkg/riskscan/scan.go`](../../core/pkg/riskscan/scan.go)
-- Receipt projector: [`core/pkg/riskscan/receipts.go`](../../core/pkg/riskscan/receipts.go)
-- Envelope contract: [`core/pkg/riskenvelope/envelope.go`](../../core/pkg/riskenvelope/envelope.go)
-- JSON Schema: [`protocols/json-schemas/risk-envelope/v1.json`](../../protocols/json-schemas/risk-envelope/v1.json)
-- Tests: [`core/pkg/riskscan/scan_test.go`](../../core/pkg/riskscan/scan_test.go), [`core/cmd/helm-ai-kernel/scan_cmd_test.go`](../../core/cmd/helm-ai-kernel/scan_cmd_test.go)
-
 ## Capability Matrix
 
-| Capability | Command or artifact | Source |
-| --- | --- | --- |
-| Static local scan | `helm-ai-kernel scan --path .` | `riskscan.Scan` |
-| RiskEnvelope JSON | `--risk-envelope out.json` | `riskscan.EnvelopeJSON` |
-| Markdown preview | `--preview out.md` | `riskscan.RenderMarkdown` |
-| HTML preview | `--preview out.html` | `html/template` in `riskscan.RenderHTML` |
-| Evidence pack tar | `--evidence-pack pack.tar` | `riskscan.WriteEvidencePack` |
-| Explicit upload | `--upload --upload-url <url> --yes` | `riskscan.UploadEnvelope` |
-| Receipt projection | `--from-receipts <dir>` | `riskscan.ScanReceipts` |
-| Local salt | `--salt-file <path>` | `riskenvelope.LoadOrCreateSaltFile` |
-| Content hash | `envelope_content_hash` | `riskenvelope.Seal` |
+| Capability | Command or artifact |
+| --- | --- |
+| Static local scan | `helm-ai-kernel scan --path .` |
+| RiskEnvelope JSON | `--risk-envelope out.json` |
+| Markdown preview | `--preview out.md` |
+| HTML preview | `--preview out.html` |
+| Evidence pack tar | `--evidence-pack pack.tar` |
+| Explicit upload | `--upload --upload-url <url> --yes` |
+| Receipt projection | `--from-receipts <dir>` |
+| Local salt | `--salt-file <path>` |
+| Content hash | `envelope_content_hash` |
 
 ## Static Scan
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,9 +18,13 @@ helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/<run-id> --prof
 ## Local Agent Setup
 
 ```bash
+helm-ai-kernel
+helm-ai-kernel setup
+helm-ai-kernel setup --json
 helm-ai-kernel setup claude-code --yes
 helm-ai-kernel setup codex --yes
 helm-ai-kernel setup codex --dry-run --json
+helm-ai-kernel setup --client cursor --print-config
 ```
 
 Setup writes local client configuration and draft policy artifacts. It does not
@@ -77,6 +81,7 @@ Point an OpenAI-compatible client at `http://127.0.0.1:9090/v1`.
 
 ```bash
 helm-ai-kernel help
+helm-ai-kernel help --all
 helm-ai-kernel mcp --help
 helm-ai-kernel verify --help
 ```

--- a/docs/reference/skill-packs.md
+++ b/docs/reference/skill-packs.md
@@ -1,0 +1,47 @@
+---
+title: Skill Packs
+last_reviewed: 2026-07-01
+---
+
+# Skill Packs
+
+Skill Packs are scoped instruction packages for agents. They can guide an
+agent, but they do not grant tool permissions.
+
+## Inspect
+
+```bash
+helm-ai-kernel skills search --json
+helm-ai-kernel skills inspect helm/repo-auditor --json
+helm-ai-kernel skills scan helm/repo-auditor --json
+```
+
+## Install For A Repo
+
+```bash
+helm-ai-kernel skills install helm/repo-auditor \
+  --agent codex \
+  --scope repo \
+  --json
+```
+
+Repo-scoped install writes the projected skill and receipt metadata. User-scope
+install escalates and writes no projected skill by default.
+
+## Export A Codex Plugin
+
+```bash
+helm-ai-kernel skills export helm/repo-auditor \
+  --format codex-plugin \
+  --output ./dist/repo-auditor
+```
+
+Exported plugin MCP entries stay pending and hooks stay off by default.
+
+## Revoke
+
+```bash
+helm-ai-kernel skills revoke helm/repo-auditor --json
+```
+
+Revocation removes HELM-managed projection files and writes a revoke receipt.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -30,7 +30,7 @@ been run.
 ```python
 from helm_sdk import HelmClient
 
-client = HelmClient(base_url="http://127.0.0.1:7715")
+client = HelmClient(base_url="http://127.0.0.1:7714")
 decision = client.evaluate_decision({
     "principal": "example-agent",
     "action": "read-ticket",

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -35,7 +35,7 @@ npm run build
 ```ts
 import { HelmClient } from "@mindburn/helm-ai-kernel";
 
-const client = new HelmClient({ baseUrl: "http://127.0.0.1:7715" });
+const client = new HelmClient({ baseUrl: "http://127.0.0.1:7714" });
 const decision = await client.evaluateDecision({
   principal: "example-agent",
   action: "read-ticket",


### PR DESCRIPTION
## Summary
- make `helm-ai-kernel` and `helm-ai-kernel setup` show the short protect/scan/verify first-run path
- add a shared support matrix with direct setup, config-print clients, wrappers, framework adapters, and `setup --json`
- publish no-nav public source docs for agent clients, framework adapters, tool runtime adapters, risk scan, and skill packs
- remove stale Claude Code print-config guidance and standardize local examples on `http://127.0.0.1:7714`

## Validation
- `cd core && go test ./cmd/helm-ai-kernel -count=1`
- `MISE_DISABLE=1 /usr/bin/python3 scripts/check_documentation_truth.py`
- `make test-cli`
- `make build`
- CLI smoke: `helm-ai-kernel`, `setup`, `setup --json`, cursor print-config, `scan`, `skills search/install/revoke`, `mcp approve/revoke/pending/receipts`
- stale string sweep for `mcp print-config --client claude-code` and `127.0.0.1:7715` across docs/core/sdk
