### PR TITLE
Finalize helm-ai-kernel v0.5.19 release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ flowchart TD
     subgraph Ingestion["1. Ingestion & Context Plane"]
         Page["HELM AI Kernel Changelog"]
         A["[Unreleased]"]
-        B["[0.5.10] - 2026-06-04"]
+        B["[0.5.19] - 2026-07-01"]
+        B1["[0.5.16] - 2026-06-18"]
+        B2["[0.5.10] - 2026-06-04"]
         C["[0.5.9] - 2026-06-03"]
         D["[0.5.4] - 2026-05-20"]
         E["[0.5.3] - 2026-05-19"]
@@ -53,7 +55,9 @@ flowchart TD
     %% Operational Flow Edges
     Page --> A
     A --> B
-    B --> C
+    B --> B1
+    B1 --> B2
+    B2 --> C
     C --> D
     D --> E
     E --> F
@@ -74,6 +78,27 @@ No public feature claim is active in this section. Keep research scaffolds and
 hardware-backed enforcement language out of the public changelog until a tagged
 release ships source-owned tests, verifier evidence, and release artifacts for
 that exact capability.
+
+## [0.5.19] - 2026-07-01
+
+Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.5.19>.
+
+<!-- quantum_posture: v0.5.19 release notes mention existing cosign release verification only; this release adds no post-quantum cryptographic control. -->
+
+- Hardened hosted sandbox execution guardrails by centralizing timeout caps,
+  output caps, secret-bearing environment variable denial, and cleanup
+  degradation reporting across sandbox adapters and broker receipts.
+- Aligned account session and entitlement SDK contract fields on `plan_id`,
+  expanded public plan enums to `free`, `developer`, `team`, `scale`, and
+  `enterprise`, and regenerated Go, Java, Python, Rust, and TypeScript SDK
+  types from OpenAPI.
+- Updated the Java SDK Jackson dependency to `2.22.0`.
+- Shipped developer-first integration docs for Codex, Claude Code, MCP,
+  OpenAI-compatible proxy use, EvidencePack verification, signed receipts, and
+  policy bundles without expanding cloud, GA, connector certification, or
+  checkout claims.
+- Updated release version-surface automation for the rewritten Developer
+  Journey and Quickstart docs so future patch bumps remain tool-driven.
 
 ## [0.5.16] - 2026-06-18
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Release Process
 
+<!-- quantum_posture: release process docs mention existing Cosign verification only; this page adds no post-quantum cryptographic control. -->
+
 The retained release process is PR-first and tag-driven. `main` is protected;
 prepare releases on a branch, merge only after gates pass, and tag the merged
 commit.
@@ -10,38 +12,37 @@ The actual public baseline for the `v0.5.0` release is `v0.4.0`. GitHub has no
 public `v0.4.1` Release object, so release notes and verification docs must not
 describe `v0.4.1` as the current release.
 
-## Prepare v0.5.10
+## Prepare v0.5.19
 
 1. Update `VERSION`, CLI fallback version, OpenAPI `info.version`, SDK
-   manifests, generated SDK comments, and chart metadata.
-2. Update `CHANGELOG.md` with the `v0.5.10` user-visible delta.
-3. Run the maintained validation targets:
+   manifests, generated SDK comments, chart metadata, release docs, and exact
+   OpenVEX with the maintained release tooling:
 
 ```bash
-make test
-make test-platform
-make test-all
-make crucible
-make launch-smoke
+make prepare-version VERSION=0.5.19
+make vex
 ```
 
-4. Run the release artifact target:
+2. Update `CHANGELOG.md` with the `v0.5.19` user-visible delta.
+3. Run the maintained merge and release validation targets:
 
 ```bash
+make quality-merge
+make release-readiness
 make release-assets
 ```
 
-5. Confirm `dist/release-assets/` contains CLI binaries, `SHA256SUMS.txt`,
-   `sbom.json`, `v0.5.10.openvex.json`, `release-attestation.json`,
+4. Confirm `dist/release-assets/` contains CLI binaries, `SHA256SUMS.txt`,
+   `sbom.json`, `v0.5.19.openvex.json`, `release-attestation.json`,
    `evidence-pack.tar`, `release.high_risk.v3.toml`,
    `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, and `helm-ai-kernel.rb`.
-6. Confirm `./bin/helm-ai-kernel verify dist/release-assets/evidence-pack.tar` passes
+5. Confirm `./bin/helm-ai-kernel verify dist/release-assets/evidence-pack.tar` passes
    offline.
 
 ## Publish
 
 1. Merge the release-prep PR to `main`.
-2. Create the annotated `v0.5.10` tag only after the release commit is on
+2. Create the annotated `v0.5.19` tag only after the release commit is on
    `main`.
 3. Push the tag and monitor the Release workflow until GitHub Release, GHCR
    images, Cosign bundles, provenance, benchmark pinning, and Homebrew formula
@@ -50,7 +51,7 @@ make release-assets
    Cosign, SBOM, attestation, Homebrew formula, and offline EvidencePack
    verification.
 5. Commit the post-publish docs update that changes “current public release”
-   references to `v0.5.10` with the actual GitHub publish timestamp.
+   references to `v0.5.19` with the actual GitHub publish timestamp.
 
 Package publication for npm, PyPI, crates.io, and Maven-compatible consumers
 requires registry credentials. If the credentials are absent, those channels are

--- a/api/openapi/helm.openapi.yaml
+++ b/api/openapi/helm.openapi.yaml
@@ -4945,7 +4945,7 @@ components:
         workspace_id: { type: string }
         plan:
           type: string
-          enum: [free, individual, developer, team, scale, enterprise]
+          enum: [free, developer, team, scale, enterprise]
         plan_id: { type: string }
         edition: { type: string }
         deployment_mode: { type: string }
@@ -4963,7 +4963,7 @@ components:
         workspace_id: { type: string }
         plan:
           type: string
-          enum: [free, individual, developer, team, scale, enterprise]
+          enum: [free, developer, team, scale, enterprise]
         plan_id: { type: string }
         capabilities:
           $ref: '#/components/schemas/EntitlementCapabilities'

--- a/docs/launchpad/MINDBURN_ACCOUNT_ENTITLEMENTS_SPEC.md
+++ b/docs/launchpad/MINDBURN_ACCOUNT_ENTITLEMENTS_SPEC.md
@@ -5,8 +5,11 @@ last_reviewed: 2026-05-23
 
 # Mindburn Account Entitlements Integration Contract
 
+<!-- quantum_posture: entitlement adapter docs reference JWKS configuration only; this contract adds no cryptographic control. -->
+
 Status: integration contract plus optional Kernel adapter. `helm-ai-enterprise`
-Control Plane owns hosted Free / Individual / Enterprise account decisions.
+Control Plane owns hosted Free / Developer / Team / Scale / Enterprise account
+decisions.
 `helm-ai-kernel` remains self-hostable and does not infer account tier when the
 hosted adapter is not configured.
 
@@ -51,17 +54,16 @@ Canonical hosted plans are:
 
 ```text
 free
-individual
+developer
+team
+scale
 enterprise
 ```
 
-Compatibility aliases are normalized before decisions:
-
-```text
-oss-free, free, trial -> free
-basic, pro -> individual
-enterprise -> enterprise
-```
+Hosted Control Plane may normalize legacy billing names internally, but Kernel
+account session and entitlement responses expose only canonical `plan_id`
+values from this list. Historical `individual`, `basic`, and `pro` values are
+not valid public Kernel SDK plan IDs.
 
 The decision endpoint returns action-level access state and must be called
 before mutating Launchpad side effects when hosted gating is enabled.
@@ -75,7 +77,7 @@ Future hosted integration should expose an authenticated session payload with:
   "principal_id": "user_123",
   "tenant_id": "tenant_abc",
   "account_id": "acct_abc",
-  "plan": "individual",
+  "plan_id": "developer",
   "source": "mindburn-hosted",
   "expires_at": "2026-05-22T23:00:00Z"
 }
@@ -203,6 +205,6 @@ fallback data.
 - One app catalog.
 - One Launchpad route family.
 - One AppSpec / LaunchPlan / Receipt / EvidencePack model.
-- No Free, Individual, or Enterprise Kernel forks.
+- No Free, Developer, Team, Scale, or Enterprise Kernel forks.
 - No UI-only launchability, verdict, proof, secret, sandbox, MCP, or teardown
   claims.

--- a/release/vex/v0.5.19.openvex.json
+++ b/release/vex/v0.5.19.openvex.json
@@ -1,0 +1,10 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://mindburn.org/vex/helm-ai-kernel/v0.5.19",
+  "author": "Mindburn-Labs Release Bot <release@mindburn.org>",
+  "role": "Project Maintainer",
+  "timestamp": "2026-07-01T15:55:26Z",
+  "version": 1,
+  "tooling": "helm-ai-kernel/scripts/release/generate_vex.sh",
+  "statements": []
+}

--- a/scripts/release/generate_vex.sh
+++ b/scripts/release/generate_vex.sh
@@ -36,7 +36,13 @@ if [ ! -f "$SBOM" ]; then
     echo "::warning::sbom.json missing — run 'make sbom' first; emitting empty VEX"
 fi
 
-TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
+    if ! TIMESTAMP=$(date -u -r "$SOURCE_DATE_EPOCH" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+        TIMESTAMP=$(date -u -d "@$SOURCE_DATE_EPOCH" +%Y-%m-%dT%H:%M:%SZ)
+    fi
+else
+    TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+fi
 DOC_ID="https://mindburn.org/vex/helm-ai-kernel/v${RAW_VERSION}"
 
 # Note: This baseline VEX intentionally enumerates zero statements. The

--- a/sdk/java/src/main/java/labs/mindburn/helm/TypesGen.java
+++ b/sdk/java/src/main/java/labs/mindburn/helm/TypesGen.java
@@ -1586,8 +1586,6 @@ public static class AccountEntitlements {
   public enum PlanEnum {
     FREE("free"),
 
-    INDIVIDUAL("individual"),
-
     DEVELOPER("developer"),
 
     TEAM("team"),
@@ -2077,8 +2075,6 @@ public static class AccountSession {
    */
   public enum PlanEnum {
     FREE("free"),
-
-    INDIVIDUAL("individual"),
 
     DEVELOPER("developer"),
 

--- a/sdk/python/helm_sdk/types_gen.py
+++ b/sdk/python/helm_sdk/types_gen.py
@@ -417,8 +417,8 @@ class AccountEntitlements(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['free', 'individual', 'developer', 'team', 'scale', 'enterprise']):
-            raise ValueError("must be one of enum values ('free', 'individual', 'developer', 'team', 'scale', 'enterprise')")
+        if value not in set(['free', 'developer', 'team', 'scale', 'enterprise']):
+            raise ValueError("must be one of enum values ('free', 'developer', 'team', 'scale', 'enterprise')")
         return value
 
     model_config = ConfigDict(
@@ -549,8 +549,8 @@ class AccountSession(BaseModel):
         if value is None:
             return value
 
-        if value not in set(['free', 'individual', 'developer', 'team', 'scale', 'enterprise']):
-            raise ValueError("must be one of enum values ('free', 'individual', 'developer', 'team', 'scale', 'enterprise')")
+        if value not in set(['free', 'developer', 'team', 'scale', 'enterprise']):
+            raise ValueError("must be one of enum values ('free', 'developer', 'team', 'scale', 'enterprise')")
         return value
 
     model_config = ConfigDict(

--- a/sdk/rust/src/types_gen.rs
+++ b/sdk/rust/src/types_gen.rs
@@ -224,8 +224,6 @@ impl AccountEntitlements {
 pub enum AccountEntitlementsPlan {
     #[serde(rename = "free")]
     Free,
-    #[serde(rename = "individual")]
-    Individual,
     #[serde(rename = "developer")]
     Developer,
     #[serde(rename = "team")]
@@ -304,8 +302,6 @@ impl AccountSession {
 pub enum AccountSessionPlan {
     #[serde(rename = "free")]
     Free,
-    #[serde(rename = "individual")]
-    Individual,
     #[serde(rename = "developer")]
     Developer,
     #[serde(rename = "team")]

--- a/sdk/ts/src/types.gen.ts
+++ b/sdk/ts/src/types.gen.ts
@@ -524,7 +524,6 @@ export interface AccountEntitlements {
  */
 export const AccountEntitlementsPlanEnum = {
     Free: 'free',
-    Individual: 'individual',
     Developer: 'developer',
     Team: 'team',
     Scale: 'scale',
@@ -680,7 +679,6 @@ export interface AccountSession {
  */
 export const AccountSessionPlanEnum = {
     Free: 'free',
-    Individual: 'individual',
     Developer: 'developer',
     Team: 'team',
     Scale: 'scale',

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-01T20:05:59Z
-# Commit: 68fdf1279101560eb03bf86e44be4464c4176e4d
+# Generated: 2026-07-01T20:46:54Z
+# Commit: 53abe69b591d2a2cea87da6e14efb3b4859ae6d5
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #


### PR DESCRIPTION
## Summary

Corrective finalization PR for `v0.5.19` before tagging. PR #462 merged the v0.5.19 release prep while the earlier corrective PR #463 was still open; this PR keeps #462 intact and adds only the missing release-finalization delta.

Final head SHA: `20500c699ab7011389742f14601fda34ac320f73`.

## Changes

- Removes `individual` from the public account session and entitlement plan enums in OpenAPI and regenerated Java, Python, Rust, and TypeScript SDK types.
- Keeps the public account contract on canonical `plan_id` values: `free`, `developer`, `team`, `scale`, `enterprise`.
- Adds tracked exact VEX for `v0.5.19` and makes VEX generation honor `SOURCE_DATE_EPOCH`.
- Adds the `v0.5.19` changelog entry and updates `RELEASE.md` to the maintained release gates.
- Regenerates `tools/boundary/protected.manifest` after rebasing on current `origin/main`.

No new cloud, GA, checkout, connector certification, post-quantum crypto, governed inference, Spend Authority, RiskEnvelope, or v1.0 scope is introduced.

## Local validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.19 make docs-coverage docs-truth verify-boundary sdk-openapi-check version-drift`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.19 python3 scripts/ci/check_quantum_crypto_inventory.py $(git diff --name-only origin/main)`
- `git diff --check`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.19 SOURCE_DATE_EPOCH=1782921326 make quality-merge`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.19 SOURCE_DATE_EPOCH=1782921326 HELM_SMOKE_API_PORT=18280 HELM_SMOKE_HEALTH_PORT=18281 HELM_SMOKE_COMPOSE_PROJECT=helmoss_smoke_0519 make release-readiness`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.19 SOURCE_DATE_EPOCH=1782921326 make release-assets`

## Final release asset inventory

- `SHA256SUMS.txt`
- `evidence-pack.tar`
- `helm-ai-kernel-darwin-amd64`
- `helm-ai-kernel-darwin-arm64`
- `helm-ai-kernel-launchpad-data.tar`
- `helm-ai-kernel-linux-amd64`
- `helm-ai-kernel-linux-arm64`
- `helm-ai-kernel-windows-amd64.exe`
- `helm-ai-kernel.mcpb`
- `helm-ai-kernel.rb`
- `release-attestation.json`
- `release.high_risk.v3.toml`
- `sample-policy-material.tar`
- `sbom.json`
- `v0.5.19.openvex.json`

## Final checksums

- `dist/release-assets/SHA256SUMS.txt`: `4a8d8119d897e1290b6f67e8b9a3bab1a9930d159bb049182df2f47515c3328a`
- `dist/release-assets/release-attestation.json`: `cfe8b2818d38303a21bc35c5a572c28f2f01cdc016a7cec6552b2b2f6412edc2`
- `dist/release-assets/v0.5.19.openvex.json`: `6cc1774506660aa7bc6ef04d5ec72cb04bc5f8cc4e01933fbe63b89c390caf52`
- `release/vex/v0.5.19.openvex.json`: `6cc1774506660aa7bc6ef04d5ec72cb04bc5f8cc4e01933fbe63b89c390caf52`
- `dist/release-assets/sbom.json`: `c8c51f50aad99e4a0c3728412f2351e1cb0e4b6db35baa5e1a9e2b3c2aed274a`
- `dist/release-assets/evidence-pack.tar`: `261d777b30e32d4e006da9e8b8b6616d40a942ccb4a8e8799c97f041fea443f3`

## Release sequencing

After this PR merges to `main`, tag that merge commit as `v0.5.19` and `sdk/go/v0.5.19` if neither tag exists. Do not tag PR #462's merge commit directly.