### PR TITLE
Use PyPI trusted publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -61,6 +61,5 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: sdk/python/dist/
           skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -652,7 +652,6 @@ jobs:
         if: steps.package.outputs.published != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: sdk/python/dist/
           skip-existing: true
       - name: Skip already published package


### PR DESCRIPTION
## Summary

Switch the Python package publish steps from the broken stored `PYPI_TOKEN` path to PyPI Trusted Publishing.

This is the minimal unblocker for HELM-34:

- `release.yml` already uses `environment: pypi-production` and `id-token: write` for the `python-sdk` job.
- `python-publish.yml` already uses the same environment and OIDC permission.
- PyPI/PyPA trusted publishing requires removing explicit username/password/token inputs so the action can exchange the GitHub OIDC identity for a short-lived PyPI token.

No package version, product behavior, release scope, docs claims, or registry target changes are included.

## Validation

```bash
MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.20 make version-drift
MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.20 ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/release.yml .github/workflows/python-publish.yml
```

## Release impact

After this lands, tag `v0.5.20` from the resulting `main` commit, let `.github/workflows/release.yml` publish, and require `make version-drift-published` to pass before proceeding to `v0.6.0`.

If PyPI Trusted Publishing is not configured for project `helm-sdk` with owner `Mindburn-Labs`, repository `helm-ai-kernel`, workflow `.github/workflows/release.yml`, and environment `pypi-production`, the release will fail with a PyPI trusted-publisher configuration error. That would be the remaining external PyPI-side action, not a repo-side token/email failure.
