### PR TITLE
Pass only docs truth read token

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -13,5 +13,6 @@ on:
 jobs:
   docs-truth:
     name: docs-truth
-    uses: Mindburn-Labs/dev-orchestration/.github/workflows/docs-truth.yml@84f503d75b1ffa9006aca8cd272d4d4683b8c12a
-    secrets: inherit
+    uses: Mindburn-Labs/dev-orchestration/.github/workflows/docs-truth.yml@34c72eb5e6243c902e77403b21ea65f9f0279316
+    secrets:
+      MINDBURN_ORG_READ_TOKEN: ${{ secrets.MINDBURN_ORG_READ_TOKEN }}


### PR DESCRIPTION
## Summary
- repins the docs-truth caller to the explicit-secret reusable workflow
- passes only MINDBURN_ORG_READ_TOKEN instead of inheriting every repo secret

## Validation
- actionlint .github/workflows/docs-truth.yml
- git diff --check