### PR TITLE
fix(release): restore PyPI token publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -61,5 +61,6 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
+          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: sdk/python/dist/
           skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -652,6 +652,7 @@ jobs:
         if: steps.package.outputs.published != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
+          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: sdk/python/dist/
           skip-existing: true
       - name: Skip already published package


### PR DESCRIPTION
## Summary
- restore `secrets.PYPI_TOKEN` for PyPI publish steps in `release.yml` and `python-publish.yml`
- keep package/source content unchanged

## Why
`v0.5.20` release run `28554948829` failed because PyPI has no matching trusted publisher for `release.yml`. Follow-up dispatches also failed for `python-publish.yml` on both tag and main refs with `invalid-publisher`. The last known successful Python publish used `PYPI_TOKEN`, so this restores the working source path until PyPI trusted publishing is configured.

## Validation
- `git diff --check`
- `actionlint -shellcheck= .github/workflows/release.yml .github/workflows/python-publish.yml`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-pypi-token-publish make version-drift`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-pypi-token-publish make quality-pr`

## Release truth
This PR does not make `v0.5.20` released. After merge, publish `helm-sdk==0.5.20`, rerun the failed release workflow jobs, then verify GitHub Release/assets/version-status before any public release claim.