### PR TITLE
fix(release): avoid version-prefix drift false positives

### DIFF
--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -22,6 +22,7 @@ DEFAULT_CONTRACT = ROOT / "release" / "version-surfaces.yaml"
 REQUEST_TIMEOUT_SECONDS = 30.0
 SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 SEMVER_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
+REJECT_TOKEN_SUFFIX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.+-"
 
 
 @dataclass
@@ -289,13 +290,18 @@ def check_http_contains(surface: dict[str, Any], version: str) -> SurfaceResult:
     text = request_text(url)
     expected = [fmt(str(token), version) for token in surface.get("contains", ["{version}"])]
     missing = [token for token in expected if token not in text]
-    rejected = [fmt(str(token), version) for token in surface.get("rejects", []) if fmt(str(token), version) in text]
+    rejected = [fmt(str(token), version) for token in surface.get("rejects", []) if rejected_token_present(text, fmt(str(token), version))]
     actual = {
         "found": [token for token in expected if token not in missing],
         "missing": missing,
         "rejected_found": rejected,
     }
     return SurfaceResult(surface["id"], "pass" if not missing and not rejected else "fail", expected, actual, url=fmt(surface.get("human_url", url), version), blocking=is_blocking(surface))
+
+
+def rejected_token_present(text: str, token: str) -> bool:
+    pattern = re.escape(token) + f"(?![{re.escape(REJECT_TOKEN_SUFFIX_CHARS)}])"
+    return re.search(pattern, text) is not None
 
 
 def check_go_proxy_module(surface: dict[str, Any], version: str) -> SurfaceResult:

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -197,6 +197,37 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertEqual(result.actual["missing"], ["io.github.mindburnlabs:helm-sdk:0.5.10"])
         self.assertEqual(result.actual["rejected_found"], ["io.github.mindburnlabs:helm-sdk:0.5.2"])
 
+    def test_http_contains_does_not_reject_version_prefix_matches(self) -> None:
+        original = drift.request_text
+        drift.request_text = lambda _url: (
+            "current docs mention version-status.json, "
+            "io.github.mindburnlabs:helm-sdk:0.5.20, "
+            "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.5.20, "
+            "and sdk/go/v0.5.20"
+        )
+        try:
+            surface = {
+                "id": "docs-site-sdk-index",
+                "kind": "http_contains",
+                "url": "https://example.test/sdk",
+                "contains": [
+                    "io.github.mindburnlabs:helm-sdk:{version}",
+                    "github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v{version}",
+                    "sdk/go/v{version}",
+                    "version-status.json",
+                ],
+                "rejects": [
+                    "io.github.mindburnlabs:helm-sdk:0.5.2",
+                    "sdk/go@main",
+                ],
+            }
+            result = drift.check_http_contains(surface, "0.5.20")
+        finally:
+            drift.request_text = original
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.actual["rejected_found"], [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make published docs rejected-token checks suffix-boundary aware
- prevent stale `0.5.2` reject tokens from matching valid `0.5.20` coordinates
- add a regression test covering the v0.5.20 docs-site false positive

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.20 python3 scripts/release/check_version_drift_test.py`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-release-v0.5.20 make version-drift-published` now passes docs-site surfaces and reports only real live publish gaps: missing GitHub Release, PyPI still at `0.5.18`, and Homebrew still at `0.5.18`.

## Release truth
This PR does not claim v0.5.20 is complete. It fixes the verifier so post-release drift reports do not confuse valid v0.5.20 package coordinates with stale v0.5.2 text.
