### PR TITLE
fix(release): allow Python publish from release tag

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: false
         type: boolean
+      release_tag:
+        description: Optional v<version> tag to publish with the current workflow.
+        required: false
+        default: ""
+        type: string
 
 permissions: read-all
 
@@ -36,7 +41,13 @@ jobs:
         run: |
           python3 scripts/ci/validate_workflow_dispatch_inputs.py publish \
             --version "${{ inputs.version }}" \
-            --dry-run "${{ inputs.dry_run }}"
+            --dry-run "${{ inputs.dry_run }}" \
+            --release-tag "${{ inputs.release_tag }}"
+      - name: Check out requested release tag
+        if: inputs.release_tag != ''
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ inputs.release_tag }}
       - name: Version checks
         working-directory: sdk/python
         run: |

--- a/scripts/ci/validate_workflow_dispatch_inputs.py
+++ b/scripts/ci/validate_workflow_dispatch_inputs.py
@@ -40,6 +40,15 @@ def validate_release_tag(value: str) -> str:
     return value
 
 
+def validate_optional_publish_tag(value: str | None, *, version: str) -> str | None:
+    if value is None or value.strip() == "":
+        return None
+    tag = validate_release_tag(value)
+    if tag != f"v{version}":
+        raise ValueError("release_tag must match v<version>")
+    return tag
+
+
 def validate_artifact_run_id(value: str) -> str:
     value = (value or "").strip()
     if not RUN_ID_RE.fullmatch(value):
@@ -54,6 +63,7 @@ def build_parser() -> argparse.ArgumentParser:
     publish = sub.add_parser("publish")
     publish.add_argument("--version", required=True)
     publish.add_argument("--dry-run", default=None)
+    publish.add_argument("--release-tag", default=None)
 
     clean_install = sub.add_parser("clean-install")
     clean_install.add_argument("--release-tag", required=True)
@@ -66,8 +76,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         if args.command == "publish":
-            validate_version(args.version)
+            version = validate_version(args.version)
             validate_bool(args.dry_run, field="dry_run")
+            validate_optional_publish_tag(args.release_tag, version=version)
         elif args.command == "clean-install":
             validate_release_tag(args.release_tag)
             validate_artifact_run_id(args.artifact_run_id)

--- a/scripts/ci/validate_workflow_dispatch_inputs_test.py
+++ b/scripts/ci/validate_workflow_dispatch_inputs_test.py
@@ -18,6 +18,14 @@ class WorkflowDispatchInputValidationTest(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     validator.validate_version(value)
 
+    def test_publish_release_tag_must_match_version(self) -> None:
+        self.assertIsNone(validator.validate_optional_publish_tag("", version="1.2.3"))
+        self.assertEqual(validator.validate_optional_publish_tag("v1.2.3", version="1.2.3"), "v1.2.3")
+        for tag in ["v1.2.4", "1.2.3", "v1.2.3;echo pwned"]:
+            with self.subTest(tag=tag):
+                with self.assertRaises(ValueError):
+                    validator.validate_optional_publish_tag(tag, version="1.2.3")
+
     def test_bool_is_strict(self) -> None:
         self.assertTrue(validator.validate_bool("true", field="dry_run"))
         self.assertFalse(validator.validate_bool("false", field="dry_run"))


### PR DESCRIPTION
## Summary
- add an optional `release_tag` input to the manual Python Publish workflow
- validate that `release_tag` is exactly `v<version>` before any tag checkout
- allow current workflow fixes to publish a prior tagged Python SDK after `main` moves forward

## Why
The v0.5.20 PyPI recovery currently depends on `main` still carrying `VERSION=0.5.20`. Once `main` is prepared for v0.6.0, the current manual workflow could no longer publish `helm-sdk==0.5.20` with the restored token path. This keeps recovery possible without using the old tag workflow.

Example recovery dispatch after the PyPI account/token blocker is fixed:

```bash
gh workflow run python-publish.yml \
  --repo Mindburn-Labs/helm-ai-kernel \
  --ref main \
  -f version=0.5.20 \
  -f release_tag=v0.5.20 \
  -f dry_run=false
```

## Validation
- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel python3 scripts/ci/validate_workflow_dispatch_inputs_test.py`
- `actionlint -shellcheck= .github/workflows/python-publish.yml`
- `git diff --check`

## Release truth
This does not complete v0.5.20 or start v0.6.0. It only keeps PyPI recovery possible after v0.6.0 prep begins.
