### PR TITLE
Use public docs truth reusable workflow

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -13,6 +13,6 @@ on:
 jobs:
   docs-truth:
     name: docs-truth
-    uses: Mindburn-Labs/dev-orchestration/.github/workflows/docs-truth.yml@34c72eb5e6243c902e77403b21ea65f9f0279316
+    uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@58c8f9c29c87bd3777ef0f88015d796570f80f9f
     secrets:
       MINDBURN_ORG_READ_TOKEN: ${{ secrets.MINDBURN_ORG_READ_TOKEN }}

--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -13,6 +13,6 @@ on:
 jobs:
   docs-truth:
     name: docs-truth
-    uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@58c8f9c29c87bd3777ef0f88015d796570f80f9f
+    uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@1382586657b369c9c81947b42f04525e3922b0f9
     secrets:
       MINDBURN_ORG_READ_TOKEN: ${{ secrets.MINDBURN_ORG_READ_TOKEN }}


### PR DESCRIPTION
## Summary
- routes this repo's docs-truth caller through the public Mindburn-Labs/.github reusable workflow
- keeps the private read token limited to MINDBURN_ORG_READ_TOKEN

## Validation
- actionlint .github/workflows/docs-truth.yml
- git diff --check