### PR TITLE
Document HELM proof loop and AI security categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ You get:  a signed receipt you can verify offline
 | Need | Link |
 | --- | --- |
 | 5-minute local proof | [Quickstart](docs/QUICKSTART.md) |
+| End-to-end proof loop | [HELM Proof Loop](docs/PROOF_LOOP.md) |
 | Local AI-agent risk audit | [Agent Risk Scan](docs/reference/agent-risk-scan.md) |
 | CLI commands | [CLI reference](docs/reference/cli.md) |
 | Security model | [Execution security model](docs/EXECUTION_SECURITY_MODEL.md) |
 | MCP tool quarantine | [MCP integration](docs/INTEGRATIONS/mcp.md) |
 | Evidence verification | [Verification](docs/VERIFICATION.md) |
+| AI security category map | [AI Security Categories](docs/AI_SECURITY_CATEGORIES.md) |
 
 ## What It Is Not
 

--- a/core/pkg/kernel/limiter_redis_test.go
+++ b/core/pkg/kernel/limiter_redis_test.go
@@ -18,7 +18,7 @@ func TestRedisLimiterStore_Integration(t *testing.T) {
 	}
 
 	policy := BackpressurePolicy{RPM: 60, Burst: 1} // 1 token/sec
-	actor := "test-redis-actor"
+	actor := "test-redis-actor-" + time.Now().Format("20060102150405.000000000")
 
 	// 1. Allow
 	allowed, err := store.Allow(ctx, actor, policy, 1)

--- a/docs/PROOF_LOOP.md
+++ b/docs/PROOF_LOOP.md
@@ -27,7 +27,7 @@ Install the kernel, run the local proof, then verify the bundle:
 brew tap mindburn-labs/tap
 brew install helm-ai-kernel
 helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
-helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/<run-id> --profile dev-local --json
+helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> --profile dev-local --json
 ```
 
 For one workstation receipt:

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -67,11 +67,12 @@ Expected shape:
 Verify the generated EvidencePack offline:
 
 ```bash
-helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/<run-id> --profile dev-local --json
+helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> --profile dev-local --json
 ```
 
-Use the `v0.6.0` release `evidence-pack.tar` from the GitHub release for
-release verification instead of a local proof bundle.
+When a GitHub Release publishes an `evidence-pack.tar`, use that release asset
+for release verification instead of a local proof bundle. Until then, the local
+proof bundle above is the verifiable path.
 
 For the full public flow, see [HELM Proof Loop](PROOF_LOOP.md).
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -70,9 +70,8 @@ Verify the generated EvidencePack offline:
 helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> --profile dev-local --json
 ```
 
-When a GitHub Release publishes an `evidence-pack.tar`, use that release asset
-for release verification instead of a local proof bundle. Until then, the local
-proof bundle above is the verifiable path.
+Use the `v0.6.0` release `evidence-pack.tar` from the GitHub release for
+release verification instead of a local proof bundle.
 
 For the full public flow, see [HELM Proof Loop](PROOF_LOOP.md).
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -70,8 +70,9 @@ Verify the generated EvidencePack offline:
 helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> --profile dev-local --json
 ```
 
-Use the `v0.6.0` release `evidence-pack.tar` from the GitHub release for
-release verification instead of a local proof bundle.
+When a GitHub Release publishes an `evidence-pack.tar`, use that release asset
+for release verification instead of a local proof bundle. Until then, the local
+proof bundle above is the verifiable path.
 
 For the full public flow, see [HELM Proof Loop](PROOF_LOOP.md).
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -70,8 +70,9 @@ Verify the generated EvidencePack offline:
 helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> --profile dev-local --json
 ```
 
-Use the `v0.6.0` release `evidence-pack.tar` from the GitHub release for
-release verification instead of a local proof bundle.
+When the `v0.6.0` GitHub Release publishes an `evidence-pack.tar`, use that
+release asset for release verification instead of a local proof bundle. Until
+then, the local proof bundle above is the verifiable path.
 
 For the full public flow, see [HELM Proof Loop](PROOF_LOOP.md).
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -73,6 +73,8 @@ helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/<run-id> --prof
 Use the `v0.6.0` release `evidence-pack.tar` from the GitHub release for
 release verification instead of a local proof bundle.
 
+For the full public flow, see [HELM Proof Loop](PROOF_LOOP.md).
+
 ## See An Escalation
 
 Ask HELM to authorize a local MCP action before dispatch:

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ Then choose one path.
 ## Start
 
 - [Quickstart](QUICKSTART.md)
+- [HELM proof loop](PROOF_LOOP.md)
 - [Protect local coding agents](quickstart/workstation-governance.md)
 - [Scan agent risk](reference/agent-risk-scan.md)
 - [OpenAI proxy](INTEGRATIONS/openai_baseurl.md)
@@ -37,6 +38,7 @@ Then choose one path.
 
 ## More
 
+- [AI security categories](AI_SECURITY_CATEGORIES.md)
 - [MCP](INTEGRATIONS/mcp.md)
 - [Conformance](CONFORMANCE.md)
 - [Troubleshooting](TROUBLESHOOTING.md)

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -393,8 +393,8 @@
       "id": "quickstart-release-evidence-pack",
       "path": "docs/QUICKSTART.md",
       "kind": "regex",
-      "pattern": "Use the `v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)` release `evidence-pack.tar`",
-      "replacement": "Use the `v{version}` release `evidence-pack.tar`"
+      "pattern": "When the `v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)` GitHub Release publishes an `evidence-pack\\.tar`",
+      "replacement": "When the `v{version}` GitHub Release publishes an `evidence-pack.tar`"
     },
     {
       "id": "release-readme-current-release",

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-02T18:42:36Z
-# Commit: ae7548d37d29120a0d0a43878dba4247053f4607
+# Generated: 2026-07-02T18:43:19Z
+# Commit: 85d8e04a7db0d0fd45d5f11eb0f80b010de834cb
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-02T14:46:49Z
-# Commit: 18cbfd0f813cca9496e29f8e7a6c08337087df9b
+# Generated: 2026-07-02T18:42:36Z
+# Commit: ae7548d37d29120a0d0a43878dba4247053f4607
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -82,7 +82,7 @@ baa84e947fb05c23c72a8805dcc502632f88d6700d2762d46fccdf25b2fa5c13  core/pkg/kerne
 469a7cf1cac67b51ceb5dbc2a8b734ac6c556172a87cc576c603b138dd350e0f  core/pkg/kernel/kernel_test.go
 6a2446a7acf88faf88ff1e6b11cbaa4dbc008fa669499a49ea1ab79073cfa40f  core/pkg/kernel/limiter.go
 132d0e4936b387541f735c40219b7fb34a930c60caa7ad59a328328209398721  core/pkg/kernel/limiter_redis.go
-7442e465921083900093c8835fc450eb60ee874c74cf59657e1fd605f9e35a8d  core/pkg/kernel/limiter_redis_test.go
+aefde19ffb99224a6de5c7584245cb83d1536207db921a85b7fac943d65faabd  core/pkg/kernel/limiter_redis_test.go
 fbecb9191cadbf90ce4ad3cd0e2603cef4f1c700c948ce4d482428ccc7002647  core/pkg/kernel/memory_integrity.go
 f3abb13e9181d2c917d393bf8f55f3b185f403eaeeb6d6c978bcfc80de80529b  core/pkg/kernel/memory_integrity_test.go
 667cac33f98fb0d455b5ecf12cf45001b2f2004c63f6d9440f06fcf3b18a28b7  core/pkg/kernel/memory_trust.go


### PR DESCRIPTION
## Summary
- Adds public kernel docs for the HELM proof loop: route an action, get ALLOW/DENY/ESCALATE, verify receipt/EvidencePack material offline.
- Adds neutral AI security category framing for ZeroDrift-style communication controls, Strix-style security testing loops, posture tools, and HELM execution firewalls.
- Publishes the new docs through docs/public-docs.manifest.json and links them from README, docs index, and quickstart.
- Fixes Redis limiter integration test isolation by using a unique actor key per run.

## Validation
- /usr/bin/python3 scripts/check_documentation_truth.py
- /usr/bin/python3 scripts/check_documentation_coverage.py
- env -u GOROOT PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" make verify-fixtures
- env -u GOROOT PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" go test ./core/pkg/kernel -run TestRedisLimiterStore_Integration -count=1
- env -u GOROOT PATH="/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" make test

## Notes
- `make docs-truth docs-coverage` via the default shell is blocked in this fresh worktree because mise does not trust this worktree path. Direct system Python checks passed.
- No new runtime API shape is introduced.