### PR TITLE
Publish proof loop docs in manifest

### DIFF
--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -28,6 +28,15 @@
       "sensitivity": "public"
     },
     {
+      "slug": "proof-loop",
+      "title": "HELM Proof Loop",
+      "section": "guide",
+      "source_path": "docs/PROOF_LOOP.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/proof-loop",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "guides/protect-local-coding-agents",
       "title": "Protect Local Coding Agents",
       "section": "guide",
@@ -42,6 +51,15 @@
       "section": "guide",
       "source_path": "docs/HOW_HELM_WORKS.md",
       "docs_origin_hint": "helm.docs.mindburn.org/how-helm-works",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
+      "slug": "ai-security-categories",
+      "title": "AI Security Categories",
+      "section": "guide",
+      "source_path": "docs/AI_SECURITY_CATEGORIES.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/ai-security-categories",
       "access": "public",
       "sensitivity": "public"
     },


### PR DESCRIPTION
## Summary
- adds public docs manifest entries for the now-tracked proof loop and AI security categories pages
- keeps the docs-source gate aligned with the files restored in #479

## Validation
- git diff --check
- python3 -m json.tool docs/public-docs.manifest.json
- make docs-coverage docs-truth