### PR TITLE
Fix PyPI trusted publishing for release workflows

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -72,6 +72,5 @@ jobs:
         if: github.event.inputs.dry_run != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: sdk/python/dist/
           skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -652,7 +652,6 @@ jobs:
         if: steps.package.outputs.published != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
           packages-dir: sdk/python/dist/
           skip-existing: true
       - name: Skip already published package


### PR DESCRIPTION
## Summary
- remove the restored PYPI_TOKEN password input from the tag release workflow
- remove the same token input from the manual python-publish recovery workflow
- keep PyPI publication on OIDC/trusted publishing so attestations are usable and the unverified mindburn token no longer blocks releases

## Validation
- python3 -m pytest scripts/ci/validate_workflow_dispatch_inputs_test.py
- python3 scripts/ci/validate_workflow_dispatch_inputs.py publish --version 0.6.0 --dry-run true --release-tag v0.6.0
- git diff --check

## Release blocker note
PyPI still needs trusted publishers configured for helm-sdk before release reruns can pass:
- repository: Mindburn-Labs/helm-ai-kernel
- workflow: release.yml
- environment: pypi-production
- workflow: python-publish.yml
- environment: pypi-production