### PR TITLE
docs: use neutral tenant KMS heading

### DIFF
--- a/docs/security/quantum-posture.md
+++ b/docs/security/quantum-posture.md
@@ -47,14 +47,14 @@ separate checks:
 Hashing and symmetric encryption are separate primitives. The urgent migration
 surface is public-key signing and key agreement, not SHA-256 receipt hashes.
 
-## Enterprise Tenant KMS
+## Tenant KMS
 
-HELM Enterprise tenant KMS keys are still classical Ed25519 key material. PR
-#168 added key-epoch posture metadata and policy-aware verification helpers so a
-caller that requires hybrid or PQ verification is rejected instead of silently
+Tenant KMS keys are still classical Ed25519 key material. PR #168 added
+key-epoch posture metadata and policy-aware verification helpers so a caller
+that requires hybrid or PQ verification is rejected instead of silently
 accepting the classical tenant key. That is downgrade resistance, not
-post-quantum tenant key material. Tenant KMS should be described as
-`classical` until an ML-DSA/PQ-backed provider exists and is verified.
+post-quantum tenant key material. Tenant KMS should be described as `classical`
+until an ML-DSA/PQ-backed provider exists and is verified.
 
 ## Public Web Boundary
 


### PR DESCRIPTION
## Summary
- Replace public-docs source heading/text that would be rewritten from Enterprise to advanced
- Keep tenant KMS posture wording neutral and accurate: downgrade-aware classical Ed25519, not PQ key material

## Validation
- python3 scripts/check_documentation_truth.py
- python3 scripts/ci/check_quantum_crypto_inventory.py --base origin/main
- git diff --check