### PR TITLE
fix(release): allow PyPI token publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -74,3 +74,4 @@ jobs:
         with:
           packages-dir: sdk/python/dist/
           skip-existing: true
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -654,6 +654,7 @@ jobs:
         with:
           packages-dir: sdk/python/dist/
           skip-existing: true
+          password: ${{ secrets.PYPI_TOKEN }}
       - name: Skip already published package
         if: steps.package.outputs.published == 'true'
         run: echo "helm-sdk@${{ steps.package.outputs.version }} is already published"


### PR DESCRIPTION
## Summary

- passes the existing `PYPI_TOKEN` secret to the PyPI publish action in `python-publish.yml`
- applies the same token path to the tag release workflow's Python SDK publish step
- keeps the current build, version-check, and `skip-existing` behavior unchanged

## Evidence

- `actionlint -shellcheck= .github/workflows/python-publish.yml .github/workflows/release.yml`
- `git diff --check`
- token-backed recovery run for `version=0.5.20`, `release_tag=v0.5.20`: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/28611543254
- PyPI JSON confirms `helm-sdk==0.5.20` now exists with wheel and sdist

## Release Truth

This PR fixes the source workflow path only. It does not by itself prove a full kernel release, GitHub Release, production deployment, or `v0.6.0` publication.
