### PR TITLE
security: verify hybrid approval receipts

### DIFF
--- a/core/pkg/api/approve_handler.go
+++ b/core/pkg/api/approve_handler.go
@@ -6,10 +6,20 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+const (
+	approvalSignatureAlgorithmEd25519 = "ed25519-sha256"
+	approvalSignatureAlgorithmHybrid  = "hybrid-ed25519-mldsa65-sha256"
+	approvalPolicyClassicalRequired   = "classical-ed25519-required"
+	approvalPolicyHybridRequired      = "hybrid-required"
+	approvalPolicyPQCRequired         = "pqc-required"
 )
 
 // ApproveHandler handles POST /api/v1/kernel/approve
@@ -57,8 +67,8 @@ func (h *ApproveHandler) RegisterPendingApproval(req *contracts.ApprovalRequest)
 // Flow:
 //  1. Parse ApprovalReceipt from request body
 //  2. Verify the intent exists in pending queue
-//  3. Decode the approver's Ed25519 public key
-//  4. Verify the signature over IntentHash
+//  3. Verify the approver public key is authorized
+//  4. Verify the profile-aware signature over the approval context
 //  5. Mark the approval as APPROVED with the receipt
 //  6. Return 200 with the signed receipt
 func (h *ApproveHandler) HandleApprove(w http.ResponseWriter, r *http.Request) {
@@ -103,17 +113,8 @@ func (h *ApproveHandler) HandleApprove(w http.ResponseWriter, r *http.Request) {
 	}
 	h.mu.Unlock()
 
-	// Decode public key
-	pubKeyBytes, err := hex.DecodeString(receipt.PublicKey)
-	if err != nil || len(pubKeyBytes) != ed25519.PublicKeySize {
-		WriteBadRequest(w, "invalid public key")
-		return
-	}
-
-	// Decode signature
-	sigBytes, err := hex.DecodeString(receipt.Signature)
-	if err != nil {
-		WriteBadRequest(w, "invalid signature encoding")
+	if err := validateApprovalReceiptEncoding(receipt); err != nil {
+		WriteBadRequest(w, err.Error())
 		return
 	}
 
@@ -128,10 +129,6 @@ func (h *ApproveHandler) HandleApprove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify Ed25519 signature over the bound context:
-	// plan_hash + policy_hash + intent_hash + nonce
-	pubKey := ed25519.PublicKey(pubKeyBytes)
-
 	// Create the canonical domain-separated message
 	message := fmt.Sprintf("HELM/Approval/v1:%s:%s:%s:%s",
 		receipt.PlanHash,
@@ -139,8 +136,8 @@ func (h *ApproveHandler) HandleApprove(w http.ResponseWriter, r *http.Request) {
 		receipt.IntentHash,
 		receipt.Nonce)
 
-	if !ed25519.Verify(pubKey, []byte(message), sigBytes) {
-		WriteForbidden(w, "signature verification failed — approval rejected")
+	if err := verifyApprovalReceiptSignature(receipt, []byte(message)); err != nil {
+		WriteForbidden(w, fmt.Sprintf("signature verification failed — approval rejected: %v", err))
 		return
 	}
 
@@ -173,4 +170,189 @@ func (h *ApproveHandler) GetPendingApprovals() []*contracts.ApprovalRequest {
 		}
 	}
 	return pending
+}
+
+func validateApprovalReceiptEncoding(receipt contracts.ApprovalReceipt) error {
+	switch approvalSignatureProfile(receipt) {
+	case helmcrypto.ReceiptProfileClassical:
+		pubKeyBytes, err := hex.DecodeString(receipt.PublicKey)
+		if err != nil || len(pubKeyBytes) != ed25519.PublicKeySize {
+			return fmt.Errorf("invalid public key")
+		}
+		if _, err := hex.DecodeString(receipt.Signature); err != nil {
+			return fmt.Errorf("invalid signature encoding")
+		}
+	case helmcrypto.ReceiptProfileHybrid:
+		edPub, mldsaPub, err := approvalHybridPublicKeys(receipt)
+		if err != nil {
+			return fmt.Errorf("invalid public key")
+		}
+		edPubBytes, err := hex.DecodeString(edPub)
+		if err != nil {
+			return fmt.Errorf("invalid public key")
+		}
+		mldsaPubBytes, err := hex.DecodeString(mldsaPub)
+		if err != nil {
+			return fmt.Errorf("invalid public key")
+		}
+		if _, err := helmcrypto.NewHybridVerifier(edPubBytes, mldsaPubBytes); err != nil {
+			return fmt.Errorf("invalid public key")
+		}
+		edSig, mldsaSig, err := approvalHybridSignatureParts(receipt.Signature)
+		if err != nil {
+			return fmt.Errorf("invalid signature encoding")
+		}
+		if _, err := hex.DecodeString(edSig); err != nil {
+			return fmt.Errorf("invalid signature encoding")
+		}
+		if _, err := hex.DecodeString(mldsaSig); err != nil {
+			return fmt.Errorf("invalid signature encoding")
+		}
+	default:
+		return fmt.Errorf("unsupported signature profile")
+	}
+	return nil
+}
+
+func verifyApprovalReceiptSignature(receipt contracts.ApprovalReceipt, message []byte) error {
+	profile := approvalSignatureProfile(receipt)
+	algorithm := approvalSignatureAlgorithm(receipt, profile)
+	if err := enforceApprovalVerificationPolicy(receipt, profile, algorithm); err != nil {
+		return err
+	}
+
+	switch profile {
+	case helmcrypto.ReceiptProfileClassical:
+		pubKeyBytes, err := hex.DecodeString(receipt.PublicKey)
+		if err != nil || len(pubKeyBytes) != ed25519.PublicKeySize {
+			return fmt.Errorf("invalid public key")
+		}
+		sigBytes, err := hex.DecodeString(receipt.Signature)
+		if err != nil {
+			return fmt.Errorf("invalid signature encoding")
+		}
+		if !ed25519.Verify(ed25519.PublicKey(pubKeyBytes), message, sigBytes) {
+			return fmt.Errorf("ed25519 signature verification failed")
+		}
+		return nil
+	case helmcrypto.ReceiptProfileHybrid:
+		edPub, mldsaPub, err := approvalHybridPublicKeys(receipt)
+		if err != nil {
+			return err
+		}
+		edSig, mldsaSig, err := approvalHybridSignatureParts(receipt.Signature)
+		if err != nil {
+			return err
+		}
+		ok, err := helmcrypto.Verify(edPub, edSig, message)
+		if err != nil || !ok {
+			return fmt.Errorf("hybrid ed25519 verification failed")
+		}
+		ok, err = helmcrypto.VerifyMLDSA65(mldsaPub, mldsaSig, message)
+		if err != nil || !ok {
+			return fmt.Errorf("hybrid ml-dsa-65 verification failed")
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported signature profile %q", profile)
+	}
+}
+
+func approvalSignatureProfile(receipt contracts.ApprovalReceipt) string {
+	if profile := strings.ToLower(strings.TrimSpace(receipt.SignatureProfile)); profile != "" {
+		return profile
+	}
+	if strings.HasPrefix(receipt.Signature, "hybrid:") {
+		return helmcrypto.ReceiptProfileHybrid
+	}
+	return helmcrypto.ReceiptProfileClassical
+}
+
+func approvalSignatureAlgorithm(receipt contracts.ApprovalReceipt, profile string) string {
+	if algorithm := strings.ToLower(strings.TrimSpace(receipt.SignatureAlgorithm)); algorithm != "" {
+		return algorithm
+	}
+	if profile == helmcrypto.ReceiptProfileHybrid {
+		return approvalSignatureAlgorithmHybrid
+	}
+	return approvalSignatureAlgorithmEd25519
+}
+
+func enforceApprovalVerificationPolicy(receipt contracts.ApprovalReceipt, profile, algorithm string) error {
+	switch strings.ToLower(strings.TrimSpace(receipt.VerificationPolicy)) {
+	case "", approvalPolicyClassicalRequired:
+		if profile != helmcrypto.ReceiptProfileClassical {
+			return fmt.Errorf("approval signature profile %q does not satisfy classical policy", profile)
+		}
+	case approvalPolicyHybridRequired:
+		if profile != helmcrypto.ReceiptProfileHybrid {
+			return fmt.Errorf("approval signature profile %q does not satisfy hybrid policy", profile)
+		}
+		if !receipt.DowngradeRejected {
+			return fmt.Errorf("hybrid approval must declare downgrade rejection")
+		}
+	case approvalPolicyPQCRequired:
+		return fmt.Errorf("approval handler does not support PQ-only approvals")
+	default:
+		return fmt.Errorf("unsupported approval verification policy %q", receipt.VerificationPolicy)
+	}
+	if len(receipt.AcceptedAlgorithms) == 0 {
+		return nil
+	}
+	for _, accepted := range receipt.AcceptedAlgorithms {
+		if normalizeApprovalAlgorithm(accepted) == normalizeApprovalAlgorithm(algorithm) {
+			return nil
+		}
+	}
+	return fmt.Errorf("approval signature algorithm %q not accepted", algorithm)
+}
+
+func approvalHybridPublicKeys(receipt contracts.ApprovalReceipt) (edPub, mldsaPub string, err error) {
+	if receipt.PublicKeySet != nil {
+		edPub = firstNonEmpty(receipt.PublicKeySet[receipt.KeyID+":ed25519"], receipt.PublicKeySet["ed25519"])
+		mldsaPub = firstNonEmpty(receipt.PublicKeySet[receipt.KeyID+":ml-dsa-65"], receipt.PublicKeySet["ml-dsa-65"])
+	}
+	if edPub == "" || mldsaPub == "" {
+		edPub, mldsaPub, err = approvalHybridEnvelopeParts(receipt.PublicKey)
+		if err != nil {
+			return "", "", err
+		}
+	}
+	return edPub, mldsaPub, nil
+}
+
+func approvalHybridSignatureParts(signature string) (edSig, mldsaSig string, err error) {
+	return approvalHybridEnvelopeParts(signature)
+}
+
+func approvalHybridEnvelopeParts(envelope string) (edPart, mldsaPart string, err error) {
+	const prefix = "hybrid:"
+	if !strings.HasPrefix(envelope, prefix) {
+		return "", "", fmt.Errorf("hybrid envelope missing prefix")
+	}
+	parts := strings.SplitN(strings.TrimPrefix(envelope, prefix), ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid hybrid envelope")
+	}
+	return parts[0], parts[1], nil
+}
+
+func normalizeApprovalAlgorithm(algorithm string) string {
+	switch strings.ToLower(strings.TrimSpace(algorithm)) {
+	case "ed25519", approvalSignatureAlgorithmEd25519:
+		return approvalSignatureAlgorithmEd25519
+	case "hybrid", "hybrid-ed25519-mldsa65", approvalSignatureAlgorithmHybrid:
+		return approvalSignatureAlgorithmHybrid
+	default:
+		return strings.ToLower(strings.TrimSpace(algorithm))
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/core/pkg/api/approve_handler.go
+++ b/core/pkg/api/approve_handler.go
@@ -299,15 +299,33 @@ func enforceApprovalVerificationPolicy(receipt contracts.ApprovalReceipt, profil
 	default:
 		return fmt.Errorf("unsupported approval verification policy %q", receipt.VerificationPolicy)
 	}
+	expectedAlgorithm, err := expectedApprovalAlgorithm(profile)
+	if err != nil {
+		return err
+	}
+	if normalizeApprovalAlgorithm(algorithm) != expectedAlgorithm {
+		return fmt.Errorf("approval signature algorithm %q does not match profile %q", algorithm, profile)
+	}
 	if len(receipt.AcceptedAlgorithms) == 0 {
 		return nil
 	}
 	for _, accepted := range receipt.AcceptedAlgorithms {
-		if normalizeApprovalAlgorithm(accepted) == normalizeApprovalAlgorithm(algorithm) {
+		if normalizeApprovalAlgorithm(accepted) == expectedAlgorithm {
 			return nil
 		}
 	}
 	return fmt.Errorf("approval signature algorithm %q not accepted", algorithm)
+}
+
+func expectedApprovalAlgorithm(profile string) (string, error) {
+	switch profile {
+	case helmcrypto.ReceiptProfileClassical:
+		return approvalSignatureAlgorithmEd25519, nil
+	case helmcrypto.ReceiptProfileHybrid:
+		return approvalSignatureAlgorithmHybrid, nil
+	default:
+		return "", fmt.Errorf("unsupported signature profile %q", profile)
+	}
 }
 
 func approvalHybridPublicKeys(receipt contracts.ApprovalReceipt) (edPub, mldsaPub string, err error) {

--- a/core/pkg/api/approve_handler.go
+++ b/core/pkg/api/approve_handler.go
@@ -22,6 +22,9 @@ const (
 	approvalPolicyPQCRequired         = "pqc-required"
 )
 
+// quantum_posture: approval receipts remain legacy Ed25519-compatible and
+// fail closed for hybrid-required Ed25519+ML-DSA-65 verification.
+
 // ApproveHandler handles POST /api/v1/kernel/approve
 // This is the backend half of the HITL bridge. The frontend uses WebCrypto API
 // to sign the intent hash, and this handler verifies the signature cryptographically.
@@ -29,7 +32,7 @@ type ApproveHandler struct {
 	mu sync.RWMutex
 	// pendingApprovals maps intent_hash → ApprovalRequest
 	pendingApprovals map[string]*contracts.ApprovalRequest
-	// allowedKeys is the set of authorized Ed25519 public keys (hex-encoded)
+	// allowedKeys is the set of authorized approver public key envelopes.
 	allowedKeys map[string]struct{}
 	// clock provides the current time (injected for deterministic testing)
 	clock func() time.Time
@@ -308,15 +311,9 @@ func enforceApprovalVerificationPolicy(receipt contracts.ApprovalReceipt, profil
 }
 
 func approvalHybridPublicKeys(receipt contracts.ApprovalReceipt) (edPub, mldsaPub string, err error) {
-	if receipt.PublicKeySet != nil {
-		edPub = firstNonEmpty(receipt.PublicKeySet[receipt.KeyID+":ed25519"], receipt.PublicKeySet["ed25519"])
-		mldsaPub = firstNonEmpty(receipt.PublicKeySet[receipt.KeyID+":ml-dsa-65"], receipt.PublicKeySet["ml-dsa-65"])
-	}
-	if edPub == "" || mldsaPub == "" {
-		edPub, mldsaPub, err = approvalHybridEnvelopeParts(receipt.PublicKey)
-		if err != nil {
-			return "", "", err
-		}
+	edPub, mldsaPub, err = approvalHybridEnvelopeParts(receipt.PublicKey)
+	if err != nil {
+		return "", "", err
 	}
 	return edPub, mldsaPub, nil
 }
@@ -346,13 +343,4 @@ func normalizeApprovalAlgorithm(algorithm string) string {
 	default:
 		return strings.ToLower(strings.TrimSpace(algorithm))
 	}
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
-		}
-	}
-	return ""
 }

--- a/core/pkg/api/approve_handler_hardening_test.go
+++ b/core/pkg/api/approve_handler_hardening_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
 )
 
 // TestApproveHandler_UnregisteredKey_Rejected verifies DRIFT-3:
@@ -101,5 +103,165 @@ func TestApproveHandler_RegisteredKey_Accepted(t *testing.T) {
 	// Should succeed (200 OK) since key is authorized
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for registered key, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveHandler_HybridRegisteredKey_Accepted(t *testing.T) {
+	signer, err := helmcrypto.NewHybridSigner("approval-hybrid")
+	if err != nil {
+		t.Fatalf("hybrid key generation failed: %v", err)
+	}
+	publicKey := signer.PublicKey()
+	handler := NewApproveHandler([]string{publicKey})
+
+	intentHash := "sha256:hybrid"
+	handler.pendingApprovals[intentHash] = &contracts.ApprovalRequest{
+		IntentHash: intentHash,
+		RiskLevel:  "HIGH",
+		Status:     contracts.ApprovalPending,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+	}
+
+	planHash := "sha256:plan-hybrid"
+	policyHash := "sha256:policy-hybrid"
+	nonce := "hybrid-nonce-1"
+	message := fmt.Sprintf("HELM/Approval/v1:%s:%s:%s:%s", planHash, policyHash, intentHash, nonce)
+	signature, err := signer.Sign([]byte(message))
+	if err != nil {
+		t.Fatalf("hybrid sign failed: %v", err)
+	}
+
+	body, err := json.Marshal(contracts.ApprovalReceipt{
+		IntentHash:         intentHash,
+		PlanHash:           planHash,
+		PolicyHash:         policyHash,
+		Nonce:              nonce,
+		PublicKey:          publicKey,
+		Signature:          signature,
+		SignatureProfile:   helmcrypto.ReceiptProfileHybrid,
+		SignatureAlgorithm: approvalSignatureAlgorithmHybrid,
+		KeyID:              "approval-hybrid",
+		PublicKeySet: map[string]string{
+			"approval-hybrid:ed25519":   signer.Ed25519Signer().PublicKey(),
+			"approval-hybrid:ml-dsa-65": signer.MLDSASigner().PublicKey(),
+		},
+		VerificationPolicy: approvalPolicyHybridRequired,
+		DowngradeRejected:  true,
+		AcceptedAlgorithms: []string{approvalSignatureAlgorithmHybrid},
+	})
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/kernel/approve", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+
+	handler.HandleApprove(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for registered hybrid key, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveHandler_HybridRequiredRejectsMissingDowngradeFlag(t *testing.T) {
+	signer, err := helmcrypto.NewHybridSigner("approval-hybrid-no-downgrade")
+	if err != nil {
+		t.Fatalf("hybrid key generation failed: %v", err)
+	}
+	publicKey := signer.PublicKey()
+	handler := NewApproveHandler([]string{publicKey})
+
+	intentHash := "sha256:hybrid-no-downgrade"
+	handler.pendingApprovals[intentHash] = &contracts.ApprovalRequest{
+		IntentHash: intentHash,
+		RiskLevel:  "HIGH",
+		Status:     contracts.ApprovalPending,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+	}
+
+	planHash := "sha256:plan-hybrid"
+	policyHash := "sha256:policy-hybrid"
+	nonce := "hybrid-nonce-2"
+	message := fmt.Sprintf("HELM/Approval/v1:%s:%s:%s:%s", planHash, policyHash, intentHash, nonce)
+	signature, err := signer.Sign([]byte(message))
+	if err != nil {
+		t.Fatalf("hybrid sign failed: %v", err)
+	}
+
+	body, err := json.Marshal(contracts.ApprovalReceipt{
+		IntentHash:         intentHash,
+		PlanHash:           planHash,
+		PolicyHash:         policyHash,
+		Nonce:              nonce,
+		PublicKey:          publicKey,
+		Signature:          signature,
+		SignatureProfile:   helmcrypto.ReceiptProfileHybrid,
+		SignatureAlgorithm: approvalSignatureAlgorithmHybrid,
+		VerificationPolicy: approvalPolicyHybridRequired,
+		AcceptedAlgorithms: []string{approvalSignatureAlgorithmHybrid},
+	})
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/kernel/approve", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+
+	handler.HandleApprove(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for missing downgrade flag, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveHandler_HybridRequiredRejectsClassicalSignature(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("key generation failed: %v", err)
+	}
+	pubHex := hex.EncodeToString(pub)
+	handler := NewApproveHandler([]string{pubHex})
+
+	intentHash := "sha256:downgrade"
+	handler.pendingApprovals[intentHash] = &contracts.ApprovalRequest{
+		IntentHash: intentHash,
+		RiskLevel:  "HIGH",
+		Status:     contracts.ApprovalPending,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+	}
+
+	planHash := "sha256:plan-downgrade"
+	policyHash := "sha256:policy-downgrade"
+	nonce := "downgrade-nonce-1"
+	message := fmt.Sprintf("HELM/Approval/v1:%s:%s:%s:%s", planHash, policyHash, intentHash, nonce)
+	signature := hex.EncodeToString(ed25519.Sign(priv, []byte(message)))
+
+	body, err := json.Marshal(contracts.ApprovalReceipt{
+		IntentHash:         intentHash,
+		PlanHash:           planHash,
+		PolicyHash:         policyHash,
+		Nonce:              nonce,
+		PublicKey:          pubHex,
+		Signature:          signature,
+		SignatureProfile:   helmcrypto.ReceiptProfileClassical,
+		SignatureAlgorithm: approvalSignatureAlgorithmEd25519,
+		VerificationPolicy: approvalPolicyHybridRequired,
+		DowngradeRejected:  true,
+		AcceptedAlgorithms: []string{approvalSignatureAlgorithmHybrid},
+	})
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/kernel/approve", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+
+	handler.HandleApprove(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for hybrid-required downgrade, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }

--- a/core/pkg/api/approve_handler_hardening_test.go
+++ b/core/pkg/api/approve_handler_hardening_test.go
@@ -17,6 +17,9 @@ import (
 	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
 )
 
+// quantum_posture: approval hardening tests cover classical allowlists,
+// hybrid Ed25519+ML-DSA-65 verification, and downgrade/key substitution denial.
+
 // TestApproveHandler_UnregisteredKey_Rejected verifies DRIFT-3:
 // Approval requests with public keys not in the AllowedApproverKeys set
 // must be rejected with 403, even if the signature is cryptographically valid.
@@ -161,6 +164,70 @@ func TestApproveHandler_HybridRegisteredKey_Accepted(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 for registered hybrid key, got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveHandler_HybridRejectsPublicKeySetOverride(t *testing.T) {
+	registeredSigner, err := helmcrypto.NewHybridSigner("approval-hybrid-registered")
+	if err != nil {
+		t.Fatalf("registered hybrid key generation failed: %v", err)
+	}
+	attackerSigner, err := helmcrypto.NewHybridSigner("approval-hybrid-attacker")
+	if err != nil {
+		t.Fatalf("attacker hybrid key generation failed: %v", err)
+	}
+	registeredPublicKey := registeredSigner.PublicKey()
+	handler := NewApproveHandler([]string{registeredPublicKey})
+
+	intentHash := "sha256:hybrid-key-substitution"
+	handler.pendingApprovals[intentHash] = &contracts.ApprovalRequest{
+		IntentHash: intentHash,
+		RiskLevel:  "HIGH",
+		Status:     contracts.ApprovalPending,
+		CreatedAt:  time.Now(),
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+	}
+
+	planHash := "sha256:plan-key-substitution"
+	policyHash := "sha256:policy-key-substitution"
+	nonce := "hybrid-nonce-substitution"
+	message := fmt.Sprintf("HELM/Approval/v1:%s:%s:%s:%s", planHash, policyHash, intentHash, nonce)
+	signature, err := attackerSigner.Sign([]byte(message))
+	if err != nil {
+		t.Fatalf("attacker hybrid sign failed: %v", err)
+	}
+
+	body, err := json.Marshal(contracts.ApprovalReceipt{
+		IntentHash:         intentHash,
+		PlanHash:           planHash,
+		PolicyHash:         policyHash,
+		Nonce:              nonce,
+		PublicKey:          registeredPublicKey,
+		Signature:          signature,
+		SignatureProfile:   helmcrypto.ReceiptProfileHybrid,
+		SignatureAlgorithm: approvalSignatureAlgorithmHybrid,
+		KeyID:              "approval-hybrid-registered",
+		PublicKeySet: map[string]string{
+			"approval-hybrid-registered:ed25519":   attackerSigner.Ed25519Signer().PublicKey(),
+			"approval-hybrid-registered:ml-dsa-65": attackerSigner.MLDSASigner().PublicKey(),
+			"ed25519":                              attackerSigner.Ed25519Signer().PublicKey(),
+			"ml-dsa-65":                            attackerSigner.MLDSASigner().PublicKey(),
+		},
+		VerificationPolicy: approvalPolicyHybridRequired,
+		DowngradeRejected:  true,
+		AcceptedAlgorithms: []string{approvalSignatureAlgorithmHybrid},
+	})
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/kernel/approve", strings.NewReader(string(body)))
+	w := httptest.NewRecorder()
+
+	handler.HandleApprove(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for attacker-controlled public_key_set, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
 

--- a/core/pkg/api/approve_handler_hardening_test.go
+++ b/core/pkg/api/approve_handler_hardening_test.go
@@ -332,3 +332,24 @@ func TestApproveHandler_HybridRequiredRejectsClassicalSignature(t *testing.T) {
 		t.Fatalf("expected 403 for hybrid-required downgrade, got %d (body: %s)", w.Code, w.Body.String())
 	}
 }
+
+func TestApprovalVerificationPolicyRejectsAlgorithmProfileMismatch(t *testing.T) {
+	t.Run("classical_profile_cannot_claim_hybrid_algorithm", func(t *testing.T) {
+		err := enforceApprovalVerificationPolicy(contracts.ApprovalReceipt{
+			VerificationPolicy: approvalPolicyClassicalRequired,
+		}, helmcrypto.ReceiptProfileClassical, approvalSignatureAlgorithmHybrid)
+		if err == nil {
+			t.Fatal("expected classical profile with hybrid algorithm metadata to fail")
+		}
+	})
+
+	t.Run("hybrid_profile_cannot_claim_classical_algorithm", func(t *testing.T) {
+		err := enforceApprovalVerificationPolicy(contracts.ApprovalReceipt{
+			VerificationPolicy: approvalPolicyHybridRequired,
+			DowngradeRejected:  true,
+		}, helmcrypto.ReceiptProfileHybrid, approvalSignatureAlgorithmEd25519)
+		if err == nil {
+			t.Fatal("expected hybrid profile with classical algorithm metadata to fail")
+		}
+	})
+}

--- a/core/pkg/contracts/approval.go
+++ b/core/pkg/contracts/approval.go
@@ -2,6 +2,9 @@ package contracts
 
 import "time"
 
+// quantum_posture: approval receipts expose explicit classical/hybrid signature
+// metadata; public_key is the registry-authoritative verification key envelope.
+
 // ApprovalReceipt represents a cryptographic approval signed by a human operator.
 // This is the HITL (Human-in-the-Loop) bridge contract that binds a human's
 // cryptographic identity to an execution intent.
@@ -35,9 +38,12 @@ type ApprovalReceipt struct {
 	// Ed25519 signature; hybrid receipts use hybrid:<ed25519_hex>:<mldsa65_hex>.
 	Signature string `json:"signature"`
 
-	SignatureProfile   string            `json:"signature_profile,omitempty"`
-	SignatureAlgorithm string            `json:"signature_algorithm,omitempty"`
-	KeyID              string            `json:"key_id,omitempty"`
+	SignatureProfile   string `json:"signature_profile,omitempty"`
+	SignatureAlgorithm string `json:"signature_algorithm,omitempty"`
+	KeyID              string `json:"key_id,omitempty"`
+
+	// PublicKeySet exposes component keys for display/interoperability. The
+	// public_key envelope remains authoritative for registry authorization.
 	PublicKeySet       map[string]string `json:"public_key_set,omitempty"`
 	VerificationPolicy string            `json:"verification_policy,omitempty"`
 	DowngradeRejected  bool              `json:"downgrade_rejected,omitempty"`

--- a/core/pkg/contracts/approval.go
+++ b/core/pkg/contracts/approval.go
@@ -8,7 +8,7 @@ import "time"
 //
 // Security Properties:
 //   - IntentHash links to the exact execution intent being approved
-//   - Signature is Ed25519 over IntentHash (produced by WebCrypto API in browser)
+//   - Signature is profile-aware over the approval context
 //   - BiometricTier indicates the authentication strength
 //   - Timestamp enables temporal ordering of approvals
 type ApprovalReceipt struct {
@@ -27,11 +27,21 @@ type ApprovalReceipt struct {
 	// ApproverID identifies the human operator
 	ApproverID string `json:"approver_id"`
 
-	// PublicKey is the Ed25519 public key of the approver (hex-encoded)
+	// PublicKey is the approver public key. Classical receipts use an Ed25519
+	// hex key; hybrid receipts use a hybrid:<ed25519_hex>:<mldsa65_hex> envelope.
 	PublicKey string `json:"public_key"`
 
-	// Signature is the Ed25519 signature over IntentHash (hex-encoded)
+	// Signature is the approval signature. Classical receipts use a hex
+	// Ed25519 signature; hybrid receipts use hybrid:<ed25519_hex>:<mldsa65_hex>.
 	Signature string `json:"signature"`
+
+	SignatureProfile   string            `json:"signature_profile,omitempty"`
+	SignatureAlgorithm string            `json:"signature_algorithm,omitempty"`
+	KeyID              string            `json:"key_id,omitempty"`
+	PublicKeySet       map[string]string `json:"public_key_set,omitempty"`
+	VerificationPolicy string            `json:"verification_policy,omitempty"`
+	DowngradeRejected  bool              `json:"downgrade_rejected,omitempty"`
+	AcceptedAlgorithms []string          `json:"accepted_algorithms,omitempty"`
 
 	// Timestamp of when the approval was signed
 	Timestamp time.Time `json:"timestamp"`

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-02T14:46:49Z
-# Commit: 18cbfd0f813cca9496e29f8e7a6c08337087df9b
+# Generated: 2026-07-02T18:46:33Z
+# Commit: 270bdd1a31aa265e573a480de6d26d6ddc801022
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -121,7 +121,7 @@ bb43d171471ec8a458f26b44374e116becb05fb1a99476d1c0ef30f033ebe98d  core/pkg/contr
 892b16853d3fb6bba0abed14a4e22dc813f4501e31c375cf0e5bc2720323fa9f  core/pkg/contracts/actuators/sandbox_test.go
 72ae12f46595d86bc220f1c0862e9bc22340724587fa5d0e4100be9e623d531a  core/pkg/contracts/agent.go
 3b6ad36ecd7e4eb74fc82fd57106282292bad4792e88db91a5f7d0321df2195b  core/pkg/contracts/agent_run_receipt.go
-9edddf5ac19b5e700c4e9bafea1dfe4c093a69eea9daeef202949e3513b75887  core/pkg/contracts/approval.go
+fb8ca705da6f96643da254a1c9cd61a9c15d78bd8517eee57b0e93299a0935d1  core/pkg/contracts/approval.go
 84f49d46862d49f31dac979e691fd9bda9f09a3ff59c3ffe0399616047c53a49  core/pkg/contracts/approval_binding.go
 b8b80ba2979df721f2bca2d7d38551a1d120f5403b2e2c74d2e9f3322556441b  core/pkg/contracts/approval_binding_test.go
 d6d0443f145537c187fe1dd6010632541a1139a589a394060ba42a66591036c0  core/pkg/contracts/attestation.proto
@@ -532,8 +532,8 @@ eb6ba1a95e78c9018b7817488067321246cd34c4959fb80e921b69119a33fbaa  core/pkg/api/a
 a92153ec046ae87617e919491cb0754d8180307db013e2be0128dcd75befa575  core/pkg/api/apidoc_drift_test.go
 1242b1847b71faaee102866d2152fe6fc6141d91fd783e36ae47bfb62d5bd117  core/pkg/api/apierror.go
 f7779991fbd5bf082e51beac146520bdae7054f419df711652f400e43f06b1c4  core/pkg/api/apierror_test.go
-517e9671291ec6de73b68161b6054437ca90de9d042548c320ef4f23f971cfd3  core/pkg/api/approve_handler.go
-b0849c44801c1a3751e3b7c1cb6884ed14baff53b059701da41a8f8aef55830a  core/pkg/api/approve_handler_hardening_test.go
+8f9366a1e5519b5d5a4eb58e080e1ec9c6396f64fffcc978259b626bfae23cd8  core/pkg/api/approve_handler.go
+139b634fe29968c81293429146853e9b4fed7c113fa90388b0dc9f91f28d9f3c  core/pkg/api/approve_handler_hardening_test.go
 3700337026ad0979b101b5873c90e4e161f5074ffa9e251ed8131d21498a8130  core/pkg/api/autonomy_decision_handler_test.go
 0c4838fba74d4179fdebb2f7bd90b0f6364072153e342ab28cfdd60780ef6ebd  core/pkg/api/autonomy_handler.go
 7324c5963a3fbfdf3a176758912963003a78134c0be8280d080977d96512461f  core/pkg/api/contract_test.go

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-02T18:56:09Z
-# Commit: 5ca55507b79bc25cfb97a1600cd11cd92ad894d3
+# Generated: 2026-07-02T21:09:45Z
+# Commit: a0d1bacdee9aef96787fd7014158528e349afc1a
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -532,8 +532,8 @@ eb6ba1a95e78c9018b7817488067321246cd34c4959fb80e921b69119a33fbaa  core/pkg/api/a
 a92153ec046ae87617e919491cb0754d8180307db013e2be0128dcd75befa575  core/pkg/api/apidoc_drift_test.go
 1242b1847b71faaee102866d2152fe6fc6141d91fd783e36ae47bfb62d5bd117  core/pkg/api/apierror.go
 f7779991fbd5bf082e51beac146520bdae7054f419df711652f400e43f06b1c4  core/pkg/api/apierror_test.go
-8f9366a1e5519b5d5a4eb58e080e1ec9c6396f64fffcc978259b626bfae23cd8  core/pkg/api/approve_handler.go
-139b634fe29968c81293429146853e9b4fed7c113fa90388b0dc9f91f28d9f3c  core/pkg/api/approve_handler_hardening_test.go
+0ade2e2f484513e1ccbf164795d06cb6d01e2112edbb45d8fc552898d0d87d6c  core/pkg/api/approve_handler.go
+36959f4da46448882a1d034cb4d8a13f1ed7ec338eebfe43fc766065528aaa05  core/pkg/api/approve_handler_hardening_test.go
 3700337026ad0979b101b5873c90e4e161f5074ffa9e251ed8131d21498a8130  core/pkg/api/autonomy_decision_handler_test.go
 0c4838fba74d4179fdebb2f7bd90b0f6364072153e342ab28cfdd60780ef6ebd  core/pkg/api/autonomy_handler.go
 7324c5963a3fbfdf3a176758912963003a78134c0be8280d080977d96512461f  core/pkg/api/contract_test.go


### PR DESCRIPTION
## Summary
- extend ApprovalReceipt with optional signature posture metadata
- make the operator approval handler verify classical or hybrid signatures through one shared policy-aware path
- reject Ed25519-only approvals when hybrid-required is requested, and require downgrade rejection metadata for hybrid-required approvals

## Validation
- go test ./core/pkg/api ./core/pkg/contracts
- go test ./core/pkg/crypto
- python3 scripts/ci/check_quantum_crypto_inventory.py --base origin/main
- python3 scripts/check_documentation_truth.py
- python3 scripts/check_documentation_coverage.py
- git diff --check

## Quantum boundary
This moves operator approval receipts from Ed25519-only verification to hybrid-capable verification when callers provide hybrid approval signatures and metadata. It does not make browser/WebCrypto approver keys post-quantum by default.