### PR TITLE
Fix GHCR manifest status check for releases

### DIFF
--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -23,6 +23,14 @@ REQUEST_TIMEOUT_SECONDS = 30.0
 SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 SEMVER_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 REJECT_TOKEN_SUFFIX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.+-"
+GHCR_MANIFEST_ACCEPT = ", ".join(
+    [
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ]
+)
 
 
 @dataclass
@@ -266,11 +274,30 @@ def ghcr_tags(repository: str) -> list[str]:
     return payload.get("tags") or []
 
 
+def ghcr_manifest_status(repository: str, tag: str) -> int:
+    token_url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
+    token = request_json(token_url)["token"]
+    req = urllib.request.Request(
+        f"https://ghcr.io/v2/{repository}/manifests/{tag}",
+        method="HEAD",
+        headers=http_headers({"Authorization": f"Bearer {token}", "Accept": GHCR_MANIFEST_ACCEPT}),
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+            return response.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+
+
 def check_ghcr_tags(surface: dict[str, Any], version: str) -> SurfaceResult:
     expected = [fmt(tag, version) for tag in surface["required_tags"]]
-    tags = ghcr_tags(surface["repository"])
-    missing = sorted(set(expected) - set(tags))
-    return SurfaceResult(surface["id"], "pass" if not missing else "fail", expected, sorted(tag for tag in tags if tag in expected), url=surface["human_url"], detail=f"missing tags: {', '.join(missing)}" if missing else None)
+    statuses = {tag: ghcr_manifest_status(surface["repository"], tag) for tag in expected}
+    found = sorted(tag for tag, status in statuses.items() if 200 <= status < 300)
+    missing = sorted(tag for tag, status in statuses.items() if not (200 <= status < 300))
+    detail = None
+    if missing:
+        detail = "missing manifests: " + ", ".join(f"{tag} ({statuses[tag]})" for tag in missing)
+    return SurfaceResult(surface["id"], "pass" if not missing else "fail", expected, found, url=surface["human_url"], detail=detail)
 
 
 def check_http_exists(surface: dict[str, Any], version: str) -> SurfaceResult:

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -101,6 +101,62 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertEqual(selection.actual, ["typo"])
         self.assertIn("unknown --only", selection.detail or "")
 
+    def test_ghcr_tags_check_verifies_required_manifests(self) -> None:
+        calls = []
+        original = drift.ghcr_manifest_status
+
+        def fake_manifest_status(repository: str, tag: str) -> int:
+            calls.append((repository, tag))
+            return 200
+
+        drift.ghcr_manifest_status = fake_manifest_status
+        try:
+            result = drift.check_ghcr_tags(
+                {
+                    "id": "ghcr-image",
+                    "repository": "mindburn-labs/helm-ai-kernel",
+                    "required_tags": ["v{version}", "v{version}-slim"],
+                    "human_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/pkgs/container/helm-ai-kernel",
+                },
+                "0.6.0",
+            )
+        finally:
+            drift.ghcr_manifest_status = original
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.actual, ["v0.6.0", "v0.6.0-slim"])
+        self.assertEqual(
+            calls,
+            [
+                ("mindburn-labs/helm-ai-kernel", "v0.6.0"),
+                ("mindburn-labs/helm-ai-kernel", "v0.6.0-slim"),
+            ],
+        )
+
+    def test_ghcr_tags_check_reports_missing_manifest_status(self) -> None:
+        original = drift.ghcr_manifest_status
+
+        def fake_manifest_status(_repository: str, tag: str) -> int:
+            return 404 if tag.endswith("-slim") else 200
+
+        drift.ghcr_manifest_status = fake_manifest_status
+        try:
+            result = drift.check_ghcr_tags(
+                {
+                    "id": "ghcr-image",
+                    "repository": "mindburn-labs/helm-ai-kernel",
+                    "required_tags": ["v{version}", "v{version}-slim"],
+                    "human_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/pkgs/container/helm-ai-kernel",
+                },
+                "0.6.0",
+            )
+        finally:
+            drift.ghcr_manifest_status = original
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.actual, ["v0.6.0"])
+        self.assertIn("v0.6.0-slim (404)", result.detail or "")
+
     def test_published_error_preserves_advisory_status(self) -> None:
         surface = {
             "id": "optional-docs-cache",


### PR DESCRIPTION
## Summary
- verify required GHCR release image tags by manifest HEAD requests instead of tag-list enumeration
- keep the existing required tag contract for main and slim images
- add focused unit coverage for present and missing manifest paths

## Validation
- python3 -m unittest check_version_drift_test.py
- python3 scripts/release/check_version_drift.py --expected-version 0.6.0 --report --write-status /private/tmp/v0.6.0-version-status-patched.json published --only ghcr-image --only ghcr-chart --only npm-sdk --only pypi-sdk --only crates-sdk --only go-proxy-sdk

## Release note
This fixes the v0.6.0 release-status blocker where GHCR tag-list returned no image tags even though both image manifests resolved.