### PR TITLE
docs: make policy bundle signing profile-aware

### DIFF
--- a/protocols/specs/rfc/policy-bundle-v1.md
+++ b/protocols/specs/rfc/policy-bundle-v1.md
@@ -37,7 +37,7 @@ my-bundle/
 │   └── budget-limits.yaml
 ├── schemas/               # Optional: custom schemas
 │   └── custom-effect.schema.json
-└── SIGNATURE              # Ed25519 detached signature
+└── SIGNATURE              # Detached bundle signature
 ```
 
 ## 4. Manifest Format
@@ -69,7 +69,8 @@ spec:
     - path: schemas/custom-effect.schema.json
   trust:
     signer_key_id: "key-corporate-2026"
-    signature_algorithm: Ed25519
+    signature_profile: classical
+    signature_algorithm: ed25519-sha256
 ```
 
 ## 5. Policy File Format
@@ -96,7 +97,14 @@ spec:
 
 ### 6.1 Signing
 
-Bundles MUST be signed with Ed25519:
+<!-- quantum_posture: policy bundle signing is profile-aware; classical
+Ed25519 is legacy-compatible, while hybrid deployments must require the hybrid
+profile and reject classical-only bundle signatures. -->
+
+Bundles MUST declare a signature profile and algorithm. The `classical`
+profile is Ed25519-compatible and not post-quantum. Deployments that require
+post-quantum durability MUST require a hybrid profile and reject
+classical-only bundle signatures as a downgrade.
 
 ```bash
 helm-ai-kernel bundle sign --key /path/to/private.key ./my-bundle/
@@ -104,6 +112,11 @@ helm-ai-kernel bundle sign --key /path/to/private.key ./my-bundle/
 
 This produces a `SIGNATURE` file containing the signature over the
 bundle's content hash (SHA-256 of the manifest + all policy files).
+
+Current profile names:
+
+- `classical` with `ed25519-sha256`
+- `hybrid` with `hybrid-ed25519-mldsa65-sha256`
 
 ### 6.2 Verification
 
@@ -191,7 +204,7 @@ Active bundle metadata MUST appear in the EvidencePack:
 A bundle loader is conformant if:
 
 1. It validates the manifest schema
-2. It verifies the Ed25519 signature before loading
+2. It verifies the declared signature profile and algorithm before loading
 3. It rejects bundles with unknown `apiVersion`
 4. It fails closed if signature verification fails
 5. It records loaded bundles in the EvidencePack

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-02T21:09:45Z
-# Commit: a0d1bacdee9aef96787fd7014158528e349afc1a
+# Generated: 2026-07-03T15:35:01Z
+# Commit: c9db4a8b56f46675cc90f5d79d355e04be26b8e7
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -918,7 +918,7 @@ de0c086ae6fc3f8eaadeabc5cbea9bd3574ed06299e31c191ac149f23e2a97b8  protocols/spec
 131014dcb8960299ae69210a86799d1f2dbae6e6d2000ed708d71699a6120aec  protocols/specs/receipts/HELM_RECEIPT_SPEC_v1.0.md
 8f012b8b85b82c7533561abb94160108587648859ceecffa802f3df86f249b77  protocols/specs/rfc/artifact-versioning-v1.md
 41e41ae7387cbfeff899b7569d4b3cb3859ce2049e0cacc80c8c521500cb02d3  protocols/specs/rfc/identifier-urn-v1.md
-0e3a1fb9e542ac8ff5d41e45134f1d29af0126745089d386d1386e247fc64e72  protocols/specs/rfc/policy-bundle-v1.md
+95a8f72b3c80023d3fa9966333e06dab8b0e1c7c7e78b198a76c6f69bfd76557  protocols/specs/rfc/policy-bundle-v1.md
 2a18e0c35cba8d7d0536a36ab502e4cf667f0de1a7dafc07343cb0b1c3dc3214  protocols/specs/rfc/reason-codes-v1.md
 f465ad9d07639d7c5ee584156857fa947eade9d2ee584e04aa46398e9456c14e  protocols/specs/rfc/receipt-format-v1.md
 e98a649ea99d4f4dfac7989f326447ac49c42840f54237f20b621687a20d06e7  protocols/specs/rfc/receipt-pq-hybrid-profile-v1.md


### PR DESCRIPTION
## Summary
- Remove Ed25519-only policy-bundle signing language from the RFC.
- Add explicit signature_profile/signature_algorithm fields to the manifest example.
- Document classical vs hybrid bundle-signature profiles and downgrade rejection for hybrid deployments.

## Validation
- rg stale Ed25519-only policy-bundle strings: no matches
- git diff --check
- make quantum-crypto-inventory
- make docs-truth