### PR TITLE
Document console hybrid receipt display posture

### DIFF
--- a/docs/security/quantum-posture.md
+++ b/docs/security/quantum-posture.md
@@ -1,6 +1,6 @@
 ---
 title: Quantum Posture
-last_reviewed: 2026-07-02
+last_reviewed: 2026-07-03
 quantum_posture: hybrid_when_configured
 ---
 
@@ -69,6 +69,18 @@ enrolled `public_key` envelope as the authority instead of trusting a supplied
 That makes operator approval verification hybrid-capable when the enrolled
 operator key and receipt are hybrid. It does not make existing Ed25519 operator
 keys post-quantum, and PQ-only operator approval policy is still unsupported.
+
+## Console Receipt Display
+
+Control-plane GeneratedSpec receipt tests prove hybrid receipts are stored and
+verified with `signature_profile=hybrid`, `signature_algorithm=hybrid-ed25519-mldsa65-sha256`,
+`verification_policy=hybrid-required`, and `downgrade_rejected=true`. The
+Console has fixture-backed contract coverage for that same receipt shape and
+displays the hybrid-required posture in receipt activity.
+
+That is display compatibility, not a claim that an authenticated live workspace
+flow has shown a production receipt end to end. Treat authenticated production
+console receipt smoke as a separate remaining gate.
 
 ## Public Web Boundary
 

--- a/docs/security/quantum-posture.md
+++ b/docs/security/quantum-posture.md
@@ -72,11 +72,14 @@ keys post-quantum, and PQ-only operator approval policy is still unsupported.
 
 ## Console Receipt Display
 
-Control-plane GeneratedSpec receipt tests prove hybrid receipts are stored and
-verified with `signature_profile=hybrid`, `signature_algorithm=hybrid-ed25519-mldsa65-sha256`,
+Raw Kernel `contracts.Receipt` hybrid signing emits
+`signature_algorithm=Hybrid-Ed25519-MLDSA65`. The control-plane/console event
+projection is a separate display contract: GeneratedSpec and approval-derived
+receipt metadata can carry `signature_profile=hybrid`, normalized
+`signature_algorithm=hybrid-ed25519-mldsa65-sha256`,
 `verification_policy=hybrid-required`, and `downgrade_rejected=true`. The
-Console has fixture-backed contract coverage for that same receipt shape and
-displays the hybrid-required posture in receipt activity.
+Console has fixture-backed contract coverage for that projected receipt shape
+and displays the hybrid-required posture in receipt activity.
 
 That is display compatibility, not a claim that an authenticated live workspace
 flow has shown a production receipt end to end. Treat authenticated production


### PR DESCRIPTION
## Summary
- Updates the Kernel-owned quantum posture doc with the console hybrid receipt display proof boundary.
- Keeps authenticated live workspace receipt smoke listed as a separate remaining gate.

## Validation
- make docs-truth
- make docs-coverage
- make quantum-crypto-inventory
- git diff --check