### PR TITLE
fix(guardian): preserve snapshot policy hash under embedded PDP (HELM-49)

### DIFF
--- a/core/pkg/guardian/guardian.go
+++ b/core/pkg/guardian/guardian.go
@@ -956,7 +956,12 @@ func (g *Guardian) EvaluateDecision(ctx context.Context, req DecisionRequest) (*
 
 		if eCtx.PDPBackend != "" {
 			decision.PolicyBackend = eCtx.PDPBackend
-			decision.PolicyContentHash = eCtx.PDPHash
+			// PDPHash is empty when the PDP came from an installed snapshot;
+			// the snapshot's PolicyHash (bound above) must survive so that
+			// IssueExecutionIntent can verify the policy epoch binding.
+			if eCtx.PDPHash != "" {
+				decision.PolicyContentHash = eCtx.PDPHash
+			}
 			decision.PolicyDecisionHash = eCtx.PDPDecisionHash
 		}
 

--- a/core/pkg/guardian/policy_snapshot_test.go
+++ b/core/pkg/guardian/policy_snapshot_test.go
@@ -125,6 +125,52 @@ func TestGuardianEarlyDenyBindsActivePolicySnapshot(t *testing.T) {
 	}
 }
 
+func TestGuardianSnapshotWithEmbeddedPDPBindsPolicyHashAndIssuesIntent(t *testing.T) {
+	scope := policyreconcile.DefaultScope
+	store := policyreconcile.NewAtomicSnapshotStore()
+	hash := "sha256:snapshot-pdp"
+	if err := store.Swap(scope, &policyreconcile.EffectivePolicySnapshot{
+		TenantID:    scope.TenantID,
+		WorkspaceID: scope.WorkspaceID,
+		PolicyEpoch: 9,
+		PolicyHash:  hash,
+		Validation:  policyreconcile.ValidationStatus{Status: policyreconcile.StatusActive},
+		Graph:       allowGraphFor("deploy"),
+		PDP:         guardianCoveragePDP{},
+	}); err != nil {
+		t.Fatalf("swap snapshot: %v", err)
+	}
+
+	g := NewGuardian(
+		&MockSigner{},
+		prg.NewGraph(),
+		pkg_artifact.NewRegistry(NewMockStore(), nil),
+		WithPolicySnapshots(store, scope),
+	)
+	decision, err := g.EvaluateDecision(context.Background(), DecisionRequest{
+		Principal: "agent-1",
+		Action:    "EXECUTE_TOOL",
+		Resource:  "deploy",
+	})
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if decision.Verdict != string(contracts.VerdictAllow) {
+		t.Fatalf("expected allow, got %+v", decision)
+	}
+	if decision.PolicyContentHash != hash || decision.PolicyEpoch != "9" {
+		t.Fatalf("snapshot+PDP decision lost policy binding: hash=%q epoch=%q", decision.PolicyContentHash, decision.PolicyEpoch)
+	}
+
+	if _, err := g.IssueExecutionIntent(context.Background(), decision, &contracts.Effect{
+		EffectID:   "effect-1",
+		EffectType: "EXECUTE_TOOL",
+		Params:     map[string]any{"tool_name": "deploy"},
+	}); err != nil {
+		t.Fatalf("issue intent under snapshot+PDP config: %v", err)
+	}
+}
+
 func TestGuardianPolicyEpochChangeBeforeIntentDenies(t *testing.T) {
 	scope := policyreconcile.DefaultScope
 	store := policyreconcile.NewAtomicSnapshotStore()

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-03T19:32:30Z
-# Commit: 5f23d3a994e365e9fb9092b400e50b8c4fffb08e
+# Generated: 2026-07-04T17:16:08Z
+# Commit: f1b5d4aee19697b8007ec886d954eded9e26e23a
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -577,7 +577,7 @@ aa4ea979d3f36460d50808f0ccee6bd48eb97cbc3c888d53b2971701b704e462  core/pkg/guard
 ba0ea6cc0860f51873387f491d29cf35006ce4cfd129a97a75130324aef51f9d  core/pkg/guardian/guardian_core_coverage_test.go
 a7e35f40e542f1d03d0d4b2f8aa3f514dbebd301754a74f5c2090ac2489bb80e  core/pkg/guardian/guardian_delegation_test.go
 1c6069fc10f370e11aefe4cab278c3994d29a72fe616aad5420aa6876bb05bde  core/pkg/guardian/guardian_edge_cases_test.go
-ae49bcbdfcbb0f8c040e5f4352aafa2ebcdf42af38a2296b05d225ecde02d1b1  core/pkg/guardian/guardian.go
+b55ff324050ee3698c728acc9535a1f95eaa16ef73b0ea9bf56e437f7fd1e13b  core/pkg/guardian/guardian.go
 d7ad656ec37a80da9538c9435229f2e06214ccdde857fdf81e86dbb18d4ad7d7  core/pkg/guardian/guardian_intervention_test.go
 078f38e20e22ae8358bfac3533fc078707bac1ffa49e6a3c7b1ee880b46b8125  core/pkg/guardian/guardian_persistence_test.go
 773c3c8aad120609e8566ef6f6c908a1c7e1a81485aaf37d1ae09d6ef99a8c2b  core/pkg/guardian/guardian_regression_test.go
@@ -589,7 +589,7 @@ b8a92ba80717a401aed15e89883c609ca40e7281b74b2b781fd9b327e9360a9c  core/pkg/guard
 c0118e244adcba44a228c918ffb6c2fddc5be3273b7383914fb81e5f933bdb54  core/pkg/guardian/intervention_test.go
 fa50013f154fd1a1ebe1dcc1448b22f0ef3650990cefef4e7693aed227130b52  core/pkg/guardian/otel.go
 27e480317e91ec0ca763f23b1cc5db4a6fa9bae0090a6f4b0d97954dd25fcdf3  core/pkg/guardian/otel_test.go
-39b19a8f33a9254ae84a548450d8a051e350960056edfac1c45741abd3924f4a  core/pkg/guardian/policy_snapshot_test.go
+fa1a85d544d0ad5594acfc7845e11c9787382f79325354d6e4e43a708577e926  core/pkg/guardian/policy_snapshot_test.go
 ed69d20637a1737e28994d74fcbd2195dbf2ac6972b053143c5839e89015400a  core/pkg/guardian/privilege.go
 1d2c50051328c3c101f74bcbc28527dd0c29dc6606322328e81755c33d49ed4e  core/pkg/guardian/privilege_test.go
 54ac38f31e1a60fd9338ac0a2071a6871f85cbb449a7585d23c364af23adec27  core/pkg/guardian/prompt_armor_test.go


### PR DESCRIPTION
## Problem
When an `EffectivePolicySnapshot` carries an embedded PDP, `PDPInterceptor` leaves `PDPHash` empty (the snapshot owns the binding). The final handler then overwrote the snapshot-bound `PolicyContentHash` with that empty value, so every ALLOW under snapshot+PDP failed `IssueExecutionIntent` with "decision missing policy hash/epoch binding".

## Fix
Only overwrite `PolicyContentHash` from the PDP when the PDP actually reported a hash. Regression test covers snapshot+embedded-PDP through intent issuance.

Fixes HELM-49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BggKqjoW6WCM93xa9VjdCx