### PR TITLE
fix(guardian): require trusted context for tainted-egress override (HELM-52)

### DIFF
--- a/core/pkg/guardian/guardian.go
+++ b/core/pkg/guardian/guardian.go
@@ -1085,7 +1085,11 @@ func taintedEgressDenied(ctx map[string]interface{}, labels []string) bool {
 	if len(labels) == 0 || ctx == nil {
 		return false
 	}
-	if approved, ok := ctx["allow_tainted_egress"].(bool); ok && approved {
+	// The egress override is a security decision: honor it only when the
+	// context was bound by a trusted transport/adapter boundary, never from
+	// caller-supplied arguments (otherwise any agent can self-approve
+	// PII/credential/secret egress).
+	if approved, ok := ctx["allow_tainted_egress"].(bool); ok && approved && trustedSecurityContext(ctx) {
 		return false
 	}
 	destination, _ := ctx["destination"].(string)

--- a/core/pkg/guardian/guardian_core_coverage_test.go
+++ b/core/pkg/guardian/guardian_core_coverage_test.go
@@ -229,8 +229,11 @@ func TestCoverageGuardianPureHelpers(t *testing.T) {
 	if taintedEgressDenied(nil, []string{contracts.TaintPII}) {
 		t.Fatal("nil context should not deny tainted egress")
 	}
-	if taintedEgressDenied(map[string]interface{}{"destination": "https://example.com", "allow_tainted_egress": true}, []string{contracts.TaintSecret}) {
-		t.Fatal("explicitly approved tainted egress should not deny")
+	if !taintedEgressDenied(map[string]interface{}{"destination": "https://example.com", "allow_tainted_egress": true}, []string{contracts.TaintSecret}) {
+		t.Fatal("caller-set approval without trusted security context must still deny")
+	}
+	if taintedEgressDenied(map[string]interface{}{"destination": "https://example.com", "allow_tainted_egress": true, ContextSecurityTrusted: true}, []string{contracts.TaintSecret}) {
+		t.Fatal("explicitly approved tainted egress from trusted context should not deny")
 	}
 	if taintedEgressDenied(map[string]interface{}{"destination": "   "}, []string{contracts.TaintCredential}) {
 		t.Fatal("missing destination should not deny")

--- a/core/pkg/guardian/interceptor_test.go
+++ b/core/pkg/guardian/interceptor_test.go
@@ -96,6 +96,47 @@ func TestInterceptorChain_ExecutionFlowAndShortCircuit(t *testing.T) {
 	})
 }
 
+func TestTaintEgressOverrideRequiresTrustedContext(t *testing.T) {
+	t.Run("caller-set override without trusted context is ignored", func(t *testing.T) {
+		t.Setenv("HELM_TAINT_TRACKING", "1")
+		g := newMinimalGuardian()
+
+		dec, err := g.EvaluateDecision(context.Background(), DecisionRequest{
+			Principal: "untrusted-agent",
+			Action:    "EXECUTE_TOOL",
+			Resource:  "http.post",
+			Context: map[string]interface{}{
+				"destination":          "https://external.egress.com/upload",
+				"taint":                []string{contracts.TaintCredential},
+				"allow_tainted_egress": true, // attacker-controlled: must not bypass
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, string(contracts.VerdictDeny), dec.Verdict)
+		assert.Equal(t, string(contracts.ReasonTaintedEgressDeny), dec.ReasonCode)
+	})
+
+	t.Run("override honored only from trusted security context", func(t *testing.T) {
+		t.Setenv("HELM_TAINT_TRACKING", "1")
+		g := newMinimalGuardian()
+
+		dec, err := g.EvaluateDecision(context.Background(), DecisionRequest{
+			Principal: "trusted-adapter",
+			Action:    "EXECUTE_TOOL",
+			Resource:  "http.post",
+			Context: map[string]interface{}{
+				ContextSecurityTrusted: true, // bound by trusted transport boundary
+				"destination":          "https://external.egress.com/upload",
+				"taint":                []string{contracts.TaintCredential},
+				"allow_tainted_egress": true,
+			},
+		})
+		assert.NoError(t, err)
+		// Gate bypassed: evaluation proceeds to PRG, which has no rule.
+		assert.Equal(t, string(contracts.ReasonNoPolicy), dec.ReasonCode)
+	})
+}
+
 func TestTaintInterceptorEgressBlock(t *testing.T) {
 	t.Run("Tainted flow egress block", func(t *testing.T) {
 		t.Setenv("HELM_TAINT_TRACKING", "1")

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-04T17:54:59Z
-# Commit: 5195bdbb08ddd4bcecd9fbd021e4d347fe75a5e9
+# Generated: 2026-07-04T18:10:57Z
+# Commit: 0101fdaba2e735ab556fae1dc599821188aed1f9
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -574,10 +574,10 @@ aa4ea979d3f36460d50808f0ccee6bd48eb97cbc3c888d53b2971701b704e462  core/pkg/guard
 05d2907a744570e725955e9967f578b098389dee199fa7af7d54c2381f770a54  core/pkg/guardian/guardian_behavior_coverage_test.go
 2a5ca32bc0c383992332eea7cd839575ee7dd4b6266c2ed64c7bd8a2bfec044f  core/pkg/guardian/guardian_bench_test.go
 85459f0cd76631d94c0ea0e886eb90237c1b29ae7512b542ed4cd4995101f532  core/pkg/guardian/guardian_contracts_test.go
-ba0ea6cc0860f51873387f491d29cf35006ce4cfd129a97a75130324aef51f9d  core/pkg/guardian/guardian_core_coverage_test.go
+6855d4df5ba134cb673af5dc89ac9197bacfd51fa17bec87e67ea4ba3fb66c39  core/pkg/guardian/guardian_core_coverage_test.go
 a7e35f40e542f1d03d0d4b2f8aa3f514dbebd301754a74f5c2090ac2489bb80e  core/pkg/guardian/guardian_delegation_test.go
 1c6069fc10f370e11aefe4cab278c3994d29a72fe616aad5420aa6876bb05bde  core/pkg/guardian/guardian_edge_cases_test.go
-b55ff324050ee3698c728acc9535a1f95eaa16ef73b0ea9bf56e437f7fd1e13b  core/pkg/guardian/guardian.go
+f4bb89f2028879a0a9f2ca0206d98908937a7602083565dba2a94f59139aa7c3  core/pkg/guardian/guardian.go
 d7ad656ec37a80da9538c9435229f2e06214ccdde857fdf81e86dbb18d4ad7d7  core/pkg/guardian/guardian_intervention_test.go
 078f38e20e22ae8358bfac3533fc078707bac1ffa49e6a3c7b1ee880b46b8125  core/pkg/guardian/guardian_persistence_test.go
 773c3c8aad120609e8566ef6f6c908a1c7e1a81485aaf37d1ae09d6ef99a8c2b  core/pkg/guardian/guardian_regression_test.go
@@ -585,7 +585,7 @@ d7ad656ec37a80da9538c9435229f2e06214ccdde857fdf81e86dbb18d4ad7d7  core/pkg/guard
 ca72cfc8728b95865c08db1cd5a538ca0a2b498527fa9e11bdfb9ae780da8e1a  core/pkg/guardian/guardian_test.go
 b8a92ba80717a401aed15e89883c609ca40e7281b74b2b781fd9b327e9360a9c  core/pkg/guardian/integration_test.go
 10c17dfabce3658162750f7b6cd56967a75debe6a9c689b05393f6ab7759bdfd  core/pkg/guardian/interceptor.go
-1852294e35d190075c1561ee6f1e3f35356eec27cfca159c5df512eff441b1f9  core/pkg/guardian/interceptor_test.go
+ff78b833c6f03eecbf994ddf44b2e41cc65346c3cd8bca55d0c1ed2bbfc4fe7d  core/pkg/guardian/interceptor_test.go
 c0118e244adcba44a228c918ffb6c2fddc5be3273b7383914fb81e5f933bdb54  core/pkg/guardian/intervention_test.go
 fa50013f154fd1a1ebe1dcc1448b22f0ef3650990cefef4e7693aed227130b52  core/pkg/guardian/otel.go
 27e480317e91ec0ca763f23b1cc5db4a6fa9bae0090a6f4b0d97954dd25fcdf3  core/pkg/guardian/otel_test.go


### PR DESCRIPTION
## Problem
`allow_tainted_egress` was honored directly from caller-supplied request context, letting any agent self-approve egress of PII/credential/secret tainted data.

## Fix
The override now applies only when the context carries the `security_context_trusted` binding set by a trusted transport/adapter boundary — the same gate as `credential_hash` and `session_id`. Updates the coverage test that asserted the insecure behavior; adds end-to-end tests for both ignored-untrusted and honored-trusted overrides.

Note: the whole gate remains opt-in via `HELM_TAINT_TRACKING`; flipping that default is left as a policy decision in HELM-52.

Fixes HELM-52 (caller-bypass half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BggKqjoW6WCM93xa9VjdCx