### PR TITLE
fix(prg): make RequirementSet.Hash a real content digest (HELM-55)

### DIFF
--- a/core/pkg/prg/engine_comprehensive_test.go
+++ b/core/pkg/prg/engine_comprehensive_test.go
@@ -1,6 +1,7 @@
 package prg
 
 import (
+	"encoding/hex"
 	"strings"
 	"testing"
 
@@ -800,6 +801,33 @@ func TestRequirementSet_Hash_NotEmpty(t *testing.T) {
 	h := rs.Hash()
 	if h == "" {
 		t.Fatal("expected non-empty hash")
+	}
+}
+
+func TestRequirementSet_Hash_IsFixedWidthDigest(t *testing.T) {
+	// The hash is bound into DecisionRecord.RequirementSetHash; it must be a
+	// real content-addressed digest (sha256:<64 hex>), not a hex dump of the
+	// raw, unbounded content string.
+	rs := RequirementSet{
+		ID:    "rs-1",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "r1", Expression: "input.action == 'deploy' && size(input.artifacts) > 0"},
+			{ID: "r2", ArtifactType: "attestation"},
+		},
+		Children: []RequirementSet{{ID: "child", Logic: OR}},
+	}
+	h := rs.Hash()
+	const prefix = "sha256:"
+	if !strings.HasPrefix(h, prefix) {
+		t.Fatalf("expected %q prefix, got %q", prefix, h)
+	}
+	hexPart := strings.TrimPrefix(h, prefix)
+	if len(hexPart) != 64 {
+		t.Fatalf("expected 64 hex chars (32-byte digest), got %d: %q", len(hexPart), hexPart)
+	}
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		t.Fatalf("digest is not valid hex: %v", err)
 	}
 }
 

--- a/core/pkg/prg/graph.go
+++ b/core/pkg/prg/graph.go
@@ -59,9 +59,11 @@ type Node struct {
 	Req Requirement
 }
 
-// Hash computes a deterministic hash.
+// Hash computes a deterministic content-addressed digest of the requirement
+// set. The result (sha256:<hex>) is bound into DecisionRecord.RequirementSetHash,
+// so it must be a fixed-width, collision-resistant digest rather than a hex
+// dump of the raw content string.
 func (rs *RequirementSet) Hash() string {
-	// Simplified recursive hash
 	content := fmt.Sprintf("id=%s:logic=%s:", rs.ID, rs.Logic)
 	for _, req := range rs.Requirements {
 		content += fmt.Sprintf("req=%s:%s:%s;", req.ID, req.ArtifactType, req.Expression)
@@ -69,7 +71,8 @@ func (rs *RequirementSet) Hash() string {
 	for _, child := range rs.Children {
 		content += "child=" + child.Hash() + ";"
 	}
-	return fmt.Sprintf("hash:%x", content)
+	sum := sha256.Sum256([]byte(content))
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // Graph maps an ActionID to its RequirementSet (Policy).


### PR DESCRIPTION
## Problem
`RequirementSet.Hash` returned `fmt.Sprintf("hash:%x", content)` — a hex dump of the raw, unbounded content string, not a digest. This value is bound into `DecisionRecord.RequirementSetHash`.

## Fix
SHA-256 the canonical content and return `sha256:<hex>`. Test asserts the fixed-width digest shape. No fixtures or replay logic pin the previous format.

Fixes HELM-55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BggKqjoW6WCM93xa9VjdCx