### PR TITLE
fix(guardian): consume budget after policy, fail closed (HELM-50)

### DIFF
--- a/core/pkg/guardian/guardian.go
+++ b/core/pkg/guardian/guardian.go
@@ -400,9 +400,11 @@ func (g *Guardian) signDecisionWithGraph(ctx context.Context, decision *contract
 		// defaulting to recording it.
 	}
 
-	// 3.5 Budget Check (Finance Gate)
+	// 3.5 Budget Check (Finance Gate).
+	// Only a fast pre-policy ceiling check runs here; the actual draw-down
+	// (Consume) is deferred until after PRG passes so a request that policy
+	// later denies never consumes budget.
 	if g.tracker != nil {
-		// Attempt to resolve Budget ID from params
 		if budgetID, ok := effect.Params["budget_id"].(string); ok && budgetID != "" {
 			cost := BudgetCost{Requests: 1}
 
@@ -418,11 +420,6 @@ func (g *Guardian) signDecisionWithGraph(ctx context.Context, decision *contract
 				decision.ReasonCode = string(contracts.ReasonBudgetExceeded)
 				decision.Reason = string(contracts.ReasonBudgetExceeded)
 				return g.signer.SignDecision(decision)
-			}
-
-			if consumeErr := g.tracker.Consume(budgetID, cost); consumeErr != nil {
-				// Log but don't fail — the Check already passed.
-				slog.Warn("guardian: budget consume failed", "budget_id", budgetID, "error", consumeErr)
 			}
 		}
 	}
@@ -472,6 +469,22 @@ func (g *Guardian) signDecisionWithGraph(ctx context.Context, decision *contract
 		decision.Reason = string(contracts.ReasonMissingRequirement)
 		g.recordBehavioralEvent(decision.SubjectID, trust.EventPolicyViolate, "PRG requirement not met")
 		return g.signer.SignDecision(decision)
+	}
+
+	// 4.5 Budget draw-down. The action has passed policy, so consume budget
+	// now. Consume re-validates the ceiling and fails closed: if it cannot
+	// record the draw (e.g. the budget was exhausted between Check and here,
+	// or the backend is unavailable) the effect is denied rather than allowed
+	// on an unrecorded consumption.
+	if g.tracker != nil {
+		if budgetID, ok := effect.Params["budget_id"].(string); ok && budgetID != "" {
+			if consumeErr := g.tracker.Consume(budgetID, BudgetCost{Requests: 1}); consumeErr != nil {
+				decision.Verdict = string(contracts.VerdictDeny)
+				decision.ReasonCode = string(contracts.ReasonBudgetError)
+				decision.Reason = fmt.Sprintf("Budget consume failed: %v", consumeErr)
+				return g.signer.SignDecision(decision)
+			}
+		}
 	}
 
 	// 5. Pass -> Sign

--- a/core/pkg/guardian/guardian_core_coverage_test.go
+++ b/core/pkg/guardian/guardian_core_coverage_test.go
@@ -1010,10 +1010,12 @@ func TestCoverageGuardianDecisionEdges(t *testing.T) {
 	consumeErrorGuardian := NewGuardian(&testSigner{}, nil, nil, WithClock(clock), WithBudgetTracker(guardianCoverageBudgetGate{allowed: true, consumeErr: errors.New("consume failed")}))
 	consumeDecision := &contracts.DecisionRecord{ID: "dec-consume", SubjectID: "agent"}
 	if err := consumeErrorGuardian.signDecisionWithGraph(ctx, consumeDecision, &contracts.Effect{EffectID: "effect-consume", EffectType: "EXECUTE_TOOL", Params: map[string]any{"budget_id": "budget-1"}}, nil, nil, allowGraphFor("EXECUTE_TOOL")); err != nil {
-		t.Fatalf("consume warning path should continue: %v", err)
+		t.Fatalf("consume error path should still sign: %v", err)
 	}
-	if consumeDecision.Verdict != string(contracts.VerdictAllow) {
-		t.Fatalf("consume error should not block allow decision: %+v", consumeDecision)
+	// A budget consume failure must fail closed: the effect is denied rather
+	// than allowed on an unrecorded consumption.
+	if consumeDecision.Verdict != string(contracts.VerdictDeny) || consumeDecision.ReasonCode != string(contracts.ReasonBudgetError) {
+		t.Fatalf("consume error should fail closed with BUDGET_ERROR, got %+v", consumeDecision)
 	}
 
 	nilGraphDecision := &contracts.DecisionRecord{ID: "dec-nil-graph", SubjectID: "agent"}

--- a/core/pkg/guardian/guardian_test.go
+++ b/core/pkg/guardian/guardian_test.go
@@ -298,6 +298,68 @@ func TestGuardian_SignDecision(t *testing.T) {
 	})
 }
 
+// consumeFailBudgetTracker allows the pre-policy Check to pass but fails the
+// post-policy Consume, modelling budget exhausted between check and consume.
+type consumeFailBudgetTracker struct {
+	consumeCalls int
+}
+
+func (c *consumeFailBudgetTracker) Check(string, BudgetCost) (bool, error) { return true, nil }
+func (c *consumeFailBudgetTracker) Consume(string, BudgetCost) error {
+	c.consumeCalls++
+	return errors.New("budget backend unavailable")
+}
+
+func TestGuardian_BudgetNotConsumedOnPolicyDeny(t *testing.T) {
+	registry := pkg_artifact.NewRegistry(NewMockStore(), nil)
+	ruleGraph := prg.NewGraph()
+	// Rule exists but never passes, so PRG denies with MISSING_REQUIREMENT.
+	_ = ruleGraph.AddRule("gated_tool", prg.RequirementSet{
+		ID:           "always-fail",
+		Logic:        prg.AND,
+		Requirements: []prg.Requirement{{ID: "never", Expression: "false"}},
+	})
+
+	tracker := newMockBudgetTracker(100)
+	g := NewGuardian(&MockSigner{}, ruleGraph, registry, WithBudgetTracker(tracker))
+
+	decision := &contracts.DecisionRecord{ID: "dec-deny"}
+	effect := &contracts.Effect{
+		EffectType: "tool_call",
+		EffectID:   "eff-deny",
+		Params:     map[string]any{"tool_name": "gated_tool", "budget_id": "b1"},
+	}
+	require.NoError(t, g.SignDecision(context.Background(), decision, effect, nil, nil))
+	assert.Equal(t, string(contracts.VerdictDeny), decision.Verdict)
+	assert.Equal(t, string(contracts.ReasonMissingRequirement), decision.ReasonCode)
+
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	assert.Equal(t, int64(0), tracker.consumed,
+		"a policy-denied request must not draw down budget")
+}
+
+func TestGuardian_BudgetConsumeFailureFailsClosed(t *testing.T) {
+	registry := pkg_artifact.NewRegistry(NewMockStore(), nil)
+	ruleGraph := prg.NewGraph()
+	_ = ruleGraph.AddRule("safe_tool", prg.RequirementSet{ID: "allow-all"})
+
+	tracker := &consumeFailBudgetTracker{}
+	g := NewGuardian(&MockSigner{}, ruleGraph, registry, WithBudgetTracker(tracker))
+
+	decision := &contracts.DecisionRecord{ID: "dec-consume-fail"}
+	effect := &contracts.Effect{
+		EffectType: "tool_call",
+		EffectID:   "eff-consume-fail",
+		Params:     map[string]any{"tool_name": "safe_tool", "budget_id": "b1"},
+	}
+	require.NoError(t, g.SignDecision(context.Background(), decision, effect, nil, nil))
+	assert.Equal(t, string(contracts.VerdictDeny), decision.Verdict,
+		"a failed budget consume must fail closed, not allow")
+	assert.Equal(t, string(contracts.ReasonBudgetError), decision.ReasonCode)
+	assert.Equal(t, 1, tracker.consumeCalls)
+}
+
 func TestGuardian_BudgetEnforcement(t *testing.T) {
 	// 1. Setup Dependencies
 	mockStore := NewMockStore()

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-04T18:40:33Z
-# Commit: d616e8a711ef19a25f570b064f044e9258550c7c
+# Generated: 2026-07-04T19:00:29Z
+# Commit: 206d92073460315f75b56977d3accc4df476b7a8
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -574,15 +574,15 @@ aa4ea979d3f36460d50808f0ccee6bd48eb97cbc3c888d53b2971701b704e462  core/pkg/guard
 05d2907a744570e725955e9967f578b098389dee199fa7af7d54c2381f770a54  core/pkg/guardian/guardian_behavior_coverage_test.go
 2a5ca32bc0c383992332eea7cd839575ee7dd4b6266c2ed64c7bd8a2bfec044f  core/pkg/guardian/guardian_bench_test.go
 85459f0cd76631d94c0ea0e886eb90237c1b29ae7512b542ed4cd4995101f532  core/pkg/guardian/guardian_contracts_test.go
-6855d4df5ba134cb673af5dc89ac9197bacfd51fa17bec87e67ea4ba3fb66c39  core/pkg/guardian/guardian_core_coverage_test.go
+b7ff91ea033e301be3b6a9b7b971db4d808060deb90d85034d97ea395bd89604  core/pkg/guardian/guardian_core_coverage_test.go
 7c16929281b29d9b1256c185e6b98997470b44e6135a3f6bb1e5e5abeb187ef8  core/pkg/guardian/guardian_delegation_test.go
 1c6069fc10f370e11aefe4cab278c3994d29a72fe616aad5420aa6876bb05bde  core/pkg/guardian/guardian_edge_cases_test.go
-f4bb89f2028879a0a9f2ca0206d98908937a7602083565dba2a94f59139aa7c3  core/pkg/guardian/guardian.go
+c85dd9339b63f9ff196f84d2d63875e7ed10472f48bb513fae6259c1754cb2bb  core/pkg/guardian/guardian.go
 d7ad656ec37a80da9538c9435229f2e06214ccdde857fdf81e86dbb18d4ad7d7  core/pkg/guardian/guardian_intervention_test.go
 078f38e20e22ae8358bfac3533fc078707bac1ffa49e6a3c7b1ee880b46b8125  core/pkg/guardian/guardian_persistence_test.go
 773c3c8aad120609e8566ef6f6c908a1c7e1a81485aaf37d1ae09d6ef99a8c2b  core/pkg/guardian/guardian_regression_test.go
 604a3143cb413e5f65278430f7f40c0c98c3eb123b7180d01c05e7b19906f678  core/pkg/guardian/guardian_stress_coverage_test.go
-ca72cfc8728b95865c08db1cd5a538ca0a2b498527fa9e11bdfb9ae780da8e1a  core/pkg/guardian/guardian_test.go
+ac6ed02511a836d82a9c31f650b93e4741f403c6f3fd150306762b12a5fc667d  core/pkg/guardian/guardian_test.go
 b8a92ba80717a401aed15e89883c609ca40e7281b74b2b781fd9b327e9360a9c  core/pkg/guardian/integration_test.go
 d0c6c074a9a73202be5c054bd2a45db92df4c39bc2546e91fed80945320ad311  core/pkg/guardian/interceptor.go
 ff78b833c6f03eecbf994ddf44b2e41cc65346c3cd8bca55d0c1ed2bbfc4fe7d  core/pkg/guardian/interceptor_test.go


### PR DESCRIPTION
## Problem
- Budget was consumed during the pre-policy check, so a PRG-denied request had already drawn down budget.
- A `Consume` error was logged and swallowed, allowing the effect on an unrecorded consumption.

## Fix
Keep the fast ceiling `Check` before PRG (fast budget-exceeded denial), but defer `Consume` until after PRG passes. `Consume` now fails closed — a consume error denies with `BUDGET_ERROR`. This also narrows the check-to-consume window since `Consume` re-validates the ceiling.

Regression tests for no-consume-on-deny and fail-closed; updates the coverage test that asserted swallow-and-allow.

Note: opt-in `budget_id` resolution and fully atomic reserve semantics require a `BudgetGate` interface change and remain tracked in HELM-50.

Fixes HELM-50 (ordering + fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BggKqjoW6WCM93xa9VjdCx