### PR TITLE
ci: fix TLA Specs — update rolling tla2tools.jar digest, fail download loudly

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -22,9 +22,20 @@ jobs:
       - name: Download TLC
         id: tlc
         env:
+          # NOTE: tlaplus v1.8.0 is a rolling pre-release; its tla2tools.jar is
+          # periodically rebuilt upstream, which changes this digest. When the
+          # job fails with a SHA-256 mismatch, re-verify the asset against the
+          # official tlaplus release and update the digest here and in
+          # scripts/tla/download-tools.sh together.
           TLA_TOOLS_VERSION: v1.8.0
-          TLA_TOOLS_SHA256: 237332bdcc79a35c7d26efa7b82c77c85c2744591c5598673a8a45085ff2a4fb
-        run: echo "jar=$(bash scripts/tla/download-tools.sh)" >> "$GITHUB_OUTPUT"
+          TLA_TOOLS_SHA256: d144885f107ead1d1e56bcfc946df4b27b61588014b8d6525471c744aa743d18
+        # Run the script and capture output separately: `echo "jar=$(...)"`
+        # swallows the script's exit code, letting later steps run with an
+        # empty classpath when the download or digest check fails.
+        run: |
+          jar="$(bash scripts/tla/download-tools.sh)"
+          test -s "$jar"
+          echo "jar=$jar" >> "$GITHUB_OUTPUT"
       - name: Guardian pipeline spec
         run: java -cp "${{ steps.tlc.outputs.jar }}" tlc2.TLC -deadlock -config proofs/guardian.cfg proofs/GuardianPipeline.tla
       - name: Safe Deprecation Mode spec

--- a/scripts/tla/download-tools.sh
+++ b/scripts/tla/download-tools.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CACHE_DIR="${ROOT_DIR}/.cache/tlc"
 DEFAULT_TLA_TOOLS_VERSION="v1.8.0"
-DEFAULT_TLA_TOOLS_SHA256="237332bdcc79a35c7d26efa7b82c77c85c2744591c5598673a8a45085ff2a4fb"
+# tlaplus v1.8.0 is a rolling pre-release: upstream periodically rebuilds
+# tla2tools.jar under the same tag. On SHA-256 mismatch, re-verify the asset
+# against the official release and update this digest and the one in
+# .github/workflows/tla.yml together.
+DEFAULT_TLA_TOOLS_SHA256="d144885f107ead1d1e56bcfc946df4b27b61588014b8d6525471c744aa743d18"
 VERSION="${TLA_TOOLS_VERSION:-$DEFAULT_TLA_TOOLS_VERSION}"
 EXPECTED_SHA256="${TLA_TOOLS_SHA256:-}"
 JAR_URL="${TLA_TOOLS_JAR_URL:-}"


### PR DESCRIPTION
## Problem
Every TLA Specs run after 2026-07-03 18:24 UTC fails. Two causes:

1. **Stale digest**: tlaplus republished the v1.8.0 `tla2tools.jar` asset today (`updated_at: 2026-07-03T18:24:26Z`). v1.8.0 is a **rolling pre-release** — assets are rebuilt under the same tag — so the pinned SHA-256 (`237332bd…`) no longer matches the asset (`d144885f…`).
2. **Swallowed failure**: the Download TLC step runs the script inside `echo "jar=$(...)"`, which masks its exit code. On digest mismatch the job continued and later steps ran `java -cp "" tlc2.TLC` → misleading `ClassNotFoundException`.

## Fix
- Pin updated to `d144885f107ead1d1e56bcfc946df4b27b61588014b8d6525471c744aa743d18` in both the workflow and `scripts/tla/download-tools.sh`. Provenance: direct download from the official tlaplus v1.8.0 release; GitHub asset metadata confirms the republish by the tlaplus org.
- Download step now captures the script output separately and fails when the script fails or returns an empty path.
- Rolling-release caveat documented at both pin sites.

## Follow-up (not in this PR)
Vendor or mirror the jar to an immutable location — hash-pinning a rolling pre-release will break again on the next upstream rebuild.

Unblocks the `model-check` failures on PRs #496–#502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BggKqjoW6WCM93xa9VjdCx