### PR TITLE
Scope release wording to Kernel and Enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,8 +101,8 @@ Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0
 - Routed docs truth through the public org reusable workflow and pinned that
   reusable workflow's docs-truth runner checkout so `MINDBURN_ORG_READ_TOKEN`
   is not paired with floating runner code.
-- Clarified public-web post-quantum wording so release documentation does not
-  imply an added post-quantum cryptographic control.
+- Clarified HELM Kernel and HELM Enterprise quantum-security wording so public
+  release material does not imply an added post-quantum cryptographic control.
 
 ## [0.5.20] - 2026-07-01
 


### PR DESCRIPTION
## Summary
- replace the v0.6.0 changelog's public-web phrase with HELM Kernel and HELM Enterprise release wording
- keep the source changelog aligned with the live GitHub Release notes scope
- update the pinned TLA tools v1.8.0 checksum so the Kernel model-check gate downloads the verified jar and runs again

## Validation
- git diff --check
- make docs-truth
- python3 scripts/ci/check_tla_tools_hardening.py
- bash scripts/tla/download-tools.sh
- local TLC model checks: GuardianPipeline, SafeDeprecationMode, HelmKernel
- PR checks: all green