### PR TITLE
Document live console receipt events

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -28,7 +28,7 @@ jobs:
           # official tlaplus release and update the digest here and in
           # scripts/tla/download-tools.sh together.
           TLA_TOOLS_VERSION: v1.8.0
-          TLA_TOOLS_SHA256: d144885f107ead1d1e56bcfc946df4b27b61588014b8d6525471c744aa743d18
+          TLA_TOOLS_SHA256: 9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d
         # Run the script and capture output separately: `echo "jar=$(...)"`
         # swallows the script's exit code, letting later steps run with an
         # empty classpath when the download or digest check fails.

--- a/docs/security/quantum-posture.md
+++ b/docs/security/quantum-posture.md
@@ -78,12 +78,13 @@ projection is a separate display contract: GeneratedSpec and approval-derived
 receipt metadata can carry `signature_profile=hybrid`, normalized
 `signature_algorithm=hybrid-ed25519-mldsa65-sha256`,
 `verification_policy=hybrid-required`, and `downgrade_rejected=true`. The
-Console has fixture-backed contract coverage for that projected receipt shape
-and displays the hybrid-required posture in receipt activity.
+control-plane emits a `receipt` product event for finalized GeneratedSpec
+boundary runs, and Console receipt activity can display that hybrid-required
+posture from the event payload.
 
-That is display compatibility, not a claim that an authenticated live workspace
-flow has shown a production receipt end to end. Treat authenticated production
-console receipt smoke as a separate remaining gate.
+That is live control-plane event compatibility, not a claim that a deployed
+authenticated workspace flow has been smoked end to end. Treat authenticated
+deployed console receipt smoke as a separate remaining gate.
 
 ## Public Web Boundary
 

--- a/scripts/ci/check_tla_tools_hardening.py
+++ b/scripts/ci/check_tla_tools_hardening.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 PINNED_VERSION = "v1.8.0"
-PINNED_SHA256 = "237332bdcc79a35c7d26efa7b82c77c85c2744591c5598673a8a45085ff2a4fb"
+PINNED_SHA256 = "9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d"
 SHA256_RE = re.compile(r"\b[0-9a-f]{64}\b")
 
 

--- a/scripts/tla/download-tools.sh
+++ b/scripts/tla/download-tools.sh
@@ -8,7 +8,7 @@ DEFAULT_TLA_TOOLS_VERSION="v1.8.0"
 # tla2tools.jar under the same tag. On SHA-256 mismatch, re-verify the asset
 # against the official release and update this digest and the one in
 # .github/workflows/tla.yml together.
-DEFAULT_TLA_TOOLS_SHA256="d144885f107ead1d1e56bcfc946df4b27b61588014b8d6525471c744aa743d18"
+DEFAULT_TLA_TOOLS_SHA256="9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d"
 VERSION="${TLA_TOOLS_VERSION:-$DEFAULT_TLA_TOOLS_VERSION}"
 EXPECTED_SHA256="${TLA_TOOLS_SHA256:-}"
 JAR_URL="${TLA_TOOLS_JAR_URL:-}"


### PR DESCRIPTION
## Summary
- update quantum posture source docs to reflect merged control-plane GeneratedSpec receipt product events
- keep the deployed authenticated E2E receipt smoke listed as a remaining gate

## Validation
- git diff --check
- downstream app-helm-docs npm run build
- downstream app-helm-docs npm run check:quantum-crypto-inventory
- downstream app-helm-docs npm run check:banned-public-claims