### PR TITLE
ci: make npm dist-tag explicit

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,11 @@ on:
         required: false
         default: ""
         type: string
+      dist_tag:
+        description: npm dist-tag to assign after publish.
+        required: false
+        default: latest
+        type: string
       dry_run:
         description: Build and pack without publishing.
         required: false
@@ -49,7 +54,8 @@ jobs:
           python3 scripts/ci/validate_workflow_dispatch_inputs.py publish \
             --version "${{ inputs.version }}" \
             --dry-run "${{ inputs.dry_run }}" \
-            --release-tag "${{ inputs.release_tag }}"
+            --release-tag "${{ inputs.release_tag }}" \
+            --dist-tag "${{ inputs.dist_tag }}"
       - name: Check out package ref
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -99,7 +105,13 @@ jobs:
         working-directory: ${{ matrix.package.path }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag "${{ inputs.dist_tag }}"
+      - name: Ensure npm dist-tag
+        if: github.event.inputs.dry_run != 'true'
+        working-directory: ${{ matrix.package.path }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm dist-tag add "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }}" "${{ inputs.dist_tag }}"
       - name: Skip already published package
         if: github.event.inputs.dry_run != 'true' && steps.package.outputs.published == 'true'
         run: echo "${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} is already published"

--- a/scripts/ci/validate_workflow_dispatch_inputs.py
+++ b/scripts/ci/validate_workflow_dispatch_inputs.py
@@ -10,6 +10,7 @@ import sys
 
 SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
 RELEASE_TAG_RE = re.compile(r"^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$")
+NPM_DIST_TAG_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._-]{0,63}$")
 RUN_ID_RE = re.compile(r"^[1-9]\d{5,19}$")
 
 
@@ -49,6 +50,15 @@ def validate_optional_publish_tag(value: str | None, *, version: str) -> str | N
     return tag
 
 
+def validate_npm_dist_tag(value: str | None) -> str:
+    value = (value or "latest").strip()
+    if not NPM_DIST_TAG_RE.fullmatch(value):
+        raise ValueError("dist_tag must start with a letter and contain only letters, numbers, dot, underscore, or dash")
+    if SEMVER_RE.fullmatch(value) or RELEASE_TAG_RE.fullmatch(value):
+        raise ValueError("dist_tag must not be parseable as SemVer")
+    return value
+
+
 def validate_artifact_run_id(value: str) -> str:
     value = (value or "").strip()
     if not RUN_ID_RE.fullmatch(value):
@@ -64,6 +74,7 @@ def build_parser() -> argparse.ArgumentParser:
     publish.add_argument("--version", required=True)
     publish.add_argument("--dry-run", default=None)
     publish.add_argument("--release-tag", default=None)
+    publish.add_argument("--dist-tag", default=None)
 
     clean_install = sub.add_parser("clean-install")
     clean_install.add_argument("--release-tag", required=True)
@@ -79,6 +90,7 @@ def main(argv: list[str] | None = None) -> int:
             version = validate_version(args.version)
             validate_bool(args.dry_run, field="dry_run")
             validate_optional_publish_tag(args.release_tag, version=version)
+            validate_npm_dist_tag(args.dist_tag)
         elif args.command == "clean-install":
             validate_release_tag(args.release_tag)
             validate_artifact_run_id(args.artifact_run_id)

--- a/scripts/ci/validate_workflow_dispatch_inputs_test.py
+++ b/scripts/ci/validate_workflow_dispatch_inputs_test.py
@@ -26,6 +26,14 @@ class WorkflowDispatchInputValidationTest(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     validator.validate_optional_publish_tag(tag, version="1.2.3")
 
+    def test_npm_dist_tag_is_channel_not_version(self) -> None:
+        self.assertEqual(validator.validate_npm_dist_tag(None), "latest")
+        self.assertEqual(validator.validate_npm_dist_tag("v0_7_backfill"), "v0_7_backfill")
+        for tag in ["1.2.3", "v1.2.3", "bad tag", "next;echo pwned", "-latest"]:
+            with self.subTest(tag=tag):
+                with self.assertRaises(ValueError):
+                    validator.validate_npm_dist_tag(tag)
+
     def test_bool_is_strict(self) -> None:
         self.assertTrue(validator.validate_bool("true", field="dry_run"))
         self.assertFalse(validator.validate_bool("false", field="dry_run"))


### PR DESCRIPTION
Supersedes closed PRs #514 and #516 after the approval-gate branch refresh.\n\nThis keeps the same intended scope:\n- add an explicit npm publish dist_tag workflow input\n- validate dist_tag with the existing workflow_dispatch validator\n- publish and repair npm dist-tags using the explicit channel\n- reject semver-like dist-tags, including v-prefixed release tags\n\nLocal validation run:\n- python3 -m unittest validate_workflow_dispatch_inputs_test.py\n- validator CLI positive/negative publish dist_tag checks\n- git diff --check