### PR TITLE
test: cover npm dist-tag validation

### DIFF
--- a/scripts/ci/validate_workflow_dispatch_inputs_test.py
+++ b/scripts/ci/validate_workflow_dispatch_inputs_test.py
@@ -26,6 +26,14 @@ class WorkflowDispatchInputValidationTest(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     validator.validate_optional_publish_tag(tag, version="1.2.3")
 
+    def test_npm_dist_tag_is_channel_not_version(self) -> None:
+        self.assertEqual(validator.validate_npm_dist_tag(None), "latest")
+        self.assertEqual(validator.validate_npm_dist_tag("v0_7_backfill"), "v0_7_backfill")
+        for tag in ["1.2.3", "v1.2.3", "bad tag", "next;echo pwned", "-latest"]:
+            with self.subTest(tag=tag):
+                with self.assertRaises(ValueError):
+                    validator.validate_npm_dist_tag(tag)
+
     def test_bool_is_strict(self) -> None:
         self.assertTrue(validator.validate_bool("true", field="dry_run"))
         self.assertFalse(validator.validate_bool("false", field="dry_run"))


### PR DESCRIPTION
Follow-up to the npm dist-tag workflow repair that landed on main as 2256bd40.\n\nThis adds the missing unit coverage for the dist_tag validator:\n- default empty dist_tag resolves to latest\n- non-semver channel tags such as v0_7_backfill are allowed\n- SemVer and v-prefixed release tags are rejected\n- whitespace/shell-like tags are rejected\n\nLocal validation run:\n- python3 -m unittest validate_workflow_dispatch_inputs_test.py\n- validator CLI positive/negative publish dist_tag checks\n- git diff --check