### PR TITLE
ci: require release provenance assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
       id-token: write
     outputs:
       binary-digest: ${{ steps.checksums.outputs.digest }}
+      slsa-subjects: ${{ steps.checksums.outputs.slsa-subjects }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -132,6 +133,7 @@ jobs:
         name: Aggregate digest set
         run: |
           echo "digest=$(shasum -a 256 dist/release-assets/SHA256SUMS.txt | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          echo "slsa-subjects=$(find dist/release-assets -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum | base64 -w0)" >> "$GITHUB_OUTPUT"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-assets
@@ -911,15 +913,29 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
+          generate_release_notes: true
           files: |
             dist/*
             cosign/**/*.cosign.bundle
             benchmarks-release/*.json
             version-status/version-status.json
 
+  slsa-provenance:
+    needs: [binaries, github-release]
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    with:
+      base64-subjects: "${{ needs.binaries.outputs.slsa-subjects }}"
+      upload-assets: true
+      upload-tag-name: ${{ github.ref_name }}
+      compile-generator: true
+
   post-release-version-drift:
     runs-on: ubuntu-latest
-    needs: [github-release, homebrew, downstream-fanout, go-sdk-tag]
+    needs: [github-release, slsa-provenance, homebrew, downstream-fanout, go-sdk-tag]
     permissions:
       contents: write
     steps:

--- a/release/README.md
+++ b/release/README.md
@@ -19,8 +19,8 @@ assets are platform binaries for Darwin, Linux, and Windows,
 `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `SHA256SUMS.txt`, `sbom.json`,
 `v0.7.0.openvex.json`, `release-attestation.json`, `evidence-pack.tar`,
 `release.high_risk.v3.toml`, `sample-policy-material.tar`,
-`helm-ai-kernel-launchpad-data.tar`, and matching `*.cosign.bundle` files for
-every primary asset.
+`helm-ai-kernel-launchpad-data.tar`, `multiple.intoto.jsonl`, and matching
+`*.cosign.bundle` files for every primary asset.
 
 There is no public GitHub Release object for `v0.4.1`; the actual public
 baseline for the `v0.5.0` delta is `v0.4.0`.
@@ -42,6 +42,7 @@ GitHub release before publication is claimed:
 - `helm-ai-kernel-launchpad-data.tar`
 - `helm-ai-kernel.mcpb`
 - `helm-ai-kernel.rb`
+- `multiple.intoto.jsonl`
 
 The sample policy material archive contains `release.high_risk.v3.toml` and
 `reference_packs/eu_ai_act_high_risk.v1.json`. The GitHub release workflow

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -569,6 +569,21 @@
       "human_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v{version}"
     },
     {
+      "id": "github-release-notes",
+      "kind": "github_release_notes",
+      "url": "https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel/releases/tags/v{version}",
+      "human_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v{version}"
+    },
+    {
+      "id": "github-release-slsa-provenance",
+      "kind": "github_release_assets",
+      "url": "https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel/releases/tags/v{version}",
+      "human_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v{version}",
+      "required_assets": [
+        "multiple.intoto.jsonl"
+      ]
+    },
+    {
       "id": "ghcr-image",
       "kind": "ghcr_tags",
       "repository": "mindburn-labs/helm-ai-kernel",

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -223,6 +223,29 @@ def check_github_release(surface: dict[str, Any], version: str) -> SurfaceResult
     return SurfaceResult(surface["id"], "pass" if actual == expected else "fail", expected, actual, url=fmt(surface["human_url"], version))
 
 
+def check_github_release_notes(surface: dict[str, Any], version: str) -> SurfaceResult:
+    url = fmt(surface["url"], version)
+    payload = request_json(url)
+    body = str(payload.get("body") or "").strip()
+    return SurfaceResult(surface["id"], "pass" if body else "fail", "non-empty release notes", bool(body), url=fmt(surface["human_url"], version))
+
+
+def check_github_release_assets(surface: dict[str, Any], version: str) -> SurfaceResult:
+    url = fmt(surface["url"], version)
+    payload = request_json(url)
+    actual = sorted(asset.get("name") for asset in payload.get("assets", []) if asset.get("name"))
+    expected = sorted(fmt(asset, version) for asset in surface["required_assets"])
+    missing = sorted(asset for asset in expected if asset not in actual)
+    return SurfaceResult(
+        surface["id"],
+        "pass" if not missing else "fail",
+        expected,
+        {"found": sorted(asset for asset in expected if asset in actual), "missing": missing},
+        url=fmt(surface["human_url"], version),
+        detail="missing assets: " + ", ".join(missing) if missing else None,
+    )
+
+
 def check_npm(surface: dict[str, Any], version: str) -> SurfaceResult:
     payload = request_json(surface["url"])
     actual = payload.get("dist-tags", {}).get("latest")
@@ -366,6 +389,8 @@ def check_pkg_go_dev(surface: dict[str, Any], version: str) -> SurfaceResult:
 
 PUBLISHED_CHECKS = {
     "github_release": check_github_release,
+    "github_release_notes": check_github_release_notes,
+    "github_release_assets": check_github_release_assets,
     "npm": check_npm,
     "pypi": check_pypi,
     "crates": check_crates,


### PR DESCRIPTION
## Summary
- publish SLSA provenance from the release workflow after the GitHub Release is created
- require non-empty GitHub release notes and the `multiple.intoto.jsonl` provenance asset in published drift checks
- document `multiple.intoto.jsonl` in the release asset contract

## Public v0.7.0 repair
- updated v0.7.0 release notes
- dispatched SLSA provenance workflow for v0.7.0: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/28796421722
- confirmed `multiple.intoto.jsonl` is now attached to v0.7.0

## Validation
- `python3 -m py_compile scripts/release/check_version_drift.py`
- `make version-drift`
- YAML parse for `.github/workflows/release.yml` and `release/version-surfaces.yaml`
- `python3 scripts/release/check_version_drift.py --expected-version 0.7.0 published --only github-release-notes --only github-release-slsa-provenance`
- `make version-drift-published`
- `make docs-coverage docs-truth`

No product, website, Company AI OS GA, checkout, or cloud-production scope.