### PR TITLE
ci: verify release SLSA subjects

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -43,8 +43,9 @@ surface for the `helm-ai-kernel` project.
 - `scorecard.yml` uploads OpenSSF Scorecard SARIF for `main` and pull requests;
   PR SARIF is normalized so GitHub code scanning sees the same branch-protection
   category that exists on `main`.
-- `slsa-provenance.yml` builds reproducible release binaries before generating
-  provenance subjects.
+- `slsa-provenance.yml` is a manual repair workflow that re-attests the
+  checksum-covered assets already attached to a published release. Normal tag
+  releases generate SLSA provenance from `release.yml`.
 - `version-drift.yml` runs the published registry drift check daily and opens or
   updates one issue when any public channel falls behind `VERSION`.
 

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,46 +1,79 @@
-name: SLSA L3 Provenance
+name: SLSA L3 Provenance Repair
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to build and upload provenance for, for example v0.5.12.
+        description: Release tag whose published assets should be re-attested, for example v0.7.0.
         required: true
         type: string
 
 permissions: read-all
 
 jobs:
-  build:
+  subjects:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: ${{ github.event.release.tag_name || inputs.tag || github.ref }}
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
-        with:
-          go-version: "1.25.10"
-          cache-dependency-path: "**/go.sum"
-      - name: Build artifacts
-        run: make release-assets
+      - name: Download published release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          mkdir -p dist/release-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --dir dist/release-assets
+      - name: Keep checksum-covered primary assets
+        run: |
+          cd dist/release-assets
+          shasum -a 256 -c SHA256SUMS.txt
+          python3 - <<'PY'
+          import pathlib
+
+          root = pathlib.Path(".")
+          keep = {"SHA256SUMS.txt"}
+          for line in root.joinpath("SHA256SUMS.txt").read_text(encoding="utf-8").splitlines():
+              if not line.strip():
+                  continue
+              _digest, name = line.split(maxsplit=1)
+              keep.add(name.lstrip("*"))
+          for path in root.iterdir():
+              if path.is_file() and path.name not in keep:
+                  path.unlink()
+          PY
       - name: Generate hashes
         id: hash
         run: |
           echo "hashes=$(find dist/release-assets -maxdepth 1 -type f -print0 | sort -z | xargs -0 sha256sum | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+  replace-existing:
+    needs: [subjects]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete existing provenance asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          api_url="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+            --jq '.assets[] | select(.name == "multiple.intoto.jsonl") | .apiUrl' || true)"
+          if [ -n "$api_url" ]; then
+            gh api --method DELETE "${api_url#https://api.github.com/}"
+          fi
+
   provenance:
-    needs: [build]
+    needs: [subjects, replace-existing]
     permissions:
       actions: read
       id-token: write
       contents: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
-      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      base64-subjects: "${{ needs.subjects.outputs.hashes }}"
       upload-assets: true
-      upload-tag-name: ${{ github.event.release.tag_name || inputs.tag || '' }}
+      upload-tag-name: ${{ inputs.tag }}
       compile-generator: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,13 @@ hardware-backed enforcement language out of the public changelog until a tagged
 release ships source-owned tests, verifier evidence, and release artifacts for
 that exact capability.
 
+- Added a published-release SLSA subject integrity gate that compares
+  `multiple.intoto.jsonl` subjects against the published `SHA256SUMS.txt`
+  manifest.
+- Converted the standalone SLSA provenance workflow into a manual repair path
+  for already-published release assets so normal tag releases use the lockstep
+  `release.yml` provenance job.
+
 ## [0.7.0] - 2026-07-05
 
 Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.0>.

--- a/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
+++ b/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
@@ -1,10 +1,12 @@
 # HELM AI Kernel OSS 1.0 Release Train
 
+<!-- quantum_posture: this planning doc mentions release signature and provenance assets but does not implement cryptographic controls. -->
+
 Status: internal release planning source, not release notes.
-Current audit date: 2026-07-05.
-Current source base: `origin/main@e5bc9b3d`.
-Current source version: `VERSION=0.6.0`.
-Current public release: `v0.6.0`.
+Current audit date: 2026-07-07.
+Current source base: `origin/main@eed014fa`.
+Current source version: `VERSION=0.7.0`.
+Current public release: `v0.7.0`.
 
 Do not add this file to the public docs manifest. Future release scope becomes
 public only through tagged release notes, changelog entries, release assets, and
@@ -14,9 +16,9 @@ published drift evidence for that exact version.
 
 | Surface | Current state | Evidence | Plan impact |
 | --- | --- | --- | --- |
-| Release baseline | `v0.6.0` is the latest public GitHub release; `main` has moved past the tag. | `gh release list`, `git log v0.6.0..origin/main` | Start the next release from current `origin/main`, not from the tag. |
-| Open PR dependencies | Open kernel PRs are this internal docs plan and the quantum inventory CI guard. No release-theme code prerequisite is open. | `gh pr list --state open` returned #509 and #510 on 2026-07-05. | Merge this docs plan before rebasing the CI guard; keep release-theme work out of both PRs. |
-| Unreleased main delta | Post-`v0.6.0` commits are guardian/kernel/PRG/TLA/release-doc hardening, not a feature train. | `git diff --stat v0.6.0..origin/main` | Fold into `v0.7.0` unless a security patch release is cut first. |
+| Release baseline | `v0.7.0` is the latest public GitHub release; `main` has moved past the tag for release-provenance guard work. | `gh release list`, `git log v0.7.0..origin/main` | Cut `v0.7.1` only for evidence/release hardening needed before `v0.8.0`. |
+| Open PR dependencies | No open kernel PR dependency is required for the next patch. | `gh pr list --state open` returned no open PRs on 2026-07-07. | Keep `v0.7.1` independent unless a release repair PR becomes necessary. |
+| Unreleased main delta | Post-`v0.7.0` commits harden npm publication and release provenance checks, not a feature train. | `git diff --stat v0.7.0..origin/main` | Fold into `v0.7.1`; do not mix in RiskEnvelope feature work. |
 | EvidencePack structure | Mandatory pack structure, optional host evidence, and declared `99_EXT/` extensions exist. | `core/pkg/conform/evidencepack.go:13` | `v0.7.0` should freeze authority and compatibility, not invent a pack layout. |
 | EvidencePack seal and verifier | Native seal and verification paths exist. | `core/pkg/evidence/seal.go:191`, `core/pkg/evidence/seal.go:349` | `v0.7.0` must define exact verifier success and tamper-failure requirements. |
 | ProofGraph | ProofGraph refs are used by runtime adapters, exports, and evidence packs. | `core/pkg/evidence/arc/pack_builder.go:39`, `core/pkg/workstation/evidence.go:63` | `v0.7.0` must freeze ref grammar, pack placement, and replay semantics. |
@@ -151,6 +153,8 @@ Allowed changes:
 
 - clearer verifier error output;
 - compatibility fixes for packs produced by retained `v0.7.0` writers;
+- published-release SLSA subject integrity checks and repair-only provenance
+  workflow fixes;
 - documentation examples that mirror tested commands;
 - conformance regression fixtures.
 

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -584,6 +584,14 @@
       ]
     },
     {
+      "id": "github-release-slsa-subjects",
+      "kind": "github_release_slsa_subjects",
+      "url": "https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel/releases/tags/v{version}",
+      "human_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v{version}",
+      "checksum_asset": "SHA256SUMS.txt",
+      "slsa_asset": "multiple.intoto.jsonl"
+    },
+    {
       "id": "ghcr-image",
       "kind": "ghcr_tags",
       "repository": "mindburn-labs/helm-ai-kernel",

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
+import hashlib
 import json
 import os
 import re
@@ -204,6 +207,12 @@ def request_json(url: str) -> Any:
         return json.loads(response.read().decode("utf-8"))
 
 
+def request_bytes(url: str) -> bytes:
+    req = urllib.request.Request(url, headers=http_headers({"Accept": "application/octet-stream, */*"}))
+    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        return response.read()
+
+
 def request_text(url: str) -> str:
     req = urllib.request.Request(url, headers=http_headers({"Accept": "text/plain, text/html, application/xml, */*"}))
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
@@ -244,6 +253,112 @@ def check_github_release_assets(surface: dict[str, Any], version: str) -> Surfac
         url=fmt(surface["human_url"], version),
         detail="missing assets: " + ", ".join(missing) if missing else None,
     )
+
+
+def parse_sha256sums(data: bytes) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for line in data.decode("utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        match = re.match(r"^([0-9a-fA-F]{64}) [ *](.+)$", line)
+        if match is None:
+            raise ValueError(f"invalid SHA256SUMS line: {line!r}")
+        digest, name = match.groups()
+        checksums[name] = digest.lower()
+    if not checksums:
+        raise ValueError("SHA256SUMS has no entries")
+    return checksums
+
+
+def decode_dsse_payload(payload: str) -> dict[str, Any]:
+    padded = payload + ("=" * (-len(payload) % 4))
+    return json.loads(base64.b64decode(padded).decode("utf-8"))
+
+
+def slsa_statements_from_bundle(data: bytes) -> list[dict[str, Any]]:
+    statements: list[dict[str, Any]] = []
+    for line in data.decode("utf-8").splitlines() or [data.decode("utf-8")]:
+        if not line.strip():
+            continue
+        doc = json.loads(line)
+        if "subject" in doc:
+            statements.append(doc)
+            continue
+        envelope = doc.get("dsseEnvelope") or doc.get("envelope") or {}
+        payload = envelope.get("payload")
+        if payload:
+            statements.append(decode_dsse_payload(payload))
+    if not statements:
+        raise ValueError("SLSA bundle has no in-toto statements")
+    return statements
+
+
+def slsa_subject_digests(data: bytes) -> dict[str, str]:
+    subjects: dict[str, str] = {}
+    for statement in slsa_statements_from_bundle(data):
+        for subject in statement.get("subject", []):
+            name = Path(str(subject.get("name", ""))).name
+            digest = subject.get("digest", {}).get("sha256")
+            if not name or not digest:
+                continue
+            digest = str(digest).lower()
+            if name in subjects and subjects[name] != digest:
+                raise ValueError(f"conflicting SLSA subject digest for {name}")
+            subjects[name] = digest
+    if not subjects:
+        raise ValueError("SLSA bundle has no sha256 subjects")
+    return subjects
+
+
+def release_asset_by_name(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {asset["name"]: asset for asset in payload.get("assets", []) if asset.get("name")}
+
+
+def check_github_release_slsa_subjects(surface: dict[str, Any], version: str) -> SurfaceResult:
+    url = fmt(surface["url"], version)
+    payload = request_json(url)
+    assets = release_asset_by_name(payload)
+    checksum_asset = surface.get("checksum_asset", "SHA256SUMS.txt")
+    slsa_asset = surface.get("slsa_asset", "multiple.intoto.jsonl")
+    missing_assets = [name for name in [checksum_asset, slsa_asset] if name not in assets]
+    if missing_assets:
+        return SurfaceResult(
+            surface["id"],
+            "fail",
+            [checksum_asset, slsa_asset],
+            {"missing_assets": missing_assets},
+            url=fmt(surface["human_url"], version),
+            detail="missing assets: " + ", ".join(missing_assets),
+        )
+
+    try:
+        checksum_bytes = request_bytes(assets[checksum_asset]["browser_download_url"])
+        slsa_bytes = request_bytes(assets[slsa_asset]["browser_download_url"])
+        expected = parse_sha256sums(checksum_bytes)
+        expected[checksum_asset] = hashlib.sha256(checksum_bytes).hexdigest()
+        subjects = slsa_subject_digests(slsa_bytes)
+    except (KeyError, ValueError, UnicodeDecodeError, binascii.Error) as exc:
+        return SurfaceResult(surface["id"], "fail", "SLSA subjects match SHA256SUMS", None, url=fmt(surface["human_url"], version), detail=str(exc))
+
+    missing = sorted(name for name in expected if name not in subjects)
+    mismatched = [
+        {"name": name, "checksum": expected[name], "slsa": subjects.get(name)}
+        for name in sorted(expected)
+        if name in subjects and subjects[name] != expected[name]
+    ]
+    extra = sorted(name for name in subjects if name not in expected)
+    actual = {
+        "matched": sorted(name for name in expected if subjects.get(name) == expected[name]),
+        "missing": missing,
+        "mismatched": mismatched,
+        "extra": extra,
+    }
+    ok = not missing and not mismatched and not extra
+    detail = None
+    if not ok:
+        detail = f"missing={len(missing)} mismatched={len(mismatched)} extra={len(extra)}"
+    return SurfaceResult(surface["id"], "pass" if ok else "fail", sorted(expected), actual, url=fmt(surface["human_url"], version), detail=detail)
 
 
 def check_npm(surface: dict[str, Any], version: str) -> SurfaceResult:
@@ -391,6 +506,7 @@ PUBLISHED_CHECKS = {
     "github_release": check_github_release,
     "github_release_notes": check_github_release_notes,
     "github_release_assets": check_github_release_assets,
+    "github_release_slsa_subjects": check_github_release_slsa_subjects,
     "npm": check_npm,
     "pypi": check_pypi,
     "crates": check_crates,

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -2,6 +2,9 @@
 """Self-tests for release version drift monitoring."""
 from __future__ import annotations
 
+import base64
+import hashlib
+import json
 import unittest
 
 import check_version_drift as drift
@@ -24,6 +27,7 @@ class VersionDriftMonitorTests(unittest.TestCase):
             "maven-sdk",
             "go-proxy-sdk",
             "pkg-go-dev-sdk",
+            "github-release-slsa-subjects",
             "docs-site-developer-journey",
             "docs-site-sdk-index",
             "docs-site-examples",
@@ -37,6 +41,8 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertEqual(kinds["docs-site-sdk-index"], "http_contains")
         self.assertTrue(blocking["go-proxy-sdk"])
         self.assertTrue(blocking["pkg-go-dev-sdk"])
+        self.assertEqual(kinds["github-release-slsa-subjects"], "github_release_slsa_subjects")
+        self.assertTrue(blocking["github-release-slsa-subjects"])
 
     def test_all_published_surface_kinds_are_supported(self) -> None:
         contract = drift.load_contract(drift.DEFAULT_CONTRACT)
@@ -156,6 +162,57 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertEqual(result.status, "fail")
         self.assertEqual(result.actual, ["v0.6.0"])
         self.assertIn("v0.6.0-slim (404)", result.detail or "")
+
+    def test_github_release_slsa_subjects_match_checksum_manifest(self) -> None:
+        asset_digest = "a" * 64
+        checksum_bytes = f"{asset_digest}  artifact.tar\n".encode()
+        checksum_digest = hashlib.sha256(checksum_bytes).hexdigest()
+        bundle = slsa_bundle(
+            {
+                "dist/release-assets/SHA256SUMS.txt": checksum_digest,
+                "dist/release-assets/artifact.tar": asset_digest,
+            }
+        )
+        original_json = drift.request_json
+        original_bytes = drift.request_bytes
+        drift.request_json = lambda _url: release_payload()
+        drift.request_bytes = lambda url: (
+            checksum_bytes if url == "https://example.test/SHA256SUMS.txt" else bundle
+        )
+        try:
+            result = drift.check_github_release_slsa_subjects(release_surface(), "0.7.1")
+        finally:
+            drift.request_json = original_json
+            drift.request_bytes = original_bytes
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.actual["missing"], [])
+        self.assertEqual(result.actual["mismatched"], [])
+        self.assertEqual(result.actual["extra"], [])
+
+    def test_github_release_slsa_subjects_report_digest_mismatch(self) -> None:
+        checksum_bytes = f"{'a' * 64}  artifact.tar\n".encode()
+        bundle = slsa_bundle(
+            {
+                "dist/release-assets/SHA256SUMS.txt": hashlib.sha256(checksum_bytes).hexdigest(),
+                "dist/release-assets/artifact.tar": "b" * 64,
+            }
+        )
+        original_json = drift.request_json
+        original_bytes = drift.request_bytes
+        drift.request_json = lambda _url: release_payload()
+        drift.request_bytes = lambda url: (
+            checksum_bytes if url == "https://example.test/SHA256SUMS.txt" else bundle
+        )
+        try:
+            result = drift.check_github_release_slsa_subjects(release_surface(), "0.7.1")
+        finally:
+            drift.request_json = original_json
+            drift.request_bytes = original_bytes
+
+        self.assertEqual(result.status, "fail")
+        self.assertEqual(result.actual["mismatched"][0]["name"], "artifact.tar")
+        self.assertIn("mismatched=1", result.detail or "")
 
     def test_published_error_preserves_advisory_status(self) -> None:
         surface = {
@@ -283,6 +340,34 @@ class VersionDriftMonitorTests(unittest.TestCase):
 
         self.assertEqual(result.status, "pass")
         self.assertEqual(result.actual["rejected_found"], [])
+
+
+def release_surface() -> dict[str, str]:
+    return {
+        "id": "github-release-slsa-subjects",
+        "kind": "github_release_slsa_subjects",
+        "url": "https://api.example.test/releases/tags/v{version}",
+        "human_url": "https://example.test/releases/tag/v{version}",
+    }
+
+
+def release_payload() -> dict[str, list[dict[str, str]]]:
+    return {
+        "assets": [
+            {"name": "SHA256SUMS.txt", "browser_download_url": "https://example.test/SHA256SUMS.txt"},
+            {"name": "multiple.intoto.jsonl", "browser_download_url": "https://example.test/multiple.intoto.jsonl"},
+        ]
+    }
+
+
+def slsa_bundle(subjects: dict[str, str]) -> bytes:
+    statement = {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "predicateType": "https://slsa.dev/provenance/v0.2",
+        "subject": [{"name": name, "digest": {"sha256": digest}} for name, digest in sorted(subjects.items())],
+    }
+    payload = base64.b64encode(json.dumps(statement).encode()).decode().rstrip("=")
+    return json.dumps({"dsseEnvelope": {"payload": payload}}).encode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Pre-v0.8.0 evidence hardening patch for the release train.

- Add a published-release gate that verifies `multiple.intoto.jsonl` subjects match the published `SHA256SUMS.txt` manifest.
- Convert the standalone SLSA workflow into a manual repair-only workflow that re-attests already-published checksum-covered assets instead of rebuilding artifacts independently.
- Refresh the internal release-train plan to current `v0.7.0` truth and record this as allowed `v0.7.1` evidence hardening scope.

## Audit Finding

Live `v0.7.0` currently has `multiple.intoto.jsonl`, but the SLSA subjects mismatch `SHA256SUMS.txt` for 6 entries: `SHA256SUMS.txt`, `evidence-pack.tar`, `helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `release-attestation.json`, and `sbom.json`. The new gate catches that exact failure.

## Validation

- `python3 -m py_compile scripts/release/check_version_drift.py scripts/release/check_version_drift_test.py`
- `python3 scripts/release/check_version_drift_test.py`
- `python3 - <<PY ... yaml.safe_load(...) ... PY` for `.github/workflows/slsa-provenance.yml` and `release/version-surfaces.yaml`
- `make version-drift`
- `make docs-coverage docs-truth`
- Expected current live failure before repair: `python3 scripts/release/check_version_drift.py --expected-version 0.7.0 published --only github-release-slsa-subjects`

## Scope Boundary

No RiskEnvelope, scan, upload, cloud, checkout, website, connector certification, or Company AI OS GA scope. This is release evidence hardening only.