### PR TITLE
ci: mirror tla2tools jar for TLA specs

### DIFF
--- a/.github/workflows/tla.yml
+++ b/.github/workflows/tla.yml
@@ -22,12 +22,10 @@ jobs:
       - name: Download TLC
         id: tlc
         env:
-          # NOTE: tlaplus v1.8.0 is a rolling pre-release; its tla2tools.jar is
-          # periodically rebuilt upstream, which changes this digest. When the
-          # job fails with a SHA-256 mismatch, re-verify the asset against the
-          # official tlaplus release and update the digest here and in
-          # scripts/tla/download-tools.sh together.
+          # NOTE: tlaplus v1.8.0 is a rolling pre-release upstream. CI uses the
+          # org-controlled mirror release and still verifies the SHA-256 digest.
           TLA_TOOLS_VERSION: v1.8.0
+          TLA_TOOLS_JAR_URL: https://github.com/Mindburn-Labs/helm-ai-kernel/releases/download/deps-tla2tools-v1.8.0/tla2tools-v1.8.0.jar
           TLA_TOOLS_SHA256: 9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d
         # Run the script and capture output separately: `echo "jar=$(...)"`
         # swallows the script's exit code, letting later steps run with an

--- a/scripts/ci/check_tla_tools_hardening.py
+++ b/scripts/ci/check_tla_tools_hardening.py
@@ -11,6 +11,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 PINNED_VERSION = "v1.8.0"
 PINNED_SHA256 = "9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d"
+PINNED_URL = (
+    "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/download/"
+    "deps-tla2tools-v1.8.0/tla2tools-v1.8.0.jar"
+)
 SHA256_RE = re.compile(r"\b[0-9a-f]{64}\b")
 
 
@@ -32,6 +36,7 @@ def forbid(text: str, token: str, path: Path) -> None:
 def check_downloader(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
     require(text, f'DEFAULT_TLA_TOOLS_VERSION="{PINNED_VERSION}"', path)
+    require(text, f'DEFAULT_TLA_TOOLS_JAR_URL="{PINNED_URL}"', path)
     require(text, f'DEFAULT_TLA_TOOLS_SHA256="{PINNED_SHA256}"', path)
     require(text, "TLA_TOOLS_VERSION must be an immutable release tag", path)
     require(text, "TLA_TOOLS_JAR_URL must use HTTPS", path)
@@ -48,6 +53,7 @@ def check_workflow(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
     require(text, "bash scripts/tla/download-tools.sh", path)
     require(text, f"TLA_TOOLS_VERSION: {PINNED_VERSION}", path)
+    require(text, f"TLA_TOOLS_JAR_URL: {PINNED_URL}", path)
     require(text, f"TLA_TOOLS_SHA256: {PINNED_SHA256}", path)
     if not SHA256_RE.search(text):
         fail(f"{path}: missing pinned TLA tools SHA-256")

--- a/scripts/tla/download-tools.sh
+++ b/scripts/tla/download-tools.sh
@@ -4,10 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CACHE_DIR="${ROOT_DIR}/.cache/tlc"
 DEFAULT_TLA_TOOLS_VERSION="v1.8.0"
-# tlaplus v1.8.0 is a rolling pre-release: upstream periodically rebuilds
-# tla2tools.jar under the same tag. On SHA-256 mismatch, re-verify the asset
-# against the official release and update this digest and the one in
-# .github/workflows/tla.yml together.
+DEFAULT_TLA_TOOLS_JAR_URL="https://github.com/Mindburn-Labs/helm-ai-kernel/releases/download/deps-tla2tools-v1.8.0/tla2tools-v1.8.0.jar"
+# tlaplus v1.8.0 is a rolling pre-release upstream, so CI defaults to the
+# org-controlled mirror above and keeps the digest check as the immutable gate.
 DEFAULT_TLA_TOOLS_SHA256="9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d"
 VERSION="${TLA_TOOLS_VERSION:-$DEFAULT_TLA_TOOLS_VERSION}"
 EXPECTED_SHA256="${TLA_TOOLS_SHA256:-}"
@@ -34,7 +33,7 @@ if [[ -z "${VERSION}" || "${VERSION}" == "latest" ]]; then
 fi
 
 if [[ -z "${JAR_URL}" ]]; then
-  JAR_URL="https://github.com/tlaplus/tlaplus/releases/download/${VERSION}/tla2tools.jar"
+  JAR_URL="${DEFAULT_TLA_TOOLS_JAR_URL}"
 fi
 
 if [[ "${JAR_URL}" != https://* ]]; then
@@ -42,7 +41,7 @@ if [[ "${JAR_URL}" != https://* ]]; then
   exit 1
 fi
 
-if [[ -z "${EXPECTED_SHA256}" && "${VERSION}" == "${DEFAULT_TLA_TOOLS_VERSION}" && "${JAR_URL}" == "https://github.com/tlaplus/tlaplus/releases/download/${DEFAULT_TLA_TOOLS_VERSION}/tla2tools.jar" ]]; then
+if [[ -z "${EXPECTED_SHA256}" && "${VERSION}" == "${DEFAULT_TLA_TOOLS_VERSION}" && "${JAR_URL}" == "${DEFAULT_TLA_TOOLS_JAR_URL}" ]]; then
   EXPECTED_SHA256="${DEFAULT_TLA_TOOLS_SHA256}"
 fi
 


### PR DESCRIPTION
## Summary
- Create/use an org-controlled `deps-tla2tools-v1.8.0` release asset for `tla2tools.jar`
- Point TLA Specs CI and `scripts/tla/download-tools.sh` at the mirror instead of the mutable upstream pre-release asset
- Extend the existing hardening guard to require the mirrored URL in both pin sites

## Evidence
- Mirror release: https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/deps-tla2tools-v1.8.0
- Asset digest: `sha256:9e27b5e19a69ae1f56aabf8403a6ed5598dbfa6e638908e5278ac39736c1543d`
- `/usr/bin/python3 scripts/ci/check_tla_tools_hardening.py` passes
- `rm -rf .cache/tlc && bash scripts/tla/download-tools.sh && shasum -a 256 .cache/tlc/*.jar` passes
- `git diff --check` passes

Linear: HELM-57