### PR TITLE
Fail closed on ambiguous sandbox network posture

### DIFF
--- a/core/pkg/runtime/sandbox/grants.go
+++ b/core/pkg/runtime/sandbox/grants.go
@@ -2,6 +2,7 @@ package sandbox
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
@@ -16,6 +17,11 @@ const (
 	BackendGVisor      BackendKind = "native-gvisor"
 	BackendFirecracker BackendKind = "native-firecracker"
 	BackendHosted      BackendKind = "hosted-adapter"
+
+	networkPostureDenyAll   = "deny-all"
+	networkPostureAllowlist = "allowlist"
+	networkPostureUnknown   = "unknown"
+	networkPostureUncertain = "uncertain"
 )
 
 type BackendProfile struct {
@@ -67,10 +73,9 @@ func GrantFromPolicy(policy *SandboxPolicy, runtimeName, profileName, imageDiges
 		preopens = append(preopens, contracts.FilesystemPreopen{Path: path, Mode: mode})
 	}
 
-	network := contracts.NetworkGrant{Mode: "deny-all"}
-	if !policy.NetworkDenyAll {
-		network.Mode = "allowlist"
-		network.Destinations = append([]string(nil), policy.NetworkAllowlist...)
+	network, err := resolveNetworkGrant(policy)
+	if err != nil {
+		return contracts.SandboxGrant{}, err
 	}
 
 	grant := contracts.SandboxGrant{
@@ -90,4 +95,27 @@ func GrantFromPolicy(policy *SandboxPolicy, runtimeName, profileName, imageDiges
 		PolicyEpoch: policyEpoch,
 	}
 	return grant.Seal()
+}
+
+func resolveNetworkGrant(policy *SandboxPolicy) (contracts.NetworkGrant, error) {
+	posture := strings.ToLower(strings.TrimSpace(policy.NetworkPosture))
+	switch posture {
+	case "":
+		if policy.NetworkDenyAll {
+			posture = networkPostureDenyAll
+		} else {
+			posture = networkPostureAllowlist
+		}
+	case networkPostureUnknown, networkPostureUncertain:
+		posture = networkPostureDenyAll
+	case networkPostureDenyAll, networkPostureAllowlist:
+	default:
+		return contracts.NetworkGrant{}, fmt.Errorf("invalid network posture %q", policy.NetworkPosture)
+	}
+
+	network := contracts.NetworkGrant{Mode: posture}
+	if posture == networkPostureAllowlist {
+		network.Destinations = append([]string(nil), policy.NetworkAllowlist...)
+	}
+	return network, nil
 }

--- a/core/pkg/runtime/sandbox/grants_test.go
+++ b/core/pkg/runtime/sandbox/grants_test.go
@@ -48,3 +48,34 @@ func TestGrantFromPolicyRequiresNetworkAllowlist(t *testing.T) {
 		t.Fatal("expected allowlist network policy without destinations to fail")
 	}
 }
+
+func TestGrantFromPolicyAmbiguousNetworkPostureFailsClosed(t *testing.T) {
+	for _, posture := range []string{"unknown", "uncertain"} {
+		t.Run(posture, func(t *testing.T) {
+			policy := &SandboxPolicy{
+				PolicyID:       posture + "-net",
+				FSAllowlist:    []string{"/workspace"},
+				NetworkPosture: posture,
+				NetworkDenyAll: false,
+			}
+			grant, err := GrantFromPolicy(policy, "wazero", posture+"-net", "", "epoch-42", time.Now().UTC())
+			if err != nil {
+				t.Fatalf("grant from policy: %v", err)
+			}
+			if grant.Network.Mode != "deny-all" {
+				t.Fatalf("network mode = %s, want deny-all", grant.Network.Mode)
+			}
+		})
+	}
+}
+
+func TestGrantFromPolicyRejectsInvalidNetworkPosture(t *testing.T) {
+	policy := &SandboxPolicy{
+		PolicyID:       "bad-posture",
+		FSAllowlist:    []string{"/workspace"},
+		NetworkPosture: "wide-open",
+	}
+	if _, err := GrantFromPolicy(policy, "wazero", "bad-posture", "", "epoch-42", time.Now().UTC()); err == nil {
+		t.Fatal("expected invalid network posture to fail")
+	}
+}

--- a/core/pkg/runtime/sandbox/policy.go
+++ b/core/pkg/runtime/sandbox/policy.go
@@ -21,6 +21,7 @@ type SandboxPolicy struct {
 	FSDenylist       []string `json:"fs_denylist"`       // Denied paths (checked first)
 	NetworkAllowlist []string `json:"network_allowlist"` // Allowed hosts/CIDRs
 	NetworkDenyAll   bool     `json:"network_deny_all"`  // If true, block all network
+	NetworkPosture   string   `json:"network_posture,omitempty"`
 	MaxMemoryBytes   int64    `json:"max_memory_bytes"`
 	MaxCPUSeconds    int64    `json:"max_cpu_seconds"`
 	Capabilities     []string `json:"capabilities"` // Allowed capabilities
@@ -156,7 +157,19 @@ func (e *PolicyEnforcer) CheckNetwork(host string) CheckResult {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	if e.policy.NetworkDenyAll {
+	network, err := resolveNetworkGrant(e.policy)
+	if err != nil {
+		v := PolicyViolation{
+			ViolationType: "NETWORK_INVALID_POLICY",
+			Detail:        err.Error(),
+			Timestamp:     e.clock(),
+			Blocked:       true,
+		}
+		e.violations = append(e.violations, v)
+		return CheckResult{Allowed: false, Reason: v.Detail}
+	}
+
+	if network.Mode == "deny-all" {
 		v := PolicyViolation{
 			ViolationType: "NETWORK_DENY_ALL",
 			Detail:        fmt.Sprintf("all network access denied, attempted: %s", host),
@@ -168,7 +181,7 @@ func (e *PolicyEnforcer) CheckNetwork(host string) CheckResult {
 	}
 
 	allowed := false
-	for _, allow := range e.policy.NetworkAllowlist {
+	for _, allow := range network.Destinations {
 		if allow == host || strings.HasSuffix(host, "."+allow) {
 			allowed = true
 			break

--- a/core/pkg/runtime/sandbox/policy_test.go
+++ b/core/pkg/runtime/sandbox/policy_test.go
@@ -81,6 +81,19 @@ func TestNetworkAllowlist(t *testing.T) {
 	}
 }
 
+func TestNetworkUnknownPostureFailsClosed(t *testing.T) {
+	p := DefaultPolicy()
+	p.NetworkDenyAll = false
+	p.NetworkAllowlist = []string{"api.example.com"}
+	p.NetworkPosture = "unknown"
+	e := NewPolicyEnforcer(p)
+
+	r := e.CheckNetwork("api.example.com")
+	if r.Allowed {
+		t.Fatal("expected unknown posture to deny network access")
+	}
+}
+
 func TestCapabilityAllowed(t *testing.T) {
 	e := NewPolicyEnforcer(DefaultPolicy())
 	r := e.CheckCapability("read")


### PR DESCRIPTION
## Summary
- add an explicit sandbox network posture field for ambiguous/unknown network state
- resolve network grants through one helper used by both grant sealing and runtime checks
- fail closed for unknown/uncertain posture and reject invalid posture strings

## Validation
- GOCACHE=/private/tmp/go-build-sandbox-uncertainty GOWORK=off go test ./pkg/runtime/sandbox -count=1
- make verify-boundary
- git diff --check origin/main...HEAD
- GitHub CI was green on the superseded PR #531 before recreating this PR to satisfy the code-owner approval ruleset without admin override

## Notes
- Supersedes #531, which was closed only because the original PR author could not satisfy the code-owner review requirement.
- This closes the audited sandbox uncertainty gap only; it does not claim production release or broader conformance completion.