### PR TITLE
Fail closed replay determinism gate

### DIFF
--- a/core/pkg/verifier/verifier.go
+++ b/core/pkg/verifier/verifier.go
@@ -836,19 +836,97 @@ func checkPolicyDecisionHashes(bundlePath string) CheckResult {
 }
 
 func checkReplayDeterminism(bundlePath string) CheckResult {
-	// Replay tapes are optional but recommended for L2+ conformance.
-	// Their absence is not a failure, but we note it explicitly.
+	required, detail := replayDeterminismRequired(bundlePath)
+	if !required {
+		return CheckResult{Name: "replay_determinism", Pass: true, Detail: detail}
+	}
+
 	tapesDir := filepath.Join(bundlePath, "08_TAPES")
 	if !dirExists(tapesDir) {
-		return CheckResult{Name: "replay_determinism", Pass: true, Detail: "warn: no tapes directory — replay verification skipped (optional for L1)"}
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: "missing 08_TAPES directory — replay evidence required"}
 	}
 
-	entries, err := os.ReadDir(tapesDir)
-	if err != nil || len(entries) == 0 {
-		return CheckResult{Name: "replay_determinism", Pass: true, Detail: "warn: no tape files — replay verification skipped (optional for L1)"}
+	manifestPath := filepath.Join(tapesDir, "tape_manifest.json")
+	if !fileExists(manifestPath) {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: "missing 08_TAPES/tape_manifest.json — replay evidence required"}
 	}
 
-	return CheckResult{Name: "replay_determinism", Pass: true, Detail: fmt.Sprintf("%d tape files available for replay", len(entries))}
+	manifestData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: fmt.Sprintf("cannot read tape manifest: %v", err)}
+	}
+	var tapeManifest map[string]any
+	if err := json.Unmarshal(manifestData, &tapeManifest); err != nil {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: fmt.Sprintf("invalid tape manifest JSON: %v", err)}
+	}
+
+	detManifestPath := filepath.Join(bundlePath, "02_PROOFGRAPH", "determinism_manifest.json")
+	if !fileExists(detManifestPath) {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: "missing 02_PROOFGRAPH/determinism_manifest.json — replay hash proof required"}
+	}
+	detManifestData, err := os.ReadFile(detManifestPath)
+	if err != nil {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: fmt.Sprintf("cannot read determinism manifest: %v", err)}
+	}
+	var detManifest map[string]any
+	if err := json.Unmarshal(detManifestData, &detManifest); err != nil {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: fmt.Sprintf("invalid determinism manifest JSON: %v", err)}
+	}
+
+	liveHash, liveOK := detManifest["live_hash"].(string)
+	replayHash, replayOK := detManifest["replay_hash"].(string)
+	if !liveOK || liveHash == "" || !replayOK || replayHash == "" {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: "determinism manifest must declare live_hash and replay_hash"}
+	}
+	if liveHash != replayHash {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: fmt.Sprintf("replay hash divergence: live=%s replay=%s", liveHash, replayHash)}
+	}
+
+	diffsDir := filepath.Join(bundlePath, "05_DIFFS")
+	if entries, err := os.ReadDir(diffsDir); err == nil && len(entries) > 0 {
+		return CheckResult{Name: "replay_determinism", Pass: false, Reason: "05_DIFFS contains replay differences"}
+	}
+
+	entryCount := 0
+	if entries, ok := tapeManifest["entries"].([]any); ok {
+		entryCount = len(entries)
+	}
+
+	return CheckResult{
+		Name:   "replay_determinism",
+		Pass:   true,
+		Detail: fmt.Sprintf("replay evidence verified: tape_manifest.json present, determinism hashes match, tape entries=%d", entryCount),
+	}
+}
+
+func replayDeterminismRequired(bundlePath string) (bool, string) {
+	indexPath := filepath.Join(bundlePath, "00_INDEX.json")
+	if !fileExists(indexPath) {
+		return false, "n/a: 00_INDEX.json missing; index integrity handles bundle validity"
+	}
+
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		return false, "n/a: cannot read 00_INDEX.json gate scope"
+	}
+
+	var document map[string]any
+	if err := json.Unmarshal(data, &document); err != nil {
+		return false, "n/a: invalid 00_INDEX.json gate scope"
+	}
+
+	gates, ok := document["gates"].([]any)
+	if !ok {
+		return false, "n/a: 00_INDEX.json has no gates declaration"
+	}
+
+	for _, gate := range gates {
+		if value, ok := gate.(string); ok && value == "G2" {
+			return true, "replay evidence required by 00_INDEX.json gates"
+		}
+	}
+
+	return false, "n/a: 00_INDEX.json gates omit G2 replay determinism"
 }
 
 // --- Helpers ---

--- a/core/pkg/verifier/verifier_behavior_coverage_test.go
+++ b/core/pkg/verifier/verifier_behavior_coverage_test.go
@@ -52,19 +52,77 @@ func TestVerifyBundle_NoDecisionHash(t *testing.T) {
 
 func TestVerifyBundle_WithTapesDirectory(t *testing.T) {
 	dir := createValidBundleFixture(t)
+	setBundleGates(t, dir, "G0", "G1", "G2")
 	tapesDir := filepath.Join(dir, "08_TAPES")
 	os.MkdirAll(tapesDir, 0o755)
-	os.WriteFile(filepath.Join(tapesDir, "tape1.json"), []byte(`{}`), 0o644)
+	sealVerifierFixture(t, dir, "test-session-001")
 	r, _ := VerifyBundle(dir)
 	found := false
 	for _, c := range r.Checks {
-		if c.Name == "replay_determinism" && c.Pass {
+		if c.Name == "replay_determinism" && !c.Pass {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatal("replay_determinism check should pass with tapes dir")
+		t.Fatal("replay_determinism check should fail when G2 is declared but replay evidence is incomplete")
 	}
+	if r.Verified {
+		t.Fatal("bundle should fail when G2 replay evidence is incomplete")
+	}
+}
+
+func TestVerifyBundle_ReplayDeterminismNAWhenG2OutOfScope(t *testing.T) {
+	dir := createValidBundleFixture(t)
+	r, _ := VerifyBundle(dir)
+	for _, c := range r.Checks {
+		if c.Name != "replay_determinism" {
+			continue
+		}
+		if !c.Pass {
+			t.Fatalf("replay_determinism should be N/A when G2 is omitted: %+v", c)
+		}
+		if c.Detail != "n/a: 00_INDEX.json gates omit G2 replay determinism" {
+			t.Fatalf("unexpected replay_determinism detail: %q", c.Detail)
+		}
+		return
+	}
+	t.Fatal("missing replay_determinism check")
+}
+
+func TestVerifyBundle_ReplayDeterminismPassesWithRequiredEvidence(t *testing.T) {
+	dir := createValidBundleFixture(t)
+	setBundleGates(t, dir, "G0", "G1", "G2")
+	tapesDir := filepath.Join(dir, "08_TAPES")
+	if err := os.MkdirAll(tapesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(tapesDir, "tape_manifest.json"), map[string]any{
+		"schema_version": "helm.tape_manifest.v1",
+		"run_id":         "test-session-001",
+		"entries":        []any{},
+	})
+	if err := os.MkdirAll(filepath.Join(dir, "02_PROOFGRAPH"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(dir, "02_PROOFGRAPH", "determinism_manifest.json"), map[string]any{
+		"schema_version": "helm.determinism.v1",
+		"live_hash":      "sha256:same",
+		"replay_hash":    "sha256:same",
+	})
+	sealVerifierFixture(t, dir, "test-session-001")
+	r, _ := VerifyBundle(dir)
+	if !r.Verified {
+		t.Fatalf("bundle should verify with required replay evidence: %+v", r.Checks)
+	}
+	for _, c := range r.Checks {
+		if c.Name == "replay_determinism" {
+			if !c.Pass {
+				t.Fatalf("replay_determinism should pass with required evidence: %+v", c)
+			}
+			return
+		}
+	}
+	t.Fatal("missing replay_determinism check")
 }
 
 func TestVerifyBundle_ReportIssueCount(t *testing.T) {

--- a/core/pkg/verifier/verifier_test.go
+++ b/core/pkg/verifier/verifier_test.go
@@ -69,6 +69,7 @@ func createValidCanonicalBundleFixture(t *testing.T) string {
 	writeJSON(t, filepath.Join(dir, "00_INDEX.json"), map[string]any{
 		"version": "1.0.0",
 		"entries": []any{},
+		"gates":   []string{"G0", "G1"},
 	})
 	writeJSON(t, filepath.Join(dir, "01_SCORE.json"), map[string]any{
 		"pass": true,
@@ -150,10 +151,38 @@ func writeSealFixtureIndex(t *testing.T, dir string) {
 		t.Fatal(err)
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
-	writeJSON(t, filepath.Join(dir, "00_INDEX.json"), map[string]any{
+	index := map[string]any{
 		"version": "1.0.0",
 		"entries": entries,
-	})
+	}
+	indexPath := filepath.Join(dir, "00_INDEX.json")
+	if data, err := os.ReadFile(indexPath); err == nil {
+		var existing map[string]any
+		if json.Unmarshal(data, &existing) == nil {
+			for key, value := range existing {
+				if key == "entries" {
+					continue
+				}
+				index[key] = value
+			}
+		}
+	}
+	writeJSON(t, indexPath, index)
+}
+
+func setBundleGates(t *testing.T, dir string, gates ...string) {
+	t.Helper()
+	indexPath := filepath.Join(dir, "00_INDEX.json")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var index map[string]any
+	if err := json.Unmarshal(data, &index); err != nil {
+		t.Fatal(err)
+	}
+	index["gates"] = gates
+	writeJSON(t, indexPath, index)
 }
 
 func TestVerifyBundle_Valid(t *testing.T) {

--- a/tests/conformance/arc/replay_determinism_test.go
+++ b/tests/conformance/arc/replay_determinism_test.go
@@ -1,8 +1,78 @@
 package arc_conformance
 
-import "testing"
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
 
-// TestReplayDeterminism ensures EvidencePacks can exactly reproduce the historical ARC state.
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/verifier"
+)
+
+// TestReplayDeterminism ensures replay determinism fails closed when the bundle
+// declares G2 replay proof but omits the required tape evidence.
 func TestReplayDeterminism(t *testing.T) {
-	t.Log("Testing EvidencePack unpack and replay determinism via the PackBuilder")
+	dir := t.TempDir()
+
+	writeJSON(t, filepath.Join(dir, "manifest.json"), map[string]any{
+		"session_id":  "arc-replay",
+		"version":     "1.0.0",
+		"exported_at": "2026-01-01T00:00:00Z",
+	})
+	writeJSON(t, filepath.Join(dir, "00_INDEX.json"), map[string]any{
+		"version": "1.0.0",
+		"gates":   []string{"G0", "G1", "G2"},
+	})
+	writeJSON(t, filepath.Join(dir, "proofgraph.json"), map[string]any{
+		"version": "1.0.0",
+		"nodes":   []any{},
+		"edges":   []any{},
+	})
+	receiptsDir := filepath.Join(dir, "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(receiptsDir, "receipt-001.json"), map[string]any{
+		"receipt_id":    "rcpt-001",
+		"decision_id":   "dec-001",
+		"decision_hash": "sha256:abc123",
+		"status":        "APPLIED",
+		"lamport_clock": 1,
+	})
+
+	report, err := verifier.VerifyBundle(dir)
+	if err != nil {
+		t.Fatalf("verify bundle: %v", err)
+	}
+	if report.Verified {
+		t.Fatal("bundle should fail when replay evidence is declared but missing")
+	}
+
+	for _, check := range report.Checks {
+		if check.Name == "replay_determinism" {
+			if check.Pass {
+				t.Fatalf("replay_determinism should fail closed: %+v", check)
+			}
+			if check.Reason == "" {
+				t.Fatalf("replay_determinism failure should explain missing proof: %+v", check)
+			}
+			return
+		}
+	}
+	t.Fatal("missing replay_determinism check")
+}
+
+func writeJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,6 +1,6 @@
 # HELM Protected Manifest
-# Generated: 2026-07-11T22:08:48Z
-# Commit: 493ff3e1b41bbe9d9ee46de01ff737c67eba2647
+# Generated: 2026-07-11T23:02:02Z
+# Commit: b5574d7c8f081f4ffed3a8e100abdc962f847a42
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
 #
@@ -418,9 +418,9 @@ f2229d08f1b6ad50f51e976305814161e9269884bf563c18fb57bb7416285d10  core/pkg/verif
 bfbe8e2d25ff38dc49eb34028cfede4e449bdc63e3b810f1b19913a11b72442b  core/pkg/verifier/externalreceipt/externalreceipt.go
 fdb3835dc6315a0730a961d458a0c1e4f9f5d79059f33b8908718f075718e12f  core/pkg/verifier/externalreceipt/externalreceipt_test.go
 e70d160b80a81e70a4d1019d9903135d25f813bbe5803b1da8582e727e8c819c  core/pkg/verifier/host_evidence_test.go
-8d65fde47b9947323c24314013b5b7caeb603f37258c6611aee1b195c2a08d49  core/pkg/verifier/verifier.go
-ce266e57a125c5f28989b6a9e50932b26c37289ea94fc8aa26ef8c83abc194da  core/pkg/verifier/verifier_behavior_coverage_test.go
-026f2fac57aba70ea4e14002e9d26f3bd0482c5d5b3c781b356f6b9658931a9c  core/pkg/verifier/verifier_test.go
+c72cf3a4275a7529e23812ddc487ba759648f9a33248ed76b1453dae709849be  core/pkg/verifier/verifier.go
+6826dbc4685bd55768db73e1d39e7195ac05571d2452337aa10c87704027f153  core/pkg/verifier/verifier_behavior_coverage_test.go
+c066a6086e521c514cfdc2e36a0cab0a99b259499332046b54506630d0ccb2d8  core/pkg/verifier/verifier_test.go
 f5332ef5eaa72e342066a9d3dad0f822415efeece0312fd97c9cb23674b2c647  core/pkg/connectors/sandbox/README.md
 54d138f657e16bc1df4cf260a562f3e0ad239f6c145129565799700401c6f78d  core/pkg/connectors/sandbox/branchfs.go
 3a43db565ecb1e9d80be41747dfcf8d591f131ef7ef2979b9066f77309ed7656  core/pkg/connectors/sandbox/bridge.go


### PR DESCRIPTION
## Summary
- make replay determinism verification fail closed when 00_INDEX.json declares G2
- require 08_TAPES/tape_manifest.json plus 02_PROOFGRAPH/determinism_manifest.json for declared replay proof
- reject hash divergence and replay diff artifacts instead of treating replay as an always-pass warning
- keep legacy/no-G2 packs N/A so existing non-replay packs remain verifiable
- regenerate the protected boundary manifest

## Validation
- env GOWORK=off go test ./pkg/verifier -count=1
- go test ./tests/conformance/arc -count=1
- go test ./core/cmd/helm-ai-kernel -count=1
- make verify-fixtures
- make quality-pr
- GitHub CI was green on superseded #530 at commit 04b32bd693de96c3b355babb26ea4e191c4f4b4a before recreating this PR to satisfy the code-owner approval ruleset without admin override

## Notes
- Supersedes #530, which was closed only because the original PR author could not satisfy the code-owner review requirement.
- This is a proof-boundary honesty improvement, not a full tape execution engine.