### PR TITLE
Governed MCP execution bridge (R3): ALLOW/DENY/ESCALATE, not deny-only

### DIFF
--- a/core/pkg/runtimeadapters/mcp/adapter.go
+++ b/core/pkg/runtimeadapters/mcp/adapter.go
@@ -12,6 +12,8 @@ import (
 	"log/slog"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/effects"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/proofgraph"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtimeadapters"
 )
@@ -19,12 +21,17 @@ import (
 // MCPAdapter intercepts MCP tool calls and routes them through HELM governance.
 type MCPAdapter struct {
 	graph  *proofgraph.Graph
+	bridge *GovernedBridge
 	logger *slog.Logger
 }
 
 // Config configures the MCPAdapter.
 type Config struct {
-	Graph  *proofgraph.Graph
+	Graph *proofgraph.Graph
+	// Bridge, when set, evaluates each tool call through the governed execution
+	// bridge (ALLOW/DENY/ESCALATE, permit, receipt, optional dispatch). When nil
+	// the adapter stays deny-only and fail-closed (BRIDGE_NOT_CONFIGURED).
+	Bridge *GovernedBridge
 	Logger *slog.Logger
 }
 
@@ -39,6 +46,7 @@ func NewMCPAdapter(cfg Config) (*MCPAdapter, error) {
 	}
 	return &MCPAdapter{
 		graph:  cfg.Graph,
+		bridge: cfg.Bridge,
 		logger: logger,
 	}, nil
 }
@@ -83,15 +91,90 @@ func (a *MCPAdapter) Intercept(ctx context.Context, req *runtimeadapters.Adapted
 		"proof_node", node.NodeHash,
 	)
 
-	// The OSS adapter records the intercepted call and denies execution until a
-	// deployment supplies a governed MCP execution bridge.
-	return &runtimeadapters.AdaptedResponse{
-		Allowed:        false,
-		DenyReason:     &runtimeadapters.DenyReason{Code: "BRIDGE_NOT_CONFIGURED", Message: "MCP adapter execution bridge is not configured", Actionable: "contact_admin"},
-		ReceiptID:      node.NodeHash,
-		DecisionID:     node.NodeHash,
-		ProofGraphNode: node.NodeHash,
-	}, nil
+	// Without a governed bridge the adapter stays fail-closed: it records the
+	// intercepted call and denies execution.
+	if a.bridge == nil {
+		return &runtimeadapters.AdaptedResponse{
+			Allowed:        false,
+			DenyReason:     &runtimeadapters.DenyReason{Code: "BRIDGE_NOT_CONFIGURED", Message: "MCP adapter execution bridge is not configured", Actionable: "contact_admin"},
+			ReceiptID:      node.NodeHash,
+			DecisionID:     node.NodeHash,
+			ProofGraphNode: node.NodeHash,
+		}, nil
+	}
+
+	return a.governed(ctx, req, inputHash, node.NodeHash)
+}
+
+// governed routes an intercepted call through the execution bridge, records an
+// EFFECT node linked to the INTENT, and maps the verdict to an AdaptedResponse.
+func (a *MCPAdapter) governed(ctx context.Context, req *runtimeadapters.AdaptedRequest, inputHash, intentNode string) (*runtimeadapters.AdaptedResponse, error) {
+	outcome := a.bridge.Govern(ctx, req, inputHash)
+
+	effectPayload, err := json.Marshal(mcpEffectPayload{
+		AdapterID:     a.ID(),
+		ToolName:      req.ToolName,
+		IntentNode:    intentNode,
+		Verdict:       string(outcome.Verdict),
+		ReasonCode:    outcome.ReasonCode,
+		DecisionID:    outcome.DecisionID,
+		ReceiptHash:   outcome.ReceiptHash,
+		DispatchState: outcome.DispatchState,
+		OutputHash:    outcome.OutputHash,
+		PermitID:      permitID(outcome.Permit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("runtimeadapters/mcp: effect payload marshal failed: %w", err)
+	}
+	effectNode, err := a.graph.Append(proofgraph.NodeTypeEffect, effectPayload, req.PrincipalID, 0)
+	if err != nil {
+		return nil, fmt.Errorf("runtimeadapters/mcp: proofgraph effect append failed: %w", err)
+	}
+
+	receiptID := outcome.ReceiptHash
+	if receiptID == "" {
+		receiptID = effectNode.NodeHash
+	}
+	decisionID := outcome.DecisionID
+	if decisionID == "" {
+		decisionID = intentNode
+	}
+
+	resp := &runtimeadapters.AdaptedResponse{
+		Allowed:        outcome.Verdict == contracts.VerdictAllow,
+		Result:         outcome.Output,
+		ReceiptID:      receiptID,
+		DecisionID:     decisionID,
+		ProofGraphNode: effectNode.NodeHash,
+	}
+	if resp.Allowed {
+		a.logger.InfoContext(ctx, "mcp tool call allowed",
+			"tool", req.ToolName, "dispatch", outcome.DispatchState, "permit", permitID(outcome.Permit))
+		return resp, nil
+	}
+
+	resp.DenyReason = &runtimeadapters.DenyReason{
+		Code:       outcome.ReasonCode,
+		Message:    outcome.Reason,
+		Actionable: actionableFor(outcome.Verdict),
+	}
+	a.logger.InfoContext(ctx, "mcp tool call not allowed",
+		"tool", req.ToolName, "verdict", outcome.Verdict, "reason", outcome.ReasonCode)
+	return resp, nil
+}
+
+func actionableFor(v contracts.Verdict) string {
+	if v == contracts.VerdictEscalate {
+		return "request_approval"
+	}
+	return "modify_scope"
+}
+
+func permitID(p *effects.EffectPermit) string {
+	if p == nil {
+		return ""
+	}
+	return p.PermitID
 }
 
 type mcpProofPayload struct {
@@ -100,4 +183,17 @@ type mcpProofPayload struct {
 	ToolName    string `json:"tool_name"`
 	PrincipalID string `json:"principal_id"`
 	InputHash   string `json:"input_hash"`
+}
+
+type mcpEffectPayload struct {
+	AdapterID     string `json:"adapter_id"`
+	ToolName      string `json:"tool_name"`
+	IntentNode    string `json:"intent_node"`
+	Verdict       string `json:"verdict"`
+	ReasonCode    string `json:"reason_code,omitempty"`
+	DecisionID    string `json:"decision_id,omitempty"`
+	ReceiptHash   string `json:"receipt_hash,omitempty"`
+	DispatchState string `json:"dispatch_state"`
+	OutputHash    string `json:"output_hash,omitempty"`
+	PermitID      string `json:"permit_id,omitempty"`
 }

--- a/core/pkg/runtimeadapters/mcp/bridge.go
+++ b/core/pkg/runtimeadapters/mcp/bridge.go
@@ -1,0 +1,531 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/effects"
+	mcpcore "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtimeadapters"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/workstation"
+)
+
+// Dispatch states recorded on a governed MCP effect.
+const (
+	DispatchStateDispatched    = "dispatched"
+	DispatchStateFailed        = "dispatch_failed"
+	DispatchStateNoDispatch    = "no_dispatch_proof"
+	DispatchStateNotDispatched = "not_dispatched"
+)
+
+// ApprovalEvidence is verifier-approved evidence that satisfies an escalation.
+type ApprovalEvidence struct {
+	ApproverID   string
+	ApprovalHash string
+	GrantedScope string
+}
+
+// ApprovalStore verifies approval evidence for an escalated request. It is keyed
+// by the request's canonical input hash so an approval is bound to the exact
+// proposed effect it was granted for.
+type ApprovalStore interface {
+	Approved(requestHash string) (ApprovalEvidence, bool)
+}
+
+// WriteClassifier reports whether a tool call is a bounded write that requires
+// human approval before dispatch, even when policy would otherwise allow it.
+type WriteClassifier func(toolName string, args map[string]any) bool
+
+// DefaultWriteClassifier flags tool names with common mutating verbs. Deployments
+// should replace it with connector-declared effect classes.
+//
+// ponytail: verb heuristic; connector effect-class metadata should drive this in
+// production (see effects.EffectRequest.EffectType).
+func DefaultWriteClassifier(toolName string, _ map[string]any) bool {
+	lower := strings.ToLower(toolName)
+	for _, verb := range []string{"create", "update", "delete", "send", "write", "add", "post", "merge", "deploy", "publish", "pay", "transfer", "remove", "set", "close", "comment"} {
+		if strings.Contains(lower, verb) {
+			return true
+		}
+	}
+	return false
+}
+
+// GovernedBridge turns an MCP tool call into a governed decision, a signed
+// workstation decision receipt, an EffectPermit, and (optionally) a dispatched
+// source-system effect. It composes the existing workstation enforcement engine
+// (ALLOW/DENY) with an approval-gated ESCALATE tier for bounded writes.
+//
+// It is fail-closed: any internal error yields a DENY outcome, never an ALLOW.
+//
+// Threat-model note: policy authority here is the workstation profile engine
+// (workstation.Decide), NOT the full 6-gate guardian PEP. It enforces
+// operate-permission and (via the boundary firewall) allowlist/identity/scope,
+// but it does not run the Threat/injection, Freeze, or full Delegation-scope
+// gates. MCP is a prime prompt-injection surface, so routing it through the
+// complete guardian pipeline is a tracked follow-up before this bridge is
+// enabled by default. DelegationSessionID is forwarded into the decision record
+// but not yet scope-enforced on this path.
+type GovernedBridge struct {
+	firewall    *mcpcore.ExecutionFirewall // optional boundary gate: allowlist/identity/scope/pinned-schema
+	serverID    string
+	scopes      []string
+	profile     contracts.WorkstationPolicyProfile
+	signingSeed []byte
+	nonces      effects.NonceStore
+	connector   effects.Connector // optional: nil => allowed but not dispatched (no-dispatch proof)
+	approvals   ApprovalStore     // optional: nil => escalations cannot be satisfied
+	isWrite     WriteClassifier
+	permitTTL   time.Duration
+	issuerID    string
+	now         func() time.Time
+}
+
+// BridgeConfig configures a GovernedBridge.
+type BridgeConfig struct {
+	// Firewall, when set, is the MCP boundary authority run BEFORE policy:
+	// server-identity (quarantine), tool allowlist (catalog), permission scope,
+	// and pinned-schema/argument canonicalization. A boundary refusal short-
+	// circuits to DENY/ESCALATE and policy is never consulted. Nil => the bridge
+	// relies on policy alone (still fail-closed via the deny-all default profile).
+	Firewall *mcpcore.ExecutionFirewall
+	// ServerID identifies the MCP server for boundary authorization. Falls back
+	// to req.Metadata["server_id"] when empty.
+	ServerID string
+	// GrantedScopes are the OAuth scopes presented for boundary scope checks.
+	GrantedScopes []string
+	// Profile is the workstation policy profile. Zero value uses the default
+	// observe/draft profile (which denies all operate-class MCP calls).
+	Profile contracts.WorkstationPolicyProfile
+	// SigningSeed is the ed25519 seed used to sign decision receipts. Zero value
+	// uses the workstation observe-only seed (non-production).
+	SigningSeed []byte
+	// Nonces prevents permit replay. Zero value uses an in-process store.
+	Nonces effects.NonceStore
+	// Connector dispatches ALLOW effects. Nil => allowed but not dispatched.
+	Connector effects.Connector
+	// Approvals verifies approval evidence for escalated writes. Nil => writes
+	// requiring approval always escalate and can never proceed.
+	Approvals ApprovalStore
+	// IsWrite classifies bounded writes that require approval. Nil => default.
+	IsWrite WriteClassifier
+	// PermitTTL bounds permit validity. Zero => 5 minutes.
+	PermitTTL time.Duration
+	// IssuerID identifies the permit issuer. Zero => "mcp-governed-bridge-v1".
+	IssuerID string
+	// Now is the clock (injectable for deterministic tests). Nil => time.Now.
+	Now func() time.Time
+}
+
+// NewGovernedBridge builds a GovernedBridge from config, applying safe defaults.
+func NewGovernedBridge(cfg BridgeConfig) *GovernedBridge {
+	profile := cfg.Profile
+	if profile.ID == "" {
+		profile = workstation.DefaultObserveDraftProfile()
+	}
+	nonces := cfg.Nonces
+	if nonces == nil {
+		nonces = NewMemoryNonceStore()
+	}
+	isWrite := cfg.IsWrite
+	if isWrite == nil {
+		isWrite = DefaultWriteClassifier
+	}
+	ttl := cfg.PermitTTL
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	issuer := cfg.IssuerID
+	if issuer == "" {
+		issuer = "mcp-governed-bridge-v1"
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &GovernedBridge{
+		firewall:    cfg.Firewall,
+		serverID:    cfg.ServerID,
+		scopes:      cfg.GrantedScopes,
+		profile:     profile,
+		signingSeed: cfg.SigningSeed,
+		nonces:      nonces,
+		connector:   cfg.Connector,
+		approvals:   cfg.Approvals,
+		isWrite:     isWrite,
+		permitTTL:   ttl,
+		issuerID:    issuer,
+		now:         now,
+	}
+}
+
+// GovernedOutcome is the result of governing one MCP tool call.
+type GovernedOutcome struct {
+	Verdict       contracts.Verdict
+	DecisionID    string
+	ReceiptHash   string
+	ReasonCode    string
+	Reason        string
+	Permit        *effects.EffectPermit
+	Output        any
+	OutputHash    string
+	DispatchState string
+	Approval      *ApprovalEvidence
+}
+
+// Govern evaluates an MCP tool call and, on ALLOW, mints a permit and (if a
+// connector is configured) dispatches the effect. inputHash is the canonical
+// hash of the request, already computed by the adapter.
+func (b *GovernedBridge) Govern(ctx context.Context, req *runtimeadapters.AdaptedRequest, inputHash string) GovernedOutcome {
+	now := b.now().UTC()
+
+	// Boundary gate (allowlist / server identity / scope / pinned schema) runs
+	// before policy. A boundary refusal short-circuits; policy is never asked to
+	// authorize a call the boundary already rejected.
+	if b.firewall != nil {
+		if outcome, ok := b.authorizeBoundary(ctx, req, inputHash); !ok {
+			return outcome
+		}
+	}
+
+	decisionReq := contracts.WorkstationDecisionRequest{
+		RequestID:    firstNonEmpty(req.SessionID, inputHash),
+		RunID:        req.SessionID,
+		ActorID:      req.PrincipalID,
+		WorkspaceID:  req.Metadata["workspace_id"],
+		AgentSurface: firstNonEmpty(req.RuntimeType, "mcp"),
+		ToolID:       req.ToolName,
+		Action:       "mcp_tool_call",
+		EffectType:   contracts.EffectTypeWorkstationMCPToolCall,
+		EffectMode:   contracts.WorkstationEffectModeOperate,
+		Target:       req.ToolName,
+		Metadata:     mergeMetadata(req.Metadata, inputHash, req.DelegationSessionID),
+		OccurredAt:   now,
+	}
+
+	receipt, err := workstation.Decide(b.profile, decisionReq, workstation.DecisionOptions{SigningSeed: b.signingSeed})
+	if err != nil {
+		// Fail closed: a decision-engine error is a denial, never an allow.
+		return GovernedOutcome{
+			Verdict:       contracts.VerdictDeny,
+			ReasonCode:    string(contracts.ReasonPDPError),
+			Reason:        fmt.Sprintf("workstation decision failed: %v", err),
+			DispatchState: DispatchStateNotDispatched,
+		}
+	}
+
+	base := GovernedOutcome{
+		DecisionID:    receipt.DecisionID,
+		ReceiptHash:   receipt.ReceiptHash,
+		ReasonCode:    receipt.ReasonCode,
+		Reason:        receipt.Reason,
+		DispatchState: DispatchStateNotDispatched,
+	}
+
+	// Base policy DENY is terminal.
+	if receipt.Verdict != contracts.WorkstationVerdictAllow {
+		base.Verdict = contracts.VerdictDeny
+		return base
+	}
+
+	// Approval-gated ESCALATE tier: policy allows it, but a bounded write needs
+	// human approval evidence bound to this exact request.
+	isWrite := b.isWrite(req.ToolName, req.Arguments)
+	if isWrite {
+		approval, ok := b.checkApproval(inputHash)
+		if !ok {
+			base.Verdict = contracts.VerdictEscalate
+			base.ReasonCode = string(contracts.ReasonApprovalRequired)
+			base.Reason = "bounded write requires human approval before dispatch"
+			return base
+		}
+		base.Approval = &approval
+	}
+
+	// ALLOW: mint a permit bound to the verdict. The nonce is deterministic over
+	// (intent, verdict, tool) — NOT the clock — so an identical request always
+	// yields the same nonce and can be recognized as a replay regardless of when
+	// it arrives.
+	permit, err := b.mintPermit(req, inputHash, receipt, now)
+	if err != nil {
+		base.Verdict = contracts.VerdictDeny
+		base.ReasonCode = string(contracts.ReasonPDPError)
+		base.Reason = err.Error()
+		return base
+	}
+
+	// Single-use replay protection is enforced for WRITES only: a bounded write
+	// may execute at most once per approved (request, verdict). Reads are
+	// idempotent and safe to retry, so they are not consumed. The check-and-record
+	// is atomic where the store supports it (the in-process default does), closing
+	// the concurrent-duplicate TOCTOU window.
+	if isWrite {
+		if fresh, err := b.consumeNonce(permit.Nonce); err != nil {
+			base.Verdict = contracts.VerdictDeny
+			base.ReasonCode = string(contracts.ReasonPDPError)
+			base.Reason = fmt.Sprintf("nonce store error: %v", err)
+			return base
+		} else if !fresh {
+			base.Verdict = contracts.VerdictDeny
+			base.ReasonCode = string(contracts.ReasonPlanTransactionConflict)
+			base.Reason = "single-use write permit already consumed (replay)"
+			return base
+		}
+	}
+
+	base.Verdict = contracts.VerdictAllow
+	base.Permit = permit
+
+	// Dispatch through the connector if one is bound; otherwise emit no-dispatch
+	// proof (allowed, but the effect was not executed by the kernel).
+	if b.connector == nil {
+		base.DispatchState = DispatchStateNoDispatch
+		return base
+	}
+	output, execErr := b.connector.Execute(ctx, permit, req.ToolName, req.Arguments)
+	if execErr != nil {
+		base.DispatchState = DispatchStateFailed
+		base.Reason = execErr.Error()
+		return base
+	}
+	outHash, hashErr := canonicalize.CanonicalHash(output)
+	if hashErr != nil {
+		// A source effect happened but we cannot canonicalize its output: record
+		// the ambiguity for reconciliation rather than claiming clean success.
+		base.DispatchState = DispatchStateFailed
+		base.Reason = fmt.Sprintf("output canonicalization failed: %v", hashErr)
+		return base
+	}
+	base.Output = output
+	base.OutputHash = outHash
+	base.DispatchState = DispatchStateDispatched
+	return base
+}
+
+// authorizeBoundary runs the MCP execution firewall. It returns (outcome,false)
+// when the boundary refuses (caller returns that outcome); (_,true) when the
+// boundary authorizes dispatch and policy evaluation should proceed. It is
+// fail-closed: schema/canonicalization or firewall errors deny.
+func (b *GovernedBridge) authorizeBoundary(ctx context.Context, req *runtimeadapters.AdaptedRequest, inputHash string) (GovernedOutcome, bool) {
+	serverID := firstNonEmpty(b.serverID, req.Metadata["server_id"])
+	effect := "read"
+	if b.isWrite(req.ToolName, req.Arguments) {
+		effect = "write"
+	}
+	argsHash := inputHash
+	if tool, ok := b.firewall.Catalog.Lookup(req.ToolName); ok {
+		hash, err := mcpcore.ValidateToolArguments(tool, req.Arguments)
+		if err != nil {
+			return GovernedOutcome{
+				Verdict:       contracts.VerdictDeny,
+				ReasonCode:    string(contracts.ReasonSchemaViolation),
+				Reason:        fmt.Sprintf("tool argument validation failed: %v", err),
+				DispatchState: DispatchStateNotDispatched,
+			}, false
+		}
+		argsHash = hash
+	}
+
+	record, err := b.firewall.AuthorizeToolCall(ctx, mcpcore.ToolCallAuthorization{
+		ServerID:      serverID,
+		ToolName:      req.ToolName,
+		Effect:        effect,
+		ArgsHash:      argsHash,
+		GrantedScopes: b.scopes,
+	})
+	if err != nil {
+		return GovernedOutcome{
+			Verdict:       contracts.VerdictDeny,
+			ReasonCode:    string(contracts.ReasonPDPError),
+			Reason:        fmt.Sprintf("boundary authorization failed: %v", err),
+			DispatchState: DispatchStateNotDispatched,
+		}, false
+	}
+	if mcpcore.ShouldDispatch(record) {
+		return GovernedOutcome{}, true
+	}
+
+	verdict := contracts.VerdictDeny
+	if record.Verdict == contracts.VerdictEscalate {
+		verdict = contracts.VerdictEscalate
+	}
+	return GovernedOutcome{
+		Verdict:       verdict,
+		DecisionID:    record.RecordID,
+		ReceiptHash:   record.RecordHash,
+		ReasonCode:    string(record.ReasonCode),
+		Reason:        "denied at MCP execution boundary",
+		DispatchState: DispatchStateNotDispatched,
+	}, false
+}
+
+func (b *GovernedBridge) checkApproval(inputHash string) (ApprovalEvidence, bool) {
+	if b.approvals == nil {
+		return ApprovalEvidence{}, false
+	}
+	ev, ok := b.approvals.Approved(inputHash)
+	// Reject empty evidence: an ApprovalStore that returns ok=true with no
+	// approver has not actually approved anything. This is a floor, not a
+	// cryptographic bind — a hardened store should also commit the evidence to
+	// inputHash.
+	if !ok || strings.TrimSpace(ev.ApproverID) == "" {
+		return ApprovalEvidence{}, false
+	}
+	return ev, true
+}
+
+// atomicNonceStore is the check-and-record-in-one-step extension of
+// effects.NonceStore. The in-process default implements it; external stores that
+// do not fall back to a (non-atomic) HasNonce+RecordNonce sequence.
+type atomicNonceStore interface {
+	RecordIfAbsent(nonce string) (bool, error)
+}
+
+// consumeNonce records the nonce and reports whether it was fresh (not seen
+// before). It uses the atomic path when the store supports it.
+func (b *GovernedBridge) consumeNonce(nonce string) (bool, error) {
+	if atomic, ok := b.nonces.(atomicNonceStore); ok {
+		return atomic.RecordIfAbsent(nonce)
+	}
+	if b.nonces.HasNonce(nonce) {
+		return false, nil
+	}
+	return true, b.nonces.RecordNonce(nonce)
+}
+
+func (b *GovernedBridge) mintPermit(req *runtimeadapters.AdaptedRequest, inputHash string, receipt *contracts.WorkstationPolicyDecisionReceipt, now time.Time) (*effects.EffectPermit, error) {
+	verdictHash, err := canonicalize.CanonicalHash(receipt)
+	if err != nil {
+		return nil, fmt.Errorf("mcp bridge: verdict hash: %w", err)
+	}
+	// Nonce binds the permit to its intent, verdict, and tool — deterministically,
+	// with NO clock component — so an identical approved write always produces the
+	// same nonce and its second dispatch is caught as a replay. inputHash and
+	// verdictHash are hex, so the "|" join is unambiguous.
+	nonceSum := sha256.Sum256([]byte(strings.Join([]string{inputHash, verdictHash, req.ToolName}, "|")))
+	permit := &effects.EffectPermit{
+		PermitID:    "permit-" + hex.EncodeToString(nonceSum[:8]),
+		IntentHash:  inputHash,
+		VerdictHash: verdictHash,
+		EffectType:  effects.EffectTypeExecute,
+		ConnectorID: connectorIDFor(b.connector),
+		Scope:       effects.EffectScope{AllowedAction: req.ToolName},
+		ResourceRef: req.ToolName,
+		ExpiresAt:   now.Add(b.permitTTL),
+		SingleUse:   true,
+		Nonce:       hex.EncodeToString(nonceSum[:]),
+		IssuedAt:    now,
+		IssuerID:    b.issuerID,
+	}
+	if receipt.DecisionID != "" {
+		permit.EvidenceBindings = map[string]string{"decision_id": receipt.DecisionID}
+	}
+	return permit, nil
+}
+
+func connectorIDFor(c effects.Connector) string {
+	if c == nil {
+		return ""
+	}
+	return c.ID()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func mergeMetadata(md map[string]string, inputHash, delegationSessionID string) map[string]string {
+	out := map[string]string{"input_hash": inputHash}
+	for k, v := range md {
+		out[k] = v
+	}
+	// Forward the delegation session so the decision record carries it. Full
+	// delegation-scope enforcement on the MCP surface is a follow-up (see the
+	// GovernedBridge threat-model note) — this preserves the reference today.
+	if strings.TrimSpace(delegationSessionID) != "" {
+		out["delegation_session_id"] = delegationSessionID
+	}
+	return out
+}
+
+// MemoryNonceStore is an in-process effects.NonceStore. It is the safe default
+// for a single-process kernel; a deployment that needs durable, cross-process
+// replay protection injects a data-plane-backed store instead.
+//
+// ponytail: in-memory map; durable permit/nonce state is a data-plane concern.
+type MemoryNonceStore struct {
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+// NewMemoryNonceStore builds an empty in-process nonce store.
+func NewMemoryNonceStore() *MemoryNonceStore {
+	return &MemoryNonceStore{seen: make(map[string]struct{})}
+}
+
+// HasNonce reports whether the nonce was already recorded.
+func (s *MemoryNonceStore) HasNonce(nonce string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.seen[nonce]
+	return ok
+}
+
+// RecordNonce marks a nonce consumed.
+func (s *MemoryNonceStore) RecordNonce(nonce string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seen[nonce] = struct{}{}
+	return nil
+}
+
+// RecordIfAbsent atomically records the nonce and reports whether it was fresh
+// (not previously seen). It closes the check-then-record TOCTOU window under
+// concurrent identical requests.
+func (s *MemoryNonceStore) RecordIfAbsent(nonce string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.seen[nonce]; ok {
+		return false, nil
+	}
+	s.seen[nonce] = struct{}{}
+	return true, nil
+}
+
+// MemoryApprovalStore is an in-process ApprovalStore keyed by request input hash.
+type MemoryApprovalStore struct {
+	mu       sync.Mutex
+	approved map[string]ApprovalEvidence
+}
+
+// NewMemoryApprovalStore builds an empty approval store.
+func NewMemoryApprovalStore() *MemoryApprovalStore {
+	return &MemoryApprovalStore{approved: make(map[string]ApprovalEvidence)}
+}
+
+// Grant records approval evidence for a request input hash.
+func (s *MemoryApprovalStore) Grant(requestHash string, ev ApprovalEvidence) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.approved[requestHash] = ev
+}
+
+// Approved returns approval evidence for a request input hash, if present.
+func (s *MemoryApprovalStore) Approved(requestHash string) (ApprovalEvidence, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ev, ok := s.approved[requestHash]
+	return ev, ok
+}

--- a/core/pkg/runtimeadapters/mcp/bridge.go
+++ b/core/pkg/runtimeadapters/mcp/bridge.go
@@ -1,3 +1,7 @@
+// quantum_posture: SHA-256 for JCS content hashing and deterministic permit
+// nonce derivation only; no signatures here (receipt signing is Ed25519 in the
+// workstation engine). Classical hash, PQ posture inherited from the signer.
+
 package mcp
 
 import (

--- a/core/pkg/runtimeadapters/mcp/bridge_test.go
+++ b/core/pkg/runtimeadapters/mcp/bridge_test.go
@@ -1,0 +1,287 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/effects"
+	mcpcore "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/proofgraph"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtimeadapters"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/workstation"
+)
+
+// operateProfile grants the mcp.mutate permission so MCP tool calls can reach
+// ALLOW (the default observe/draft profile denies all operate-class calls).
+func operateProfile() contracts.WorkstationPolicyProfile {
+	p := workstation.DefaultObserveDraftProfile()
+	p.Operate.Permissions = []string{contracts.WorkstationPermissionMCPMutate}
+	return p
+}
+
+func fixedClock() func() time.Time {
+	t := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return t }
+}
+
+func newAdapter(t *testing.T, cfg BridgeConfig) (*MCPAdapter, *proofgraph.Graph) {
+	t.Helper()
+	graph := proofgraph.NewGraph()
+	adapter, err := NewMCPAdapter(Config{Graph: graph, Bridge: NewGovernedBridge(cfg)})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	return adapter, graph
+}
+
+// Smoke 1: a safe read is ALLOWED (policy grants mcp permission; not a write).
+func TestGovernedBridgeAllowsSafeRead(t *testing.T) {
+	adapter, graph := newAdapter(t, BridgeConfig{Profile: operateProfile(), Now: fixedClock()})
+	req := &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue",
+		Arguments: map[string]any{"issue_id": "ENG-1"}, PrincipalID: "ve-assistant",
+	}
+	resp, err := adapter.Intercept(context.Background(), req)
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if !resp.Allowed {
+		t.Fatalf("expected ALLOW, got deny: %+v", resp.DenyReason)
+	}
+	if resp.ReceiptID == "" || resp.DecisionID == "" {
+		t.Errorf("expected receipt + decision refs, got %+v", resp)
+	}
+	node, ok := graph.Get(resp.ProofGraphNode)
+	if !ok || node.Kind != proofgraph.NodeTypeEffect {
+		t.Errorf("expected an EFFECT proof node, got %+v", node)
+	}
+}
+
+// Smoke 2: a write with no operate permission is DENIED (fail-closed policy).
+func TestGovernedBridgeDeniesUnpermittedWrite(t *testing.T) {
+	// Default observe/draft profile: no operate permissions.
+	adapter, _ := newAdapter(t, BridgeConfig{Now: fixedClock()})
+	req := &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "gmail.send",
+		Arguments: map[string]any{"to": "bob@example.com"}, PrincipalID: "ve-assistant",
+	}
+	resp, err := adapter.Intercept(context.Background(), req)
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if resp.Allowed {
+		t.Fatal("expected DENY for unpermitted write")
+	}
+	if resp.DenyReason == nil || resp.DenyReason.Code == "" {
+		t.Errorf("expected a deny reason code, got %+v", resp.DenyReason)
+	}
+}
+
+// Smoke 3: a bounded write that policy allows is ESCALATED for approval, then
+// ALLOWED once approval evidence is bound to the request.
+func TestGovernedBridgeEscalatesThenAllowsWrite(t *testing.T) {
+	req := &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.create_issue",
+		Arguments:   map[string]any{"team_id": "T1", "title": "Ship it"},
+		PrincipalID: "ve-assistant",
+	}
+	inputHash, err := canonicalize.CanonicalHash(req)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+
+	// Without approval: ESCALATE.
+	approvals := NewMemoryApprovalStore()
+	adapter, _ := newAdapter(t, BridgeConfig{Profile: operateProfile(), Approvals: approvals, Now: fixedClock()})
+	resp, err := adapter.Intercept(context.Background(), req)
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if resp.Allowed {
+		t.Fatal("expected ESCALATE (not allowed) before approval")
+	}
+	if resp.DenyReason == nil || resp.DenyReason.Code != string(contracts.ReasonApprovalRequired) {
+		t.Fatalf("expected APPROVAL_REQUIRED, got %+v", resp.DenyReason)
+	}
+	if resp.DenyReason.Actionable != "request_approval" {
+		t.Errorf("escalation must be actionable via request_approval, got %q", resp.DenyReason.Actionable)
+	}
+
+	// Bind approval evidence to this exact request, then retry: ALLOW.
+	approvals.Grant(inputHash, ApprovalEvidence{ApproverID: "ivan", ApprovalHash: "abc", GrantedScope: "linear.create_issue"})
+	adapter2, _ := newAdapter(t, BridgeConfig{Profile: operateProfile(), Approvals: approvals, Now: fixedClock()})
+	resp2, err := adapter2.Intercept(context.Background(), req)
+	if err != nil {
+		t.Fatalf("intercept after approval: %v", err)
+	}
+	if !resp2.Allowed {
+		t.Fatalf("expected ALLOW after approval, got %+v", resp2.DenyReason)
+	}
+}
+
+// Replay: an approved bounded WRITE is single-use. A second identical dispatch
+// (real or fixed clock — the nonce is clock-independent) is denied as a replay.
+func TestGovernedBridgeWriteIsSingleUse(t *testing.T) {
+	req := &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.create_issue",
+		Arguments: map[string]any{"team_id": "T1", "title": "Ship it"}, PrincipalID: "ve-assistant",
+	}
+	inputHash, err := canonicalize.CanonicalHash(req)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	approvals := NewMemoryApprovalStore()
+	approvals.Grant(inputHash, ApprovalEvidence{ApproverID: "ivan"})
+	bridge := NewGovernedBridge(BridgeConfig{Profile: operateProfile(), Approvals: approvals, Now: fixedClock()})
+	graph := proofgraph.NewGraph()
+	adapter, err := NewMCPAdapter(Config{Graph: graph, Bridge: bridge})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	first, err := adapter.Intercept(context.Background(), req)
+	if err != nil || !first.Allowed {
+		t.Fatalf("first approved write should ALLOW: %v %+v", err, first.DenyReason)
+	}
+	second, err := adapter.Intercept(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second intercept: %v", err)
+	}
+	if second.Allowed {
+		t.Fatal("expected a second identical write to be denied as single-use replay")
+	}
+	if second.DenyReason == nil || second.DenyReason.Code != string(contracts.ReasonPlanTransactionConflict) {
+		t.Fatalf("expected canonical replay reason, got %+v", second.DenyReason)
+	}
+}
+
+// Reads are idempotent: the same read may be retried and is allowed each time
+// (reads do not consume the single-use nonce).
+func TestGovernedBridgeAllowsReadRetry(t *testing.T) {
+	bridge := NewGovernedBridge(BridgeConfig{Profile: operateProfile(), Now: fixedClock()})
+	graph := proofgraph.NewGraph()
+	adapter, err := NewMCPAdapter(Config{Graph: graph, Bridge: bridge})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	req := &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue",
+		Arguments: map[string]any{"issue_id": "ENG-1"}, PrincipalID: "ve-assistant",
+	}
+	for i := 0; i < 2; i++ {
+		resp, err := adapter.Intercept(context.Background(), req)
+		if err != nil || !resp.Allowed {
+			t.Fatalf("read attempt %d should ALLOW: %v %+v", i, err, resp.DenyReason)
+		}
+	}
+}
+
+// fakeConnector records dispatches and can be told to fail.
+type fakeConnector struct {
+	id      string
+	fail    bool
+	calls   int
+	lastArg map[string]any
+}
+
+func (f *fakeConnector) ID() string { return f.id }
+func (f *fakeConnector) Execute(_ context.Context, _ *effects.EffectPermit, _ string, params map[string]any) (any, error) {
+	f.calls++
+	f.lastArg = params
+	if f.fail {
+		return nil, errTestDispatch
+	}
+	return map[string]any{"ok": true}, nil
+}
+
+var errTestDispatch = errTest("connector boom")
+
+type errTest string
+
+func (e errTest) Error() string { return string(e) }
+
+// Dispatch path: an allowed read with a bound connector is executed, and the
+// connector's output is canonicalized into the effect record.
+func TestGovernedBridgeDispatchesThroughConnector(t *testing.T) {
+	conn := &fakeConnector{id: "linear"}
+	bridge := NewGovernedBridge(BridgeConfig{Profile: operateProfile(), Connector: conn, Now: fixedClock()})
+	graph := proofgraph.NewGraph()
+	adapter, _ := NewMCPAdapter(Config{Graph: graph, Bridge: bridge})
+	resp, err := adapter.Intercept(context.Background(), &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue",
+		Arguments: map[string]any{"issue_id": "ENG-1"}, PrincipalID: "ve-assistant",
+	})
+	if err != nil || !resp.Allowed {
+		t.Fatalf("expected ALLOW+dispatch: %v %+v", err, resp.DenyReason)
+	}
+	if conn.calls != 1 {
+		t.Fatalf("expected connector to be called once, got %d", conn.calls)
+	}
+	if resp.Result == nil {
+		t.Error("expected dispatched output in Result")
+	}
+}
+
+// Dispatch failure: the connector error is recorded; the call is not reported as
+// a clean allow-with-output (Result stays nil, truth lives in the effect node).
+func TestGovernedBridgeRecordsDispatchFailure(t *testing.T) {
+	conn := &fakeConnector{id: "linear", fail: true}
+	bridge := NewGovernedBridge(BridgeConfig{Profile: operateProfile(), Connector: conn, Now: fixedClock()})
+	graph := proofgraph.NewGraph()
+	adapter, _ := NewMCPAdapter(Config{Graph: graph, Bridge: bridge})
+	resp, err := adapter.Intercept(context.Background(), &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue",
+		Arguments: map[string]any{"issue_id": "ENG-1"}, PrincipalID: "ve-assistant",
+	})
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if resp.Result != nil {
+		t.Errorf("dispatch failed — Result must be nil, got %v", resp.Result)
+	}
+}
+
+// Boundary gate: an execution firewall with an unapproved server / non-allowlisted
+// tool refuses the call BEFORE policy is consulted (fail-closed at the boundary).
+func TestGovernedBridgeBoundaryRefusesUnapprovedCall(t *testing.T) {
+	// Empty catalog + default quarantine: no server approved, no tool registered.
+	firewall := mcpcore.NewExecutionFirewall(nil, nil, "epoch-test")
+	adapter, _ := newAdapter(t, BridgeConfig{
+		Firewall: firewall,
+		ServerID: "unapproved-server",
+		Profile:  operateProfile(), // policy WOULD allow — boundary must still refuse
+		Now:      fixedClock(),
+	})
+	resp, err := adapter.Intercept(context.Background(), &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue", PrincipalID: "ve-assistant",
+	})
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if resp.Allowed {
+		t.Fatal("expected boundary to refuse an unapproved-server / non-allowlisted call")
+	}
+	if resp.DenyReason == nil || resp.DenyReason.Code == "" {
+		t.Errorf("expected a boundary reason code, got %+v", resp.DenyReason)
+	}
+}
+
+// No bridge configured: adapter stays deny-only and fail-closed.
+func TestAdapterWithoutBridgeIsFailClosed(t *testing.T) {
+	graph := proofgraph.NewGraph()
+	adapter, err := NewMCPAdapter(Config{Graph: graph})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	resp, err := adapter.Intercept(context.Background(), &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue", PrincipalID: "ve-assistant",
+	})
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if resp.Allowed || resp.DenyReason == nil || resp.DenyReason.Code != "BRIDGE_NOT_CONFIGURED" {
+		t.Fatalf("expected BRIDGE_NOT_CONFIGURED deny, got %+v", resp)
+	}
+}

--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -223,7 +223,7 @@
       "id": "tracked-file-hygiene",
       "title": "Tracked file hygiene",
       "description": "Blocks accidentally tracked databases, archives, logs, and binary artifacts.",
-      "command": "bash -lc \"set -o pipefail; ! git ls-files | rg '\\\\.(db|sqlite|log|tar|tar\\\\.gz|zip|exe|dll|so|dylib)$' | rg -v '^reference_packs/.*evidence-?pack\\\\.tar$'\"",
+      "command": "bash -lc \"set -o pipefail; ! git ls-files | grep -E '\\\\.(db|sqlite|log|tar|tar\\\\.gz|zip|exe|dll|so|dylib)$' | grep -Ev '^reference_packs/.*evidence-?pack\\\\.tar$'\"",
       "timeout_seconds": 60
     },
     {


### PR DESCRIPTION
## Summary
Replaces the deny-only MCP `RuntimeAdapter` (`BRIDGE_NOT_CONFIGURED`) with an **optional** `GovernedBridge` that produces real **ALLOW / DENY / ESCALATE** verdicts through source-owned evidence. Composes existing kernel machinery rather than re-wiring it:

1. **`mcp.ExecutionFirewall`** boundary gate — tool allowlist, server identity (quarantine), permission scope, pinned schema, JCS argument hash — runs **before** policy; a boundary refusal short-circuits.
2. **`workstation.Decide`** → signed `WorkstationPolicyDecisionReceipt` (ALLOW/DENY, Ed25519 + JCS).
3. **Approval-gated ESCALATE tier** for bounded writes; approval is bound to the canonical request input hash.
4. **Single-use `EffectPermit`** for writes — clock-independent nonce, atomic replay protection; reads are idempotent and retryable.
5. Optional **`effects.Connector`** dispatch, else a no-dispatch proof.
6. ProofGraph **EFFECT** node linked to the INTENT.

**Fail-closed by default:** with no `Bridge` configured the adapter stays deny-only, so this is purely additive. This closes the R3 exit gate: *MCP is no longer observe/deny-only — it can allow, deny, and escalate through source-owned evidence.*

## kernel-guardian review — applied
Mandatory kernel-guardian review ran on the diff. Must-fixes resolved:
- **H1** approved writes could replay under a real clock → nonce is now deterministic over (intent, verdict, tool) and single-use is enforced for writes only (reads stay retryable).
- **H2** non-atomic nonce check/record (TOCTOU) → `RecordIfAbsent` atomic path (in-process default implements it).
- **H3** non-canonical reason codes → reuse canonical `ERR_PLAN_TRANSACTION_CONFLICT` / `PDP_ERROR` (avoids touching the protected `contracts/verdict.go` registry).
- Hardening: non-empty approval floor (M4), delegation-session forwarding (M5), dispatch-path test coverage (M3).

## Documented follow-ups (not blocking R3)
- Route the MCP surface through the full 6-gate guardian PEP (Threat/injection, Freeze, Delegation-scope) before enabling by default — MCP is a prime injection surface. Recorded in the `GovernedBridge` doc comment.
- Surface `DispatchState` on the shared `AdaptedResponse` (currently only in the EFFECT node) — shared-type change deferred.

## Validation
- `go test ./pkg/runtimeadapters/mcp/...`: 13/13 PASS (allow-read, deny-write, escalate→approve, write-single-use replay, read-retry, dispatch, dispatch-failure, boundary-deny, no-bridge-fail-closed)
- `go test -race`: PASS · `go vet`: clean · `gofmt`: clean · full `go build ./...`: clean
- Dependency packages (mcp, effects, workstation) tests: PASS

Program: HELM Magic 5 launch, workstream R3 (governed MCP execution bridge). Tracker: `docs/ai/helm-magic5-program-tracker.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)