### PR TITLE
fix(release): bring mcp-bundle.json under the version-surfaces contract (HELM-162)

### DIFF
--- a/mcp-bundle.json
+++ b/mcp-bundle.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "1.0",
   "name": "helm-governance",
-  "version": "0.4.0",
+  "version": "0.7.2",
   "description": "HELM Execution Authority — fail-closed AI governance firewall with policy enforcement, profile-aware signed receipts, and tamper-evident EvidencePack audit trail.",
   "author": {
     "name": "Mindburn Labs",

--- a/release/README.md
+++ b/release/README.md
@@ -11,6 +11,7 @@ files. It is not a complete copy of any GitHub release.
 | --- | --- |
 | `vex.openvex.json` | Baseline OpenVEX document kept in-tree for policy review. |
 | `vex/policies.yaml` | Maintainer policy file consumed by `scripts/release/generate_vex.sh`. |
+| `version-surfaces.yaml` | Version-surface contract consumed by `make prepare-version` and `check_version_drift.py`; every in-tree version claim (SDK manifests, docs, `mcp-bundle.json`) must be listed here. |
 
 ## Current Release Target
 

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -10,6 +10,12 @@
       "expected": "{version}"
     },
     {
+      "id": "mcp-bundle-manifest-version",
+      "path": "mcp-bundle.json",
+      "kind": "json",
+      "field": "version"
+    },
+    {
       "id": "helm-chart-version",
       "path": "deploy/helm-chart/Chart.yaml",
       "kind": "regex",


### PR DESCRIPTION
## What

`mcp-bundle.json` declared `0.4.0` while `VERSION` is `0.7.2` — the file is not consumed by `mcp pack` (the MCPB manifest is generated dynamically in `mcp_cmd.go`), but it is a documented public surface (`docs/DEVELOPER_SURFACE_MAP.md`) and was hand-drifting.

- adds a **blocking** `json` surface `mcp-bundle-manifest-version` to `release/version-surfaces.yaml`, so `check_version_drift` gates it and `make prepare-version` bumps it
- syncs the value to `0.7.2`

Scope note: this covers the version-drift half of [HELM-162](https://linear.app/mindburn/issue/HELM-162); the Windows channel (winget/scoop) half stays with Sergey on the issue.

## Commands run

```
python3 scripts/release/check_version_drift.py --report local   # green, incl. new surface:
# OK mcp-bundle-manifest-version [blocking]: expected='0.7.2' actual='0.7.2' mcp-bundle.json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)