### PR TITLE
docs: correct unpublished 0.7.2 release state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ flowchart TD
     subgraph Ingestion["1. Ingestion & Context Plane"]
         Page["HELM AI Kernel Changelog"]
         A["[Unreleased]"]
-        A00["[0.7.2] - 2026-07-13"]
+        A00["[0.7.2] - 2026-07-14"]
         A0["[0.7.1] - 2026-07-07"]
         A1["[0.7.0] - 2026-07-05"]
         A2["[0.6.0] - 2026-07-02"]
@@ -89,13 +89,20 @@ hardware-backed enforcement language out of the public changelog until a tagged
 release ships source-owned tests, verifier evidence, and release artifacts for
 that exact capability.
 
-## [0.7.2] - 2026-07-13
+## [0.7.2] - 2026-07-14
 
-Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2>.
+GitHub Release: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2>.
+
+The tag and 34-asset GitHub Release were published from
+`586a5d62239fee43d5e0b251674644ac8a90fc8a`. Release run `29338793179`
+remains red because its Homebrew merge step failed, and post-release version
+drift was skipped. The formula later landed through Homebrew PR 17, whose
+exact-head autonomous permit failed; that later repository state does not
+retroactively make the release run or authority proof green.
 
 <!-- quantum_posture: v0.7.2 release notes cover a Go toolchain rebuild, an OpenAPI contract alignment, enforcement and containment hardening, and dependency updates; none add a post-quantum cryptographic control. -->
 
-- The tag-triggered release workflow will rebuild both container images on Go
+- The tag-triggered release workflow rebuilt both container images on Go
   1.25.12 (up from 1.25.10), which includes the cumulative upstream
   standard-library security fixes for `crypto/x509`, `mime`, `net/textproto`,
   `crypto/tls`, and `os`. Post-release Trivy and Artifact Hub evidence is

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,21 +8,30 @@ commit.
 
 ## Current Release State
 
-`main` declares `0.7.2`, but `v0.7.2` has neither a tag nor a GitHub Release.
-The latest published GitHub release and tag is `v0.7.1`.
+Git tag `v0.7.2` resolves to `586a5d62239fee43d5e0b251674644ac8a90fc8a`,
+and GitHub published the `v0.7.2` Release with 34 attached assets at
+`2026-07-14T14:40:01Z`.
 
-## Prepare v0.7.2
+That provider state is not full lockstep-release acceptance. Release run
+`29338793179` failed in its Homebrew job, and the post-release version-drift
+job was skipped. Homebrew PR 17 later merged the formula, but its exact-head
+autonomous permit failed. Treat the GitHub tag, Release object, attached
+assets, registry jobs, Homebrew state, and post-release verification as
+separate evidence surfaces.
+
+## Prepare the next release
 
 1. Update `VERSION`, CLI fallback version, OpenAPI `info.version`, SDK
    manifests, generated SDK comments, chart metadata, release docs, and exact
    OpenVEX with the maintained release tooling:
 
 ```bash
-make prepare-version VERSION=0.7.2
+NEXT_VERSION=x.y.z
+make prepare-version VERSION="${NEXT_VERSION}"
 make vex
 ```
 
-2. Update `CHANGELOG.md` with the `v0.7.2` user-visible delta.
+2. Update `CHANGELOG.md` with the `v${NEXT_VERSION}` user-visible delta.
 3. Run the maintained merge and release validation targets:
 
 ```bash
@@ -33,7 +42,7 @@ make release-assets
 ```
 
 4. Confirm `dist/release-assets/` contains CLI binaries, `SHA256SUMS.txt`,
-   `sbom.json`, `v0.7.2.openvex.json`, `release-attestation.json`,
+   `sbom.json`, `v${NEXT_VERSION}.openvex.json`, `release-attestation.json`,
    `evidence-pack.tar`, `release.high_risk.v3.toml`,
    `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, and `helm-ai-kernel.rb`.
 5. Confirm `./bin/helm-ai-kernel verify dist/release-assets/evidence-pack.tar` passes
@@ -42,7 +51,7 @@ make release-assets
 ## Publish
 
 1. Merge the release-prep PR to `main`.
-2. Create the annotated `v0.7.2` tag only after the release commit is on
+2. Create the annotated `v${NEXT_VERSION}` tag only after the release commit is on
    `main`.
 3. Push the tag and monitor the Release workflow until GitHub Release, GHCR
    images, Cosign bundles, provenance, benchmark pinning, Go SDK subdirectory
@@ -57,7 +66,8 @@ make version-drift-published
 ```
 
 6. Commit the post-publish docs update that changes “current public release”
-   references to `v0.7.2` with the actual GitHub publish timestamp.
+   references to `v${NEXT_VERSION}` with the actual GitHub publish timestamp
+   and records any failed or skipped lockstep jobs.
 
 Package publication for npm, PyPI, crates.io, and Maven-compatible consumers
 requires registry credentials. If required registry credentials are absent, the

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,24 +6,23 @@ The retained release process is PR-first and tag-driven. `main` is protected;
 prepare releases on a branch, merge only after gates pass, and tag the merged
 commit.
 
-## Current Baseline
+## Current Release State
 
-The actual public baseline for the `v0.5.0` release is `v0.4.0`. GitHub has no
-public `v0.4.1` Release object, so release notes and verification docs must not
-describe `v0.4.1` as the current release.
+`main` declares `0.7.2`, but `v0.7.2` has neither a tag nor a GitHub Release.
+The latest published GitHub release and tag is `v0.7.1`.
 
-## Prepare v0.6.0
+## Prepare v0.7.2
 
 1. Update `VERSION`, CLI fallback version, OpenAPI `info.version`, SDK
    manifests, generated SDK comments, chart metadata, release docs, and exact
    OpenVEX with the maintained release tooling:
 
 ```bash
-make prepare-version VERSION=0.6.0
+make prepare-version VERSION=0.7.2
 make vex
 ```
 
-2. Update `CHANGELOG.md` with the `v0.6.0` user-visible delta.
+2. Update `CHANGELOG.md` with the `v0.7.2` user-visible delta.
 3. Run the maintained merge and release validation targets:
 
 ```bash
@@ -34,7 +33,7 @@ make release-assets
 ```
 
 4. Confirm `dist/release-assets/` contains CLI binaries, `SHA256SUMS.txt`,
-   `sbom.json`, `v0.6.0.openvex.json`, `release-attestation.json`,
+   `sbom.json`, `v0.7.2.openvex.json`, `release-attestation.json`,
    `evidence-pack.tar`, `release.high_risk.v3.toml`,
    `sample-policy-material.tar`, `helm-ai-kernel.mcpb`, and `helm-ai-kernel.rb`.
 5. Confirm `./bin/helm-ai-kernel verify dist/release-assets/evidence-pack.tar` passes
@@ -43,7 +42,7 @@ make release-assets
 ## Publish
 
 1. Merge the release-prep PR to `main`.
-2. Create the annotated `v0.6.0` tag only after the release commit is on
+2. Create the annotated `v0.7.2` tag only after the release commit is on
    `main`.
 3. Push the tag and monitor the Release workflow until GitHub Release, GHCR
    images, Cosign bundles, provenance, benchmark pinning, Go SDK subdirectory
@@ -58,7 +57,7 @@ make version-drift-published
 ```
 
 6. Commit the post-publish docs update that changes “current public release”
-   references to `v0.6.0` with the actual GitHub publish timestamp.
+   references to `v0.7.2` with the actual GitHub publish timestamp.
 
 Package publication for npm, PyPI, crates.io, and Maven-compatible consumers
 requires registry credentials. If required registry credentials are absent, the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,9 +15,9 @@ Security fixes are expected on the current minor version and, when practical, th
 
 | Version | Supported |
 | --- | --- |
-| `0.5.x` | Yes |
-| `0.4.x` | Yes |
-| `0.3.x` | Best effort |
+| `0.7.x` | Yes |
+| `0.6.x` | Yes |
+| `0.5.x` | Best effort |
 | Older | No |
 
 ## Verification Material

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,11 +57,10 @@ The signing identity is the GitHub Actions workflow itself
 Verification commands and the recovery path are documented in
 [docs/VERIFICATION.md](docs/VERIFICATION.md).
 
-The current public GitHub release, `v0.5.8`, attaches
-OpenVEX and Cosign bundle material for every primary asset. Verify
-`SHA256SUMS.txt`, `sbom.json`, `v0.5.8.openvex.json`,
-`release-attestation.json`, offline `evidence-pack.tar`, and matching
-`*.cosign.bundle` files.
+The current public GitHub release and tag is `v0.7.1`. `main` declares
+`0.7.2`, but `v0.7.2` is not tagged or published. Verify only the assets
+attached to the `v0.7.1` GitHub Release. After a future `v0.7.2` publication,
+update this paragraph with its actual assets and GitHub publish timestamp.
 
 ## Continuous Fuzzing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security Policy
 
+<!-- quantum_posture: this policy documents existing Sigstore and Cosign release verification; it does not add a post-quantum cryptographic control. -->
+
 ## Reporting a Vulnerability
 
 Do not open public issues for security-sensitive reports.
@@ -57,10 +59,13 @@ The signing identity is the GitHub Actions workflow itself
 Verification commands and the recovery path are documented in
 [docs/VERIFICATION.md](docs/VERIFICATION.md).
 
-The current public GitHub release and tag is `v0.7.1`. `main` declares
-`0.7.2`, but `v0.7.2` is not tagged or published. Verify only the assets
-attached to the `v0.7.1` GitHub Release. After a future `v0.7.2` publication,
-update this paragraph with its actual assets and GitHub publish timestamp.
+The current public GitHub release and tag is `v0.7.2`, published at
+`2026-07-14T14:40:01Z` from
+`586a5d62239fee43d5e0b251674644ac8a90fc8a`. Its Release page attaches
+checksums, SBOM, OpenVEX, release attestation, EvidencePack, binaries, and
+matching Cosign bundles. Verify those assets directly; the Release workflow's
+Homebrew job failed and post-release version drift was skipped, so the Release
+object alone is not proof that every lockstep channel completed.
 
 ## Continuous Fuzzing
 

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -1,6 +1,6 @@
 ---
 title: Release and Security Evidence
-last_reviewed: 2026-07-12
+last_reviewed: 2026-07-15
 ---
 
 # HELM AI Kernel Release and Security Evidence
@@ -53,18 +53,23 @@ flowchart TD
 ```
 
 
-The current published GitHub release and tag is `v0.7.1`.
+Current GitHub release and tag: `v0.7.2`.
 
-Current source release target: `v0.7.2`. It is not yet a tag or published
-release: the deterministic target URL
-`https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2` currently
-has no release behind it and must not be used as release evidence. After a
-successful `v0.7.2` publication, verify the actual attached assets before
-claiming them here. The expected versioned names include
-`v0.7.2.openvex.json` and `v0.7.2.json`, alongside the applicable binaries,
-`SHA256SUMS.txt`, SBOM, attestation, EvidencePack, `version-status.json`, and
-matching `*.cosign.bundle` files where produced. Browser UI bundles are not
-Kernel release assets.
+The GitHub Release object is
+[`v0.7.2`](https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2),
+published at `2026-07-14T14:40:01Z` from
+`586a5d62239fee43d5e0b251674644ac8a90fc8a`. The Release page exposes 34
+assets, including platform binaries, `SHA256SUMS.txt`, `sbom.json`,
+`v0.7.2.openvex.json`, `v0.7.2.json`, `release-attestation.json`,
+`evidence-pack.tar`, `version-status.json`, SLSA provenance, and matching
+Cosign bundles for the primary assets. Browser UI bundles are not Kernel
+release assets.
+
+This is provider evidence, not a blanket release-complete claim. Release run
+`29338793179` failed in the Homebrew job, post-release version drift was
+skipped, and the later Homebrew formula PR merged despite a failed exact-head
+autonomous permit. Verify the exact assets and each required channel before
+claiming lockstep completion.
 
 ## Public Release Material
 
@@ -107,7 +112,7 @@ customer or high-assurance profile, release verification must pass with
 equivalent high-assurance profile, proving the trusted external signer,
 Rekor/RFC3161 anchor receipt, and active S3 Object Lock storage receipt.
 
-For `v0.5.10`, use checksum verification, SBOM inspection, OpenVEX inspection,
+For `v0.7.2`, use checksum verification, SBOM inspection, OpenVEX inspection,
 release metadata inspection, offline EvidencePack verification,
 reproducible-build validation, and Cosign verification against the attached
 bundles.

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -1,6 +1,6 @@
 ---
 title: Release and Security Evidence
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-12
 ---
 
 # HELM AI Kernel Release and Security Evidence
@@ -53,15 +53,14 @@ flowchart TD
 ```
 
 
-Current source release target: `v0.7.2`:
-<https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2>. The
-release is complete only when GitHub shows Darwin/Linux/Windows binaries,
-`SHA256SUMS.txt`, `sbom.json`, `v0.7.2.openvex.json`,
-`release-attestation.json`, `evidence-pack.tar`, `release.high_risk.v3.toml`,
-`sample-policy-material.tar`, `helm-ai-kernel-launchpad-data.tar`,
-`helm-ai-kernel.mcpb`, `helm-ai-kernel.rb`, `v0.7.2.json`,
-`version-status.json`, and matching `*.cosign.bundle` files for each primary
-asset. Browser UI bundles are not Kernel release assets.
+The current published GitHub release and tag is `v0.7.1`. The source tree
+declares `0.7.2`, but `v0.7.2` is neither tagged nor published, so its release
+URL and asset set are unavailable. After a future `v0.7.2` publication, verify
+the actual GitHub assets before naming them here; a complete release is expected
+to include the applicable binaries, `SHA256SUMS.txt`, SBOM, OpenVEX,
+attestation, EvidencePack, `version-status.json`, and matching
+`*.cosign.bundle` files where produced. Browser UI bundles are not Kernel
+release assets.
 
 ## Public Release Material
 

--- a/docs/RELEASE_SECURITY.md
+++ b/docs/RELEASE_SECURITY.md
@@ -53,14 +53,18 @@ flowchart TD
 ```
 
 
-The current published GitHub release and tag is `v0.7.1`. The source tree
-declares `0.7.2`, but `v0.7.2` is neither tagged nor published, so its release
-URL and asset set are unavailable. After a future `v0.7.2` publication, verify
-the actual GitHub assets before naming them here; a complete release is expected
-to include the applicable binaries, `SHA256SUMS.txt`, SBOM, OpenVEX,
-attestation, EvidencePack, `version-status.json`, and matching
-`*.cosign.bundle` files where produced. Browser UI bundles are not Kernel
-release assets.
+The current published GitHub release and tag is `v0.7.1`.
+
+Current source release target: `v0.7.2`. It is not yet a tag or published
+release: the deterministic target URL
+`https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2` currently
+has no release behind it and must not be used as release evidence. After a
+successful `v0.7.2` publication, verify the actual attached assets before
+claiming them here. The expected versioned names include
+`v0.7.2.openvex.json` and `v0.7.2.json`, alongside the applicable binaries,
+`SHA256SUMS.txt`, SBOM, attestation, EvidencePack, `version-status.json`, and
+matching `*.cosign.bundle` files where produced. Browser UI bundles are not
+Kernel release assets.
 
 ## Public Release Material
 

--- a/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
+++ b/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
@@ -19,9 +19,9 @@ published drift evidence for that exact version.
 | Release baseline | `v0.7.1` is the latest published GitHub release and tag. `main` declares `0.7.2`, but `v0.7.2` has neither a tag nor a GitHub Release. | `VERSION`, `gh release view v0.7.1`, `git ls-remote --tags origin v0.7.2` | Keep public release claims on `v0.7.1` until `v0.7.2` is tagged, published, and verified. |
 | Open PR dependencies | Five kernel PRs are open as of this audit; branch presence does not declare release scope. | `gh pr list --state open` on 2026-07-12 | Re-evaluate approved, green prerequisites at the release cut. |
 | Unreleased main delta | `main` source version `0.7.2` remains untagged and unpublished. | `VERSION`, `git ls-remote --tags origin v0.7.2`, `gh release view v0.7.2` | Establish release scope and pass the release gates before tagging. |
-| EvidencePack structure | Mandatory pack structure, optional host evidence, and declared `99_EXT/` extensions exist. | `core/pkg/conform/evidencepack.go:13` | `v0.7.0` should freeze authority and compatibility, not invent a pack layout. |
-| EvidencePack seal and verifier | Native seal and verification paths exist. | `core/pkg/evidence/seal.go:191`, `core/pkg/evidence/seal.go:349` | `v0.7.0` must define exact verifier success and tamper-failure requirements. |
-| ProofGraph | ProofGraph refs are used by runtime adapters, exports, and evidence packs. | `core/pkg/evidence/arc/pack_builder.go:39`, `core/pkg/workstation/evidence.go:63` | `v0.7.0` must freeze ref grammar, pack placement, and replay semantics. |
+| EvidencePack structure | Mandatory pack structure, optional host evidence, and declared `99_EXT/` extensions exist. | `core/pkg/conform/evidencepack.go:13` | Historical `v0.7.0` scope; future release planning must start from the current release state above. |
+| EvidencePack seal and verifier | Native seal and verification paths exist. | `core/pkg/evidence/seal.go:191`, `core/pkg/evidence/seal.go:349` | Historical `v0.7.0` exit criteria; do not treat this row as a current release-gap claim. |
+| ProofGraph | ProofGraph refs are used by runtime adapters, exports, and evidence packs. | `core/pkg/evidence/arc/pack_builder.go:39`, `core/pkg/workstation/evidence.go:63` | Historical `v0.7.0` scope; verify current behavior through source and release evidence. |
 | Agent risk scan | `helm-ai-kernel scan` exists with RiskEnvelope, preview, evidence-pack, receipt projection, and upload gates. | `core/cmd/helm-ai-kernel/scan_cmd.go:31`, `core/pkg/riskscan/scan.go:56` | `v0.8.0` should stabilize and contract-freeze the scan surface. |
 | RiskEnvelope schema | JSON Schema and Go model exist with raw-data non-collection fields. | `protocols/json-schemas/risk-envelope/v1.json:19`, `core/pkg/riskenvelope/envelope.go:142` | `v0.8.0` must decide SDK/API parity and lock schema compatibility. |
 | RiskEnvelope SDK parity | OpenAPI/SDKs expose MCP scan, not the local RiskEnvelope contract. | `api/openapi/helm.openapi.yaml:3204` | Add OpenAPI component and SDK generated types, or explicitly declare CLI-only scope. |
@@ -100,9 +100,13 @@ make release-assets
 15. Close or retarget superseded PRs and update Linear with final release
     evidence.
 
-## `v0.7.0` Missing Parts
+## Historical `v0.7.0` Planning Record
 
-Required implementation:
+`v0.7.0` is already a published historical release. The following original
+planning record is retained for provenance only; it is not a claim that these
+items remain missing from current `main`.
+
+Original planned implementation:
 
 - Define the frozen EvidencePack authority contract:
   - mandatory top-level entries and optional entries;
@@ -147,9 +151,13 @@ Release note boundary:
 - Do not say: customer-grade audit archive, compliance certification, cloud
   attestation, or production legal evidence.
 
-## `v0.7.1` Missing Parts
+## Historical `v0.7.1` Planning Record
 
-Allowed changes:
+`v0.7.1` is the current published release. The following original scope is
+retained for release-history context and does not define an unimplemented
+backlog for current `main`.
+
+Original allowed changes:
 
 - clearer verifier error output;
 - compatibility fixes for packs produced by retained `v0.7.0` writers;

--- a/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
+++ b/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
@@ -3,10 +3,10 @@
 <!-- quantum_posture: this planning doc mentions release signature and provenance assets but does not implement cryptographic controls. -->
 
 Status: internal release planning source, not release notes.
-Current audit date: 2026-07-12.
-Current source base: `origin/main@1f599d18`.
-Current source version: `VERSION=0.7.2` (untagged).
-Current public release and tag: `v0.7.1`.
+Current audit date: 2026-07-15.
+Current source base: `origin/main@586a5d62`.
+Current source version: `VERSION=0.7.2`.
+Current GitHub release and tag: `v0.7.2` (lockstep acceptance incomplete).
 
 Do not add this file to the public docs manifest. Future release scope becomes
 public only through tagged release notes, changelog entries, release assets, and
@@ -16,9 +16,9 @@ published drift evidence for that exact version.
 
 | Surface | Current state | Evidence | Plan impact |
 | --- | --- | --- | --- |
-| Release baseline | `v0.7.1` is the latest published GitHub release and tag. `main` declares `0.7.2`, but `v0.7.2` has neither a tag nor a GitHub Release. | `VERSION`, `gh release view v0.7.1`, `git ls-remote --tags origin v0.7.2` | Keep public release claims on `v0.7.1` until `v0.7.2` is tagged, published, and verified. |
-| Open PR dependencies | Five kernel PRs are open as of this audit; branch presence does not declare release scope. | `gh pr list --state open` on 2026-07-12 | Re-evaluate approved, green prerequisites at the release cut. |
-| Unreleased main delta | `main` source version `0.7.2` remains untagged and unpublished. | `VERSION`, `git ls-remote --tags origin v0.7.2`, `gh release view v0.7.2` | Establish release scope and pass the release gates before tagging. |
+| Release baseline | `v0.7.2` is the latest GitHub tag and Release, published from exact current `main`; the release run is red because Homebrew failed and post-release drift skipped. | `VERSION`, `gh release view v0.7.2`, release run `29338793179` | Keep tag/assets/channel/runtime evidence separate; do not call the lockstep release complete from the Release object alone. |
+| Open PR dependencies | Eighteen kernel PRs are open as of this audit; branch presence does not declare release scope. | `gh pr list --state open` on 2026-07-15 | Re-evaluate approved, green prerequisites at the next release cut. |
+| Unreleased main delta | Tag `v0.7.2` and current `origin/main` both resolve to `586a5d62`; this candidate docs PR is not part of that release. | `git rev-parse v0.7.2 origin/main` | Establish the next release scope only through a new, authorized release train. |
 | EvidencePack structure | Mandatory pack structure, optional host evidence, and declared `99_EXT/` extensions exist. | `core/pkg/conform/evidencepack.go:13` | Historical `v0.7.0` scope; future release planning must start from the current release state above. |
 | EvidencePack seal and verifier | Native seal and verification paths exist. | `core/pkg/evidence/seal.go:191`, `core/pkg/evidence/seal.go:349` | Historical `v0.7.0` exit criteria; do not treat this row as a current release-gap claim. |
 | ProofGraph | ProofGraph refs are used by runtime adapters, exports, and evidence packs. | `core/pkg/evidence/arc/pack_builder.go:39`, `core/pkg/workstation/evidence.go:63` | Historical `v0.7.0` scope; verify current behavior through source and release evidence. |
@@ -33,6 +33,7 @@ published drift evidence for that exact version.
 | --- | --- | --- | --- |
 | `v0.7.0` | EvidencePack and ProofGraph beta | Freeze EvidencePack authority, ProofGraph refs, transparency proofs, offline verifier, conformance oracle, and tamper-failure coverage. | Downloaded release pack verifies offline; tampered pack fails. |
 | `v0.7.1` | Evidence hardening | Verifier UX, pack compatibility, docs/examples, and conformance regressions only. | Focused verifier/proofgraph tests plus release gates pass. |
+| `v0.7.2` | Enforcement and dependency hardening | Governed MCP execution, boundary-contract alignment, emergency-stop and replay hardening, and dependency/toolchain refreshes. | GitHub assets exist; lockstep acceptance remains blocked on the red release run and skipped post-release drift. |
 | `v0.8.0` | RiskEnvelope and agent risk scan beta | Stabilize `helm-ai-kernel scan`, RiskEnvelope schema, local preview, EvidencePack export, optional anonymized upload, observe/shadow/enforce mapping, and SDK parity. | Redaction tests prove no raw secret, prompt, command body, source snippet, or sensitive path leakage. |
 | `v0.8.1` | Risk scan hardening | Redaction, schema parity, SDK examples, upload/privacy docs only. | Scan CLI/API, SDK, docs-truth, and RiskEnvelope tests pass. |
 | `v0.9.0` | Release candidate freeze | No net-new features. Refresh OpenAPI, proto, schemas, SDKs, chart, Homebrew, VEX, changelog, release docs, repo manifest, and fanout readiness. | `make quality-release`, `make release-readiness`, and `make release-assets` pass from clean `origin/main`. |
@@ -153,7 +154,7 @@ Release note boundary:
 
 ## Historical `v0.7.1` Planning Record
 
-`v0.7.1` is the current published release. The following original scope is
+`v0.7.1` is the published historical predecessor to `v0.7.2`. The following original scope is
 retained for release-history context and does not define an unimplemented
 backlog for current `main`.
 

--- a/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
+++ b/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
@@ -3,10 +3,10 @@
 <!-- quantum_posture: this planning doc mentions release signature and provenance assets but does not implement cryptographic controls. -->
 
 Status: internal release planning source, not release notes.
-Current audit date: 2026-07-07.
-Current source base: `origin/main@eed014fa`.
-Current source version: `VERSION=0.7.0`.
-Current public release: `v0.7.0`.
+Current audit date: 2026-07-12.
+Current source base: `origin/main@1f599d18`.
+Current source version: `VERSION=0.7.2` (untagged).
+Current public release and tag: `v0.7.1`.
 
 Do not add this file to the public docs manifest. Future release scope becomes
 public only through tagged release notes, changelog entries, release assets, and
@@ -16,9 +16,9 @@ published drift evidence for that exact version.
 
 | Surface | Current state | Evidence | Plan impact |
 | --- | --- | --- | --- |
-| Release baseline | `v0.7.0` is the latest public GitHub release; `main` has moved past the tag for release-provenance guard work. | `gh release list`, `git log v0.7.0..origin/main` | Cut `v0.7.1` only for evidence/release hardening needed before `v0.8.0`. |
-| Open PR dependencies | No open kernel PR dependency is required for the next patch. | `gh pr list --state open` returned no open PRs on 2026-07-07. | Keep `v0.7.1` independent unless a release repair PR becomes necessary. |
-| Unreleased main delta | Post-`v0.7.0` commits harden npm publication and release provenance checks, not a feature train. | `git diff --stat v0.7.0..origin/main` | Fold into `v0.7.1`; do not mix in RiskEnvelope feature work. |
+| Release baseline | `v0.7.1` is the latest published GitHub release and tag. `main` declares `0.7.2`, but `v0.7.2` has neither a tag nor a GitHub Release. | `VERSION`, `gh release view v0.7.1`, `git ls-remote --tags origin v0.7.2` | Keep public release claims on `v0.7.1` until `v0.7.2` is tagged, published, and verified. |
+| Open PR dependencies | Five kernel PRs are open as of this audit; branch presence does not declare release scope. | `gh pr list --state open` on 2026-07-12 | Re-evaluate approved, green prerequisites at the release cut. |
+| Unreleased main delta | `main` source version `0.7.2` remains untagged and unpublished. | `VERSION`, `git ls-remote --tags origin v0.7.2`, `gh release view v0.7.2` | Establish release scope and pass the release gates before tagging. |
 | EvidencePack structure | Mandatory pack structure, optional host evidence, and declared `99_EXT/` extensions exist. | `core/pkg/conform/evidencepack.go:13` | `v0.7.0` should freeze authority and compatibility, not invent a pack layout. |
 | EvidencePack seal and verifier | Native seal and verification paths exist. | `core/pkg/evidence/seal.go:191`, `core/pkg/evidence/seal.go:349` | `v0.7.0` must define exact verifier success and tamper-failure requirements. |
 | ProofGraph | ProofGraph refs are used by runtime adapters, exports, and evidence packs. | `core/pkg/evidence/arc/pack_builder.go:39`, `core/pkg/workstation/evidence.go:63` | `v0.7.0` must freeze ref grammar, pack placement, and replay semantics. |

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -252,8 +252,8 @@
       "id": "release-security-doc-current-release",
       "path": "docs/RELEASE_SECURITY.md",
       "kind": "regex",
-      "pattern": "Current source release target: `v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)`",
-      "replacement": "Current source release target: `v{version}`"
+      "pattern": "Current GitHub release and tag: `v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)`",
+      "replacement": "Current GitHub release and tag: `v{version}`"
     },
     {
       "id": "release-security-doc-release-url",


### PR DESCRIPTION
## What changed

- Correct current-release references to distinguish published `v0.7.1` from the untagged/unpublished `0.7.2` source state.
- State the deterministic `v0.7.2` target URL and asset names only as unavailable source-release expectations, never as published evidence.
- Mark historic v0.7.0/v0.7.1 planning sections as release-history records rather than current missing-work claims.

## Why

Release source version, GitHub tag/release, deployment, and package-channel truth are separate states. The prior docs blurred them.

## Validation

- `make version-drift`
- `python3 scripts/check_documentation_truth.py`
- `git diff --check`

Post-publication wording remains intentionally deferred until a real tag, GitHub Release, assets, and release verification exist.