### PR TITLE
release: finalize v0.7.2 changelog and OpenVEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ flowchart TD
     subgraph Ingestion["1. Ingestion & Context Plane"]
         Page["HELM AI Kernel Changelog"]
         A["[Unreleased]"]
+        A00["[0.7.2] - 2026-07-13"]
         A0["[0.7.1] - 2026-07-07"]
         A1["[0.7.0] - 2026-07-05"]
         A2["[0.6.0] - 2026-07-02"]
@@ -58,7 +59,8 @@ flowchart TD
 
     %% Operational Flow Edges
     Page --> A
-    A --> A0
+    A --> A00
+    A00 --> A0
     A0 --> A1
     A1 --> A2
     A2 --> B
@@ -87,16 +89,27 @@ hardware-backed enforcement language out of the public changelog until a tagged
 release ships source-owned tests, verifier evidence, and release artifacts for
 that exact capability.
 
-- Prepared the corrective `v0.7.2` source target to align the canonical
-  `BoundaryStatus` OpenAPI schema and generated Java, Python, Rust, and
-  TypeScript models with the JSON already emitted by
-  `GET /api/v1/boundary/status`.
-- Replaced legacy generated properties such as `receipt_store_ready`,
-  `signer_ready`, `last_checkpoint_id`, and `checked_at` with the existing
-  runtime properties, and documented the consumer migration mapping.
-- This correction does not change Kernel runtime JSON behavior and is not a
-  released version until the normal tag-driven release train and published
-  artifact verification complete.
+## [0.7.2] - 2026-07-13
+
+Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2>.
+
+<!-- quantum_posture: v0.7.2 release notes cover a Go standard-library toolchain rebuild and an OpenAPI contract alignment only; this release adds no post-quantum cryptographic control. -->
+
+- Rebuilt both container images on Go 1.25.12 (up from 1.25.10) to clear five
+  Go standard-library CVEs baked into the binaries at compile time —
+  `CVE-2026-27145` (`crypto/x509`), `CVE-2026-42504` (`mime`),
+  `CVE-2026-42507` (`net/textproto`), `CVE-2026-39822` (`os.Root`), and
+  `CVE-2026-42505` (Encrypted Client Hello). Rebuild only; no code or runtime
+  behavior change.
+- Aligned the canonical `BoundaryStatus` OpenAPI schema and the generated Java,
+  Python, Rust, and TypeScript models with the JSON already emitted by
+  `GET /api/v1/boundary/status`. Replaced legacy generated properties such as
+  `receipt_store_ready`, `signer_ready`, `last_checkpoint_id`, and `checked_at`
+  with the existing runtime properties, and documented the consumer migration
+  mapping. This correction does not change Kernel runtime JSON behavior.
+
+No RiskEnvelope, scan, upload, cloud, checkout, website, connector
+certification, or Company AI OS GA scope is included.
 
 ## [0.7.1] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,11 +95,11 @@ Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0
 
 <!-- quantum_posture: v0.7.2 release notes cover a Go standard-library toolchain rebuild and an OpenAPI contract alignment only; this release adds no post-quantum cryptographic control. -->
 
-- Rebuilt both container images on Go 1.25.12 (up from 1.25.10) to clear five
-  Go standard-library CVEs baked into the binaries at compile time —
-  `CVE-2026-27145` (`crypto/x509`), `CVE-2026-42504` (`mime`),
-  `CVE-2026-42507` (`net/textproto`), `CVE-2026-39822` (`os.Root`), and
-  `CVE-2026-42505` (Encrypted Client Hello). Rebuild only; no code or runtime
+- The tag-triggered release workflow will rebuild both container images on Go
+  1.25.12 (up from 1.25.10), which includes the cumulative upstream
+  standard-library security fixes for `crypto/x509`, `mime`, `net/textproto`,
+  `crypto/tls`, and `os`. Post-release Trivy and Artifact Hub evidence is
+  required before claiming any CVE clearance. Rebuild only; no code or runtime
   behavior change.
 - Aligned the canonical `BoundaryStatus` OpenAPI schema and the generated Java,
   Python, Rust, and TypeScript models with the JSON already emitted by

--- a/release/vex/v0.7.2.openvex.json
+++ b/release/vex/v0.7.2.openvex.json
@@ -1,0 +1,10 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://mindburn.org/vex/helm-ai-kernel/v0.7.2",
+  "author": "Mindburn-Labs Release Bot <release@mindburn.org>",
+  "role": "Project Maintainer",
+  "timestamp": "2026-07-12T19:32:09Z",
+  "version": 1,
+  "tooling": "helm-ai-kernel/scripts/release/generate_vex.sh",
+  "statements": []
+}


### PR DESCRIPTION
## Purpose

This PR adds the two source-controlled **pre-tag assets** required for the
`v0.7.2` release train:

1. A dated `0.7.2` block in `CHANGELOG.md`, moving the already-staged
   `BoundaryStatus` notes out of `[Unreleased]`.
2. `release/vex/v0.7.2.openvex.json`, which `stage_release_assets.sh` requires
   when the future `v0.7.2` tag triggers `release.yml`.

It does **not** create a tag, publish images, package a chart, or publish a
GitHub release. It also does not authorize the release to be cut; the broader
release train still needs its independent security, review, and release gates.

## Security-claim boundary

`main` already pins Go 1.25.12. The upstream Go release history records
cumulative standard-library security fixes in `crypto/x509`, `mime`,
`net/textproto`, `crypto/tls`, and `os`. Once an approved `v0.7.2` tag is
created, the release workflow will rebuild the two container images using that
toolchain.

This PR makes **no claim that a CVE is already cleared**: no `v0.7.2` image has
been built or scanned yet. Post-release Trivy, Artifact Hub, and published
artifact evidence are required before asserting any CVE clearance or a changed
Artifact Hub grade. `GO-2026-5932` (`x/crypto/openpgp`) remains a separate
tracking concern.

## Scope

- No version-surface changes; `main` is already at `0.7.2`.
- No toolchain changes; `main` already pins Go 1.25.12.
- No runtime, product, or cryptographic behavior change.

## Validation

```text
/usr/bin/python3 scripts/release/check_version_drift.py local
Documentation truth check passed: 651 coverage rows resolve to live sources and docs.
git diff --check
```

## Release sequence after approval and merge

1. Complete the remaining independent security and release approvals.
2. Merge this metadata PR to `main`.
3. Run the approved release process from final `main`, including tag creation.
4. Collect release receipts and image-scanning evidence before making public
   CVE-clearance or Artifact-Hub-grade claims.
