### PR TITLE
fix(kernel): prove Desktop sidecar readiness

### DIFF
--- a/core/cmd/helm-ai-kernel/desktop_ready_route.go
+++ b/core/cmd/helm-ai-kernel/desktop_ready_route.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// This route is intentionally absent outside a Desktop-launched Kernel. The
+// native shell uses the per-launch token to prove that the process listening on
+// its loopback port is the Kernel it started before it gives the Console an
+// admin credential for that endpoint.
+const (
+	desktopReadyTokenEnv     = "HELM_DESKTOP_KERNEL_READY_TOKEN"
+	desktopReadyPath         = "/_helm/desktop-ready"
+	desktopReadyNonceHeader  = "X-HELM-Desktop-Nonce"
+	desktopReadyProofHeader  = "X-HELM-Desktop-Proof"
+	desktopReadyMaxNonceSize = 256
+)
+
+func registerDesktopReadyRoute(mux *http.ServeMux) {
+	token := strings.TrimSpace(os.Getenv(desktopReadyTokenEnv))
+	if token == "" {
+		return
+	}
+
+	mux.HandleFunc(desktopReadyPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			w.Header().Set("Allow", "GET, HEAD")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		nonce := strings.TrimSpace(r.Header.Get(desktopReadyNonceHeader))
+		if !validDesktopReadyNonce(nonce) {
+			// Do not expose a signing oracle to malformed callers. The token is
+			// still held only by the launched Kernel process.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set(desktopReadyProofHeader, desktopReadyProof(token, nonce))
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func validDesktopReadyNonce(nonce string) bool {
+	if nonce == "" || len(nonce) > desktopReadyMaxNonceSize {
+		return false
+	}
+	for _, ch := range nonce {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') && (ch < 'A' || ch > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func desktopReadyProof(token, nonce string) string {
+	mac := hmac.New(sha256.New, []byte(token))
+	_, _ = mac.Write([]byte(nonce))
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/core/cmd/helm-ai-kernel/desktop_ready_route_test.go
+++ b/core/cmd/helm-ai-kernel/desktop_ready_route_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDesktopReadyRouteIsAbsentWithoutLaunchToken(t *testing.T) {
+	t.Setenv(desktopReadyTokenEnv, "")
+	mux := http.NewServeMux()
+	registerDesktopReadyRoute(mux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, desktopReadyPath, nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+}
+
+func TestDesktopReadyRouteProvesOnlyValidNonceForLaunchToken(t *testing.T) {
+	t.Setenv(desktopReadyTokenEnv, "desktop-secret")
+	mux := http.NewServeMux()
+	registerDesktopReadyRoute(mux)
+
+	req := httptest.NewRequest(http.MethodGet, desktopReadyPath, nil)
+	req.Header.Set(desktopReadyNonceHeader, "a1b2c3")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+	if got, want := rec.Header().Get(desktopReadyProofHeader), desktopReadyProof("desktop-secret", "a1b2c3"); got != want {
+		t.Fatalf("proof = %q, want %q", got, want)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("cache-control = %q", got)
+	}
+
+	invalid := httptest.NewRequest(http.MethodGet, desktopReadyPath, nil)
+	invalid.Header.Set(desktopReadyNonceHeader, "not a hex nonce")
+	invalidRec := httptest.NewRecorder()
+	mux.ServeHTTP(invalidRec, invalid)
+	if invalidRec.Code != http.StatusNotFound {
+		t.Fatalf("invalid nonce status = %d, want %d", invalidRec.Code, http.StatusNotFound)
+	}
+	if invalidRec.Header().Get(desktopReadyProofHeader) != "" {
+		t.Fatal("invalid nonce unexpectedly received a proof")
+	}
+}
+
+func TestDesktopReadyRouteRejectsMutations(t *testing.T) {
+	t.Setenv(desktopReadyTokenEnv, "desktop-secret")
+	mux := http.NewServeMux()
+	registerDesktopReadyRoute(mux)
+
+	req := httptest.NewRequest(http.MethodPost, desktopReadyPath, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+	if got := rec.Header().Get("Allow"); got != "GET, HEAD" {
+		t.Fatalf("allow = %q", got)
+	}
+}

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -404,6 +404,7 @@ func runServerWithOptions(opts serverOptions) {
 		}
 	}
 	mux := http.NewServeMux()
+	registerDesktopReadyRoute(mux)
 	if extraRoutes != nil {
 		extraRoutes(mux)
 	}

--- a/core/cmd/helm-ai-kernel/mcp_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_cmd.go
@@ -114,11 +114,13 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 		transport string
 		port      int
 		authMode  string
+		dataDir   string
 	)
 
 	cmd.StringVar(&transport, "transport", "stdio", "Transport: stdio, http")
 	cmd.IntVar(&port, "port", 9100, "Port for HTTP transport")
 	cmd.StringVar(&authMode, "auth", "none", "Auth mode: none, static-header, oauth")
+	cmd.StringVar(&dataDir, "data-dir", "data", "Data directory for local MCP signing state")
 
 	if err := cmd.Parse(args); err != nil {
 		return 2
@@ -130,13 +132,13 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "Error: stdio transport only supports --auth none")
 			return 2
 		}
-		if err := serveLocalMCPStdio(os.Stdin, stdout); err != nil {
+		if err := serveLocalMCPStdioWithDataDir(os.Stdin, stdout, dataDir); err != nil {
 			fmt.Fprintf(stderr, "Error: MCP stdio server failed: %v\n", err)
 			return 2
 		}
 		return 0
 	case "http":
-		server, err := newLocalMCPHTTPServer(port, authMode)
+		server, err := newLocalMCPHTTPServerWithDataDir(port, authMode, dataDir)
 		if err != nil {
 			fmt.Fprintf(stderr, "Error: %v\n", err)
 			return 2

--- a/core/cmd/helm-ai-kernel/mcp_runtime.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime.go
@@ -42,7 +42,11 @@ type mcpRPCError struct {
 }
 
 func newLocalMCPRuntime() (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
-	signer, err := loadOrGenerateSigner()
+	return newLocalMCPRuntimeWithDataDir("data")
+}
+
+func newLocalMCPRuntimeWithDataDir(dataDir string) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -199,7 +203,11 @@ func resolveLocalMCPPath(rawPath string) (string, error) {
 }
 
 func serveLocalMCPStdio(stdin io.Reader, stdout io.Writer) error {
-	catalog, executor, err := newLocalMCPRuntime()
+	return serveLocalMCPStdioWithDataDir(stdin, stdout, "data")
+}
+
+func serveLocalMCPStdioWithDataDir(stdin io.Reader, stdout io.Writer, dataDir string) error {
+	catalog, executor, err := newLocalMCPRuntimeWithDataDir(dataDir)
 	if err != nil {
 		return err
 	}
@@ -401,19 +409,24 @@ func handleMCPRPCRequest(req *mcpRPCRequest, catalog *mcppkg.ToolCatalog, execut
 }
 
 func newLocalMCPHTTPServer(port int, authMode string) (*http.Server, error) {
+	return newLocalMCPHTTPServerWithDataDir(port, authMode, "data")
+}
+
+func newLocalMCPHTTPServerWithDataDir(port int, authMode, dataDir string) (*http.Server, error) {
 	// SEC: Default to localhost to prevent accidental network exposure.
 	mcpBind := "127.0.0.1"
 	if envBind := os.Getenv("HELM_BIND_ADDR"); envBind != "" {
 		mcpBind = envBind
 	}
 	baseURL := fmt.Sprintf("http://%s:%d", mcpBind, port)
-	gateway, err := newConfiguredLocalMCPGateway(mcppkg.GatewayConfig{
-		BaseURL:  baseURL,
-		AuthMode: authMode,
-	})
+	catalog, executor, err := newLocalMCPRuntimeWithDataDir(dataDir)
 	if err != nil {
 		return nil, err
 	}
+	gateway := mcppkg.NewGateway(catalog, mcppkg.GatewayConfig{
+		BaseURL:  baseURL,
+		AuthMode: authMode,
+	}, mcppkg.WithExecutor(executor))
 
 	mux := http.NewServeMux()
 	gateway.RegisterRoutes(mux)

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/shadow"
 )
 
@@ -26,27 +27,35 @@ var (
 )
 
 type setupOptions struct {
-	Target  string
-	Scope   string
-	Yes     bool
-	DryRun  bool
-	JSON    bool
-	DataDir string
+	Target       string
+	Operation    string
+	Scope        string
+	Workspace    string
+	WorkspaceSet bool
+	Yes          bool
+	DryRun       bool
+	JSON         bool
+	NoQuickstart bool
+	DataDir      string
 }
 
 type setupSummary struct {
-	Target           string `json:"target"`
-	BinaryPath       string `json:"binary_path"`
-	ClientConfigPath string `json:"client_config_path"`
-	HookConfigPath   string `json:"hook_config_path"`
-	DataDir          string `json:"data_dir"`
-	KernelURL        string `json:"kernel_url"`
-	ScanGrade        string `json:"scan_grade"`
-	DraftPolicyPath  string `json:"draft_policy_path"`
-	UninstallCommand string `json:"uninstall_command"`
-	Scope            string `json:"scope,omitempty"`
-	MCPInstalled     bool   `json:"mcp_installed,omitempty"`
-	HookInstalled    bool   `json:"hook_installed,omitempty"`
+	Operation         string   `json:"operation"`
+	Target            string   `json:"target"`
+	Workspace         string   `json:"workspace"`
+	BinaryPath        string   `json:"binary_path"`
+	ClientConfigPath  string   `json:"client_config_path"`
+	HookConfigPath    string   `json:"hook_config_path"`
+	DataDir           string   `json:"data_dir"`
+	KernelURL         string   `json:"kernel_url"`
+	ScanGrade         string   `json:"scan_grade"`
+	DraftPolicyPath   string   `json:"draft_policy_path"`
+	UninstallCommand  string   `json:"uninstall_command"`
+	Scope             string   `json:"scope,omitempty"`
+	MCPInstalled      bool     `json:"mcp_installed,omitempty"`
+	HookInstalled     bool     `json:"hook_installed,omitempty"`
+	QuickstartStarted bool     `json:"quickstart_started"`
+	PlannedActions    []string `json:"planned_actions"`
 }
 
 func init() {
@@ -110,6 +119,11 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 	if code != 0 {
 		return code
 	}
+	if opts.DryRun {
+		opts.Operation = "preview"
+	} else {
+		opts.Operation = "install"
+	}
 	if !opts.Yes && !opts.DryRun {
 		fmt.Fprintln(stderr, "setup: pass --yes to install local config, or --dry-run to preview changes")
 		return 2
@@ -127,7 +141,7 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup: create data dir: %v\n", err)
 		return 1
 	}
-	grade, policyPath, err := runSetupAutoconfigure(opts.DataDir)
+	grade, policyPath, err := runSetupAutoconfigure(opts.DataDir, opts.Workspace)
 	if err != nil {
 		fmt.Fprintf(stderr, "setup: autoconfigure: %v\n", err)
 		return 1
@@ -145,6 +159,9 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 	summary.MCPInstalled = true
 	summary.HookInstalled = true
 	printSetupSummary(stdout, summary, opts.JSON)
+	if opts.NoQuickstart {
+		return 0
+	}
 	if !opts.JSON {
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stdout, "Leave this terminal open. HELM is starting the local Kernel proof path now.")
@@ -162,6 +179,7 @@ func runSetupStatusCmd(args []string, stdout, stderr io.Writer) int {
 	if code != 0 {
 		return code
 	}
+	opts.Operation = "status"
 	summary, err := buildSetupSummary(opts)
 	if err != nil {
 		fmt.Fprintf(stderr, "setup status: %v\n", err)
@@ -183,6 +201,11 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 	opts, code := parseSetupInspectArgs("setup remove", args, stderr, true)
 	if code != 0 {
 		return code
+	}
+	if opts.DryRun {
+		opts.Operation = "preview_remove"
+	} else {
+		opts.Operation = "remove"
 	}
 	if !opts.Yes && !opts.DryRun {
 		fmt.Fprintln(stderr, "setup remove: pass --yes to remove local config, or --dry-run to preview changes")
@@ -218,8 +241,9 @@ func printSetupUsage(w io.Writer) {
 	fmt.Fprintln(w, "  helm-ai-kernel setup --json")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Manage:")
-	fmt.Fprintln(w, "  helm-ai-kernel setup status <claude-code|codex> [--scope user|project] [--json] [--data-dir DIR]")
-	fmt.Fprintln(w, "  helm-ai-kernel setup remove <claude-code|codex> [--scope user|project] [--yes] [--dry-run] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "  helm-ai-kernel setup codex --scope project --workspace DIR --dry-run --json")
+	fmt.Fprintln(w, "  helm-ai-kernel setup status <claude-code|codex> [--scope user|project] [--workspace DIR] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "  helm-ai-kernel setup remove <claude-code|codex> [--scope user|project] [--workspace DIR] [--yes] [--dry-run] [--json] [--data-dir DIR]")
 	fmt.Fprintln(w, "")
 	printSupportMatrix(w)
 	fmt.Fprintln(w, "")
@@ -231,13 +255,20 @@ func parseSetupInstallArgs(args []string, stderr io.Writer) (setupOptions, int) 
 	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.StringVar(&opts.Scope, "scope", opts.Scope, "Install scope: user or project")
+	fs.StringVar(&opts.Workspace, "workspace", "", "Workspace to scan and configure (required for project scope)")
 	fs.BoolVar(&opts.Yes, "yes", false, "Install without prompting")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "Print planned changes without writing config")
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
+	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Install without starting the blocking Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
 	if err := fs.Parse(args[1:]); err != nil {
 		return opts, 2
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "workspace" {
+			opts.WorkspaceSet = true
+		}
+	})
 	opts.Target = args[0]
 	return normalizeSetupOptions(opts, stderr)
 }
@@ -251,8 +282,10 @@ func parseSetupInspectArgs(name string, args []string, stderr io.Writer, include
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.StringVar(&opts.Scope, "scope", opts.Scope, "Install scope: user or project")
+	fs.StringVar(&opts.Workspace, "workspace", "", "Workspace to inspect or remove from (required for project scope)")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "Print planned changes without writing config")
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
+	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Report a headless setup without a Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
 	if includeYes {
 		fs.BoolVar(&opts.Yes, "yes", false, "Remove without prompting")
@@ -260,6 +293,11 @@ func parseSetupInspectArgs(name string, args []string, stderr io.Writer, include
 	if err := fs.Parse(args[1:]); err != nil {
 		return opts, 2
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "workspace" {
+			opts.WorkspaceSet = true
+		}
+	})
 	if fs.NArg() != 0 {
 		fmt.Fprintf(stderr, "%s: unexpected argument %q\n", name, fs.Arg(0))
 		return opts, 2
@@ -280,11 +318,42 @@ func normalizeSetupOptions(opts setupOptions, stderr io.Writer) (setupOptions, i
 		fmt.Fprintf(stderr, "setup: --scope must be user or project, got %q\n", opts.Scope)
 		return opts, 2
 	}
+	if opts.Scope == "project" && !opts.WorkspaceSet {
+		fmt.Fprintln(stderr, "setup: --scope project requires an explicit --workspace DIR")
+		return opts, 2
+	}
+	if opts.Scope == "user" && opts.WorkspaceSet {
+		fmt.Fprintln(stderr, "setup: --workspace is only valid with --scope project")
+		return opts, 2
+	}
 	if opts.DataDir == "" {
 		opts.DataDir = defaultSetupDataDir()
 	}
 	if abs, err := filepath.Abs(opts.DataDir); err == nil {
 		opts.DataDir = abs
+	}
+	if opts.Workspace == "" {
+		workspace, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(stderr, "setup: determine workspace: %v\n", err)
+			return opts, 2
+		}
+		opts.Workspace = workspace
+	}
+	if abs, err := filepath.Abs(opts.Workspace); err == nil {
+		opts.Workspace = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(opts.Workspace); err == nil {
+		opts.Workspace = resolved
+	}
+	info, err := os.Stat(opts.Workspace)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup: workspace: %v\n", err)
+		return opts, 2
+	}
+	if !info.IsDir() {
+		fmt.Fprintf(stderr, "setup: workspace must be a directory, got %q\n", opts.Workspace)
+		return opts, 2
 	}
 	return opts, 0
 }
@@ -309,17 +378,54 @@ func buildSetupSummary(opts setupOptions) (setupSummary, error) {
 		bin = abs
 	}
 	return setupSummary{
-		Target:           opts.Target,
-		BinaryPath:       bin,
-		ClientConfigPath: setupClientConfigPath(opts),
-		HookConfigPath:   setupHookConfigPath(opts),
-		DataDir:          opts.DataDir,
-		KernelURL:        "http://127.0.0.1:7714",
-		ScanGrade:        "not_run",
-		DraftPolicyPath:  filepath.Join(opts.DataDir, "autoconfigure", "policy.draft.json"),
-		UninstallCommand: fmt.Sprintf("helm-ai-kernel setup remove %s --scope %s --yes --data-dir %s", opts.Target, opts.Scope, shellQuote(opts.DataDir)),
-		Scope:            opts.Scope,
+		Operation:         opts.Operation,
+		Target:            opts.Target,
+		Workspace:         opts.Workspace,
+		BinaryPath:        bin,
+		ClientConfigPath:  setupClientConfigPath(opts),
+		HookConfigPath:    setupHookConfigPath(opts),
+		DataDir:           opts.DataDir,
+		KernelURL:         setupKernelURL(opts),
+		ScanGrade:         "not_run",
+		DraftPolicyPath:   filepath.Join(opts.DataDir, "autoconfigure", "policy.draft.json"),
+		UninstallCommand:  setupUninstallCommand(opts),
+		Scope:             opts.Scope,
+		QuickstartStarted: opts.Operation == "install" && !opts.NoQuickstart,
+		PlannedActions:    setupPlannedActions(opts),
 	}, nil
+}
+
+func setupPlannedActions(opts setupOptions) []string {
+	actions := []string{
+		"scan selected workspace and write draft-only inventory artifacts",
+		"configure the HELM MCP server with the selected local data directory",
+		"configure the HELM PreToolUse hook for supported Codex tools",
+	}
+	if opts.NoQuickstart {
+		return actions
+	}
+	return append(actions, "start the local Quickstart proof path")
+}
+
+func setupKernelURL(opts setupOptions) string {
+	if opts.NoQuickstart {
+		return ""
+	}
+	return "http://127.0.0.1:7714"
+}
+
+func setupUninstallCommand(opts setupOptions) string {
+	workspace := ""
+	if opts.Scope == "project" {
+		workspace = " --workspace " + shellQuote(opts.Workspace)
+	}
+	return fmt.Sprintf(
+		"helm-ai-kernel setup remove %s --scope %s%s --yes --data-dir %s",
+		opts.Target,
+		opts.Scope,
+		workspace,
+		shellQuote(opts.DataDir),
+	)
 }
 
 func printSetupSummary(stdout io.Writer, summary setupSummary, jsonOut bool) {
@@ -328,6 +434,7 @@ func printSetupSummary(stdout io.Writer, summary setupSummary, jsonOut bool) {
 		return
 	}
 	fmt.Fprintf(stdout, "HELM setup for %s\n", summary.Target)
+	fmt.Fprintf(stdout, "  Workspace:     %s\n", summary.Workspace)
 	fmt.Fprintf(stdout, "  MCP config:    %s\n", summary.ClientConfigPath)
 	fmt.Fprintf(stdout, "  Hook config:   %s\n", summary.HookConfigPath)
 	fmt.Fprintf(stdout, "  Data dir:      %s\n", summary.DataDir)
@@ -335,14 +442,20 @@ func printSetupSummary(stdout io.Writer, summary setupSummary, jsonOut bool) {
 	fmt.Fprintf(stdout, "  Scan grade:    %s\n", summary.ScanGrade)
 	fmt.Fprintf(stdout, "  Draft policy:  %s\n", summary.DraftPolicyPath)
 	fmt.Fprintf(stdout, "  Uninstall:     %s\n", summary.UninstallCommand)
+	if len(summary.PlannedActions) > 0 {
+		fmt.Fprintln(stdout, "  Planned:")
+		for _, action := range summary.PlannedActions {
+			fmt.Fprintf(stdout, "    - %s\n", action)
+		}
+	}
 	if summary.MCPInstalled || summary.HookInstalled {
 		fmt.Fprintf(stdout, "  Installed:     mcp=%v hook=%v\n", summary.MCPInstalled, summary.HookInstalled)
 	}
 }
 
-func runSetupAutoconfigure(dataDir string) (string, string, error) {
+func runSetupAutoconfigure(dataDir, workspace string) (string, string, error) {
 	outDir := filepath.Join(dataDir, "autoconfigure")
-	report, err := shadow.NewScanner().Scan(".")
+	report, err := shadow.NewScanner().Scan(workspace)
 	if err != nil {
 		return "", "", err
 	}
@@ -364,12 +477,12 @@ func runSetupAutoconfigure(dataDir string) (string, string, error) {
 func installSetupMCP(opts setupOptions, bin string) error {
 	switch opts.Target {
 	case "claude-code":
-		return setupExecCommand("claude", "mcp", "add", "--transport", "stdio", "--scope", opts.Scope, setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
+		return setupExecCommand("claude", "mcp", "add", "--transport", "stdio", "--scope", opts.Scope, setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio", "--data-dir", opts.DataDir)
 	case "codex":
 		if opts.Scope == "project" {
-			return upsertCodexProjectMCP(setupClientConfigPath(opts), bin)
+			return upsertCodexProjectMCP(setupClientConfigPath(opts), bin, opts.DataDir)
 		}
-		return setupExecCommand("codex", "mcp", "add", setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
+		return setupExecCommand("codex", "mcp", "add", setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio", "--data-dir", opts.DataDir)
 	default:
 		return fmt.Errorf("unsupported target %q", opts.Target)
 	}
@@ -398,14 +511,22 @@ func removeSetupHook(opts setupOptions, bin string) error {
 }
 
 func setupMCPInstalled(opts setupOptions, path string) bool {
-	if opts.Target == "claude-code" && opts.Scope == "user" {
-		return fileContains(path, setupMCPServerName)
+	if opts.Target == "codex" && opts.Scope == "project" {
+		return codexProjectMCPInstalled(path, opts.DataDir)
 	}
 	return fileContains(path, setupMCPServerName)
 }
 
 func setupHookInstalled(opts setupOptions, path, bin string) bool {
-	return fileContains(path, setupHookCommand(opts, bin))
+	root, err := readJSONObject(path)
+	if err != nil {
+		return false
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return hookCommandPresent(arrayValue(hooks, "PreToolUse"), setupHookCommand(opts, bin))
 }
 
 func setupQuickstartProfile(target string) string {
@@ -419,12 +540,12 @@ func setupClientConfigPath(opts setupOptions) string {
 	switch opts.Target {
 	case "claude-code":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".mcp.json")
+			return filepath.Join(opts.Workspace, ".mcp.json")
 		}
 		return filepath.Join(homeDirOrDot(), ".claude.json")
 	case "codex":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".codex", "config.toml")
+			return filepath.Join(opts.Workspace, ".codex", "config.toml")
 		}
 		return filepath.Join(homeDirOrDot(), ".codex", "config.toml")
 	default:
@@ -436,12 +557,12 @@ func setupHookConfigPath(opts setupOptions) string {
 	switch opts.Target {
 	case "claude-code":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".claude", "settings.json")
+			return filepath.Join(opts.Workspace, ".claude", "settings.json")
 		}
 		return filepath.Join(homeDirOrDot(), ".claude", "settings.json")
 	case "codex":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".codex", "hooks.json")
+			return filepath.Join(opts.Workspace, ".codex", "hooks.json")
 		}
 		return filepath.Join(homeDirOrDot(), ".codex", "hooks.json")
 	default:
@@ -546,14 +667,11 @@ func readJSONObject(path string) (map[string]any, error) {
 }
 
 func writeJSONObject(path string, root map[string]any) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
-	}
 	data, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o600)
+	return writePrivateFileAtomic(path, append(data, '\n'))
 }
 
 func objectValue(root map[string]any, key string) map[string]any {
@@ -600,24 +718,27 @@ func hookCommandFromAny(v any) string {
 	return command
 }
 
-func upsertCodexProjectMCP(path, bin string) error {
+func upsertCodexProjectMCP(path, bin, dataDir string) error {
 	current := ""
 	if raw, err := os.ReadFile(path); err == nil {
 		current = string(raw)
+		if err := validateCodexProjectTOML(current); err != nil {
+			return fmt.Errorf("parse existing Codex config: %w", err)
+		}
 	} else if !os.IsNotExist(err) {
 		return err
 	}
 	current = removeTOMLTable(current, "[mcp_servers."+setupMCPServerName+"]")
-	block := fmt.Sprintf("[mcp_servers.%s]\ncommand = %q\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\"]\n", setupMCPServerName, bin)
+	block := fmt.Sprintf("[mcp_servers.%s]\ncommand = %q\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", %q]\n", setupMCPServerName, bin, dataDir)
 	next := strings.TrimRight(current, "\n")
 	if next != "" {
 		next += "\n\n"
 	}
 	next += block
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
+	if err := validateCodexProjectTOML(next); err != nil {
+		return fmt.Errorf("validate updated Codex config: %w", err)
 	}
-	return os.WriteFile(path, []byte(next), 0o600)
+	return writePrivateFileAtomic(path, []byte(next))
 }
 
 func removeCodexProjectMCP(path string) error {
@@ -628,8 +749,85 @@ func removeCodexProjectMCP(path string) error {
 	if err != nil {
 		return err
 	}
-	next := removeTOMLTable(string(raw), "[mcp_servers."+setupMCPServerName+"]")
-	return os.WriteFile(path, []byte(strings.TrimRight(next, "\n")+"\n"), 0o600)
+	if err := validateCodexProjectTOML(string(raw)); err != nil {
+		return fmt.Errorf("parse existing Codex config: %w", err)
+	}
+	next := strings.TrimRight(removeTOMLTable(string(raw), "[mcp_servers."+setupMCPServerName+"]"), "\n") + "\n"
+	if err := validateCodexProjectTOML(next); err != nil {
+		return fmt.Errorf("validate updated Codex config: %w", err)
+	}
+	return writePrivateFileAtomic(path, []byte(next))
+}
+
+type codexProjectConfig struct {
+	MCPServers map[string]codexMCPServer `toml:"mcp_servers"`
+}
+
+type codexMCPServer struct {
+	Command string   `toml:"command"`
+	Args    []string `toml:"args"`
+}
+
+func validateCodexProjectTOML(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var config map[string]any
+	_, err := toml.Decode(raw, &config)
+	return err
+}
+
+func codexProjectMCPInstalled(path, dataDir string) bool {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var config codexProjectConfig
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		return false
+	}
+	server, ok := config.MCPServers[setupMCPServerName]
+	if !ok || strings.TrimSpace(server.Command) == "" {
+		return false
+	}
+	wantArgs := []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}
+	return len(server.Args) == len(wantArgs) && equalSetupStrings(server.Args, wantArgs)
+}
+
+func equalSetupStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func writePrivateFileAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".helm-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func removeTOMLTable(input, table string) string {

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/BurntSushi/toml"
 )
 
 func TestSetupNoArgsPrintsChooser(t *testing.T) {
@@ -168,16 +170,15 @@ func TestSetupInstallClaudeWritesHookAndRunsQuickstart(t *testing.T) {
 
 func TestSetupInstallJSONKeepsQuickstartOutputOffStdout(t *testing.T) {
 	tmp := t.TempDir()
-	oldWD, _ := os.Getwd()
-	if err := os.Chdir(tmp); err != nil {
+	workspace := filepath.Join(tmp, "workspace")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 	stubSetupSideEffects(t)
 
 	var stdout, stderr bytes.Buffer
 	dataDir := filepath.Join(tmp, "helm")
-	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--workspace", workspace, "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("setup exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
 	}
@@ -197,32 +198,78 @@ func TestSetupInstallJSONKeepsQuickstartOutputOffStdout(t *testing.T) {
 
 func TestSetupCodexProjectRemoveUndoLocalConfig(t *testing.T) {
 	tmp := t.TempDir()
-	oldWD, _ := os.Getwd()
-	if err := os.Chdir(tmp); err != nil {
+	workspace := filepath.Join(tmp, "workspace")
+	if err := os.MkdirAll(filepath.Join(workspace, ".codex"), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("resolve workspace: %v", err)
+	}
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	if err := os.WriteFile(configPath, []byte("model = \"gpt-5\"\n\n[mcp_servers.other]\ncommand = \"other-mcp\"\nargs = [\"serve\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hookPath := filepath.Join(workspace, ".codex", "hooks.json")
+	if err := os.WriteFile(hookPath, []byte("{\"hooks\":{\"PreToolUse\":[{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"other-hook\"}]}]}}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	restore := stubSetupSideEffects(t)
 
 	var stdout, stderr bytes.Buffer
 	dataDir := filepath.Join(tmp, "helm")
-	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--workspace", workspace, "--yes", "--no-quickstart", "--json", "--data-dir", dataDir}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("setup exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
 	}
 	if len(restore.execCalls) != 0 {
 		t.Fatalf("codex project setup should write config directly, exec calls = %#v", restore.execCalls)
 	}
-	codexConfig := filepath.Join(tmp, ".codex", "config.toml")
-	raw, err := os.ReadFile(codexConfig)
+	var installed setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &installed); err != nil {
+		t.Fatalf("decode setup summary: %v\n%s", err, stdout.String())
+	}
+	if installed.Workspace != canonicalWorkspace || installed.KernelURL != "" || installed.QuickstartStarted {
+		t.Fatalf("unexpected headless setup summary: %#v", installed)
+	}
+	if len(restore.quickstartArgs) != 0 {
+		t.Fatalf("--no-quickstart invoked Quickstart: %#v", restore.quickstartArgs)
+	}
+	if installed.Operation != "install" {
+		t.Fatalf("operation = %q, want install", installed.Operation)
+	}
+	invRaw, err := os.ReadFile(filepath.Join(dataDir, "autoconfigure", "inventory.json"))
+	if err != nil {
+		t.Fatalf("read inventory: %v", err)
+	}
+	var inventory AutoconfigureInventory
+	if err := json.Unmarshal(invRaw, &inventory); err != nil {
+		t.Fatalf("decode inventory: %v", err)
+	}
+	if inventory.ScanRoot != canonicalWorkspace {
+		t.Fatalf("scan root = %q, want selected workspace %q", inventory.ScanRoot, canonicalWorkspace)
+	}
+	if !setupMCPInstalled(setupOptions{Target: "codex", Scope: "project", Workspace: workspace, WorkspaceSet: true, DataDir: dataDir}, configPath) {
+		t.Fatal("semantic status did not recognize the installed Codex MCP server")
+	}
+
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read codex config: %v", err)
 	}
 	if !strings.Contains(string(raw), "[mcp_servers.helm-ai-kernel-governance]") {
 		t.Fatalf("codex config missing MCP table:\n%s", string(raw))
 	}
-	hookConfig := filepath.Join(tmp, ".codex", "hooks.json")
-	raw, err = os.ReadFile(hookConfig)
+	var config codexProjectConfig
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		t.Fatalf("parse codex config: %v\n%s", err, raw)
+	}
+	server := config.MCPServers[setupMCPServerName]
+	wantArgs := []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}
+	if !equalSetupStrings(server.Args, wantArgs) {
+		t.Fatalf("MCP args = %#v, want %#v", server.Args, wantArgs)
+	}
+	raw, err = os.ReadFile(hookPath)
 	if err != nil {
 		t.Fatalf("read hook config: %v", err)
 	}
@@ -232,23 +279,97 @@ func TestSetupCodexProjectRemoveUndoLocalConfig(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code = Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	code = Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--workspace", workspace, "--no-quickstart", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("status exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	var status setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("decode status summary: %v\n%s", err, stdout.String())
+	}
+	if !status.MCPInstalled || !status.HookInstalled || status.KernelURL != "" {
+		t.Fatalf("unexpected setup status: %#v", status)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--yes", "--no-quickstart", "--json", "--data-dir", dataDir}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("remove exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
 	}
-	raw, err = os.ReadFile(codexConfig)
+	raw, err = os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read codex config after remove: %v", err)
 	}
 	if strings.Contains(string(raw), "helm-ai-kernel-governance") {
 		t.Fatalf("codex config still contains HELM server:\n%s", string(raw))
 	}
-	raw, err = os.ReadFile(hookConfig)
+	if !strings.Contains(string(raw), "[mcp_servers.other]") || !strings.Contains(string(raw), "model = \"gpt-5\"") {
+		t.Fatalf("remove did not preserve unrelated Codex config:\n%s", string(raw))
+	}
+	raw, err = os.ReadFile(hookPath)
 	if err != nil {
 		t.Fatalf("read hook config after remove: %v", err)
 	}
 	if strings.Contains(string(raw), "hook pre-tool --client codex") {
 		t.Fatalf("hook config still contains HELM command:\n%s", string(raw))
+	}
+	if !strings.Contains(string(raw), "other-hook") {
+		t.Fatalf("remove did not preserve unrelated Codex hook:\n%s", string(raw))
+	}
+}
+
+func TestSetupProjectScopeRequiresExplicitWorkspace(t *testing.T) {
+	tmp := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--dry-run", "--json", "--data-dir", filepath.Join(tmp, "helm")}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "requires an explicit --workspace") {
+		t.Fatalf("project setup without workspace code=%d stderr=%s", code, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "user", "--workspace", tmp, "--dry-run", "--json", "--data-dir", filepath.Join(tmp, "helm")}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "only valid with --scope project") {
+		t.Fatalf("user setup with workspace code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestSetupCodexProjectRejectsMalformedConfigWithoutOverwriting(t *testing.T) {
+	tmp := t.TempDir()
+	workspace := filepath.Join(tmp, "workspace")
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	invalid := "[mcp_servers\ncommand = \"broken\"\n"
+	if err := os.WriteFile(configPath, []byte(invalid), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stubSetupSideEffects(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--workspace", workspace, "--yes", "--no-quickstart", "--data-dir", filepath.Join(tmp, "helm")}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "parse existing Codex config") {
+		t.Fatalf("malformed config setup code=%d stderr=%s", code, stderr.String())
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != invalid {
+		t.Fatalf("malformed config was changed:\n%s", raw)
+	}
+}
+
+func TestLocalMCPRuntimeUsesExplicitDataDir(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "kernel-store")
+	if _, _, err := newLocalMCPRuntimeWithDataDir(dataDir); err != nil {
+		t.Fatalf("create local MCP runtime: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "root.key")); err != nil {
+		t.Fatalf("custom MCP data dir did not receive the signer root key: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

Adds a Desktop-only `/_helm/desktop-ready` route, enabled only when the native shell supplies a per-launch token. The route returns a nonce-bound HMAC proof and never accepts or exposes the Kernel admin credential.

## Why

The Desktop shell must prove that the loopback process is the Kernel it launched before passing a Kernel credential to the Console.

## Validation

- `go test ./core/cmd/helm-ai-kernel -count=1` (Go 1.22.12)
- live HMAC probe against a freshly built Kernel binary

## Dependency

Required by the HELM Desktop packaged-sidecar repair. This is intentionally draft while the companion Desktop/Console PRs remain in review.