### PR TITLE
feat(release-permit): add deterministic machine quorum reducer

### DIFF
--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/releasepermit"
+)
+
+const maxInputBytes = 2 << 20
+
+type repeatedFlag []string
+
+func (values *repeatedFlag) String() string { return fmt.Sprint([]string(*values)) }
+func (values *repeatedFlag) Set(value string) error {
+	*values = append(*values, value)
+	return nil
+}
+
+func main() {
+	var contextPath string
+	var outputPath string
+	var reviewPaths repeatedFlag
+	flag.StringVar(&contextPath, "context", "", "path to release-permit context JSON")
+	flag.Var(&reviewPaths, "review", "path to review JSON; provide once per required reviewer")
+	flag.StringVar(&outputPath, "output", "release-permit.json", "path for the permit JSON")
+	flag.Parse()
+
+	if contextPath == "" || len(reviewPaths) == 0 || outputPath == "" {
+		fatal(errors.New("--context, at least one --review, and --output are required"))
+	}
+
+	var context releasepermit.Context
+	if err := decodeStrictFile(contextPath, &context); err != nil {
+		fatal(fmt.Errorf("read context: %w", err))
+	}
+	reviews := make([]releasepermit.Review, 0, len(reviewPaths))
+	for _, path := range reviewPaths {
+		var review releasepermit.Review
+		if err := decodeStrictFile(path, &review); err != nil {
+			fatal(fmt.Errorf("read review %q: %w", path, err))
+		}
+		reviews = append(reviews, review)
+	}
+
+	permit, err := releasepermit.Evaluate(context, reviews)
+	if err != nil {
+		fatal(fmt.Errorf("evaluate release permit: %w", err))
+	}
+	encoded, err := json.MarshalIndent(permit, "", "  ")
+	if err != nil {
+		fatal(fmt.Errorf("encode release permit: %w", err))
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(outputPath, encoded, 0o644); err != nil {
+		fatal(fmt.Errorf("write release permit: %w", err))
+	}
+	if _, err := os.Stdout.Write(encoded); err != nil {
+		fatal(fmt.Errorf("print release permit: %w", err))
+	}
+	if permit.Decision != releasepermit.DecisionAllow {
+		os.Exit(3)
+	}
+}
+
+func decodeStrictFile(path string, destination any) error {
+	// #nosec G304 -- paths are explicit command inputs in a protected workflow.
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if len(content) > maxInputBytes {
+		return fmt.Errorf("input exceeds %d bytes", maxInputBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("input contains more than one JSON value")
+		}
+		return fmt.Errorf("read trailing data: %w", err)
+	}
+	return nil
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "release-permit-verify:", err)
+	os.Exit(2)
+}

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -204,7 +204,8 @@ func validateExactShape(content []byte, destination any) error {
 		}
 	case *releasepermit.Review:
 		if err := requireKeys(root, []string{
-			"schema", "repository", "pull_request", "base_sha", "head_sha", "workflow_sha",
+			"schema", "repository", "pull_request", "base_sha", "head_sha", "merge_sha",
+			"merge_tree_sha", "workflow_sha",
 			"run_id", "run_attempt", "context_sha256", "reviewer", "verdict",
 			"response_sha256", "findings",
 		}, nil, "review"); err != nil {

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/releasepermit"
 )
@@ -36,19 +40,22 @@ func main() {
 	}
 
 	var context releasepermit.Context
-	if err := decodeStrictFile(contextPath, &context); err != nil {
+	contextContent, err := decodeStrictFile(contextPath, &context)
+	if err != nil {
 		fatal(fmt.Errorf("read context: %w", err))
 	}
+	contextDigest := sha256.Sum256(contextContent)
+	contextSHA256 := hex.EncodeToString(contextDigest[:])
 	reviews := make([]releasepermit.Review, 0, len(reviewPaths))
 	for _, path := range reviewPaths {
 		var review releasepermit.Review
-		if err := decodeStrictFile(path, &review); err != nil {
+		if _, err := decodeStrictFile(path, &review); err != nil {
 			fatal(fmt.Errorf("read review %q: %w", path, err))
 		}
 		reviews = append(reviews, review)
 	}
 
-	permit, err := releasepermit.Evaluate(context, reviews)
+	permit, err := releasepermit.Evaluate(context, contextSHA256, reviews)
 	if err != nil {
 		fatal(fmt.Errorf("evaluate release permit: %w", err))
 	}
@@ -68,28 +75,235 @@ func main() {
 	}
 }
 
-func decodeStrictFile(path string, destination any) error {
+func decodeStrictFile(path string, destination any) ([]byte, error) {
 	// #nosec G304 -- paths are explicit command inputs in a protected workflow.
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(content) > maxInputBytes {
-		return fmt.Errorf("input exceeds %d bytes", maxInputBytes)
+		return nil, fmt.Errorf("input exceeds %d bytes", maxInputBytes)
+	}
+	if !json.Valid(content) {
+		return nil, errors.New("input is not exactly one valid JSON value")
+	}
+	if err := rejectDuplicateKeys(content); err != nil {
+		return nil, err
+	}
+	if err := validateExactShape(content, destination); err != nil {
+		return nil, err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(content))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(destination); err != nil {
-		return err
+		return nil, err
 	}
 	var trailing any
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
 		if err == nil {
+			return nil, errors.New("input contains more than one JSON value")
+		}
+		return nil, fmt.Errorf("read trailing data: %w", err)
+	}
+	return content, nil
+}
+
+func rejectDuplicateKeys(content []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
+	if err := scanJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
 			return errors.New("input contains more than one JSON value")
 		}
-		return fmt.Errorf("read trailing data: %w", err)
+		return fmt.Errorf("read trailing token: %w", err)
 	}
 	return nil
+}
+
+func scanJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		seen := map[string]struct{}{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("object key is not a string")
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return fmt.Errorf("duplicate JSON key %q", key)
+			}
+			seen[key] = struct{}{}
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return errors.New("object did not end with }")
+		}
+	case '[':
+		for decoder.More() {
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return errors.New("array did not end with ]")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+	return nil
+}
+
+func validateExactShape(content []byte, destination any) error {
+	root, err := decodeObject(content, "root")
+	if err != nil {
+		return err
+	}
+	switch destination.(type) {
+	case *releasepermit.Context:
+		if err := requireKeys(root, []string{
+			"schema", "repository", "event", "pull_request", "base_ref", "base_sha",
+			"head_sha", "merge_sha", "merge_tree_sha", "workflow_repository",
+			"workflow_path", "workflow_ref", "workflow_sha", "run_id", "run_attempt",
+			"issued_at", "required_reviewers",
+		}, nil, "context"); err != nil {
+			return err
+		}
+		reviewers, err := decodeArray(root["required_reviewers"], "required_reviewers")
+		if err != nil {
+			return err
+		}
+		for index, raw := range reviewers {
+			if err := validateReviewer(raw, fmt.Sprintf("required_reviewers[%d]", index)); err != nil {
+				return err
+			}
+		}
+	case *releasepermit.Review:
+		if err := requireKeys(root, []string{
+			"schema", "repository", "pull_request", "base_sha", "head_sha", "workflow_sha",
+			"run_id", "run_attempt", "context_sha256", "reviewer", "verdict",
+			"response_sha256", "findings",
+		}, nil, "review"); err != nil {
+			return err
+		}
+		if err := validateReviewer(root["reviewer"], "reviewer"); err != nil {
+			return err
+		}
+		findings, err := decodeArray(root["findings"], "findings")
+		if err != nil {
+			return err
+		}
+		for index, raw := range findings {
+			finding, err := decodeObject(raw, fmt.Sprintf("findings[%d]", index))
+			if err != nil {
+				return err
+			}
+			if err := requireKeys(
+				finding,
+				[]string{"severity", "code", "summary"},
+				[]string{"path", "line"},
+				fmt.Sprintf("findings[%d]", index),
+			); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported strict JSON destination %T", destination)
+	}
+	return nil
+}
+
+func validateReviewer(raw json.RawMessage, label string) error {
+	reviewer, err := decodeObject(raw, label)
+	if err != nil {
+		return err
+	}
+	return requireKeys(reviewer, []string{"provider", "model"}, nil, label)
+}
+
+func decodeObject(content []byte, label string) (map[string]json.RawMessage, error) {
+	if trimmed := bytes.TrimSpace(content); len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, fmt.Errorf("%s must be an object", label)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(content, &object); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", label, err)
+	}
+	return object, nil
+}
+
+func decodeArray(content []byte, label string) ([]json.RawMessage, error) {
+	if trimmed := bytes.TrimSpace(content); len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil, fmt.Errorf("%s must be an explicit array", label)
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(content, &values); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", label, err)
+	}
+	return values, nil
+}
+
+func requireKeys(
+	object map[string]json.RawMessage,
+	required []string,
+	optional []string,
+	label string,
+) error {
+	requiredSet := make(map[string]struct{}, len(required))
+	allowed := make(map[string]struct{}, len(required)+len(optional))
+	for _, key := range required {
+		requiredSet[key] = struct{}{}
+		allowed[key] = struct{}{}
+	}
+	for _, key := range optional {
+		allowed[key] = struct{}{}
+	}
+	var missing, unexpected []string
+	for key := range requiredSet {
+		if _, ok := object[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	for key := range object {
+		if _, ok := allowed[key]; !ok {
+			unexpected = append(unexpected, key)
+		}
+	}
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return fmt.Errorf(
+		"%s keys invalid; missing=%s unexpected=%s",
+		label,
+		strings.Join(missing, ","),
+		strings.Join(unexpected, ","),
+	)
 }
 
 func fatal(err error) {

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -69,5 +69,5 @@ func writeJSONFixture(t *testing.T, content string) string {
 }
 
 func validReviewJSON() string {
-	return `{"schema":"mindburn.release-review/v1","repository":"Mindburn-Labs/example","pull_request":42,"base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"context_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","reviewer":{"provider":"anthropic","model":"claude-fable-5"},"verdict":"ALLOW","response_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","findings":[]}`
+	return `{"schema":"mindburn.release-review/v1","repository":"Mindburn-Labs/example","pull_request":42,"base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","merge_sha":"4444444444444444444444444444444444444444","merge_tree_sha":"5555555555555555555555555555555555555555","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"context_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","reviewer":{"provider":"anthropic","model":"claude-fable-5"},"verdict":"ALLOW","response_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","findings":[]}`
 }

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/releasepermit"
+)
+
+func TestDecodeStrictReviewAcceptsExactShape(t *testing.T) {
+	var review releasepermit.Review
+	if _, err := decodeStrictFile(writeJSONFixture(t, validReviewJSON()), &review); err != nil {
+		t.Fatalf("decodeStrictFile() error = %v", err)
+	}
+	if review.Findings == nil {
+		t.Fatal("Findings = nil, want explicit empty array")
+	}
+}
+
+func TestDecodeStrictReviewRejectsAmbiguousShapes(t *testing.T) {
+	valid := validReviewJSON()
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "duplicate key",
+			content: strings.Replace(valid, `"verdict":"ALLOW"`, `"verdict":"ALLOW","verdict":"DENY"`, 1),
+			want:    `duplicate JSON key "verdict"`,
+		},
+		{
+			name:    "case folded key",
+			content: strings.Replace(valid, `"verdict":"ALLOW"`, `"Verdict":"ALLOW"`, 1),
+			want:    "keys invalid",
+		},
+		{
+			name:    "null findings",
+			content: strings.Replace(valid, `"findings":[]`, `"findings":null`, 1),
+			want:    "findings must be an explicit array",
+		},
+		{
+			name:    "missing findings",
+			content: strings.Replace(valid, `,"findings":[]`, "", 1),
+			want:    "missing=findings",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var review releasepermit.Review
+			_, err := decodeStrictFile(writeJSONFixture(t, test.content), &review)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("decodeStrictFile() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func writeJSONFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func validReviewJSON() string {
+	return `{"schema":"mindburn.release-review/v1","repository":"Mindburn-Labs/example","pull_request":42,"base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"context_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","reviewer":{"provider":"anthropic","model":"claude-fable-5"},"verdict":"ALLOW","response_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","findings":[]}`
+}

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -22,9 +22,12 @@ var (
 // permit. A structurally invalid context is an error because no trustworthy
 // decision can be bound to it. Invalid, stale, missing, or denying reviews
 // produce a well-formed DENY permit.
-func Evaluate(context Context, reviews []Review) (Permit, error) {
+func Evaluate(context Context, contextSHA256 string, reviews []Review) (Permit, error) {
 	if err := validateContext(context); err != nil {
 		return Permit{}, err
+	}
+	if !hexSHA256Pattern.MatchString(contextSHA256) {
+		return Permit{}, errors.New("context_sha256 must be lowercase hexadecimal")
 	}
 
 	permit := Permit{
@@ -35,6 +38,8 @@ func Evaluate(context Context, reviews []Review) (Permit, error) {
 		BaseRef:            context.BaseRef,
 		BaseSHA:            context.BaseSHA,
 		HeadSHA:            context.HeadSHA,
+		MergeSHA:           context.MergeSHA,
+		MergeTreeSHA:       context.MergeTreeSHA,
 		WorkflowRepository: context.WorkflowRepository,
 		WorkflowPath:       context.WorkflowPath,
 		WorkflowRef:        context.WorkflowRef,
@@ -42,6 +47,7 @@ func Evaluate(context Context, reviews []Review) (Permit, error) {
 		RunID:              context.RunID,
 		RunAttempt:         context.RunAttempt,
 		IssuedAt:           context.IssuedAt,
+		ContextSHA256:      contextSHA256,
 		Reviews:            make([]ReviewSummary, 0, len(context.RequiredReviewers)),
 		Reasons:            []Reason{},
 	}
@@ -51,28 +57,33 @@ func Evaluate(context Context, reviews []Review) (Permit, error) {
 		required[reviewerKey(reviewer)] = reviewer
 	}
 
-	provided := make(map[string]Review, len(reviews))
+	provided := make(map[string][]Review, len(reviews))
 	for _, review := range reviews {
 		key := reviewerKey(review.Reviewer)
-		if _, exists := provided[key]; exists {
-			permit.addReason("REVIEW_DUPLICATE", key, "more than one review used the same provider and model")
-			continue
-		}
-		provided[key] = review
+		provided[key] = append(provided[key], review)
 		if _, expected := required[key]; !expected {
 			permit.addReason("REVIEW_UNEXPECTED", key, "reviewer is not part of the required quorum")
+		}
+	}
+	for key, group := range provided {
+		if len(group) > 1 {
+			permit.addReason("REVIEW_DUPLICATE", key, "more than one review used the same provider and model")
 		}
 	}
 
 	for _, expected := range context.RequiredReviewers {
 		key := reviewerKey(expected)
-		review, ok := provided[key]
-		if !ok {
+		group := provided[key]
+		if len(group) == 0 {
 			permit.addReason("REVIEW_MISSING", key, "required reviewer did not produce a result")
 			continue
 		}
+		if len(group) > 1 {
+			permit.addReason("REVIEW_MISSING", key, "required reviewer did not produce one unique result")
+			continue
+		}
 
-		summary, reasons := validateReview(context, review)
+		summary, reasons := validateReview(context, contextSHA256, group[0])
 		permit.Reviews = append(permit.Reviews, summary)
 		for _, reason := range reasons {
 			permit.addReason(reason.Code, reason.Reviewer, reason.Detail)
@@ -129,6 +140,12 @@ func validateContext(context Context) error {
 	if !hexSHA40Pattern.MatchString(context.HeadSHA) {
 		problems = append(problems, "head_sha must be a lowercase 40-character Git SHA")
 	}
+	if !hexSHA40Pattern.MatchString(context.MergeSHA) {
+		problems = append(problems, "merge_sha must be a lowercase 40-character Git SHA")
+	}
+	if !hexSHA40Pattern.MatchString(context.MergeTreeSHA) {
+		problems = append(problems, "merge_tree_sha must be a lowercase 40-character Git SHA")
+	}
 	if !repositoryPattern.MatchString(context.WorkflowRepository) {
 		problems = append(problems, "invalid workflow_repository")
 	}
@@ -174,7 +191,7 @@ func validateContext(context Context) error {
 	return nil
 }
 
-func validateReview(context Context, review Review) (ReviewSummary, []Reason) {
+func validateReview(context Context, contextSHA256 string, review Review) (ReviewSummary, []Reason) {
 	key := reviewerKey(review.Reviewer)
 	summary := ReviewSummary{
 		Reviewer:       review.Reviewer,
@@ -198,6 +215,9 @@ func validateReview(context Context, review Review) (ReviewSummary, []Reason) {
 		review.RunAttempt != context.RunAttempt {
 		add("REVIEW_METADATA_MISMATCH", "review is not bound to the requested repository, commit, workflow, and run")
 	}
+	if review.ContextSHA256 != contextSHA256 {
+		add("REVIEW_CONTEXT_MISMATCH", "review is not bound to the complete permit context")
+	}
 	if !hexSHA256Pattern.MatchString(review.ResponseSHA256) {
 		add("REVIEW_DIGEST_INVALID", "response_sha256 must be lowercase hexadecimal")
 	}
@@ -206,8 +226,8 @@ func validateReview(context Context, review Review) (ReviewSummary, []Reason) {
 	} else if review.Verdict == DecisionDeny {
 		add("REVIEW_DENIED", "reviewer denied the proposed change")
 	}
-	if len(review.Findings) > 200 {
-		add("REVIEW_FINDINGS_INVALID", "review contains more than 200 findings")
+	if review.Findings == nil || len(review.Findings) > 200 {
+		add("REVIEW_FINDINGS_INVALID", "review findings must be an explicit array of at most 200 items")
 	}
 	for _, finding := range review.Findings {
 		if finding.Code == "" || finding.Summary == "" || len(finding.Code) > 120 || len(finding.Summary) > 2000 {

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -168,6 +168,10 @@ func validateContext(context Context) error {
 	if !hexSHA40Pattern.MatchString(context.WorkflowSHA) {
 		problems = append(problems, "workflow_sha must be a lowercase 40-character Git SHA")
 	}
+	if context.Repository == context.WorkflowRepository &&
+		(context.WorkflowSHA == context.HeadSHA || context.WorkflowSHA == context.MergeSHA) {
+		problems = append(problems, "authority workflow cannot review its own head or merge commit")
+	}
 	if context.RunID <= 0 || context.RunAttempt <= 0 {
 		problems = append(problems, "run_id and run_attempt must be positive")
 	}

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -61,6 +61,10 @@ func Evaluate(context Context, contextSHA256 string, reviews []Review) (Permit, 
 	for _, review := range reviews {
 		key := reviewerKey(review.Reviewer)
 		provided[key] = append(provided[key], review)
+		if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
+			strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
+			permit.addReason("REVIEW_REVIEWER_INVALID", key, "reviewer provider and model must be non-empty and cannot contain slash")
+		}
 		if _, expected := required[key]; !expected {
 			permit.addReason("REVIEW_UNEXPECTED", key, "reviewer is not part of the required quorum")
 		}
@@ -153,7 +157,12 @@ func validateContext(context Context) error {
 		(!strings.HasSuffix(context.WorkflowPath, ".yml") && !strings.HasSuffix(context.WorkflowPath, ".yaml")) {
 		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
 	}
-	if !strings.HasPrefix(context.WorkflowRef, "refs/heads/") && !strings.HasPrefix(context.WorkflowRef, "refs/tags/") {
+	workflowRef := context.WorkflowRef
+	workflowIdentityPrefix := context.WorkflowRepository + "/" + context.WorkflowPath + "@"
+	if strings.HasPrefix(workflowRef, workflowIdentityPrefix) {
+		workflowRef = strings.TrimPrefix(workflowRef, workflowIdentityPrefix)
+	}
+	if !strings.HasPrefix(workflowRef, "refs/heads/") && !strings.HasPrefix(workflowRef, "refs/tags/") {
 		problems = append(problems, "workflow_ref must be a branch or tag ref")
 	}
 	if !hexSHA40Pattern.MatchString(context.WorkflowSHA) {
@@ -174,6 +183,9 @@ func validateContext(context Context) error {
 			key := reviewerKey(reviewer)
 			if reviewer.Provider == "" || reviewer.Model == "" {
 				problems = append(problems, "reviewer provider and model are required")
+			}
+			if strings.Contains(reviewer.Provider, "/") || strings.Contains(reviewer.Model, "/") {
+				problems = append(problems, "reviewer provider and model cannot contain slash")
 			}
 			if seenKeys[key] {
 				problems = append(problems, "required reviewers must be unique")
@@ -205,6 +217,10 @@ func validateReview(context Context, contextSHA256 string, review Review) (Revie
 
 	if review.Schema != ReviewSchema {
 		add("REVIEW_SCHEMA_INVALID", "unsupported review schema")
+	}
+	if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
+		strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
+		add("REVIEW_REVIEWER_INVALID", "reviewer provider and model must be non-empty and cannot contain slash")
 	}
 	if review.Repository != context.Repository ||
 		review.PullRequest != context.PullRequest ||

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -226,6 +226,8 @@ func validateReview(context Context, contextSHA256 string, review Review) (Revie
 		review.PullRequest != context.PullRequest ||
 		review.BaseSHA != context.BaseSHA ||
 		review.HeadSHA != context.HeadSHA ||
+		review.MergeSHA != context.MergeSHA ||
+		review.MergeTreeSHA != context.MergeTreeSHA ||
 		review.WorkflowSHA != context.WorkflowSHA ||
 		review.RunID != context.RunID ||
 		review.RunAttempt != context.RunAttempt {

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -1,0 +1,247 @@
+package releasepermit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	repositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+	hexSHA40Pattern   = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	hexSHA256Pattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+// Evaluate validates a two-provider review quorum and returns a deterministic
+// permit. A structurally invalid context is an error because no trustworthy
+// decision can be bound to it. Invalid, stale, missing, or denying reviews
+// produce a well-formed DENY permit.
+func Evaluate(context Context, reviews []Review) (Permit, error) {
+	if err := validateContext(context); err != nil {
+		return Permit{}, err
+	}
+
+	permit := Permit{
+		Schema:             PermitSchema,
+		Decision:           DecisionAllow,
+		Repository:         context.Repository,
+		PullRequest:        context.PullRequest,
+		BaseRef:            context.BaseRef,
+		BaseSHA:            context.BaseSHA,
+		HeadSHA:            context.HeadSHA,
+		WorkflowRepository: context.WorkflowRepository,
+		WorkflowPath:       context.WorkflowPath,
+		WorkflowRef:        context.WorkflowRef,
+		WorkflowSHA:        context.WorkflowSHA,
+		RunID:              context.RunID,
+		RunAttempt:         context.RunAttempt,
+		IssuedAt:           context.IssuedAt,
+		Reviews:            make([]ReviewSummary, 0, len(context.RequiredReviewers)),
+		Reasons:            []Reason{},
+	}
+
+	required := make(map[string]Reviewer, len(context.RequiredReviewers))
+	for _, reviewer := range context.RequiredReviewers {
+		required[reviewerKey(reviewer)] = reviewer
+	}
+
+	provided := make(map[string]Review, len(reviews))
+	for _, review := range reviews {
+		key := reviewerKey(review.Reviewer)
+		if _, exists := provided[key]; exists {
+			permit.addReason("REVIEW_DUPLICATE", key, "more than one review used the same provider and model")
+			continue
+		}
+		provided[key] = review
+		if _, expected := required[key]; !expected {
+			permit.addReason("REVIEW_UNEXPECTED", key, "reviewer is not part of the required quorum")
+		}
+	}
+
+	for _, expected := range context.RequiredReviewers {
+		key := reviewerKey(expected)
+		review, ok := provided[key]
+		if !ok {
+			permit.addReason("REVIEW_MISSING", key, "required reviewer did not produce a result")
+			continue
+		}
+
+		summary, reasons := validateReview(context, review)
+		permit.Reviews = append(permit.Reviews, summary)
+		for _, reason := range reasons {
+			permit.addReason(reason.Code, reason.Reviewer, reason.Detail)
+		}
+	}
+
+	if len(reviews) != len(context.RequiredReviewers) {
+		permit.addReason("REVIEW_COUNT_MISMATCH", "", fmt.Sprintf(
+			"received %d reviews for a %d-reviewer quorum",
+			len(reviews), len(context.RequiredReviewers),
+		))
+	}
+
+	if len(permit.Reasons) > 0 {
+		permit.Decision = DecisionDeny
+	}
+	sort.Slice(permit.Reasons, func(i, j int) bool {
+		left := permit.Reasons[i].Code + "\x00" + permit.Reasons[i].Reviewer + "\x00" + permit.Reasons[i].Detail
+		right := permit.Reasons[j].Code + "\x00" + permit.Reasons[j].Reviewer + "\x00" + permit.Reasons[j].Detail
+		return left < right
+	})
+
+	digestInput := permit
+	digestInput.PermitID = ""
+	encoded, err := json.Marshal(digestInput)
+	if err != nil {
+		return Permit{}, fmt.Errorf("marshal permit digest input: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	permit.PermitID = "sha256:" + hex.EncodeToString(digest[:])
+	return permit, nil
+}
+
+func validateContext(context Context) error {
+	var problems []string
+	if context.Schema != ContextSchema {
+		problems = append(problems, "unsupported context schema")
+	}
+	if !repositoryPattern.MatchString(context.Repository) {
+		problems = append(problems, "invalid repository")
+	}
+	if context.Event != "pull_request" {
+		problems = append(problems, "event must be pull_request")
+	}
+	if context.PullRequest <= 0 {
+		problems = append(problems, "pull_request must be positive")
+	}
+	if !strings.HasPrefix(context.BaseRef, "refs/heads/") {
+		problems = append(problems, "base_ref must be a branch ref")
+	}
+	if !hexSHA40Pattern.MatchString(context.BaseSHA) {
+		problems = append(problems, "base_sha must be a lowercase 40-character Git SHA")
+	}
+	if !hexSHA40Pattern.MatchString(context.HeadSHA) {
+		problems = append(problems, "head_sha must be a lowercase 40-character Git SHA")
+	}
+	if !repositoryPattern.MatchString(context.WorkflowRepository) {
+		problems = append(problems, "invalid workflow_repository")
+	}
+	if !strings.HasPrefix(context.WorkflowPath, ".github/workflows/") ||
+		(!strings.HasSuffix(context.WorkflowPath, ".yml") && !strings.HasSuffix(context.WorkflowPath, ".yaml")) {
+		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
+	}
+	if !strings.HasPrefix(context.WorkflowRef, "refs/heads/") && !strings.HasPrefix(context.WorkflowRef, "refs/tags/") {
+		problems = append(problems, "workflow_ref must be a branch or tag ref")
+	}
+	if !hexSHA40Pattern.MatchString(context.WorkflowSHA) {
+		problems = append(problems, "workflow_sha must be a lowercase 40-character Git SHA")
+	}
+	if context.RunID <= 0 || context.RunAttempt <= 0 {
+		problems = append(problems, "run_id and run_attempt must be positive")
+	}
+	if _, err := time.Parse(time.RFC3339, context.IssuedAt); err != nil {
+		problems = append(problems, "issued_at must be RFC3339")
+	}
+	if len(context.RequiredReviewers) != 2 {
+		problems = append(problems, "exactly two reviewers are required")
+	} else {
+		seenKeys := map[string]bool{}
+		seenProviders := map[string]bool{}
+		for _, reviewer := range context.RequiredReviewers {
+			key := reviewerKey(reviewer)
+			if reviewer.Provider == "" || reviewer.Model == "" {
+				problems = append(problems, "reviewer provider and model are required")
+			}
+			if seenKeys[key] {
+				problems = append(problems, "required reviewers must be unique")
+			}
+			if seenProviders[reviewer.Provider] {
+				problems = append(problems, "required reviewers must use distinct providers")
+			}
+			seenKeys[key] = true
+			seenProviders[reviewer.Provider] = true
+		}
+	}
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func validateReview(context Context, review Review) (ReviewSummary, []Reason) {
+	key := reviewerKey(review.Reviewer)
+	summary := ReviewSummary{
+		Reviewer:       review.Reviewer,
+		Verdict:        review.Verdict,
+		ResponseSHA256: review.ResponseSHA256,
+	}
+	var reasons []Reason
+	add := func(code, detail string) {
+		reasons = append(reasons, Reason{Code: code, Reviewer: key, Detail: detail})
+	}
+
+	if review.Schema != ReviewSchema {
+		add("REVIEW_SCHEMA_INVALID", "unsupported review schema")
+	}
+	if review.Repository != context.Repository ||
+		review.PullRequest != context.PullRequest ||
+		review.BaseSHA != context.BaseSHA ||
+		review.HeadSHA != context.HeadSHA ||
+		review.WorkflowSHA != context.WorkflowSHA ||
+		review.RunID != context.RunID ||
+		review.RunAttempt != context.RunAttempt {
+		add("REVIEW_METADATA_MISMATCH", "review is not bound to the requested repository, commit, workflow, and run")
+	}
+	if !hexSHA256Pattern.MatchString(review.ResponseSHA256) {
+		add("REVIEW_DIGEST_INVALID", "response_sha256 must be lowercase hexadecimal")
+	}
+	if review.Verdict != DecisionAllow && review.Verdict != DecisionDeny {
+		add("REVIEW_VERDICT_INVALID", "verdict must be ALLOW or DENY")
+	} else if review.Verdict == DecisionDeny {
+		add("REVIEW_DENIED", "reviewer denied the proposed change")
+	}
+	if len(review.Findings) > 200 {
+		add("REVIEW_FINDINGS_INVALID", "review contains more than 200 findings")
+	}
+	for _, finding := range review.Findings {
+		if finding.Code == "" || finding.Summary == "" || len(finding.Code) > 120 || len(finding.Summary) > 2000 {
+			add("REVIEW_FINDINGS_INVALID", "finding code and bounded summary are required")
+			continue
+		}
+		if finding.Line < 0 {
+			add("REVIEW_FINDINGS_INVALID", "finding line cannot be negative")
+			continue
+		}
+		switch finding.Severity {
+		case "P0", "P1", "P2":
+			summary.BlockingFindings++
+		case "P3":
+			summary.AdvisoryFindings++
+		default:
+			add("REVIEW_FINDINGS_INVALID", "finding severity must be P0, P1, P2, or P3")
+		}
+	}
+	if summary.BlockingFindings > 0 {
+		add("BLOCKING_FINDING", fmt.Sprintf("review contains %d P0-P2 findings", summary.BlockingFindings))
+	}
+	return summary, reasons
+}
+
+func (permit *Permit) addReason(code, reviewer, detail string) {
+	for _, existing := range permit.Reasons {
+		if existing.Code == code && existing.Reviewer == reviewer && existing.Detail == detail {
+			return
+		}
+	}
+	permit.Reasons = append(permit.Reasons, Reason{Code: code, Reviewer: reviewer, Detail: detail})
+}
+
+func reviewerKey(reviewer Reviewer) string {
+	return reviewer.Provider + "/" + reviewer.Model
+}

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -60,6 +60,18 @@ func TestEvaluateDeniesStaleHead(t *testing.T) {
 	assertDeniedFor(t, permit, "REVIEW_METADATA_MISMATCH")
 }
 
+func TestEvaluateDeniesMergeTreeSubstitution(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].MergeTreeSHA = "6666666666666666666666666666666666666666"
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_METADATA_MISMATCH")
+}
+
 func TestEvaluateDeniesMissingReviewer(t *testing.T) {
 	context := validContext()
 	reviews := validReviews(context)[:1]
@@ -290,6 +302,8 @@ func validReview(context Context, reviewer Reviewer, digest string) Review {
 		PullRequest:    context.PullRequest,
 		BaseSHA:        context.BaseSHA,
 		HeadSHA:        context.HeadSHA,
+		MergeSHA:       context.MergeSHA,
+		MergeTreeSHA:   context.MergeTreeSHA,
 		WorkflowSHA:    context.WorkflowSHA,
 		RunID:          context.RunID,
 		RunAttempt:     context.RunAttempt,

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -146,6 +146,18 @@ func TestEvaluateRejectsMismatchedGitHubWorkflowRefIdentity(t *testing.T) {
 	}
 }
 
+func TestEvaluateRejectsSelfReviewingAuthorityContext(t *testing.T) {
+	for _, authoritySHA := range []string{testHeadSHA, testMergeSHA} {
+		context := validContext()
+		context.Repository = context.WorkflowRepository
+		context.WorkflowSHA = authoritySHA
+
+		if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+			t.Fatalf("Evaluate() error = nil for workflow SHA %q, want self-reviewing authority context error", authoritySHA)
+		}
+	}
+}
+
 func TestEvaluateRejectsAmbiguousReviewerIdentity(t *testing.T) {
 	context := validContext()
 	context.RequiredReviewers[0].Provider = "anthropic/team"

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -112,6 +112,37 @@ func TestEvaluateRejectsInvalidContext(t *testing.T) {
 	}
 }
 
+func TestEvaluateAcceptsGitHubWorkflowRefIdentity(t *testing.T) {
+	context := validContext()
+	context.WorkflowRef = context.WorkflowRepository + "/" + context.WorkflowPath + "@refs/heads/codex/autonomous-release-permit"
+
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if permit.Decision != DecisionAllow {
+		t.Fatalf("Decision = %q, want %q; reasons = %#v", permit.Decision, DecisionAllow, permit.Reasons)
+	}
+}
+
+func TestEvaluateRejectsMismatchedGitHubWorkflowRefIdentity(t *testing.T) {
+	context := validContext()
+	context.WorkflowRef = "Mindburn-Labs/other/.github/workflows/ci.yml@refs/heads/main"
+
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want mismatched workflow identity error")
+	}
+}
+
+func TestEvaluateRejectsAmbiguousReviewerIdentity(t *testing.T) {
+	context := validContext()
+	context.RequiredReviewers[0].Provider = "anthropic/team"
+
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want ambiguous reviewer identity error")
+	}
+}
+
 func TestEvaluatePermitIDIsIndependentOfInputReviewOrder(t *testing.T) {
 	context := validContext()
 	reviews := validReviews(context)
@@ -154,6 +185,70 @@ func TestEvaluateDeniesNilFindings(t *testing.T) {
 		t.Fatalf("Evaluate() error = %v", err)
 	}
 	assertDeniedFor(t, permit, "REVIEW_FINDINGS_INVALID")
+}
+
+func TestEvaluateDeniesInvalidReviewFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Review)
+		code   string
+	}{
+		{
+			name: "empty reviewer",
+			mutate: func(review *Review) {
+				review.Reviewer.Provider = ""
+			},
+			code: "REVIEW_REVIEWER_INVALID",
+		},
+		{
+			name: "invalid verdict",
+			mutate: func(review *Review) {
+				review.Verdict = "MAYBE"
+			},
+			code: "REVIEW_VERDICT_INVALID",
+		},
+		{
+			name: "denied verdict",
+			mutate: func(review *Review) {
+				review.Verdict = DecisionDeny
+			},
+			code: "REVIEW_DENIED",
+		},
+		{
+			name: "invalid response digest",
+			mutate: func(review *Review) {
+				review.ResponseSHA256 = "not-a-digest"
+			},
+			code: "REVIEW_DIGEST_INVALID",
+		},
+		{
+			name: "invalid finding severity",
+			mutate: func(review *Review) {
+				review.Findings = []Finding{{Severity: "P4", Code: "BAD", Summary: "invalid severity"}}
+			},
+			code: "REVIEW_FINDINGS_INVALID",
+		},
+		{
+			name: "too many findings",
+			mutate: func(review *Review) {
+				review.Findings = make([]Finding, 201)
+			},
+			code: "REVIEW_FINDINGS_INVALID",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context := validContext()
+			reviews := validReviews(context)
+			test.mutate(&reviews[0])
+			permit, err := Evaluate(context, testContextSHA, reviews)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			assertDeniedFor(t, permit, test.code)
+		})
+	}
 }
 
 func validContext() Context {

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -1,0 +1,172 @@
+package releasepermit
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	testBaseSHA     = "1111111111111111111111111111111111111111"
+	testHeadSHA     = "2222222222222222222222222222222222222222"
+	testWorkflowSHA = "3333333333333333333333333333333333333333"
+	testResponseA   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testResponseB   = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func TestEvaluateAllowsTwoProviderQuorum(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].Findings = []Finding{{Severity: "P3", Code: "STYLE", Summary: "Non-blocking naming improvement"}}
+
+	permit, err := Evaluate(context, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if permit.Decision != DecisionAllow {
+		t.Fatalf("Decision = %q, want %q; reasons = %#v", permit.Decision, DecisionAllow, permit.Reasons)
+	}
+	if permit.PermitID == "" {
+		t.Fatal("PermitID is empty")
+	}
+	if got := permit.Reviews[0].AdvisoryFindings; got != 1 {
+		t.Fatalf("AdvisoryFindings = %d, want 1", got)
+	}
+}
+
+func TestEvaluateDeniesBlockingFinding(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[1].Findings = []Finding{{Severity: "P1", Code: "AUTH_BYPASS", Summary: "Authorization is bypassed"}}
+
+	permit, err := Evaluate(context, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "BLOCKING_FINDING")
+}
+
+func TestEvaluateDeniesStaleHead(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].HeadSHA = "4444444444444444444444444444444444444444"
+
+	permit, err := Evaluate(context, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_METADATA_MISMATCH")
+}
+
+func TestEvaluateDeniesMissingReviewer(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)[:1]
+
+	permit, err := Evaluate(context, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_MISSING")
+	assertDeniedFor(t, permit, "REVIEW_COUNT_MISMATCH")
+}
+
+func TestEvaluateDeniesDuplicateReviewer(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[1].Reviewer = reviews[0].Reviewer
+
+	permit, err := Evaluate(context, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_DUPLICATE")
+	assertDeniedFor(t, permit, "REVIEW_MISSING")
+}
+
+func TestEvaluateRejectsInvalidContext(t *testing.T) {
+	context := validContext()
+	context.RequiredReviewers[1].Provider = context.RequiredReviewers[0].Provider
+
+	if _, err := Evaluate(context, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want invalid distinct-provider context error")
+	}
+}
+
+func TestEvaluatePermitIDIsIndependentOfInputReviewOrder(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	first, err := Evaluate(context, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate(first) error = %v", err)
+	}
+	reversed := []Review{reviews[1], reviews[0]}
+	second, err := Evaluate(context, reversed)
+	if err != nil {
+		t.Fatalf("Evaluate(second) error = %v", err)
+	}
+	if first.PermitID != second.PermitID {
+		t.Fatalf("PermitID differs by input order: %q != %q", first.PermitID, second.PermitID)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("permits differ by input order:\nfirst: %#v\nsecond: %#v", first, second)
+	}
+}
+
+func validContext() Context {
+	return Context{
+		Schema:             ContextSchema,
+		Repository:         "Mindburn-Labs/example",
+		Event:              "pull_request",
+		PullRequest:        42,
+		BaseRef:            "refs/heads/main",
+		BaseSHA:            testBaseSHA,
+		HeadSHA:            testHeadSHA,
+		WorkflowRepository: "Mindburn-Labs/.github",
+		WorkflowPath:       ".github/workflows/autonomous-release-permit.yml",
+		WorkflowRef:        "refs/heads/main",
+		WorkflowSHA:        testWorkflowSHA,
+		RunID:              101,
+		RunAttempt:         1,
+		IssuedAt:           "2026-07-14T10:00:00Z",
+		RequiredReviewers: []Reviewer{
+			{Provider: "anthropic", Model: "claude-fable-5"},
+			{Provider: "openai", Model: "gpt-5.6-sol"},
+		},
+	}
+}
+
+func validReviews(context Context) []Review {
+	return []Review{
+		validReview(context, context.RequiredReviewers[0], testResponseA),
+		validReview(context, context.RequiredReviewers[1], testResponseB),
+	}
+}
+
+func validReview(context Context, reviewer Reviewer, digest string) Review {
+	return Review{
+		Schema:         ReviewSchema,
+		Repository:     context.Repository,
+		PullRequest:    context.PullRequest,
+		BaseSHA:        context.BaseSHA,
+		HeadSHA:        context.HeadSHA,
+		WorkflowSHA:    context.WorkflowSHA,
+		RunID:          context.RunID,
+		RunAttempt:     context.RunAttempt,
+		Reviewer:       reviewer,
+		Verdict:        DecisionAllow,
+		ResponseSHA256: digest,
+		Findings:       []Finding{},
+	}
+}
+
+func assertDeniedFor(t *testing.T, permit Permit, code string) {
+	t.Helper()
+	if permit.Decision != DecisionDeny {
+		t.Fatalf("Decision = %q, want %q", permit.Decision, DecisionDeny)
+	}
+	for _, reason := range permit.Reasons {
+		if reason.Code == code {
+			return
+		}
+	}
+	t.Fatalf("reasons %#v do not contain %q", permit.Reasons, code)
+}

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -9,6 +9,9 @@ const (
 	testBaseSHA     = "1111111111111111111111111111111111111111"
 	testHeadSHA     = "2222222222222222222222222222222222222222"
 	testWorkflowSHA = "3333333333333333333333333333333333333333"
+	testMergeSHA    = "4444444444444444444444444444444444444444"
+	testMergeTree   = "5555555555555555555555555555555555555555"
+	testContextSHA  = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
 	testResponseA   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	testResponseB   = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 )
@@ -18,7 +21,7 @@ func TestEvaluateAllowsTwoProviderQuorum(t *testing.T) {
 	reviews := validReviews(context)
 	reviews[0].Findings = []Finding{{Severity: "P3", Code: "STYLE", Summary: "Non-blocking naming improvement"}}
 
-	permit, err := Evaluate(context, reviews)
+	permit, err := Evaluate(context, testContextSHA, reviews)
 	if err != nil {
 		t.Fatalf("Evaluate() error = %v", err)
 	}
@@ -38,7 +41,7 @@ func TestEvaluateDeniesBlockingFinding(t *testing.T) {
 	reviews := validReviews(context)
 	reviews[1].Findings = []Finding{{Severity: "P1", Code: "AUTH_BYPASS", Summary: "Authorization is bypassed"}}
 
-	permit, err := Evaluate(context, reviews)
+	permit, err := Evaluate(context, testContextSHA, reviews)
 	if err != nil {
 		t.Fatalf("Evaluate() error = %v", err)
 	}
@@ -50,7 +53,7 @@ func TestEvaluateDeniesStaleHead(t *testing.T) {
 	reviews := validReviews(context)
 	reviews[0].HeadSHA = "4444444444444444444444444444444444444444"
 
-	permit, err := Evaluate(context, reviews)
+	permit, err := Evaluate(context, testContextSHA, reviews)
 	if err != nil {
 		t.Fatalf("Evaluate() error = %v", err)
 	}
@@ -61,7 +64,7 @@ func TestEvaluateDeniesMissingReviewer(t *testing.T) {
 	context := validContext()
 	reviews := validReviews(context)[:1]
 
-	permit, err := Evaluate(context, reviews)
+	permit, err := Evaluate(context, testContextSHA, reviews)
 	if err != nil {
 		t.Fatalf("Evaluate() error = %v", err)
 	}
@@ -74,7 +77,7 @@ func TestEvaluateDeniesDuplicateReviewer(t *testing.T) {
 	reviews := validReviews(context)
 	reviews[1].Reviewer = reviews[0].Reviewer
 
-	permit, err := Evaluate(context, reviews)
+	permit, err := Evaluate(context, testContextSHA, reviews)
 	if err != nil {
 		t.Fatalf("Evaluate() error = %v", err)
 	}
@@ -82,11 +85,29 @@ func TestEvaluateDeniesDuplicateReviewer(t *testing.T) {
 	assertDeniedFor(t, permit, "REVIEW_MISSING")
 }
 
+func TestEvaluateDuplicateEvidenceIsOrderIndependent(t *testing.T) {
+	context := validContext()
+	firstReview := validReview(context, context.RequiredReviewers[0], testResponseA)
+	secondReview := validReview(context, context.RequiredReviewers[0], testResponseB)
+
+	first, err := Evaluate(context, testContextSHA, []Review{firstReview, secondReview})
+	if err != nil {
+		t.Fatalf("Evaluate(first) error = %v", err)
+	}
+	second, err := Evaluate(context, testContextSHA, []Review{secondReview, firstReview})
+	if err != nil {
+		t.Fatalf("Evaluate(second) error = %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("duplicate permits differ by input order:\nfirst: %#v\nsecond: %#v", first, second)
+	}
+}
+
 func TestEvaluateRejectsInvalidContext(t *testing.T) {
 	context := validContext()
 	context.RequiredReviewers[1].Provider = context.RequiredReviewers[0].Provider
 
-	if _, err := Evaluate(context, validReviews(context)); err == nil {
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
 		t.Fatal("Evaluate() error = nil, want invalid distinct-provider context error")
 	}
 }
@@ -94,12 +115,12 @@ func TestEvaluateRejectsInvalidContext(t *testing.T) {
 func TestEvaluatePermitIDIsIndependentOfInputReviewOrder(t *testing.T) {
 	context := validContext()
 	reviews := validReviews(context)
-	first, err := Evaluate(context, reviews)
+	first, err := Evaluate(context, testContextSHA, reviews)
 	if err != nil {
 		t.Fatalf("Evaluate(first) error = %v", err)
 	}
 	reversed := []Review{reviews[1], reviews[0]}
-	second, err := Evaluate(context, reversed)
+	second, err := Evaluate(context, testContextSHA, reversed)
 	if err != nil {
 		t.Fatalf("Evaluate(second) error = %v", err)
 	}
@@ -111,6 +132,30 @@ func TestEvaluatePermitIDIsIndependentOfInputReviewOrder(t *testing.T) {
 	}
 }
 
+func TestEvaluateDeniesContextSubstitution(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].ContextSHA256 = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_CONTEXT_MISMATCH")
+}
+
+func TestEvaluateDeniesNilFindings(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].Findings = nil
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_FINDINGS_INVALID")
+}
+
 func validContext() Context {
 	return Context{
 		Schema:             ContextSchema,
@@ -120,6 +165,8 @@ func validContext() Context {
 		BaseRef:            "refs/heads/main",
 		BaseSHA:            testBaseSHA,
 		HeadSHA:            testHeadSHA,
+		MergeSHA:           testMergeSHA,
+		MergeTreeSHA:       testMergeTree,
 		WorkflowRepository: "Mindburn-Labs/.github",
 		WorkflowPath:       ".github/workflows/autonomous-release-permit.yml",
 		WorkflowRef:        "refs/heads/main",
@@ -151,6 +198,7 @@ func validReview(context Context, reviewer Reviewer, digest string) Review {
 		WorkflowSHA:    context.WorkflowSHA,
 		RunID:          context.RunID,
 		RunAttempt:     context.RunAttempt,
+		ContextSHA256:  testContextSHA,
 		Reviewer:       reviewer,
 		Verdict:        DecisionAllow,
 		ResponseSHA256: digest,

--- a/core/pkg/releasepermit/types.go
+++ b/core/pkg/releasepermit/types.go
@@ -28,6 +28,8 @@ type Context struct {
 	BaseRef            string     `json:"base_ref"`
 	BaseSHA            string     `json:"base_sha"`
 	HeadSHA            string     `json:"head_sha"`
+	MergeSHA           string     `json:"merge_sha"`
+	MergeTreeSHA       string     `json:"merge_tree_sha"`
 	WorkflowRepository string     `json:"workflow_repository"`
 	WorkflowPath       string     `json:"workflow_path"`
 	WorkflowRef        string     `json:"workflow_ref"`
@@ -58,6 +60,7 @@ type Review struct {
 	WorkflowSHA    string    `json:"workflow_sha"`
 	RunID          int64     `json:"run_id"`
 	RunAttempt     int64     `json:"run_attempt"`
+	ContextSHA256  string    `json:"context_sha256"`
 	Reviewer       Reviewer  `json:"reviewer"`
 	Verdict        string    `json:"verdict"`
 	ResponseSHA256 string    `json:"response_sha256"`
@@ -92,6 +95,8 @@ type Permit struct {
 	BaseRef            string          `json:"base_ref"`
 	BaseSHA            string          `json:"base_sha"`
 	HeadSHA            string          `json:"head_sha"`
+	MergeSHA           string          `json:"merge_sha"`
+	MergeTreeSHA       string          `json:"merge_tree_sha"`
 	WorkflowRepository string          `json:"workflow_repository"`
 	WorkflowPath       string          `json:"workflow_path"`
 	WorkflowRef        string          `json:"workflow_ref"`
@@ -99,6 +104,7 @@ type Permit struct {
 	RunID              int64           `json:"run_id"`
 	RunAttempt         int64           `json:"run_attempt"`
 	IssuedAt           string          `json:"issued_at"`
+	ContextSHA256      string          `json:"context_sha256"`
 	Reviews            []ReviewSummary `json:"reviews"`
 	Reasons            []Reason        `json:"reasons"`
 }

--- a/core/pkg/releasepermit/types.go
+++ b/core/pkg/releasepermit/types.go
@@ -1,0 +1,104 @@
+// Package releasepermit reduces independent, commit-bound AI review results
+// into a deterministic release decision. Model output is advisory until this
+// reducer validates the complete review quorum and its GitHub workflow binding.
+package releasepermit
+
+const (
+	ContextSchema = "mindburn.release-permit-context/v1"
+	ReviewSchema  = "mindburn.release-review/v1"
+	PermitSchema  = "mindburn.release-permit/v1"
+
+	DecisionAllow = "ALLOW"
+	DecisionDeny  = "DENY"
+)
+
+// Reviewer identifies one independently executed model review lane.
+type Reviewer struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// Context binds a permit to the exact pull request, commit, policy workflow,
+// and GitHub Actions execution that requested it.
+type Context struct {
+	Schema             string     `json:"schema"`
+	Repository         string     `json:"repository"`
+	Event              string     `json:"event"`
+	PullRequest        int64      `json:"pull_request"`
+	BaseRef            string     `json:"base_ref"`
+	BaseSHA            string     `json:"base_sha"`
+	HeadSHA            string     `json:"head_sha"`
+	WorkflowRepository string     `json:"workflow_repository"`
+	WorkflowPath       string     `json:"workflow_path"`
+	WorkflowRef        string     `json:"workflow_ref"`
+	WorkflowSHA        string     `json:"workflow_sha"`
+	RunID              int64      `json:"run_id"`
+	RunAttempt         int64      `json:"run_attempt"`
+	IssuedAt           string     `json:"issued_at"`
+	RequiredReviewers  []Reviewer `json:"required_reviewers"`
+}
+
+// Finding is one model-reported issue. P0-P2 findings block a permit; P3 is
+// retained as advisory evidence.
+type Finding struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Summary  string `json:"summary"`
+	Path     string `json:"path,omitempty"`
+	Line     int    `json:"line,omitempty"`
+}
+
+// Review is the protected workflow envelope around one model response.
+type Review struct {
+	Schema         string    `json:"schema"`
+	Repository     string    `json:"repository"`
+	PullRequest    int64     `json:"pull_request"`
+	BaseSHA        string    `json:"base_sha"`
+	HeadSHA        string    `json:"head_sha"`
+	WorkflowSHA    string    `json:"workflow_sha"`
+	RunID          int64     `json:"run_id"`
+	RunAttempt     int64     `json:"run_attempt"`
+	Reviewer       Reviewer  `json:"reviewer"`
+	Verdict        string    `json:"verdict"`
+	ResponseSHA256 string    `json:"response_sha256"`
+	Findings       []Finding `json:"findings"`
+}
+
+// Reason records one deterministic cause for a denied permit.
+type Reason struct {
+	Code     string `json:"code"`
+	Reviewer string `json:"reviewer,omitempty"`
+	Detail   string `json:"detail"`
+}
+
+// ReviewSummary retains the model identity and response digest without
+// treating raw model prose as an authorization record.
+type ReviewSummary struct {
+	Reviewer         Reviewer `json:"reviewer"`
+	Verdict          string   `json:"verdict"`
+	ResponseSHA256   string   `json:"response_sha256"`
+	BlockingFindings int      `json:"blocking_findings"`
+	AdvisoryFindings int      `json:"advisory_findings"`
+}
+
+// Permit is the deterministic output consumed by a required GitHub workflow.
+// PermitID is a SHA-256 digest over the same structure with PermitID empty.
+type Permit struct {
+	Schema             string          `json:"schema"`
+	PermitID           string          `json:"permit_id"`
+	Decision           string          `json:"decision"`
+	Repository         string          `json:"repository"`
+	PullRequest        int64           `json:"pull_request"`
+	BaseRef            string          `json:"base_ref"`
+	BaseSHA            string          `json:"base_sha"`
+	HeadSHA            string          `json:"head_sha"`
+	WorkflowRepository string          `json:"workflow_repository"`
+	WorkflowPath       string          `json:"workflow_path"`
+	WorkflowRef        string          `json:"workflow_ref"`
+	WorkflowSHA        string          `json:"workflow_sha"`
+	RunID              int64           `json:"run_id"`
+	RunAttempt         int64           `json:"run_attempt"`
+	IssuedAt           string          `json:"issued_at"`
+	Reviews            []ReviewSummary `json:"reviews"`
+	Reasons            []Reason        `json:"reasons"`
+}

--- a/core/pkg/releasepermit/types.go
+++ b/core/pkg/releasepermit/types.go
@@ -57,6 +57,8 @@ type Review struct {
 	PullRequest    int64     `json:"pull_request"`
 	BaseSHA        string    `json:"base_sha"`
 	HeadSHA        string    `json:"head_sha"`
+	MergeSHA       string    `json:"merge_sha"`
+	MergeTreeSHA   string    `json:"merge_tree_sha"`
 	WorkflowSHA    string    `json:"workflow_sha"`
 	RunID          int64     `json:"run_id"`
 	RunAttempt     int64     `json:"run_attempt"`


### PR DESCRIPTION
## Summary

- add a source-owned release-permit context, review, reason, and permit contract
- require a distinct-provider 2-of-2 quorum bound to repository, PR, base/head/merge commits, merge tree, complete context digest, workflow SHA, and Actions run
- fail closed on stale, duplicate, missing, malformed, blocking, or mismatched evidence
- add a strict CLI reducer with bounded input and exact JSON shape validation

## Validation

- focused go test -race and go vet passed
- full make lint passed
- full make test passed
- local cross-repo proof produced ALLOW for two bound reviews and DENY for missing, duplicate, and blocking reviews; malformed output was rejected before reduction
- Kernel Guardian preflight: GO for evaluation PR, no CRITICAL or HIGH findings

## Scope

This is merge-eligibility evidence only. It does not authorize deployment, production promotion, billing, migrations, secrets, or external effects. Strict current-base enforcement and the protected authority-change lane are activation blockers.

Tracking: HELM-176.