### PR TITLE
docs(changelog): complete v0.7.2 notes for shipped enforcement + deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ that exact capability.
 
 Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2>.
 
-<!-- quantum_posture: v0.7.2 release notes cover a Go standard-library toolchain rebuild and an OpenAPI contract alignment only; this release adds no post-quantum cryptographic control. -->
+<!-- quantum_posture: v0.7.2 release notes cover a Go toolchain rebuild, an OpenAPI contract alignment, enforcement and containment hardening, and dependency updates; none add a post-quantum cryptographic control. -->
 
 - The tag-triggered release workflow will rebuild both container images on Go
   1.25.12 (up from 1.25.10), which includes the cumulative upstream
@@ -107,6 +107,21 @@ Release target: <https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0
   `receipt_store_ready`, `signer_ready`, `last_checkpoint_id`, and `checked_at`
   with the existing runtime properties, and documented the consumer migration
   mapping. This correction does not change Kernel runtime JSON behavior.
+- Replaced the deny-only MCP runtime adapter with an optional governed
+  execution bridge that returns real `ALLOW`/`DENY`/`ESCALATE` verdicts: the
+  `mcp.ExecutionFirewall` boundary gate (allowlist, server identity, permission
+  scope, pinned schema, JCS argument hash) runs before policy; `workstation.Decide`
+  issues a signed decision receipt; writes go through an approval-gated
+  `ESCALATE` tier bound to the canonical request hash and a single-use,
+  replay-protected `EffectPermit`; and each effect is linked to its intent in
+  the ProofGraph. Fail-closed by default — with no bridge configured the adapter
+  stays deny-only.
+- Added a scoped emergency-stop fence with a recorded cryptography posture, and
+  preserved JCS Unicode separators in its reference pack.
+- Made the replay-determinism verifier gate fail closed.
+- Made the sandbox fail closed on an ambiguous network posture.
+- Updated the `golang.org/x/crypto`, Jackson Databind, and Python `cryptography`
+  build dependencies to current patched releases.
 
 No RiskEnvelope, scan, upload, cloud, checkout, website, connector
 certification, or Company AI OS GA scope is included.


### PR DESCRIPTION
## Why this PR is needed

The `v0.7.2` tag captures **13 commits since `v0.7.1`**, but the current 0.7.2
changelog block only documents two of them (the Go 1.25.12 rebuild and the
`BoundaryStatus` OpenAPI alignment). Several **developer-visible** changes ship
in the same tag with no changelog line. Since the tag is the public release
record, this PR completes the 0.7.2 notes before it is cut.

This is documentation only — no code, surface, or version change.

## What is added to the 0.7.2 block

| Ref | Change | Why it belongs in the notes |
| --- | --- | --- |
| #534 | Governed MCP execution bridge — real `ALLOW`/`DENY`/`ESCALATE` verdicts, replacing the deny-only adapter | New developer-visible enforcement path; fail-closed by default |
| #540 | Scoped emergency-stop fence (with recorded cryptography posture; JCS Unicode separators preserved) | New containment feature |
| #533 | Replay-determinism verifier gate now fails closed | Verifier behavior change |
| #532 | Sandbox fails closed on ambiguous network posture | Sandbox behavior change |
| #522, #539, #538 | `golang.org/x/crypto`, Jackson Databind, and Python `cryptography` build dependency updates | Security-relevant dependency hardening |

The `quantum_posture` annotation is widened to match the broader scope while
keeping its assertion true — **none** of these add a post-quantum cryptographic
control.

## Wording discipline

Descriptions are source-backed against the referenced commits and add **no new
capability, GA, or CVE-clearance claim** — matching the house style applied to
this block on merge of #550 (CVE clearance stays evidence-gated post-release).

## Validation

```
$ make docs-truth
Documentation coverage check passed: 651 rows cover 383 active surfaces.
Documentation truth check passed: 651 coverage rows resolve to live sources and docs.
$ python3 scripts/release/check_version_drift.py local --tag v0.7.2
drift: PASS
```

## Sequencing

This must merge **before** the `v0.7.2` tag is pushed, so the tagged release
carries the complete notes. No version surfaces or VEX change here — those are
already on `main` (#536, #550).

Refs **HELM-133**.
