### PR TITLE
docs: separate Kernel from HELM product motions

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -15,4 +15,4 @@ jobs:
     name: docs-truth
     uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@1382586657b369c9c81947b42f04525e3922b0f9
     secrets:
-      MINDBURN_ORG_READ_TOKEN: ${{ secrets.MINDBURN_ORG_READ_TOKEN }}
+      MINDBURN_ORG_READ_TOKEN: ${{ secrets.PLATFORM_DESIGN_SYSTEM_REPO_READ_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ You get:  a signed receipt you can verify offline
 
 - Not Kubernetes Helm.
 - Not the hosted HELM Enterprise product.
+- Not HELM Company Builder, Company OS, or HELM Network. Those are target
+  commercial experiences around this boundary, not Kernel features or evidence
+  that they are generally available.
+- Not an app generator, foundation model, social network, bank, escrow service,
+  payment rail, or general ledger. Users may build with any compatible external
+  tool and route consequential actions through this boundary.
 - Not a vague AI-safety claim.
 
 It is the open-source execution boundary: policy in, action checked, receipt out.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You get:  a signed receipt you can verify offline
 | CLI commands | [CLI reference](docs/reference/cli.md) |
 | Security model | [Execution security model](docs/EXECUTION_SECURITY_MODEL.md) |
 | MCP tool quarantine | [MCP integration](docs/INTEGRATIONS/mcp.md) |
+| Client implementation handoff | [Implementation partner handoff](docs/guides/implementation-partner.md) |
 | Evidence verification | [Verification](docs/VERIFICATION.md) |
 | AI security category map | [AI Security Categories](docs/AI_SECURITY_CATEGORIES.md) |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,16 @@
 
 HELM's public work is constrained to the OSS kernel, CLI, contracts, SDKs, Console, examples, deployment material, and verification artifacts described in `README.md` and `docs/KERNEL_SCOPE.md`.
 
+## Strategic Relationship
+
+Mindburn Labs' conditional strategy may use this Kernel beneath Company Builder
+(B2C), Company OS (B2B), and HELM Network experiences. That does not add their
+commercial journeys, revenue targets, plan codes, Network writes, or customer
+claims to the OSS roadmap. The Kernel's role remains the open, model-neutral,
+fail-closed authority and proof boundary. External builders and agents may
+route actions through it; their planning and generation do not move into Kernel
+authority semantics.
+
 ## Now
 
 - Make the GitHub landing page convert first-time visitors into stars, discussions, local demo runs, and first issues.

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -1,21 +1,20 @@
 ---
 title: MCP
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-15
 ---
 
 # MCP
 
-Use HELM as a pre-dispatch firewall for MCP tool calls.
+Use the current MCP surface to generate client configuration, inspect local
+quarantine state, evaluate a scoped call before dispatch, revoke approval, and
+produce receipt-backed no-dispatch evidence.
 
-```text
-tools/list -> visible tools are filtered
-tools/call -> HELM evaluates before dispatch
-ALLOW -> call upstream
-DENY -> block
-ESCALATE -> block, write receipt, show scoped approval command
-```
+The public commands do **not** yet prove a general-purpose upstream MCP proxy.
+`mcp wrap` emits a wrapper profile; it does not launch the upstream command.
+Generated client configuration also does not prove that a native client loaded
+HELM or that arbitrary tool calls cross the boundary.
 
-## Wrap A Server
+## Generate A Wrapper Profile
 
 ```bash
 helm-ai-kernel mcp wrap \
@@ -25,12 +24,27 @@ helm-ai-kernel mcp wrap \
   --json
 ```
 
-Print or install client config:
+Treat the JSON as configuration input to inspect and install through the owning
+client. Do not treat this command as a running proxy.
+
+## Generate Client Configuration
+
+Print a configuration without changing the client:
 
 ```bash
 helm-ai-kernel mcp print-config --client codex
+helm-ai-kernel setup claude-code --dry-run --json
+```
+
+Generate the Claude Code plugin and MCP configuration artifacts:
+
+```bash
 helm-ai-kernel mcp install --client claude-code
 ```
+
+The install command writes the local artifacts and prints the separate
+`claude plugin install` command. Run and verify that client-owned step yourself.
+Setup does not approve detected tools.
 
 ## Authorize Before Dispatch
 
@@ -40,8 +54,10 @@ helm-ai-kernel mcp authorize-call \
   --tool-name pwd
 ```
 
-An unknown or unapproved server returns `ESCALATE`. The action is not
-dispatched. Use the approval loop in [Quickstart](/quickstart#see-an-escalation).
+An unknown or unapproved server returns `ESCALATE`. The authorization check does
+not dispatch the tool call. Use the approval loop in
+[Quickstart](/quickstart#see-an-escalation), then rerun the original configured
+call path.
 
 ## Scan Before Approval
 
@@ -57,7 +73,7 @@ helm-ai-kernel scan \
 
 For API clients, the same public surface is exposed as
 `POST /api/v1/mcp/scan`. A scan is advisory: it records the detected surface and
-does not dispatch, approve, or resume any tool call.
+does not dispatch, approve, or resume a tool call.
 
 ## Effect Scope
 
@@ -83,9 +99,9 @@ helm-ai-kernel mcp revoke \
   --reason "inspection finished"
 ```
 
-Revoked and expired grants fail closed on the next evaluation.
+Revoked and expired grants fail closed on the next configured evaluation.
 
-## Inspect
+## Inspect And Prove
 
 ```bash
 helm-ai-kernel mcp pending --json
@@ -93,15 +109,31 @@ helm-ai-kernel mcp receipts --json
 helm-ai-kernel mcp get --server-id helm-demo-shell --json
 ```
 
-Run the no-dispatch proof:
+Run the local no-dispatch proof:
 
 ```bash
 helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
 ```
 
-## What Still Blocks
+Verify the emitted EvidencePack offline:
 
-HELM denies mismatched scopes, expired or revoked approvals, schema drift,
-side-effect scope mismatch, and policy-forbidden actions. Missing approval or
-unknown tool/server state escalates only when a developer can resolve it with a
-local scoped approval or schema review.
+```bash
+helm-ai-kernel verify \
+  --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> \
+  --profile dev-local \
+  --json
+```
+
+## Current Boundary
+
+The source-owned proof covers configuration generation, quarantine, scoped
+authorization, expiry, revocation, no-dispatch behavior, receipts, and offline
+verification. Before a live client rollout, separately prove:
+
+- the native client loaded the generated configuration;
+- the intended policy graph is wired into the selected MCP runtime;
+- the exact tool call reaches the configured boundary;
+- the allowed path has an explicit executor or upstream proxy;
+- denied and escalated calls do not dispatch;
+- schema drift, expired approval, and revocation fail closed; and
+- the resulting receipt or EvidencePack verifies outside the client.

--- a/docs/INTEGRATIONS/openclaw.md
+++ b/docs/INTEGRATIONS/openclaw.md
@@ -1,59 +1,42 @@
 ---
 title: OpenClaw
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-15
 ---
 
 # OpenClaw
 
-Use HELM as a pre-dispatch boundary for OpenClaw-style skill calls.
+The integration source includes a mapping for OpenClaw-style skill calls. It is
+a source adapter, not a published registry install surface and not evidence of
+upstream endorsement.
 
 ```text
-OpenClaw skill call
--> fromOpenClawSkillCall(...)
--> HELM evaluate
--> ALLOW: dispatch
--> DENY or ESCALATE: block and write a receipt
+OpenClaw-style skill call
+-> source adapter maps the action
+-> documented local HELM HTTP or SDK contract
+-> ALLOW: the owning wrapper may dispatch
+-> DENY or ESCALATE: the owning wrapper stays blocked
+-> source read-back and receipt verification
 ```
 
-## Adapter
+## Use Today
 
-The supported adapter lives in `helm-agent-integrations`:
+Use one of the verified clients on [SDKs](/sdks), or generate a client from the
+[public OpenAPI](/openapi.yaml). Keep the call in your own wrapper until HELM
+returns its verdict. Do not install an unpublished adapter package.
 
-```ts
-import { fromOpenClawSkillCall, preflightAction } from "@mindburn/helm-tool-wrapper";
+## Evidence Required Before Dispatch
 
-const intent = fromOpenClawSkillCall({
-  skill: "gmail-send",
-  input: {
-    to: "ops@example.invalid",
-    subject: "Draft follow-up",
-  },
-  conversation_id: "local-session",
-});
-
-const decision = await preflightAction({
-  helmUrl: "http://127.0.0.1:7714",
-  actionUrn: intent.actionUrn,
-  input: intent.input,
-  metadata: intent.metadata,
-});
-```
-
-Dispatch the OpenClaw skill only when HELM returns `ALLOW`. For `DENY` or
-`ESCALATE`, show the decision and receipt path to the developer.
-
-## Receipt Sample
-
-The integration repository includes a local sample for an external send that
-escalates before dispatch:
-
-```bash
-python3 scripts/generate_samples.py --check
-python3 scripts/verify_samples.py
-cat receipts/samples/openclaw-email-escalate.json
-```
+- exact skill and action mapping;
+- bounded credential and resource scope;
+- local HELM base URL and route authentication;
+- blocked `DENY` and `ESCALATE` cases;
+- explicit `ALLOW` executor owned by the wrapper;
+- source-system result read-back;
+- receipt or EvidencePack verification; and
+- rollback, revocation, and support ownership.
 
 ## Scope
 
-This page covers the OpenClaw skill-call boundary only. It does not claim
-upstream endorsement or a hosted OpenClaw runtime.
+This page covers the source mapping and required boundary contract only. It does
+not claim a hosted OpenClaw runtime, automatic interception, or a released
+adapter package.

--- a/docs/INTEGRATIONS/tool-runtime-adapters.md
+++ b/docs/INTEGRATIONS/tool-runtime-adapters.md
@@ -1,48 +1,40 @@
 ---
 title: Tool Runtime Adapters
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-15
 ---
 
 # Tool Runtime Adapters
 
-Use tool runtime adapters when the agent runtime proposes a concrete side
-effect and your wrapper must ask HELM before dispatch.
+Use a runtime adapter only when the owning runtime exposes a concrete call you
+can stop before dispatch. The adapter must map that call into the documented
+HELM HTTP or SDK contract, wait for the verdict, and keep `DENY` and `ESCALATE`
+blocked.
 
-## Supported Wrappers
+## Source Adapter Inventory
 
-| Runtime | Helper |
-| --- | --- |
-| OpenClaw | `fromOpenClawSkillCall` |
-| Hermes | `fromHermesToolCall` |
-| Mastra | `fromMastraToolCall` |
-| Browser Use | `fromBrowserUseAction` |
-| TinyFish | `fromTinyFishSearch`, `fromTinyFishFetch`, `fromTinyFishBrowserSession`, `fromTinyFishAgentRun` |
-| E2B | `fromE2BExecution` |
-| Composio | `fromComposioAction` |
+The separately versioned integration source contains mappings for OpenClaw,
+Hermes, Mastra, Browser Use, TinyFish, E2B, and Composio call shapes. Source
+availability is not a registry-package or client-load claim.
 
-## Pattern
+This page intentionally publishes no adapter package install command. Use one of
+the verified SDK coordinates on [SDKs](/sdks), or generate a client from the
+[public OpenAPI](/openapi.yaml), until a separately released adapter package and
+clean registry check exist.
 
-```ts
-import { preflightAction, fromOpenClawSkillCall } from "@mindburn/helm-tool-wrapper";
+## Required Dispatch Pattern
 
-const intent = fromOpenClawSkillCall({
-  skill: "gmail-send",
-  input: { to: "ops@example.invalid", subject: "Draft follow-up" },
-  conversation_id: "local-session",
-});
+1. Capture the exact runtime call before its side effect.
+2. Map action, resource, context, tenant, and principal into the selected HELM
+   contract.
+3. Call the local boundary with the documented authentication for that route.
+4. Dispatch only on `ALLOW`.
+5. Keep `DENY` and `ESCALATE` blocked.
+6. Read the source result back when the external system changes state.
+7. Retain the decision record and verify the exported evidence offline.
 
-const decision = await preflightAction({
-  helmUrl: "http://127.0.0.1:7714",
-  actionUrn: intent.actionUrn,
-  input: intent.input,
-  metadata: intent.metadata,
-});
-```
+## Release Gate
 
-Dispatch only when the verdict is `ALLOW`. For `DENY` or `ESCALATE`, keep the
-runtime blocked and show the receipt details to the developer.
-
-## Runtime Examples
-
-- [OpenClaw](openclaw.md)
-- [Hermes](hermes.md)
+Do not call an adapter supported from source alone. A public adapter install path
+requires a versioned package, registry availability, source-to-package
+provenance, a clean install, a routed allow case, blocked deny and escalate
+cases, receipt verification, and an explicit support owner.

--- a/docs/guides/govern-mcp-tools.md
+++ b/docs/guides/govern-mcp-tools.md
@@ -1,12 +1,12 @@
 ---
 title: Govern MCP Tools
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-15
 ---
 
 # Govern MCP Tools
 
-Wrap an MCP server, require schema pins, and inspect the receipts for allowed,
-denied, or escalated tool calls.
+Generate a scoped MCP profile, require schema pins, and inspect authorization
+receipts before you wire an executor or upstream proxy.
 
 ## 1. Start HELM
 
@@ -14,7 +14,7 @@ denied, or escalated tool calls.
 helm-ai-kernel serve --policy ./release.high_risk.v3.toml
 ```
 
-## 2. Wrap The Server
+## 2. Generate The Wrapper Profile
 
 ```bash
 helm-ai-kernel mcp wrap \
@@ -24,7 +24,10 @@ helm-ai-kernel mcp wrap \
   --json
 ```
 
-## 3. Configure The Client
+This emits configuration. It does not start the upstream command or prove that a
+native MCP client loaded the profile.
+
+## 3. Generate Client Configuration
 
 ```bash
 helm-ai-kernel mcp print-config --client codex
@@ -37,17 +40,29 @@ Claude Code uses:
 helm-ai-kernel mcp install --client claude-code
 ```
 
-## 4. Verify Behavior
+That command writes plugin and MCP configuration artifacts, then prints the
+separate client-owned install command. Inspect and run that step explicitly.
+
+## 4. Verify The Local Proof
 
 ```bash
-./scripts/launch/demo-mcp.sh
+helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
 ```
 
-## 5. Inspect Receipts
+## 5. Inspect And Verify Receipts
 
 ```bash
-helm-ai-kernel receipts tail --agent mcp-demo-agent --server http://127.0.0.1:7714
+helm-ai-kernel mcp receipts --json
+helm-ai-kernel verify \
+  --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> \
+  --profile dev-local \
+  --json
 ```
+
+Before a live rollout, prove client load, policy-graph wiring, the exact routed
+call, a real executor or upstream proxy, no-dispatch on `DENY` and `ESCALATE`,
+revocation, schema drift, and offline verification. The profile-generation path
+alone is not a general-purpose MCP proxy.
 
 ## Source Truth
 

--- a/docs/guides/implementation-partner.md
+++ b/docs/guides/implementation-partner.md
@@ -63,6 +63,9 @@ Do not present any local base URL as a hosted HELM endpoint.
 | Selected HTTP MCP runtime | `http://localhost:9100/mcp` |
 
 The command, port, policy, and client must refer to the same runtime mode.
+These loopback URLs are the only base URLs in this packet. A public docs URL,
+health endpoint, or QA hostname is not a partner credential or a production API
+endpoint.
 
 ## 5. Apply Route Authentication
 
@@ -81,7 +84,35 @@ If the selected SDK cannot send a required identity header, stop and use direct
 HTTP or a client generated from `/openapi.yaml`. Never remove a required scope
 merely to make an example run.
 
-## 6. Prove Dispatch And No-Dispatch
+## 6. Run One Protected HTTP Evaluation
+
+Use the server-owned values supplied by the environment owner. The tenant and
+principal headers are mandatory for the current evaluate contract; the
+workspace header is mandatory only when the scoped emergency fence is enabled.
+
+```bash
+export HELM_BASE_URL=http://127.0.0.1:8080
+export HELM_ADMIN_API_KEY='<environment-owned-admin-key>'
+export HELM_TENANT_ID='<server-owned-tenant-id>'
+export HELM_PRINCIPAL_ID='<server-owned-principal-id>'
+
+curl --fail-with-body --silent --show-error \
+  -X POST "$HELM_BASE_URL/api/v1/evaluate" \
+  -H "Authorization: Bearer $HELM_ADMIN_API_KEY" \
+  -H "X-Helm-Tenant-ID: $HELM_TENANT_ID" \
+  -H "X-Helm-Principal-ID: $HELM_PRINCIPAL_ID" \
+  -H "Idempotency-Key: navigotech-local-read-001" \
+  -H 'Content-Type: application/json' \
+  --data-binary "{\"principal\":\"$HELM_PRINCIPAL_ID\",\"action\":\"ticket.read\",\"resource\":\"ticket:demo-001\",\"context\":{\"effect_class\":\"read\",\"integration\":\"navigotech-local-proof\"}}"
+```
+
+Do not expect `ALLOW` merely because the request is well formed. `DENY` or
+`ESCALATE` is a valid fail-closed proof when the policy, scope, approval, or
+route is incomplete. Record the returned decision and receipt references before
+connecting an executor. If the environment requires `X-Helm-Workspace-ID`, add
+the exact server-owned value; never source it from request JSON.
+
+## 7. Prove Dispatch And No-Dispatch
 
 For the exact client action, record:
 
@@ -98,7 +129,7 @@ For the exact client action, record:
 Setup output or generated configuration is not proof that a native client loaded
 HELM. Observe the configured event or call crossing the boundary.
 
-## 7. Revoke And Hand Off
+## 8. Revoke And Hand Off
 
 Revoke temporary MCP approval when the proof ends:
 
@@ -112,7 +143,7 @@ Give the client the version pin, configuration diff, policy, credential scope,
 approval path, source read-back, evidence bundle, verifier command, revocation
 procedure, rollback procedure, limitations, and support owner.
 
-## 8. Repeat Without Founder Assistance
+## 9. Repeat Without Founder Assistance
 
 The implementation channel is repeatable only after the partner completes the
 same bounded proof for a second unrelated client without Mindburn founder or

--- a/docs/guides/implementation-partner.md
+++ b/docs/guides/implementation-partner.md
@@ -55,12 +55,13 @@ Do not present any local base URL as a hosted HELM endpoint.
 
 ## 4. Pin Runtime Mode And Base URL
 
-| Runtime mode | Base URL |
-| --- | --- |
-| `quickstart` or `serve` | `http://127.0.0.1:7714` |
-| `server` | `http://127.0.0.1:8080` |
-| OpenAI-compatible proxy | `http://127.0.0.1:9090/v1` |
-| Selected HTTP MCP runtime | `http://localhost:9100/mcp` |
+| Runtime mode | Start command | Base URL |
+| --- | --- | --- |
+| `quickstart` | `helm-ai-kernel quickstart` | `http://127.0.0.1:7714` |
+| `serve` | `helm-ai-kernel serve --policy <policy.toml>` | `http://127.0.0.1:7714` |
+| `server` | `helm-ai-kernel server` | `http://127.0.0.1:8080` |
+| OpenAI-compatible proxy | `helm-ai-kernel proxy --port 9090` | `http://127.0.0.1:9090/v1` |
+| Selected HTTP MCP runtime | runtime-specific; see [MCP](/integrations/mcp) | `http://localhost:9100/mcp` |
 
 The command, port, policy, and client must refer to the same runtime mode.
 These loopback URLs are the only base URLs in this packet. A public docs URL,
@@ -84,11 +85,27 @@ If the selected SDK cannot send a required identity header, stop and use direct
 HTTP or a client generated from `/openapi.yaml`. Never remove a required scope
 merely to make an example run.
 
+At v0.7.2, the handwritten TypeScript and Python clients cannot set the
+principal header, and the Go client cannot set the optional workspace header.
+Use those convenience clients only for routes covered by their helpers. For a
+protected evaluate call, direct HTTP or a generated OpenAPI client is the
+documented path until the required header helpers ship in a verified release.
+
 ## 6. Run One Protected HTTP Evaluation
 
 Use the server-owned values supplied by the environment owner. The tenant and
 principal headers are mandatory for the current evaluate contract; the
 workspace header is mandatory only when the scoped emergency fence is enabled.
+Start the local API server with the same server-owned values in its environment:
+
+```bash
+HELM_ADMIN_API_KEY='<environment-owned-admin-key>' \
+HELM_RUNTIME_TENANT_ID='<server-owned-tenant-id>' \
+HELM_RUNTIME_PRINCIPAL_ID='<server-owned-principal-id>' \
+helm-ai-kernel server
+```
+
+Then, in a separate terminal, run the decision and receipt proof:
 
 ```bash
 export HELM_BASE_URL=http://127.0.0.1:8080
@@ -104,13 +121,20 @@ curl --fail-with-body --silent --show-error \
   -H "Idempotency-Key: navigotech-local-read-001" \
   -H 'Content-Type: application/json' \
   --data-binary "{\"principal\":\"$HELM_PRINCIPAL_ID\",\"action\":\"ticket.read\",\"resource\":\"ticket:demo-001\",\"context\":{\"effect_class\":\"read\",\"integration\":\"navigotech-local-proof\"}}"
+
+curl --fail-with-body --silent --show-error \
+  "$HELM_BASE_URL/api/v1/receipts?limit=10" \
+  -H "Authorization: Bearer $HELM_ADMIN_API_KEY" \
+  -H "X-Helm-Tenant-ID: $HELM_TENANT_ID" \
+  -H "X-Helm-Principal-ID: $HELM_PRINCIPAL_ID"
 ```
 
 Do not expect `ALLOW` merely because the request is well formed. `DENY` or
 `ESCALATE` is a valid fail-closed proof when the policy, scope, approval, or
 route is incomplete. Record the returned decision and receipt references before
-connecting an executor. If the environment requires `X-Helm-Workspace-ID`, add
-the exact server-owned value; never source it from request JSON.
+connecting an executor. The receipt query proves boundary persistence, not
+upstream dispatch. If the environment requires `X-Helm-Workspace-ID`, add the
+exact server-owned value to both requests; never source it from request JSON.
 
 ## 7. Prove Dispatch And No-Dispatch
 

--- a/docs/guides/implementation-partner.md
+++ b/docs/guides/implementation-partner.md
@@ -70,11 +70,8 @@ endpoint.
 
 ## 5. Apply Route Authentication
 
-Protected operations use:
-
-```text
-Authorization: Bearer $HELM_ADMIN_API_KEY
-```
+Protected operations use the exported `HELM_ADMIN_API_KEY` as the HTTP bearer
+credential.
 
 Tenant-scoped routes also bind tenant and principal identity. When the scoped
 emergency fence is enabled, the server can additionally require
@@ -115,7 +112,7 @@ export HELM_PRINCIPAL_ID='<server-owned-principal-id>'
 
 curl --fail-with-body --silent --show-error \
   -X POST "$HELM_BASE_URL/api/v1/evaluate" \
-  --oauth2-bearer "$HELM_ADMIN_API_KEY" \
+  -H "Authorization: ${HELM_AUTH_SCHEME:-Bearer} ${HELM_ADMIN_API_KEY:?HELM_ADMIN_API_KEY is required}" \
   -H "X-Helm-Tenant-ID: $HELM_TENANT_ID" \
   -H "X-Helm-Principal-ID: $HELM_PRINCIPAL_ID" \
   -H "Idempotency-Key: navigotech-local-read-001" \
@@ -124,7 +121,7 @@ curl --fail-with-body --silent --show-error \
 
 curl --fail-with-body --silent --show-error \
   "$HELM_BASE_URL/api/v1/receipts?limit=10" \
-  --oauth2-bearer "$HELM_ADMIN_API_KEY" \
+  -H "Authorization: ${HELM_AUTH_SCHEME:-Bearer} ${HELM_ADMIN_API_KEY:?HELM_ADMIN_API_KEY is required}" \
   -H "X-Helm-Tenant-ID: $HELM_TENANT_ID" \
   -H "X-Helm-Principal-ID: $HELM_PRINCIPAL_ID"
 ```

--- a/docs/guides/implementation-partner.md
+++ b/docs/guides/implementation-partner.md
@@ -115,7 +115,7 @@ export HELM_PRINCIPAL_ID='<server-owned-principal-id>'
 
 curl --fail-with-body --silent --show-error \
   -X POST "$HELM_BASE_URL/api/v1/evaluate" \
-  -H "Authorization: Bearer $HELM_ADMIN_API_KEY" \
+  --oauth2-bearer "$HELM_ADMIN_API_KEY" \
   -H "X-Helm-Tenant-ID: $HELM_TENANT_ID" \
   -H "X-Helm-Principal-ID: $HELM_PRINCIPAL_ID" \
   -H "Idempotency-Key: navigotech-local-read-001" \
@@ -124,7 +124,7 @@ curl --fail-with-body --silent --show-error \
 
 curl --fail-with-body --silent --show-error \
   "$HELM_BASE_URL/api/v1/receipts?limit=10" \
-  -H "Authorization: Bearer $HELM_ADMIN_API_KEY" \
+  --oauth2-bearer "$HELM_ADMIN_API_KEY" \
   -H "X-Helm-Tenant-ID: $HELM_TENANT_ID" \
   -H "X-Helm-Principal-ID: $HELM_PRINCIPAL_ID"
 ```

--- a/docs/guides/implementation-partner.md
+++ b/docs/guides/implementation-partner.md
@@ -1,0 +1,120 @@
+---
+title: Implementation Partner Handoff
+last_reviewed: 2026-07-15
+---
+
+# Implementation Partner Handoff
+
+This guide packages the local, self-hosted HELM AI Kernel v0.7.2 surface for an
+implementation partner. It does not describe a hosted HELM API.
+
+NavigoTech Innovation is an official HELM implementation partner as of
+2026-07-15. Partner status does not widen runtime authority: every client action
+still needs an exact routed boundary, identity scope, policy, approval path,
+source read-back, and evidence contract.
+
+## 1. Install The Pinned CLI
+
+```bash
+brew tap mindburn-labs/tap
+brew update
+brew install mindburn-labs/tap/helm-ai-kernel
+helm-ai-kernel --version
+```
+
+The expected release for this packet is `0.7.2`. If the registry or local cache
+does not return that release, stop and use the signed asset from the
+[v0.7.2 release](https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2).
+
+## 2. Run A Clean Local Proof
+
+```bash
+helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
+
+helm-ai-kernel verify \
+  --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> \
+  --profile dev-local \
+  --json
+```
+
+Keep the emitted run ID, receipt paths, verification result, CLI version, and
+environment in the implementation record.
+
+## 3. Choose One Documented Surface
+
+| Need | Surface | Current boundary |
+| --- | --- | --- |
+| No-key sandbox proof | Public demo HTTP or TypeScript SDK | Synthetic demo only |
+| Typed application call | [SDKs](/sdks) | Local clients; auth helpers differ by language |
+| Exact route contract | [HTTP API](/reference/http-api) | Filtered 16-operation public contract |
+| Generated client | [OpenAPI YAML](/openapi.yaml) | Prefer when an SDK lacks required headers |
+| Existing OpenAI client | [OpenAI proxy](/integrations/openai-compatible-proxy) | Local proxy mode |
+| MCP configuration and authorization proof | [MCP](/integrations/mcp) | Not a general-purpose upstream proxy |
+
+Do not present any local base URL as a hosted HELM endpoint.
+
+## 4. Pin Runtime Mode And Base URL
+
+| Runtime mode | Base URL |
+| --- | --- |
+| `quickstart` or `serve` | `http://127.0.0.1:7714` |
+| `server` | `http://127.0.0.1:8080` |
+| OpenAI-compatible proxy | `http://127.0.0.1:9090/v1` |
+| Selected HTTP MCP runtime | `http://localhost:9100/mcp` |
+
+The command, port, policy, and client must refer to the same runtime mode.
+
+## 5. Apply Route Authentication
+
+Protected operations use:
+
+```text
+Authorization: Bearer $HELM_ADMIN_API_KEY
+```
+
+Tenant-scoped routes also bind tenant and principal identity. When the scoped
+emergency fence is enabled, the server can additionally require
+`X-Helm-Workspace-ID`. Use [HTTP API](/reference/http-api) for the route class and
+[SDKs](/sdks#authentication-coverage) for the per-language header gap.
+
+If the selected SDK cannot send a required identity header, stop and use direct
+HTTP or a client generated from `/openapi.yaml`. Never remove a required scope
+merely to make an example run.
+
+## 6. Prove Dispatch And No-Dispatch
+
+For the exact client action, record:
+
+1. action, resource, effect class, tenant, principal, and workspace;
+2. least-authority credential and expiry;
+3. policy version and expected verdict;
+4. named approval path for `ESCALATE`;
+5. explicit executor or upstream path for `ALLOW`;
+6. no-dispatch observation for `DENY` and unresolved `ESCALATE`;
+7. source-system response and read-back;
+8. reconciliation status and exception owner; and
+9. receipt or EvidencePack plus offline verifier result.
+
+Setup output or generated configuration is not proof that a native client loaded
+HELM. Observe the configured event or call crossing the boundary.
+
+## 7. Revoke And Hand Off
+
+Revoke temporary MCP approval when the proof ends:
+
+```bash
+helm-ai-kernel mcp revoke \
+  --server-id <server-id> \
+  --reason "implementation proof complete"
+```
+
+Give the client the version pin, configuration diff, policy, credential scope,
+approval path, source read-back, evidence bundle, verifier command, revocation
+procedure, rollback procedure, limitations, and support owner.
+
+## 8. Repeat Without Founder Assistance
+
+The implementation channel is repeatable only after the partner completes the
+same bounded proof for a second unrelated client without Mindburn founder or
+engineering intervention. A partner announcement or generated configuration is
+not a substitute for that second independent install.

--- a/docs/guides/implementation-partner.md
+++ b/docs/guides/implementation-partner.md
@@ -8,10 +8,10 @@ last_reviewed: 2026-07-15
 This guide packages the local, self-hosted HELM AI Kernel v0.7.2 surface for an
 implementation partner. It does not describe a hosted HELM API.
 
-NavigoTech Innovation is an official HELM implementation partner as of
-2026-07-15. Partner status does not widen runtime authority: every client action
-still needs an exact routed boundary, identity scope, policy, approval path,
-source read-back, and evidence contract.
+NavigoTech Innovation is an official HELM implementation partner.
+Partner status does not widen runtime authority: every client action still
+needs an exact routed boundary, identity scope, policy, approval path, source
+read-back, and evidence contract.
 
 ## 1. Install The Pinned CLI
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: HELM documentation
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-15
 ---
 
 # HELM documentation
@@ -45,3 +45,4 @@ Then choose one path.
 - [CLI](reference/cli.md)
 - [HTTP API](reference/http-api.md)
 - [SDKs](sdks/00_INDEX.md)
+- [Implementation partner handoff](guides/implementation-partner.md)

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -55,6 +55,15 @@
       "sensitivity": "public"
     },
     {
+      "slug": "guides/implementation-partner",
+      "title": "Implementation Partner Handoff",
+      "section": "guide",
+      "source_path": "docs/guides/implementation-partner.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/guides/implementation-partner",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "how-helm-works",
       "title": "How HELM Works",
       "section": "guide",

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -1,20 +1,58 @@
 ---
 title: SDKs
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-15
 ---
 
 # SDKs
 
-Use an SDK when you want typed access to the local HELM HTTP API. Use the
-OpenAI-compatible proxy when an existing app can set `base_url` or `baseURL`.
+Use an SDK for typed access to a local HELM AI Kernel HTTP surface. Use the
+OpenAI-compatible proxy when an existing application can set `base_url` or
+`baseURL`.
+
+This guide publishes no hosted HELM API base URL.
 
 ## Local Base URLs
 
-| Surface | Base URL |
-| --- | --- |
-| HELM boundary | `http://127.0.0.1:7714` |
-| API server | `http://127.0.0.1:8080` |
-| OpenAI proxy | `http://127.0.0.1:9090/v1` |
+| Runtime mode | Base URL | Use |
+| --- | --- | --- |
+| `quickstart` or `serve` | `http://127.0.0.1:7714` | Local boundary and proof loop |
+| `server` | `http://127.0.0.1:8080` | Generic API server |
+| OpenAI proxy | `http://127.0.0.1:9090/v1` | OpenAI-compatible calls |
+| HTTP MCP transport | `http://localhost:9100/mcp` | Selected MCP runtime only |
+
+Pin the mode and base URL together. Do not move an example between ports without
+starting the corresponding runtime.
+
+## Verified v0.7.2 Coordinates
+
+Run a clean registry check before copying these into a managed client estate.
+The following four coordinates were available for the v0.7.2 release:
+
+Source version claims are tied to the repository `VERSION` (`0.7.2` for this release).
+The matching Go subdirectory tag is `sdk/go/v0.7.2`.
+
+```bash
+npm install @mindburn/helm-ai-kernel@0.7.2
+python -m pip install helm-sdk==0.7.2
+go get github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.7.2
+```
+
+The matching Java coordinate is `io.github.mindburnlabs:helm-sdk:0.7.2`:
+
+```xml
+<dependency>
+  <groupId>io.github.mindburnlabs</groupId>
+  <artifactId>helm-sdk</artifactId>
+  <version>0.7.2</version>
+</dependency>
+```
+
+Rust source and a v0.7.2 crate artifact exist under `sdk/rust/`, but public
+registry discovery was inconsistent at the last review. Recheck the target
+registry before publishing `cargo add` as a supported install path.
+
+Use `version-status.json` and `make version-drift-published` before changing a
+pinned version claim.
 
 ## Clients In This Repository
 
@@ -26,70 +64,52 @@ OpenAI-compatible proxy when an existing app can set `base_url` or `baseURL`.
 | Rust | `sdk/rust/` | `make test-sdk-rust` |
 | Java | `sdk/java/` | `make test-sdk-java` |
 
-Registry package availability can differ from source availability. Verify the
-target package registry before publishing pinned install instructions.
-Use `version-status.json` or `make version-drift-published` before making a
-pinned package claim.
+## Authentication Coverage
 
-Current source identity includes the Java coordinate
-`io.github.mindburnlabs:helm-sdk:0.7.2`; verify registry availability before
-presenting it as an install path.
+Protected routes require `Authorization: Bearer $HELM_ADMIN_API_KEY`. Tenant-
+scoped routes also bind tenant and principal headers. A scoped emergency fence
+can additionally require `X-Helm-Workspace-ID`.
 
-Source version claims are tied to the repository `VERSION` (`0.7.2` for this release). Current source package coordinates include:
+| Client | API key | Tenant | Principal | Workspace |
+| --- | --- | --- | --- | --- |
+| Go | yes | yes | yes | no helper |
+| TypeScript | yes | yes | no helper | no helper |
+| Python | yes | yes | no helper | no helper |
+| Java | yes | no helper | no helper | no helper |
+| Rust | no helper | no helper | no helper | no helper |
 
-- Go module: `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.7.2`
-- Go subdirectory tag: `sdk/go/v0.7.2`
-- Java dependency:
+When the chosen client lacks a required header, use the documented HTTP route or
+generate a client from the [public OpenAPI](/openapi.yaml). Do not silently omit
+server-required identity scope.
 
-```xml
-<dependency>
-  <groupId>io.github.mindburnlabs</groupId>
-  <artifactId>helm-sdk</artifactId>
-  <version>0.7.2</version>
-</dependency>
-```
+## Public TypeScript Sandbox
 
-## Python
-
-```python
-from helm_sdk import HelmClient
-
-client = HelmClient(base_url="http://127.0.0.1:7714")
-```
-
-## TypeScript
+The public demo route is the shortest no-admin-key SDK proof. It is a sandbox
+example, not a protected action sample:
 
 ```ts
 import { HelmClient } from "@mindburn/helm-ai-kernel";
 
-const client = new HelmClient({ baseUrl: "http://127.0.0.1:7714" });
-```
+const helm = new HelmClient({ baseUrl: "http://127.0.0.1:7714" });
+const demo = await helm.runPublicDemo("dangerous_shell");
+const verification = await helm.verifyPublicDemoReceipt(
+  demo.receipt,
+  demo.proof_refs.receipt_hash,
+);
 
-## Go
-
-```go
-client := helm.New("http://127.0.0.1:7714")
-```
-
-## Rust
-
-```rust
-let client = HelmClient::new("http://127.0.0.1:7714");
-```
-
-## Java
-
-```java
-HelmClient client = new HelmClient("http://127.0.0.1:7714");
+console.log(demo, verification);
 ```
 
 ## Client Behavior
 
 | Condition | Do this |
 | --- | --- |
-| `ALLOW` | Continue with the governed result |
+| `ALLOW` | Continue only through the wrapper or executor that requested the decision |
 | `DENY` | Stop and show the reason code |
-| `ESCALATE` | Show the approval hint; do not continue automatically |
-| Missing receipt | Confirm the app called HELM instead of the upstream directly |
+| `ESCALATE` | Keep the call blocked; show the scoped approval hint |
+| Missing receipt | Confirm the application called HELM instead of the upstream directly |
+| Required header missing | Stop and use a client path that can send the server-required scope |
 
-SDK helpers are local clients for the Kernel boundary.
+SDK helpers are clients for local Kernel contracts. Source availability alone
+does not prove registry availability, native-client loading, hosted service
+availability, or interception of calls that bypass HELM.

--- a/docs/sdks/00_INDEX.md
+++ b/docs/sdks/00_INDEX.md
@@ -66,9 +66,10 @@ pinned version claim.
 
 ## Authentication Coverage
 
-Protected routes require `Authorization: Bearer $HELM_ADMIN_API_KEY`. Tenant-
-scoped routes also bind tenant and principal headers. A scoped emergency fence
-can additionally require `X-Helm-Workspace-ID`.
+Protected routes require an HTTP `Authorization` header whose scheme is
+`Bearer` and whose credential is `$HELM_ADMIN_API_KEY`. Tenant-scoped routes
+also bind tenant and principal headers. A scoped emergency fence can
+additionally require `X-Helm-Workspace-ID`.
 
 | Client | API key | Tenant | Principal | Workspace |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
## Summary
- Makes explicit that Company Builder, Company OS, Network, external builders, social surfaces, and financial rails are outside the OSS Kernel feature boundary.
- companion to Mindburn-Labs/docs#74

## Validation
- make docs-coverage docs-truth: PASS
- diff check: PASS

## Truth boundary
Target product motions remain distinct from current implementation, release, revenue, and public-claim truth.