### PR TITLE
feat(setup): harden project lifecycle and review evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 title: HELM AI Kernel Changelog
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-14
 ---
 
 # Changelog
@@ -84,10 +84,13 @@ All notable changes to the retained HELM AI Kernel surface are documented here. 
 
 ## [Unreleased]
 
-No public feature claim is active in this section. Keep research scaffolds and
-hardware-backed enforcement language out of the public changelog until a tagged
-release ships source-owned tests, verifier evidence, and release artifacts for
-that exact capability.
+- Documented the source-backed native-client lifecycle boundary: private Codex
+  project namespaces, durable receipt-envelope recovery, explicit legacy-state
+  migration, and selected-hook/MCP limits. The new maintainer review protocol
+  keeps local configuration and Kernel-only synthetic-denial proof separate
+  from a real native-client session.
+- No tagged release, real native-client session result, or broader desktop
+  enforcement claim is created by this documentation and lifecycle work.
 
 ## [0.7.2] - 2026-07-13
 

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -5,9 +5,10 @@
 - Public/private: Public OSS repo.
 - HELM normative status: Canonical HELM AI Kernel under UCS v1.3.
 - Current status: Active implementation with Go server, guardian evaluation, receipt storage/verification paths, API contracts, Dockerfile, Helm chart, tests, and docs.
-- Implemented capabilities: Guardian decision evaluation, API/server wiring, receipt persistence and verification primitives, external host evidence ingestion/verification/correlation, deployment assets, conformance/test scaffolding.
+- Implemented capabilities: Guardian decision evaluation, API/server wiring, receipt persistence and verification primitives, external host evidence ingestion/verification/correlation, deployment assets, conformance/test scaffolding, and Codex project-scoped setup/recovery with signed lifecycle evidence.
 - Not implemented: No Console source code in this repo; no hosted Enterprise automation production claim; no named buyer production rollout claim; no L4 conformance claim; no eBPF, seccomp, TPM, hardware enclave, or packet-blocking enforcement claim unless a tested code path proves it.
-- Public claims: HELM AI Kernel is the fail-closed execution firewall for AI agents; dangerous actions must be denied or escalated before dispatch; receipts can be verified and tampering must fail; HELM can consume and correlate external host/network evidence without claiming host-level enforcement.
+- Public claims: HELM AI Kernel is the fail-closed execution firewall for AI agents; dangerous actions that reach a configured boundary must be denied or escalated before dispatch; receipts can be verified and tampering must fail; HELM can consume and correlate external host/network evidence without claiming host-level enforcement.
+- Native-client boundary: Codex project setup stores an isolated project binding, recovery journal, and generated artifacts beneath a shared local authority. A matching config and Kernel-only synthetic denial are local setup evidence, not proof that a live Codex client loaded or obeyed the configuration. Claude Code setup resolves a direct CLI, requests MCP registration through that CLI, and writes selected hook configuration; it is not equivalent to the Codex project lifecycle or MCP-config readback.
 - Claim evidence: `core/cmd/helm-ai-kernel`, `core/pkg/guardian`, `core/pkg/receipt`, `core/pkg/evidence/externalhost`, `core/pkg/correlation/hostaction`, `core/pkg/verifier/externalreceipt`, `api/openapi`, `Dockerfile`, `charts/helm-ai-kernel`, `README.md`.
 - Tests that prove each claim: `go test ./...`, API contract checks, demo receipt smoke tests after API routes are enabled.
 - Docs that mention each claim: `README.md`, `docs/`, `examples/`, deployment/runbook docs.
@@ -15,5 +16,5 @@
 - Stale claims removed: Any unsupported hosted Enterprise automation, entitlement-enforcement, or production-conformance claim must remain absent until smoke-tested.
 - Remaining gaps: Keep release/version claims tied to published GitHub release assets and docs gates.
 - Verification commands: `make test` if available, `go test ./...`, API contract checks, Docker/Helm chart smoke commands from runbooks.
-- Last audited date: 2026-07-01.
+- Last audited date: 2026-07-14.
 - Owner: Mindburn Labs.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **A local firewall for AI-agent actions.**
 
-HELM sits between Claude Code, Codex, MCP tools, shell commands, and other agent
-actions. It decides `ALLOW`, `DENY`, or `ESCALATE`, then writes a signed receipt
-you can verify later.
+HELM evaluates actions that reach its configured MCP, proxy, wrapper, or hook
+boundary. It decides `ALLOW`, `DENY`, or `ESCALATE`, then writes a signed
+receipt you can verify later.
 
 ![HELM AI Kernel: one boundary, one decision, one receipt](docs/assets/readme-boundary-preview.png)
 
@@ -63,6 +63,7 @@ You get:  a signed receipt you can verify offline
 | CLI commands | [CLI reference](docs/reference/cli.md) |
 | Security model | [Execution security model](docs/EXECUTION_SECURITY_MODEL.md) |
 | MCP tool quarantine | [MCP integration](docs/INTEGRATIONS/mcp.md) |
+| Native client lifecycle and review limits | [Maintainer protocol](docs/INTEGRATIONS/native-client-lifecycle.md) |
 | Evidence verification | [Verification](docs/VERIFICATION.md) |
 | AI security category map | [AI Security Categories](docs/AI_SECURITY_CATEGORIES.md) |
 
@@ -73,6 +74,11 @@ You get:  a signed receipt you can verify offline
 - Not a vague AI-safety claim.
 
 It is the open-source execution boundary: policy in, action checked, receipt out.
+
+Codex project setup proves generated local configuration and a Kernel-only
+synthetic denial. It does not by itself prove that a live Codex session loaded
+the configuration; see the native-client lifecycle protocol before making that
+claim.
 
 ## Free Forever
 

--- a/core/cmd/helm-ai-kernel/hook_cmd.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/workstation"
 )
@@ -95,13 +96,36 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 		return 2
 	}
 	opts.Client = client
-	if abs, err := filepath.Abs(opts.DataDir); err == nil {
-		opts.DataDir = abs
+	normalizedDataDir, err := normalizeSetupDataDir(opts.DataDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "hook pre-tool: invalid --data-dir: %v\n", err)
+		return 2
+	}
+	opts.DataDir = normalizedDataDir
+	if opts.Client == "codex" {
+		recoveryRequired, recoveryErr := setupRecoveryRequired(opts.DataDir)
+		if recoveryErr != nil || recoveryRequired {
+			reason := "HELM local Codex setup recovery is pending; tool use is denied until `setup recover` completes"
+			if recoveryErr != nil {
+				reason = "HELM local Codex setup recovery state is invalid; tool use is denied until it is inspected"
+				fmt.Fprintf(stderr, "hook pre-tool: inspect Codex setup recovery state: %v\n", recoveryErr)
+			}
+			_ = json.NewEncoder(stdout).Encode(hookDecisionOutput{HookSpecificOutput: hookSpecificOutput{
+				HookEventName:            "PreToolUse",
+				PermissionDecision:       "deny",
+				PermissionDecisionReason: reason,
+			}})
+			return 0
+		}
+		if err := requireCodexProjectRuntimeAdmission(opts.DataDir); err != nil {
+			fmt.Fprintf(stderr, "hook pre-tool: inspect Codex project runtime provenance: %v\n", err)
+			return emitHookDeny(stdout, "HELM local Codex setup provenance is invalid; tool use is denied until it is repaired")
+		}
 	}
 	payload, err := decodePreToolPayload(stdin)
 	if err != nil {
 		fmt.Fprintf(stderr, "hook pre-tool: %v\n", err)
-		return 2
+		return emitHookDeny(stdout, "HELM could not decode the selected tool effect; tool use is denied")
 	}
 	classification := classifyPreToolPayload(payload)
 	if !classification.ShouldDecide {
@@ -110,15 +134,15 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 	receipt, err := buildHookDecisionReceipt(opts, payload, classification)
 	if err != nil {
 		fmt.Fprintf(stderr, "hook pre-tool: %v\n", err)
-		return 1
+		return emitHookDeny(stdout, "HELM could not evaluate the selected tool effect; tool use is denied")
 	}
 	if receipt.Verdict != contracts.WorkstationVerdictDeny {
 		return 0
 	}
-	receiptPath, err := writeDecisionReceipt("", filepath.Join(opts.DataDir, "receipts", "hooks"), receipt)
+	receiptPath, err := writeHookDecisionReceipt(opts.DataDir, receipt)
 	if err != nil {
 		fmt.Fprintf(stderr, "hook pre-tool: write receipt: %v\n", err)
-		return 1
+		return emitHookDeny(stdout, "HELM denied the selected tool effect because its decision receipt could not be persisted")
 	}
 	reason := fmt.Sprintf("HELM denied %s: %s (receipt: %s)", classification.Reason, receipt.ReasonCode, receiptPath)
 	out := hookDecisionOutput{HookSpecificOutput: hookSpecificOutput{
@@ -128,6 +152,56 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 	}}
 	_ = json.NewEncoder(stdout).Encode(out)
 	return 0
+}
+
+// emitHookDeny deliberately returns the hook's successful protocol exit code:
+// clients consume the structured deny decision, while a non-zero command exit
+// is client-version dependent and must never become an accidental allow.
+func emitHookDeny(stdout io.Writer, reason string) int {
+	_ = json.NewEncoder(stdout).Encode(hookDecisionOutput{HookSpecificOutput: hookSpecificOutput{
+		HookEventName:            "PreToolUse",
+		PermissionDecision:       "deny",
+		PermissionDecisionReason: reason,
+	}})
+	return 0
+}
+
+// writeHookDecisionReceipt confines hook-generated receipts to the already
+// normalized HELM data directory. The generic workstation writer deliberately
+// supports arbitrary operator-selected --out paths, so it must not be used by
+// an unattended client hook.
+func writeHookDecisionReceipt(dataDir string, receipt *contracts.WorkstationPolicyDecisionReceipt) (string, error) {
+	if receipt == nil || !safeHookDecisionFilename(receipt.DecisionID) {
+		return "", fmt.Errorf("hook decision receipt id is invalid")
+	}
+	receiptDir := filepath.Join(dataDir, "receipts", "hooks")
+	if err := ensureSetupAuthoritySubdirectory(dataDir, filepath.Join("receipts", "hooks")); err != nil {
+		return "", fmt.Errorf("prepare hook receipt directory: %w", err)
+	}
+	data, err := canonicalize.JCS(receipt)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(receiptDir, receipt.DecisionID+".json")
+	if filepath.Base(path) != receipt.DecisionID+".json" {
+		return "", fmt.Errorf("hook decision receipt path escapes its data directory")
+	}
+	if err := writeSetupPrivateFile(path, append(data, '\n')); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func safeHookDecisionFilename(value string) bool {
+	if value == "" || filepath.Base(value) != value || strings.ContainsRune(value, '\x00') {
+		return false
+	}
+	for _, char := range value {
+		if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '_' || char == '-') {
+			return false
+		}
+	}
+	return true
 }
 
 func printHookUsage(w io.Writer) {
@@ -143,6 +217,10 @@ func decodePreToolPayload(stdin io.Reader) (preToolPayload, error) {
 	}
 	if payload.ToolName == "" {
 		payload.ToolName = payload.ToolNameCamel
+	}
+	payload.ToolName = strings.TrimSpace(payload.ToolName)
+	if payload.ToolName == "" {
+		return payload, fmt.Errorf("hook payload is missing tool_name")
 	}
 	if payload.ToolInput == nil {
 		payload.ToolInput = payload.ToolInputCamel
@@ -283,8 +361,13 @@ func sensitiveApplyPatchTarget(command string) string {
 }
 
 func isHelmSelfMCPTool(tool string) bool {
-	t := strings.ToLower(tool)
-	return strings.Contains(t, "helm-ai-kernel") || strings.Contains(t, "helm_ai_kernel") || strings.Contains(t, "helm-ai-kernel-governance")
+	// A self-call skip prevents the hook from recursively governing the
+	// governance server. It is intentionally an exact server namespace, not a
+	// substring: a foreign MCP server can otherwise name itself
+	// "evil-helm-ai-kernel" and escape the hook entirely.
+	prefix := "mcp__" + setupMCPServerName + "__"
+	t := strings.ToLower(strings.TrimSpace(tool))
+	return strings.HasPrefix(t, prefix) && len(t) > len(prefix)
 }
 
 func isSensitiveWriteTarget(path string) bool {

--- a/core/cmd/helm-ai-kernel/hook_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd_test.go
@@ -118,6 +118,62 @@ func TestHookPreToolDeniesCodexMCPButSkipsHelmSelfMCP(t *testing.T) {
 	if receipts := globReceipts(t, tmp); len(receipts) != 1 {
 		t.Fatalf("self HELM MCP call wrote receipt, receipts = %v", receipts)
 	}
+
+	stdout.Reset()
+	stderr.Reset()
+	spoofed := `{"toolName":"mcp__evil-helm-ai-kernel-governance__write","toolInput":{"path":"/tmp/x"}}`
+	code = runHookPreToolCmd([]string{"--client", "codex", "--data-dir", tmp}, strings.NewReader(spoofed), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("substring-spoofed MCP server escaped hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if receipts := globReceipts(t, tmp); len(receipts) != 2 {
+		t.Fatalf("spoofed MCP deny did not persist a receipt, receipts = %v", receipts)
+	}
+}
+
+func TestHookPreToolFailsClosedWhenReceiptPathIsSymlinked(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	external := filepath.Join(t.TempDir(), "external")
+	if err := os.MkdirAll(external, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(tmp, "receipts")); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"tool_name":"Write","tool_input":{"file_path":".env"}}`
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) || !strings.Contains(stdout.String(), "could not be persisted") {
+		t.Fatalf("symlinked hook receipt path did not fail closed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	entries, err := os.ReadDir(external)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("hook receipt escaped through symlink: entries=%v err=%v", entries, err)
+	}
+}
+
+func TestWriteHookDecisionReceiptRejectsSymlinkedFinalPath(t *testing.T) {
+	tmp := t.TempDir()
+	receipt := &contracts.WorkstationPolicyDecisionReceipt{DecisionID: "wpd_test"}
+	receiptDir := filepath.Join(tmp, "receipts", "hooks")
+	if err := os.MkdirAll(receiptDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(t.TempDir(), "external.json")
+	if err := os.WriteFile(external, []byte("do-not-touch"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, filepath.Join(receiptDir, receipt.DecisionID+".json")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeHookDecisionReceipt(tmp, receipt); err == nil {
+		t.Fatal("symlinked final hook receipt path was accepted")
+	}
+	got, err := os.ReadFile(external)
+	if err != nil || string(got) != "do-not-touch" {
+		t.Fatalf("symlinked final hook receipt target changed: got=%q err=%v", got, err)
+	}
 }
 
 func TestHookPreToolDeniesSensitiveWrite(t *testing.T) {
@@ -131,6 +187,19 @@ func TestHookPreToolDeniesSensitiveWrite(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
 		t.Fatalf("sensitive write should be denied, output = %s", stdout.String())
+	}
+}
+
+func TestHookPreToolFailsClosedForMalformedOrUnnamedPayload(t *testing.T) {
+	tmp := t.TempDir()
+	for _, payload := range []string{"not-json", `{"tool_input":{"path":"/tmp/x"}}`} {
+		t.Run(payload, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+			if code != 0 || !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) || !strings.Contains(stdout.String(), "could not decode") {
+				t.Fatalf("malformed hook payload did not produce structured deny: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+		})
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/lite_mode.go
+++ b/core/cmd/helm-ai-kernel/lite_mode.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
@@ -27,6 +28,11 @@ func setupLiteModeWithDataDir(ctx context.Context, dataDir string) (*sql.DB, led
 	if dataDir == "" {
 		dataDir = "data"
 	}
+	normalizedDataDir, err := ensureSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("invalid or unsafe lite-mode data dir: %w", err)
+	}
+	dataDir = normalizedDataDir
 	return setupLiteModeWithDBPath(ctx, filepath.Join(dataDir, "helm.db"))
 }
 
@@ -44,16 +50,30 @@ func setupLiteModeWithDBPath(ctx context.Context, dbPath string) (*sql.DB, ledge
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to open sqlite: %w", err)
 	}
+	// The ledger schema is initialized before the receipt store configures its
+	// SQLite pragmas. Set the one-writer pool and busy timeout immediately so
+	// two project-scoped setups sharing a deliberate authority data-dir wait
+	// for one another rather than leaving one valid recovery journal behind on
+	// a transient SQLITE_BUSY during first use.
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(time.Hour)
+	if _, err := db.Exec("PRAGMA busy_timeout=10000;"); err != nil {
+		_ = db.Close()
+		return nil, nil, nil, fmt.Errorf("failed to set sqlite busy timeout: %w", err)
+	}
 
 	// Initialize Ledger
 	lgr := ledger.NewSQLLedger(db)
 	if err := lgr.Init(ctx); err != nil {
+		_ = db.Close()
 		return nil, nil, nil, fmt.Errorf("failed to init sqlite ledger: %w", err)
 	}
 
 	// Initialize Receipt Store
 	receiptStore, err := store.NewSQLiteReceiptStore(db)
 	if err != nil {
+		_ = db.Close()
 		return nil, nil, nil, fmt.Errorf("failed to init sqlite receipt store: %w", err)
 	}
 
@@ -74,14 +94,20 @@ func loadOrGenerateSignerWithDataDir(dataDir string) (crypto.Signer, error) {
 	if dataDir == "" {
 		dataDir = "data"
 	}
-	if err := os.MkdirAll(dataDir, 0750); err != nil {
-		return nil, fmt.Errorf("failed to create data dir: %w", err)
+	profile := os.Getenv("HELM_RECEIPT_PROFILE")
+	if profile != "" && profile != crypto.ReceiptProfileClassical && profile != crypto.ReceiptProfileHybrid {
+		return nil, fmt.Errorf("unknown HELM_RECEIPT_PROFILE %q (expected %q or %q)", profile, crypto.ReceiptProfileClassical, crypto.ReceiptProfileHybrid)
 	}
+	normalizedDataDir, err := ensureSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("invalid or unsafe signer data dir: %w", err)
+	}
+	dataDir = normalizedDataDir
 	edSigner, err := loadOrGenerateEd25519Root(dataDir)
 	if err != nil {
 		return nil, err
 	}
-	switch profile := os.Getenv("HELM_RECEIPT_PROFILE"); profile {
+	switch profile {
 	case "", crypto.ReceiptProfileClassical:
 		return edSigner, nil
 	case crypto.ReceiptProfileHybrid:
@@ -92,25 +118,23 @@ func loadOrGenerateSignerWithDataDir(dataDir string) (crypto.Signer, error) {
 		log.Printf("[helm] trust: PQ-hybrid receipt profile enabled (Ed25519 + ML-DSA-65)")
 		return crypto.NewHybridSignerFromSigners(edSigner, mldsaSigner, "root")
 	default:
-		return nil, fmt.Errorf("unknown HELM_RECEIPT_PROFILE %q (expected %q or %q)", profile, crypto.ReceiptProfileClassical, crypto.ReceiptProfileHybrid)
+		return nil, fmt.Errorf("unsupported HELM_RECEIPT_PROFILE %q", profile)
 	}
 }
 
 func loadOrGenerateEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
 	keyPath := filepath.Join(dataDir, "root.key")
-	if _, err := os.Stat(keyPath); err == nil {
-		// Load existing key
-		keyHex, err := os.ReadFile(keyPath)
+	state, err := readSetupExistingPrivateFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect root.key: %w", err)
+	}
+	if state.Exists {
+		signer, err := ed25519SignerFromRootKey(state.Data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read root.key: %w", err)
+			return nil, err
 		}
-		seed, err := hex.DecodeString(string(keyHex))
-		if err != nil {
-			return nil, fmt.Errorf("invalid root.key format: %w", err)
-		}
-		priv := ed25519.NewKeyFromSeed(seed)
 		log.Printf("[helm] trust: loaded persistent root key")
-		return crypto.NewEd25519SignerFromKey(priv, "root"), nil
+		return signer, nil
 	}
 
 	// Generate new persistent key if not in production
@@ -129,12 +153,23 @@ func loadOrGenerateEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
 	}
 
 	seed := priv.Seed()
-	if err := os.WriteFile(keyPath, []byte(hex.EncodeToString(seed)), 0600); err != nil {
+	created, err := writeSetupPrivateFileIfAbsent(keyPath, []byte(hex.EncodeToString(seed)))
+	if err != nil {
 		return nil, fmt.Errorf("failed to save root.key: %w", err)
+	}
+	if !created {
+		state, err := readSetupExistingPrivateFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("reload concurrently-created root.key: %w", err)
+		}
+		if !state.Exists {
+			return nil, fmt.Errorf("root.key disappeared after concurrent authority creation")
+		}
+		return ed25519SignerFromRootKey(state.Data)
 	}
 
 	pubPath := filepath.Join(dataDir, "root.pub")
-	if err := os.WriteFile(pubPath, []byte(hex.EncodeToString(pub)), 0644); err != nil {
+	if err := writeSetupPrivateFile(pubPath, []byte(hex.EncodeToString(pub))); err != nil {
 		log.Printf("⚠️  failed to save root.pub: %v", err)
 	}
 
@@ -147,23 +182,17 @@ func loadOrGenerateEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
 // alongside the Ed25519 root key.
 func loadOrGenerateMLDSARoot(dataDir string) (*crypto.MLDSASigner, error) {
 	keyPath := filepath.Join(dataDir, "root.mldsa65.key")
-	if _, err := os.Stat(keyPath); err == nil {
-		keyHex, err := os.ReadFile(keyPath)
+	state, err := readSetupExistingPrivateFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect root.mldsa65.key: %w", err)
+	}
+	if state.Exists {
+		signer, err := mldsaSignerFromRootKey(state.Data)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read root.mldsa65.key: %w", err)
+			return nil, err
 		}
-		seedBytes, err := hex.DecodeString(string(keyHex))
-		if err != nil {
-			return nil, fmt.Errorf("invalid root.mldsa65.key format: %w", err)
-		}
-		if len(seedBytes) != mldsa65.SeedSize {
-			return nil, fmt.Errorf("invalid root.mldsa65.key seed size: %d, expected %d", len(seedBytes), mldsa65.SeedSize)
-		}
-		var seed [mldsa65.SeedSize]byte
-		copy(seed[:], seedBytes)
-		_, priv := mldsa65.NewKeyFromSeed(&seed)
 		log.Printf("[helm] trust: loaded persistent ml-dsa-65 root key")
-		return crypto.NewMLDSASignerFromKey(priv, "root"), nil
+		return signer, nil
 	}
 
 	if envBool("HELM_PRODUCTION") {
@@ -176,8 +205,97 @@ func loadOrGenerateMLDSARoot(dataDir string) (*crypto.MLDSASigner, error) {
 		return nil, fmt.Errorf("failed to generate ml-dsa-65 key: %w", err)
 	}
 	seed := priv.Seed()
-	if err := os.WriteFile(keyPath, []byte(hex.EncodeToString(seed)), 0600); err != nil {
+	created, err := writeSetupPrivateFileIfAbsent(keyPath, []byte(hex.EncodeToString(seed)))
+	if err != nil {
 		return nil, fmt.Errorf("failed to save root.mldsa65.key: %w", err)
 	}
+	if !created {
+		state, err := readSetupExistingPrivateFile(keyPath)
+		if err != nil {
+			return nil, fmt.Errorf("reload concurrently-created root.mldsa65.key: %w", err)
+		}
+		if !state.Exists {
+			return nil, fmt.Errorf("root.mldsa65.key disappeared after concurrent authority creation")
+		}
+		return mldsaSignerFromRootKey(state.Data)
+	}
+	return crypto.NewMLDSASignerFromKey(priv, "root"), nil
+}
+
+// loadExistingSignerWithDataDir is the non-mutating counterpart to
+// loadOrGenerateSignerWithDataDir. Recovery and removal provenance must never
+// create a new authority, a public-key sidecar, or a database merely by
+// checking whether a prior installation is trustworthy.
+func loadExistingSignerWithDataDir(dataDir string) (crypto.Signer, error) {
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	normalizedDataDir, err := requireSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("invalid or unsafe signer data dir: %w", err)
+	}
+	dataDir = normalizedDataDir
+	edSigner, err := loadExistingEd25519Root(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	switch profile := os.Getenv("HELM_RECEIPT_PROFILE"); profile {
+	case "", crypto.ReceiptProfileClassical:
+		return edSigner, nil
+	case crypto.ReceiptProfileHybrid:
+		mldsaSigner, err := loadExistingMLDSARoot(dataDir)
+		if err != nil {
+			return nil, err
+		}
+		return crypto.NewHybridSignerFromSigners(edSigner, mldsaSigner, "root")
+	default:
+		return nil, fmt.Errorf("unknown HELM_RECEIPT_PROFILE %q (expected %q or %q)", profile, crypto.ReceiptProfileClassical, crypto.ReceiptProfileHybrid)
+	}
+}
+
+func loadExistingEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
+	state, err := readSetupExistingPrivateFile(filepath.Join(dataDir, "root.key"))
+	if err != nil {
+		return nil, fmt.Errorf("inspect root.key: %w", err)
+	}
+	if !state.Exists {
+		return nil, fmt.Errorf("root.key does not exist")
+	}
+	return ed25519SignerFromRootKey(state.Data)
+}
+
+func ed25519SignerFromRootKey(raw []byte) (*crypto.Ed25519Signer, error) {
+	seed, err := hex.DecodeString(string(raw))
+	if err != nil {
+		return nil, fmt.Errorf("invalid root.key format: %w", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("invalid root.key seed size: %d, expected %d", len(seed), ed25519.SeedSize)
+	}
+	return crypto.NewEd25519SignerFromKey(ed25519.NewKeyFromSeed(seed), "root"), nil
+}
+
+func loadExistingMLDSARoot(dataDir string) (*crypto.MLDSASigner, error) {
+	state, err := readSetupExistingPrivateFile(filepath.Join(dataDir, "root.mldsa65.key"))
+	if err != nil {
+		return nil, fmt.Errorf("inspect root.mldsa65.key: %w", err)
+	}
+	if !state.Exists {
+		return nil, fmt.Errorf("root.mldsa65.key does not exist")
+	}
+	return mldsaSignerFromRootKey(state.Data)
+}
+
+func mldsaSignerFromRootKey(raw []byte) (*crypto.MLDSASigner, error) {
+	seedBytes, err := hex.DecodeString(string(raw))
+	if err != nil {
+		return nil, fmt.Errorf("invalid root.mldsa65.key format: %w", err)
+	}
+	if len(seedBytes) != mldsa65.SeedSize {
+		return nil, fmt.Errorf("invalid root.mldsa65.key seed size: %d, expected %d", len(seedBytes), mldsa65.SeedSize)
+	}
+	var seed [mldsa65.SeedSize]byte
+	copy(seed[:], seedBytes)
+	_, priv := mldsa65.NewKeyFromSeed(&seed)
 	return crypto.NewMLDSASignerFromKey(priv, "root"), nil
 }

--- a/core/cmd/helm-ai-kernel/mcp_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_cmd.go
@@ -114,11 +114,13 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 		transport string
 		port      int
 		authMode  string
+		dataDir   string
 	)
 
 	cmd.StringVar(&transport, "transport", "stdio", "Transport: stdio, http")
 	cmd.IntVar(&port, "port", 9100, "Port for HTTP transport")
 	cmd.StringVar(&authMode, "auth", "none", "Auth mode: none, static-header, oauth")
+	cmd.StringVar(&dataDir, "data-dir", "", "Kernel local-state directory for stdio transport")
 
 	if err := cmd.Parse(args); err != nil {
 		return 2
@@ -130,12 +132,24 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "Error: stdio transport only supports --auth none")
 			return 2
 		}
-		if err := serveLocalMCPStdio(os.Stdin, stdout); err != nil {
+		if dataDir != "" {
+			normalizedDataDir, err := normalizeSetupDataDir(dataDir)
+			if err != nil {
+				fmt.Fprintf(stderr, "Error: invalid --data-dir: %v\n", err)
+				return 2
+			}
+			dataDir = normalizedDataDir
+		}
+		if err := serveLocalMCPStdioWithDataDir(os.Stdin, stdout, dataDir); err != nil {
 			fmt.Fprintf(stderr, "Error: MCP stdio server failed: %v\n", err)
 			return 2
 		}
 		return 0
 	case "http":
+		if dataDir != "" {
+			fmt.Fprintln(stderr, "Error: --data-dir is supported only with stdio transport")
+			return 2
+		}
 		server, err := newLocalMCPHTTPServer(port, authMode)
 		if err != nil {
 			fmt.Fprintf(stderr, "Error: %v\n", err)

--- a/core/cmd/helm-ai-kernel/mcp_mediation_proof_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_mediation_proof_test.go
@@ -360,6 +360,36 @@ func TestMCPMediationProofUnsupportedWebSocketTransportFailsClosed(t *testing.T)
 	}
 }
 
+func TestMCPServeStdioUsesExplicitDataDir(t *testing.T) {
+	dir := chdirTempDir(t)
+	stateDir := filepath.Join(dir, "kernel-state")
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStdin := os.Stdin
+	os.Stdin = reader
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = reader.Close()
+	})
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runMCPServe([]string{"--transport", "stdio", "--data-dir", stateDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("mcp serve exit = %d stderr = %s", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "root.key")); err != nil {
+		t.Fatalf("mcp serve did not use explicit data dir for signer state: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "data", "root.key")); !os.IsNotExist(err) {
+		t.Fatalf("mcp serve unexpectedly used default data dir: %v", err)
+	}
+}
+
 func proofCatalog(t *testing.T) *mcppkg.ToolCatalog {
 	t.Helper()
 	catalog := mcppkg.NewToolCatalog()

--- a/core/cmd/helm-ai-kernel/mcp_runtime.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime.go
@@ -42,16 +42,56 @@ type mcpRPCError struct {
 }
 
 func newLocalMCPRuntime() (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
-	signer, err := loadOrGenerateSigner()
+	return newLocalMCPRuntimeWithDataDir("")
+}
+
+// newLocalMCPRuntimeWithDataDir binds a client-spawned MCP process to the
+// caller-selected local signer/state directory. An empty data directory keeps
+// the historical default for standalone invocations.
+func newLocalMCPRuntimeWithDataDir(dataDir string) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
+	if dataDir != "" {
+		signer, configured, err := admitCodexProjectRuntime(dataDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		if configured {
+			return newLocalMCPRuntimeWithSigner(signer)
+		}
+	}
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
 	if err != nil {
 		return nil, nil, err
 	}
 	return newLocalMCPRuntimeWithSigner(signer)
 }
 
+func newLocalMCPRuntimeWithDataDirAndHandler(dataDir string, handler mcppkg.ToolHandler) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
+	if dataDir != "" {
+		signer, configured, err := admitCodexProjectRuntime(dataDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		if configured {
+			return newLocalMCPRuntimeWithSignerAndHandler(signer, handler)
+		}
+	}
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	return newLocalMCPRuntimeWithSignerAndHandler(signer, handler)
+}
+
 func newLocalMCPRuntimeWithSigner(signer helmcrypto.Signer) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
+	return newLocalMCPRuntimeWithSignerAndHandler(signer, runLocalMCPTool)
+}
+
+func newLocalMCPRuntimeWithSignerAndHandler(signer helmcrypto.Signer, handler mcppkg.ToolHandler) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
 	if signer == nil {
 		return nil, nil, fmt.Errorf("mcp signer is required")
+	}
+	if handler == nil {
+		return nil, nil, fmt.Errorf("mcp tool handler is required")
 	}
 	catalog := mcppkg.NewInMemoryCatalog()
 	catalog.RegisterCommonTools()
@@ -62,7 +102,7 @@ func newLocalMCPRuntimeWithSigner(signer helmcrypto.Signer) (*mcppkg.ToolCatalog
 	guard := guardian.NewGuardian(signer, prg.NewGraph(), nil)
 	firewall := mcppkg.NewGovernanceFirewall(guard, catalog)
 
-	return catalog, mcppkg.ToolExecutor(firewall.WrapToolHandler(runLocalMCPTool)), nil
+	return catalog, mcppkg.ToolExecutor(firewall.WrapToolHandler(handler)), nil
 }
 
 func newLocalMCPGateway() (*mcppkg.Gateway, error) {
@@ -199,7 +239,38 @@ func resolveLocalMCPPath(rawPath string) (string, error) {
 }
 
 func serveLocalMCPStdio(stdin io.Reader, stdout io.Writer) error {
-	catalog, executor, err := newLocalMCPRuntime()
+	return serveLocalMCPStdioWithDataDir(stdin, stdout, "")
+}
+
+func serveLocalMCPStdioWithDataDir(stdin io.Reader, stdout io.Writer, dataDir string) error {
+	var admittedSigner helmcrypto.Signer
+	if dataDir != "" {
+		normalizedDataDir, err := normalizeSetupDataDir(dataDir)
+		if err != nil {
+			return fmt.Errorf("normalize MCP state data-dir: %w", err)
+		}
+		dataDir = normalizedDataDir
+		if err := requireMCPSetupRecoveryClear(dataDir); err != nil {
+			return err
+		}
+		signer, configured, err := admitCodexProjectRuntime(dataDir)
+		if err != nil {
+			return err
+		}
+		if configured {
+			admittedSigner = signer
+		}
+	}
+	var (
+		catalog  *mcppkg.ToolCatalog
+		executor mcppkg.ToolExecutor
+		err      error
+	)
+	if admittedSigner != nil {
+		catalog, executor, err = newLocalMCPRuntimeWithSigner(admittedSigner)
+	} else {
+		catalog, executor, err = newLocalMCPRuntimeWithDataDir(dataDir)
+	}
 	if err != nil {
 		return err
 	}
@@ -213,6 +284,14 @@ func serveLocalMCPStdio(stdin io.Reader, stdout io.Writer) error {
 			}
 			return err
 		}
+		if dataDir != "" {
+			if err := requireMCPSetupRecoveryClear(dataDir); err != nil {
+				return err
+			}
+			if err := requireCodexProjectRuntimeAdmission(dataDir); err != nil {
+				return err
+			}
+		}
 
 		resp, err := handleMCPRPCRequest(req, catalog, executor)
 		if err != nil {
@@ -225,6 +304,17 @@ func serveLocalMCPStdio(stdin io.Reader, stdout io.Writer) error {
 			return err
 		}
 	}
+}
+
+func requireMCPSetupRecoveryClear(dataDir string) error {
+	recoveryRequired, err := setupRecoveryRequired(dataDir)
+	if err != nil {
+		return fmt.Errorf("inspect setup recovery state: %w", err)
+	}
+	if recoveryRequired {
+		return fmt.Errorf("refusing MCP execution while a Codex project setup recovery is pending")
+	}
+	return nil
 }
 
 func readMCPRequest(reader *bufio.Reader) (*mcpRPCRequest, error) {

--- a/core/cmd/helm-ai-kernel/mcp_runtime_failclosed_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime_failclosed_test.go
@@ -1,14 +1,33 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
 )
+
+func setupProvenNativeCodexProjectForRuntime(t *testing.T) (string, setupSummary) {
+	t.Helper()
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup codex exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("decode setup summary: %v\n%s", err, stdout.String())
+	}
+	return dataDir, summary
+}
 
 func TestLocalMCPRuntimeFailsClosedWithoutPolicyGraph(t *testing.T) {
 	dir := chdirTempDir(t)
@@ -34,5 +53,157 @@ func TestLocalMCPRuntimeFailsClosedWithoutPolicyGraph(t *testing.T) {
 	}
 	if strings.Contains(resp.Content, "sensitive") {
 		t.Fatalf("blocked MCP response leaked file content: %q", resp.Content)
+	}
+}
+
+func TestLocalMCPStdioRefusesPendingCodexSetupRecovery(t *testing.T) {
+	dir := chdirTempDir(t)
+	stateDir := filepath.Join(dir, "kernel-state")
+	if err := prepareSetupRecoveryDirectory(stateDir); err != nil {
+		t.Fatal(err)
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := inspectSetupKernelBinary(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	txnID, err := newSetupRecoveryTransactionID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptID, err := newSetupLifecycleReceiptID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	specs, err := expectedSetupRecoveryPlans("install")
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans := make([]setupRecoveryFilePlan, 0, len(specs))
+	for _, spec := range specs {
+		plans = append(plans, setupRecoveryFilePlan{ID: spec.ID, StageFile: spec.StageFile})
+	}
+	journal := setupRecoveryJournal{
+		SchemaVersion:      setupRecoverySchema,
+		TransactionID:      txnID,
+		Operation:          "install",
+		Target:             "codex",
+		Scope:              "project",
+		WorkspacePathHash:  workspacePathHash,
+		DataDirPathHash:    canonicalize.HashBytes([]byte(stateDir)),
+		BinaryPath:         identity.Path,
+		BinaryContentHash:  identity.ContentHash,
+		LifecycleReceiptID: receiptID,
+		Phase:              setupRecoveryPhasePrepared,
+		Files:              plans,
+	}
+	if err := writeSetupRecoveryJournal(stateDir, journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, stateDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("pending recovery did not block MCP stdio startup: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "root.key")); !os.IsNotExist(err) {
+		t.Fatalf("recovery-blocked MCP startup initialized signer state: %v", err)
+	}
+}
+
+func TestLocalMCPRuntimeWithDataDirFailsClosedBeforeFileWrite(t *testing.T) {
+	dir := chdirTempDir(t)
+	stateDir := filepath.Join(dir, "kernel-state")
+	sentinel := filepath.Join(dir, "must-not-exist.sentinel")
+
+	_, executor, err := newLocalMCPRuntimeWithDataDir(stateDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := executor(context.Background(), mcppkg.ToolExecutionRequest{
+		ToolName:  "file_write",
+		SessionID: "mcp-test",
+		Arguments: map[string]any{
+			"path":    sentinel,
+			"content": "must not exist",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.IsError {
+		t.Fatalf("expected local MCP file_write to fail closed, got %+v", resp)
+	}
+	if _, err := os.Stat(sentinel); !os.IsNotExist(err) {
+		t.Fatalf("denied MCP file_write created sentinel: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "root.key")); err != nil {
+		t.Fatalf("runtime did not use explicit data dir for signer state: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "data", "root.key")); !os.IsNotExist(err) {
+		t.Fatalf("runtime unexpectedly used default data dir: %v", err)
+	}
+}
+
+func TestConfiguredCodexRuntimeRejectsDamagedLifecycleProofWithoutNewAuthority(t *testing.T) {
+	cases := []struct {
+		name   string
+		damage func(t *testing.T, dataDir string, summary setupSummary)
+	}{
+		{
+			name: "missing root key",
+			damage: func(t *testing.T, dataDir string, _ setupSummary) {
+				t.Helper()
+				if err := os.Remove(filepath.Join(dataDir, "root.key")); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "missing install binding",
+			damage: func(t *testing.T, dataDir string, _ setupSummary) {
+				t.Helper()
+				if err := os.Remove(setupCodexProjectBindingPath(dataDir)); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "missing lifecycle evidence",
+			damage: func(t *testing.T, _ string, summary setupSummary) {
+				t.Helper()
+				if err := os.Remove(summary.LifecycleEvidencePath); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir, summary := setupProvenNativeCodexProjectForRuntime(t)
+			tc.damage(t, dataDir, summary)
+
+			if _, _, err := newLocalMCPRuntimeWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "provenance") {
+				t.Fatalf("direct configured runtime bypassed provenance admission: %v", err)
+			}
+			if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "runtime provenance") {
+				t.Fatalf("damaged native lifecycle proof started MCP runtime: %v", err)
+			}
+			if tc.name == "missing root key" {
+				if _, err := os.Stat(filepath.Join(dataDir, "root.key")); !os.IsNotExist(err) {
+					t.Fatalf("runtime recreated missing lifecycle authority: %v", err)
+				}
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"mcp__filesystem__write_file","tool_input":{"path":"/tmp/x"}}`), &stdout, &stderr)
+			if code != 0 || !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) || !strings.Contains(stdout.String(), "provenance") {
+				t.Fatalf("damaged native lifecycle proof did not deny hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+		})
 	}
 }

--- a/core/cmd/helm-ai-kernel/setup_authority_dir_owner_other.go
+++ b/core/cmd/helm-ai-kernel/setup_authority_dir_owner_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !freebsd && !openbsd && !netbsd && !dragonfly && !windows
+
+package main
+
+import "os"
+
+// Platforms without the POSIX ownership API still receive strict directory
+// type, symlink, and writable-mode checks from requireSetupAuthorityDirectory.
+func requireSetupAuthorityDirectoryOwner(_ string, _ os.FileInfo) error { return nil }

--- a/core/cmd/helm-ai-kernel/setup_authority_dir_owner_unix.go
+++ b/core/cmd/helm-ai-kernel/setup_authority_dir_owner_unix.go
@@ -1,0 +1,24 @@
+//go:build darwin || linux || freebsd || openbsd || netbsd || dragonfly
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// requireSetupAuthorityDirectoryOwner rejects state directories owned by a
+// different local account. Even without broad write permissions, that owner
+// can replace a child or change its mode later.
+func requireSetupAuthorityDirectoryOwner(path string, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("cannot determine authority state directory ownership: %s", path)
+	}
+	uid := os.Getuid()
+	if uid >= 0 && stat.Uid != uint32(uid) {
+		return fmt.Errorf("authority state directory is not owned by the current user: %s", path)
+	}
+	return nil
+}

--- a/core/cmd/helm-ai-kernel/setup_authority_dir_owner_windows.go
+++ b/core/cmd/helm-ai-kernel/setup_authority_dir_owner_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package main
+
+import "os"
+
+// Windows ACL inspection requires a security-descriptor implementation. The
+// portable directory mode and symlink checks still apply; this build does not
+// claim the POSIX owner check on Windows.
+func requireSetupAuthorityDirectoryOwner(_ string, _ os.FileInfo) error { return nil }

--- a/core/cmd/helm-ai-kernel/setup_autoconfigure_transaction.go
+++ b/core/cmd/helm-ai-kernel/setup_autoconfigure_transaction.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// setupAutoconfigureTransaction preserves only the three artifacts generated
+// by `setup`. It keeps private snapshots in memory and restores them only when
+// the exact bytes written by HELM still exist, so a failed setup cannot leave
+// generated workspace inventory behind or overwrite a concurrent user edit.
+type setupAutoconfigureTransaction struct {
+	files []setupTransactionFile
+	dirs  []setupDirectoryState
+}
+
+type setupDirectoryState struct {
+	path   string
+	exists bool
+}
+
+func beginSetupAutoconfigureTransaction(dataDir string) (*setupAutoconfigureTransaction, error) {
+	absDataDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	paths := []string{
+		filepath.Join(absDataDir, "autoconfigure", "inventory.json"),
+		filepath.Join(absDataDir, "autoconfigure", "policy.draft.json"),
+		filepath.Join(absDataDir, "autoconfigure", "mcp_quarantine_plan.json"),
+	}
+	tx := &setupAutoconfigureTransaction{}
+	for _, path := range paths {
+		before, err := readSetupFileState(path)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot autoconfigure artifact %s: %w", path, err)
+		}
+		tx.files = append(tx.files, setupTransactionFile{before: before, after: before})
+	}
+	for _, dir := range []string{absDataDir, filepath.Join(absDataDir, "autoconfigure")} {
+		state, err := snapshotSetupDirectory(dir)
+		if err != nil {
+			return nil, err
+		}
+		tx.dirs = append(tx.dirs, state)
+	}
+	return tx, nil
+}
+
+func snapshotSetupDirectory(path string) (setupDirectoryState, error) {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return setupDirectoryState{path: path}, nil
+	}
+	if err != nil {
+		return setupDirectoryState{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return setupDirectoryState{}, fmt.Errorf("refusing to write setup artifacts through symlinked directory %s", path)
+	}
+	if !info.IsDir() {
+		return setupDirectoryState{}, fmt.Errorf("setup artifact directory is not a directory: %s", path)
+	}
+	return setupDirectoryState{path: path, exists: true}, nil
+}
+
+func (tx *setupAutoconfigureTransaction) ensureDataDir() error {
+	if tx == nil || len(tx.dirs) == 0 {
+		return fmt.Errorf("autoconfigure transaction is not initialized")
+	}
+	if err := os.MkdirAll(tx.dirs[0].path, 0o750); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (tx *setupAutoconfigureTransaction) writeJSON(path string, value any) error {
+	data, err := marshalSetupJSONArtifact(value)
+	if err != nil {
+		return err
+	}
+	return tx.replace(path, data)
+}
+
+func (tx *setupAutoconfigureTransaction) replace(path string, data []byte) error {
+	if tx == nil {
+		return fmt.Errorf("autoconfigure transaction is not initialized")
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	for index := range tx.files {
+		file := &tx.files[index]
+		if file.before.Path != absPath {
+			continue
+		}
+		current, err := readSetupFileState(absPath)
+		if err != nil {
+			return err
+		}
+		if !sameSetupFileState(current, file.before) {
+			return fmt.Errorf("autoconfigure artifact changed concurrently before HELM could modify it: %s", absPath)
+		}
+		if err := writeSetupPrivateFile(absPath, data); err != nil {
+			return err
+		}
+		file.after = setupFileState{Path: absPath, Exists: true, Data: append([]byte(nil), data...)}
+		file.mutated = true
+		return nil
+	}
+	return fmt.Errorf("untracked autoconfigure artifact path %s", absPath)
+}
+
+func (tx *setupAutoconfigureTransaction) rollback() error {
+	if tx == nil {
+		return nil
+	}
+	var rollbackErrors []error
+	for index := len(tx.files) - 1; index >= 0; index-- {
+		if err := rollbackSetupTransactionFile(tx.files[index], "autoconfigure artifact"); err != nil {
+			rollbackErrors = append(rollbackErrors, err)
+		}
+	}
+	// Empty directories created by this attempt are safe to remove. A nonempty
+	// directory is retained and reported rather than risking a concurrent file.
+	for index := len(tx.dirs) - 1; index >= 0; index-- {
+		dir := tx.dirs[index]
+		if dir.exists {
+			continue
+		}
+		if err := os.Remove(dir.path); err != nil && !os.IsNotExist(err) {
+			rollbackErrors = append(rollbackErrors, fmt.Errorf("remove empty setup directory %s: %w", dir.path, err))
+		}
+	}
+	return errors.Join(rollbackErrors...)
+}
+
+func rollbackSetupAutoconfigure(tx *setupAutoconfigureTransaction, cause error) error {
+	if rollbackErr := tx.rollback(); rollbackErr != nil {
+		return fmt.Errorf("%w; autoconfigure rollback failed: %v", cause, rollbackErr)
+	}
+	return cause
+}

--- a/core/cmd/helm-ai-kernel/setup_binary_identity.go
+++ b/core/cmd/helm-ai-kernel/setup_binary_identity.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+// setupKernelBinaryIdentity pins a native-client configuration to a concrete
+// executable rather than a basename-shaped path. It intentionally refuses a
+// symlink at this boundary so a later target swap cannot silently change the
+// program that Codex or the hook will launch.
+type setupKernelBinaryIdentity struct {
+	Path        string
+	ContentHash string
+}
+
+func inspectSetupKernelBinary(path string) (setupKernelBinaryIdentity, error) {
+	if !filepath.IsAbs(path) || strings.ContainsRune(path, '\x00') {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("Kernel binary path must be absolute")
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("resolve Kernel binary %s: %w", path, err)
+	}
+	resolved, err = filepath.Abs(resolved)
+	if err != nil {
+		return setupKernelBinaryIdentity{}, err
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("inspect Kernel binary %s: %w", resolved, err)
+	}
+	if !info.Mode().IsRegular() {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("Kernel binary is not a regular file: %s", resolved)
+	}
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("Kernel binary is not executable: %s", resolved)
+	}
+	if !isHELMKernelExecutable(resolved) {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("Kernel binary does not have a HELM executable name: %s", resolved)
+	}
+	contents, err := os.ReadFile(resolved)
+	if err != nil {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("read Kernel binary %s: %w", resolved, err)
+	}
+	return setupKernelBinaryIdentity{Path: resolved, ContentHash: canonicalize.HashBytes(contents)}, nil
+}

--- a/core/cmd/helm-ai-kernel/setup_claude_code_binary.go
+++ b/core/cmd/helm-ai-kernel/setup_claude_code_binary.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const setupClaudeCodeBinaryEnv = "CLAUDE_CODE_BIN"
+
+var setupClaudeCodeLookPath = exec.LookPath
+
+// resolveSetupClaudeCodeBinary chooses the client executable without reading
+// any client configuration. An explicit path is required for the override so
+// it cannot silently fall back to a different PATH entry at execution time.
+func resolveSetupClaudeCodeBinary() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(setupClaudeCodeBinaryEnv)); override != "" {
+		if !filepath.IsAbs(override) && !strings.ContainsRune(override, os.PathSeparator) {
+			return "", fmt.Errorf("%s must be an executable path, not a command name", setupClaudeCodeBinaryEnv)
+		}
+		binary, err := resolveSetupClaudeCodeExecutable(override)
+		if err != nil {
+			return "", fmt.Errorf("%s must point to an executable file: %w", setupClaudeCodeBinaryEnv, err)
+		}
+		return binary, nil
+	}
+
+	path, err := setupClaudeCodeLookPath("claude")
+	if err != nil {
+		return "", fmt.Errorf("locate Claude Code CLI: %w; set %s to its executable path", err, setupClaudeCodeBinaryEnv)
+	}
+	binary, err := resolveSetupClaudeCodeExecutable(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve Claude Code CLI from PATH: %w; set %s to its executable path", err, setupClaudeCodeBinaryEnv)
+	}
+	if isSetupMiseShim(path) || isSetupMiseShim(binary) {
+		return "", fmt.Errorf("refusing Claude Code CLI resolved through a mise shim; set %s to a direct executable path", setupClaudeCodeBinaryEnv)
+	}
+	return binary, nil
+}
+
+func resolveSetupClaudeCodeExecutable(path string) (string, error) {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	binary, err := exec.LookPath(absolute)
+	if err != nil {
+		return "", err
+	}
+	binary, err = filepath.EvalSymlinks(binary)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(binary)
+	if err != nil {
+		return "", err
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("not a regular file")
+	}
+	return binary, nil
+}
+
+func isSetupMiseShim(path string) bool {
+	return strings.Contains(filepath.ToSlash(filepath.Clean(path)), "/mise/shims/")
+}

--- a/core/cmd/helm-ai-kernel/setup_claude_code_binary_test.go
+++ b/core/cmd/helm-ai-kernel/setup_claude_code_binary_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveSetupClaudeCodeBinaryUsesExecutableOverride(t *testing.T) {
+	claude := writeSetupExecutable(t, filepath.Join(t.TempDir(), "direct-claude"))
+	t.Setenv(setupClaudeCodeBinaryEnv, claude)
+
+	oldLookPath := setupClaudeCodeLookPath
+	setupClaudeCodeLookPath = func(string) (string, error) {
+		return "", errors.New("PATH lookup must not run when CLAUDE_CODE_BIN is set")
+	}
+	t.Cleanup(func() { setupClaudeCodeLookPath = oldLookPath })
+
+	binary, err := resolveSetupClaudeCodeBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binary != claude {
+		t.Fatalf("binary = %q, want %q", binary, claude)
+	}
+}
+
+func TestResolveSetupClaudeCodeBinaryRejectsMiseShimFromPATH(t *testing.T) {
+	shim := writeSetupExecutable(t, filepath.Join(t.TempDir(), "mise", "shims", "claude"))
+	t.Setenv(setupClaudeCodeBinaryEnv, "")
+
+	oldLookPath := setupClaudeCodeLookPath
+	setupClaudeCodeLookPath = func(string) (string, error) { return shim, nil }
+	t.Cleanup(func() { setupClaudeCodeLookPath = oldLookPath })
+
+	_, err := resolveSetupClaudeCodeBinary()
+	if err == nil || !strings.Contains(err.Error(), "mise shim") || !strings.Contains(err.Error(), setupClaudeCodeBinaryEnv) {
+		t.Fatalf("expected mise shim guidance, got %v", err)
+	}
+}
+
+func TestResolveSetupClaudeCodeBinaryUsesDirectPATHExecutable(t *testing.T) {
+	claude := writeSetupExecutable(t, filepath.Join(t.TempDir(), "bin", "claude"))
+	t.Setenv(setupClaudeCodeBinaryEnv, "")
+
+	oldLookPath := setupClaudeCodeLookPath
+	setupClaudeCodeLookPath = func(string) (string, error) { return claude, nil }
+	t.Cleanup(func() { setupClaudeCodeLookPath = oldLookPath })
+
+	binary, err := resolveSetupClaudeCodeBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binary != claude {
+		t.Fatalf("binary = %q, want %q", binary, claude)
+	}
+}
+
+func TestInstallSetupMCPUsesResolvedClaudeCodeBinary(t *testing.T) {
+	claude := writeSetupExecutable(t, filepath.Join(t.TempDir(), "direct-claude"))
+	t.Setenv(setupClaudeCodeBinaryEnv, claude)
+
+	oldExec := setupExecCommand
+	var got []string
+	setupExecCommand = func(name string, args ...string) error {
+		got = append([]string{name}, args...)
+		return nil
+	}
+	t.Cleanup(func() { setupExecCommand = oldExec })
+
+	err := installSetupMCP(setupOptions{Target: "claude-code", Scope: "project", DataDir: t.TempDir()}, "/tmp/helm-ai-kernel")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) == 0 || got[0] != claude || !strings.Contains(strings.Join(got[1:], " "), "mcp add") {
+		t.Fatalf("Claude MCP command = %#v", got)
+	}
+}
+
+func writeSetupExecutable(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -10,10 +10,17 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/shadow"
 )
 
 const setupMCPServerName = "helm-ai-kernel-governance"
+
+const (
+	setupHookOwnershipStatus = "HELM native client setup v1"
+	setupLegacyHookStatus    = "Checking HELM policy"
+	setupMCPOwnershipMarker  = "HELM native client setup v1"
+)
 
 var (
 	setupRunQuickstart = runQuickstartCmd
@@ -32,21 +39,34 @@ type setupOptions struct {
 	DryRun  bool
 	JSON    bool
 	DataDir string
+
+	// lifecycleReceiptID is set only by the durable Codex-project recovery
+	// journal so a resumed operation can prove or complete the same receipt.
+	lifecycleReceiptID       string
+	lifecycleRecoveryManaged bool
 }
 
 type setupSummary struct {
-	Target           string `json:"target"`
-	BinaryPath       string `json:"binary_path"`
-	ClientConfigPath string `json:"client_config_path"`
-	HookConfigPath   string `json:"hook_config_path"`
-	DataDir          string `json:"data_dir"`
-	KernelURL        string `json:"kernel_url"`
-	ScanGrade        string `json:"scan_grade"`
-	DraftPolicyPath  string `json:"draft_policy_path"`
-	UninstallCommand string `json:"uninstall_command"`
-	Scope            string `json:"scope,omitempty"`
-	MCPInstalled     bool   `json:"mcp_installed,omitempty"`
-	HookInstalled    bool   `json:"hook_installed,omitempty"`
+	Target                  string `json:"target"`
+	BinaryPath              string `json:"binary_path"`
+	ClientConfigPath        string `json:"client_config_path"`
+	HookConfigPath          string `json:"hook_config_path"`
+	DataDir                 string `json:"data_dir"`
+	KernelURL               string `json:"kernel_url"`
+	ScanGrade               string `json:"scan_grade"`
+	DraftPolicyPath         string `json:"draft_policy_path"`
+	UninstallCommand        string `json:"uninstall_command"`
+	Scope                   string `json:"scope,omitempty"`
+	MCPConfigured           bool   `json:"mcp_configured"`
+	HookConfigured          bool   `json:"hook_configured"`
+	LocalConfigVerified     bool   `json:"local_config_verified"`
+	Configured              bool   `json:"configured"`
+	ClientLoadObserved      bool   `json:"client_load_observed"`
+	SyntheticDenialVerified bool   `json:"synthetic_denial_verified,omitempty"`
+	LifecycleReceiptID      string `json:"lifecycle_receipt_id,omitempty"`
+	LifecycleEvidencePath   string `json:"lifecycle_evidence_path,omitempty"`
+	RecoveryRequired        bool   `json:"recovery_required,omitempty"`
+	RecoveryCleanupPending  bool   `json:"recovery_cleanup_pending,omitempty"`
 }
 
 func init() {
@@ -68,8 +88,12 @@ func runSetupCmd(args []string, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "status":
 		return runSetupStatusCmd(args[1:], stdout, stderr)
+	case "migrate":
+		return runSetupMigrateCmd(args[1:], stdout, stderr)
 	case "remove":
 		return runSetupRemoveCmd(args[1:], stdout, stderr)
+	case "recover":
+		return runSetupRecoverCmd(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		printSetupUsage(stdout)
 		return 0
@@ -123,6 +147,73 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 		printSetupSummary(stdout, summary, opts.JSON)
 		return 0
 	}
+	if opts.Target == "codex" && opts.Scope == "project" {
+		securedDataDir, authorityErr := validateSetupAuthorityDataDirIfPresent(opts.DataDir)
+		if authorityErr != nil {
+			fmt.Fprintf(stderr, "setup: unsafe Codex project authority state: %v\n", authorityErr)
+			return 1
+		}
+		opts.DataDir = securedDataDir
+		summary.DataDir = securedDataDir
+		pending, recoveryErr := setupRecoveryRequired(opts.DataDir)
+		if recoveryErr != nil {
+			fmt.Fprintf(stderr, "setup: inspect Codex project recovery state: %v\n", recoveryErr)
+			return 1
+		}
+		if pending {
+			fmt.Fprintln(stderr, "setup: Codex project recovery is required before changing local config; run `helm-ai-kernel setup recover codex --scope project --yes`")
+			return 1
+		}
+		// Keep invalid profile/configuration preflight read-only. The lock itself
+		// creates a secure authority root, so acquire it only after checks that
+		// must not leave local state behind have passed; prepare repeats them
+		// under the lock before any configuration mutation.
+		if err := validateSetupLifecycleReceiptProfile(); err != nil {
+			fmt.Fprintf(stderr, "setup: prepare crash-safe Codex project setup: %v\n", err)
+			return 1
+		}
+		if err := preflightCodexProjectSetup(opts, summary); err != nil {
+			fmt.Fprintf(stderr, "setup: prepare crash-safe Codex project setup: %v\n", err)
+			return 1
+		}
+		lifecycleLock, lockErr := acquireSetupCodexProjectLifecycleLock(opts.DataDir)
+		if lockErr != nil {
+			fmt.Fprintf(stderr, "setup: acquire Codex project lifecycle lock: %v\n", lockErr)
+			return 1
+		}
+		defer func() { _ = lifecycleLock.Close() }()
+		// Another lifecycle command can complete between the read-only preflight
+		// and lock acquisition. Re-check under the lock before publishing a
+		// recovery journal or changing client configuration.
+		pending, recoveryErr = setupRecoveryRequired(opts.DataDir)
+		if recoveryErr != nil {
+			fmt.Fprintf(stderr, "setup: inspect Codex project recovery state after lifecycle lock: %v\n", recoveryErr)
+			return 1
+		}
+		if pending {
+			fmt.Fprintln(stderr, "setup: Codex project recovery is required before changing local config; run `helm-ai-kernel setup recover codex --scope project --yes`")
+			return 1
+		}
+		preparation, err := prepareCodexProjectRecoveryInstall(opts, summary)
+		if err != nil {
+			fmt.Fprintf(stderr, "setup: prepare crash-safe Codex project setup: %v\n", err)
+			return 1
+		}
+		lifecycle, recoveredSummary, err := resumeCodexProjectRecovery(opts, preparation.summary, preparation.journal)
+		if err != nil {
+			fmt.Fprintf(stderr, "setup: Codex project setup did not complete; local recovery is required before retrying: %v\n", err)
+			return 1
+		}
+		summary = recoveredSummary
+		summary.SyntheticDenialVerified = lifecycle.SyntheticDenialVerified
+		summary.LifecycleReceiptID = lifecycle.ReceiptID
+		summary.LifecycleEvidencePath = lifecycle.EvidencePath
+		printSetupSummary(stdout, summary, opts.JSON)
+		// Codex project configuration starts the MCP server over stdio on demand.
+		// A separate quickstart HTTP server neither proves nor enables that client
+		// lifecycle, and would keep this setup command running indefinitely.
+		return 0
+	}
 	if err := os.MkdirAll(opts.DataDir, 0o750); err != nil {
 		fmt.Fprintf(stderr, "setup: create data dir: %v\n", err)
 		return 1
@@ -142,8 +233,7 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup: install pre-tool hook: %v\n", err)
 		return 1
 	}
-	summary.MCPInstalled = true
-	summary.HookInstalled = true
+	refreshSetupConfiguration(opts, &summary)
 	printSetupSummary(stdout, summary, opts.JSON)
 	if !opts.JSON {
 		fmt.Fprintln(stdout)
@@ -167,16 +257,122 @@ func runSetupStatusCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup status: %v\n", err)
 		return 2
 	}
-	summary.MCPInstalled = setupMCPInstalled(opts, summary.ClientConfigPath)
-	summary.HookInstalled = setupHookInstalled(opts, summary.HookConfigPath, summary.BinaryPath)
-	if grade := readSetupScanGrade(filepath.Join(opts.DataDir, "autoconfigure", "inventory.json")); grade != "" {
+	refreshSetupConfiguration(opts, &summary)
+	if opts.Target == "codex" && opts.Scope == "project" {
+		inspection, recoveryErr := inspectSetupRecovery(opts.DataDir)
+		if recoveryErr != nil {
+			fmt.Fprintf(stderr, "setup status: inspect Codex project recovery state: %v\n", recoveryErr)
+			return 2
+		}
+		summary.RecoveryRequired = inspection.State == setupRecoveryStatePrepared || inspection.State == setupRecoveryStatePending
+		summary.RecoveryCleanupPending = inspection.State == setupRecoveryStateCommitted
+	}
+	scanInventoryPath := filepath.Join(opts.DataDir, "autoconfigure", "inventory.json")
+	if opts.Target == "codex" && opts.Scope == "project" {
+		scanInventoryPath = filepath.Join(setupCodexProjectArtifactsDir(opts.DataDir), "inventory.json")
+	}
+	if grade := readSetupScanGrade(scanInventoryPath); grade != "" {
 		summary.ScanGrade = grade
 	}
 	printSetupSummary(stdout, summary, opts.JSON)
-	if summary.MCPInstalled && summary.HookInstalled {
+	if summary.Configured && !summary.RecoveryRequired {
 		return 0
 	}
 	return 1
+}
+
+func runSetupRecoverCmd(args []string, stdout, stderr io.Writer) int {
+	opts, code := parseSetupInspectArgs("setup recover", args, stderr, true)
+	if code != 0 {
+		return code
+	}
+	if opts.Target != "codex" || opts.Scope != "project" {
+		fmt.Fprintln(stderr, "setup recover: recovery is available only for Codex project scope")
+		return 2
+	}
+	if !opts.DryRun {
+		securedDataDir, authorityErr := requireSetupAuthorityDataDir(opts.DataDir)
+		if authorityErr != nil {
+			fmt.Fprintf(stderr, "setup recover: unsafe Codex project authority state: %v\n", authorityErr)
+			return 1
+		}
+		opts.DataDir = securedDataDir
+	}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup recover: %v\n", err)
+		return 2
+	}
+	inspection, err := inspectSetupRecovery(opts.DataDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup recover: inspect recovery state: %v\n", err)
+		return 1
+	}
+	if inspection.State == setupRecoveryStateAbsent {
+		fmt.Fprintln(stderr, "setup recover: no pending Codex project recovery journal")
+		return 1
+	}
+	if opts.DryRun {
+		summary.RecoveryRequired = inspection.State == setupRecoveryStatePrepared || inspection.State == setupRecoveryStatePending
+		summary.RecoveryCleanupPending = inspection.State == setupRecoveryStateCommitted
+		printSetupSummary(stdout, summary, opts.JSON)
+		return 0
+	}
+	if !opts.Yes {
+		fmt.Fprintln(stderr, "setup recover: pass --yes to resume the recorded local transaction")
+		return 2
+	}
+	lifecycleLock, lockErr := acquireSetupCodexProjectLifecycleLock(opts.DataDir)
+	if lockErr != nil {
+		fmt.Fprintf(stderr, "setup recover: acquire Codex project lifecycle lock: %v\n", lockErr)
+		return 1
+	}
+	defer func() { _ = lifecycleLock.Close() }()
+	// Re-read durable recovery state under the lock; an install/remove process
+	// may have completed or published a new transaction after the earlier
+	// inspection.
+	inspection, err = inspectSetupRecovery(opts.DataDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup recover: inspect recovery state after lifecycle lock: %v\n", err)
+		return 1
+	}
+	if inspection.State == setupRecoveryStateAbsent {
+		fmt.Fprintln(stderr, "setup recover: no pending Codex project recovery journal")
+		return 1
+	}
+	if inspection.State == setupRecoveryStatePrepared {
+		if err := cleanupIncompleteSetupRecoveryDirectory(opts.DataDir); err != nil {
+			fmt.Fprintf(stderr, "setup recover: remove incomplete pre-journal residue: %v\n", err)
+			return 1
+		}
+		refreshSetupConfiguration(opts, &summary)
+		printSetupSummary(stdout, summary, opts.JSON)
+		return 0
+	}
+	if inspection.State == setupRecoveryStateCommitted {
+		if err := cleanupCommittedSetupRecoveryDirectory(opts.DataDir); err != nil {
+			fmt.Fprintf(stderr, "setup recover: remove committed transaction residue: %v\n", err)
+			return 1
+		}
+		refreshSetupConfiguration(opts, &summary)
+		printSetupSummary(stdout, summary, opts.JSON)
+		return 0
+	}
+	journal := inspection.Journal
+	if journal == nil {
+		fmt.Fprintln(stderr, "setup recover: recovery state has no resumable journal")
+		return 1
+	}
+	lifecycle, recoveredSummary, err := resumeCodexProjectRecovery(opts, summary, journal)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup recover: recovery did not complete; the journal was retained: %v\n", err)
+		return 1
+	}
+	recoveredSummary.LifecycleReceiptID = lifecycle.ReceiptID
+	recoveredSummary.LifecycleEvidencePath = lifecycle.EvidencePath
+	recoveredSummary.SyntheticDenialVerified = lifecycle.SyntheticDenialVerified
+	printSetupSummary(stdout, recoveredSummary, opts.JSON)
+	return 0
 }
 
 func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
@@ -193,7 +389,99 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup remove: %v\n", err)
 		return 2
 	}
-	if !opts.DryRun {
+	if opts.DryRun {
+		refreshSetupConfiguration(opts, &summary)
+		printSetupSummary(stdout, summary, opts.JSON)
+		return 0
+	}
+	if opts.Target == "codex" && opts.Scope == "project" {
+		securedDataDir, authorityErr := validateSetupAuthorityDataDirIfPresent(opts.DataDir)
+		if authorityErr != nil {
+			fmt.Fprintf(stderr, "setup remove: unsafe Codex project authority state: %v\n", authorityErr)
+			return 1
+		}
+		opts.DataDir = securedDataDir
+		summary.DataDir = securedDataDir
+		pending, recoveryErr := setupRecoveryRequired(opts.DataDir)
+		if recoveryErr != nil {
+			fmt.Fprintf(stderr, "setup remove: inspect Codex project recovery state: %v\n", recoveryErr)
+			return 1
+		}
+		if pending {
+			fmt.Fprintln(stderr, "setup remove: Codex project recovery is required before changing local config; run `helm-ai-kernel setup recover codex --scope project --yes`")
+			return 1
+		}
+		if err := validateSetupLifecycleReceiptProfile(); err != nil {
+			fmt.Fprintf(stderr, "setup remove: prepare crash-safe Codex project removal: %v\n", err)
+			return 1
+		}
+		// Preserve the no-op removal contract: unowned/missing configuration must
+		// not create a lifecycle root merely to take a lock. This mirrors the
+		// non-mutating branches in prepareCodexProjectRecoveryRemove; a possible
+		// owned configuration still takes the lock and is fully revalidated below.
+		clientBefore, inspectErr := readSetupFileState(summary.ClientConfigPath)
+		if inspectErr != nil {
+			fmt.Fprintf(stderr, "setup remove: prepare crash-safe Codex project removal: %v\n", inspectErr)
+			return 1
+		}
+		hookBefore, inspectErr := readSetupFileState(summary.HookConfigPath)
+		if inspectErr != nil {
+			fmt.Fprintf(stderr, "setup remove: prepare crash-safe Codex project removal: %v\n", inspectErr)
+			return 1
+		}
+		if inspectErr := requireCodexProjectHookSourceForRemoval(clientBefore.Data); inspectErr != nil {
+			fmt.Fprintf(stderr, "setup remove: prepare crash-safe Codex project removal: %v\n", inspectErr)
+			return 1
+		}
+		mcp, inspectErr := readCodexMCPServerFromBytes(clientBefore.Data)
+		if inspectErr != nil {
+			fmt.Fprintf(stderr, "setup remove: prepare crash-safe Codex project removal: %v\n", inspectErr)
+			return 1
+		}
+		if mcp == nil || !isHELMCodexMCPServerCore(*mcp) {
+			if strings.Contains(string(hookBefore.Data), setupHookOwnershipStatus) {
+				if mcp == nil {
+					fmt.Fprintln(stderr, "setup remove: Codex hook looks HELM-managed but no MCP install binding can prove automatic removal")
+				} else {
+					fmt.Fprintln(stderr, "setup remove: Codex hook looks HELM-managed but its MCP server is not a proven HELM installation")
+				}
+				return 1
+			}
+			refreshSetupConfiguration(opts, &summary)
+			printSetupSummary(stdout, summary, opts.JSON)
+			return 0
+		}
+		lifecycleLock, lockErr := acquireSetupCodexProjectLifecycleLock(opts.DataDir)
+		if lockErr != nil {
+			fmt.Fprintf(stderr, "setup remove: acquire Codex project lifecycle lock: %v\n", lockErr)
+			return 1
+		}
+		defer func() { _ = lifecycleLock.Close() }()
+		pending, recoveryErr = setupRecoveryRequired(opts.DataDir)
+		if recoveryErr != nil {
+			fmt.Fprintf(stderr, "setup remove: inspect Codex project recovery state after lifecycle lock: %v\n", recoveryErr)
+			return 1
+		}
+		if pending {
+			fmt.Fprintln(stderr, "setup remove: Codex project recovery is required before changing local config; run `helm-ai-kernel setup recover codex --scope project --yes`")
+			return 1
+		}
+		preparation, err := prepareCodexProjectRecoveryRemove(opts, summary)
+		if err != nil {
+			fmt.Fprintf(stderr, "setup remove: prepare crash-safe Codex project removal: %v\n", err)
+			return 1
+		}
+		if preparation.journal != nil {
+			lifecycle, recoveredSummary, err := resumeCodexProjectRecovery(opts, preparation.summary, preparation.journal)
+			if err != nil {
+				fmt.Fprintf(stderr, "setup remove: Codex project removal did not complete; local recovery is required before retrying: %v\n", err)
+				return 1
+			}
+			summary = recoveredSummary
+			summary.LifecycleReceiptID = lifecycle.ReceiptID
+			summary.LifecycleEvidencePath = lifecycle.EvidencePath
+		}
+	} else if !opts.DryRun {
 		if err := removeSetupHook(opts, summary.BinaryPath); err != nil {
 			fmt.Fprintf(stderr, "setup remove: remove hook: %v\n", err)
 			return 1
@@ -202,6 +490,7 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stderr, "setup remove: remove MCP server: %v\n", err)
 			return 1
 		}
+		refreshSetupConfiguration(opts, &summary)
 	}
 	printSetupSummary(stdout, summary, opts.JSON)
 	return 0
@@ -219,7 +508,9 @@ func printSetupUsage(w io.Writer) {
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Manage:")
 	fmt.Fprintln(w, "  helm-ai-kernel setup status <claude-code|codex> [--scope user|project] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "  helm-ai-kernel setup migrate codex --scope project --yes [--dry-run] [--json] [--data-dir DIR]")
 	fmt.Fprintln(w, "  helm-ai-kernel setup remove <claude-code|codex> [--scope user|project] [--yes] [--dry-run] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "  helm-ai-kernel setup recover codex --scope project --yes [--json] [--data-dir DIR]")
 	fmt.Fprintln(w, "")
 	printSupportMatrix(w)
 	fmt.Fprintln(w, "")
@@ -283,9 +574,12 @@ func normalizeSetupOptions(opts setupOptions, stderr io.Writer) (setupOptions, i
 	if opts.DataDir == "" {
 		opts.DataDir = defaultSetupDataDir()
 	}
-	if abs, err := filepath.Abs(opts.DataDir); err == nil {
-		opts.DataDir = abs
+	dataDir, err := normalizeSetupDataDir(opts.DataDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup: %v\n", err)
+		return opts, 2
 	}
+	opts.DataDir = dataDir
 	return opts, 0
 }
 
@@ -305,18 +599,27 @@ func buildSetupSummary(opts setupOptions) (setupSummary, error) {
 	if err != nil {
 		return setupSummary{}, fmt.Errorf("locate executable: %w", err)
 	}
-	if abs, err := filepath.Abs(bin); err == nil {
-		bin = abs
+	identity, err := inspectSetupKernelBinary(bin)
+	if err != nil {
+		return setupSummary{}, err
+	}
+	draftPolicyPath := filepath.Join(opts.DataDir, "autoconfigure", "policy.draft.json")
+	if opts.Target == "codex" && opts.Scope == "project" {
+		paths, err := newSetupCodexProjectPaths(opts)
+		if err != nil {
+			return setupSummary{}, err
+		}
+		draftPolicyPath = filepath.Join(paths.ArtifactsDir, "policy.draft.json")
 	}
 	return setupSummary{
 		Target:           opts.Target,
-		BinaryPath:       bin,
+		BinaryPath:       identity.Path,
 		ClientConfigPath: setupClientConfigPath(opts),
 		HookConfigPath:   setupHookConfigPath(opts),
 		DataDir:          opts.DataDir,
 		KernelURL:        "http://127.0.0.1:7714",
 		ScanGrade:        "not_run",
-		DraftPolicyPath:  filepath.Join(opts.DataDir, "autoconfigure", "policy.draft.json"),
+		DraftPolicyPath:  draftPolicyPath,
 		UninstallCommand: fmt.Sprintf("helm-ai-kernel setup remove %s --scope %s --yes --data-dir %s", opts.Target, opts.Scope, shellQuote(opts.DataDir)),
 		Scope:            opts.Scope,
 	}, nil
@@ -335,41 +638,74 @@ func printSetupSummary(stdout io.Writer, summary setupSummary, jsonOut bool) {
 	fmt.Fprintf(stdout, "  Scan grade:    %s\n", summary.ScanGrade)
 	fmt.Fprintf(stdout, "  Draft policy:  %s\n", summary.DraftPolicyPath)
 	fmt.Fprintf(stdout, "  Uninstall:     %s\n", summary.UninstallCommand)
-	if summary.MCPInstalled || summary.HookInstalled {
-		fmt.Fprintf(stdout, "  Installed:     mcp=%v hook=%v\n", summary.MCPInstalled, summary.HookInstalled)
+	fmt.Fprintf(stdout, "  Local config:  mcp=%v hook=%v exact=%v\n", summary.MCPConfigured, summary.HookConfigured, summary.LocalConfigVerified)
+	fmt.Fprintf(stdout, "  Integration:   configured=%v client_load_observed=%v (local config is not client-session proof)\n", summary.Configured, summary.ClientLoadObserved)
+	if summary.RecoveryRequired {
+		fmt.Fprintln(stdout, "  Recovery:      required=true (MCP startup is blocked until `setup recover` completes)")
+	}
+	if summary.RecoveryCleanupPending {
+		fmt.Fprintln(stdout, "  Recovery:      committed cleanup is pending (the completed transaction is safe; `setup recover --yes` removes only HELM residue)")
+	}
+	if summary.SyntheticDenialVerified {
+		fmt.Fprintf(stdout, "  Synthetic deny: verified=true (Kernel-only, no client session)\n")
+	}
+	if summary.LifecycleReceiptID != "" {
+		fmt.Fprintf(stdout, "  Lifecycle receipt: %s\n", summary.LifecycleReceiptID)
+	}
+	if summary.LifecycleEvidencePath != "" {
+		fmt.Fprintf(stdout, "  Lifecycle evidence: %s\n", summary.LifecycleEvidencePath)
 	}
 }
 
 func runSetupAutoconfigure(dataDir string) (string, string, error) {
-	outDir := filepath.Join(dataDir, "autoconfigure")
+	return runSetupAutoconfigureWithWriter(dataDir, writeJSONArtifact)
+}
+
+func runSetupAutoconfigureWithWriter(dataDir string, writeArtifact func(string, any) error) (string, string, error) {
+	return runSetupAutoconfigureTo(filepath.Join(dataDir, "autoconfigure"), writeArtifact)
+}
+
+func runSetupAutoconfigureTo(outDir string, writeArtifact func(string, any) error) (string, string, error) {
 	report, err := shadow.NewScanner().Scan(".")
 	if err != nil {
 		return "", "", err
 	}
 	inv := buildInventory(report)
-	if err := writeJSONArtifact(filepath.Join(outDir, "inventory.json"), inv); err != nil {
+	if err := writeArtifact(filepath.Join(outDir, "inventory.json"), inv); err != nil {
 		return "", "", err
 	}
 	draft, plan := buildPolicyDraft(inv)
 	policyPath := filepath.Join(outDir, "policy.draft.json")
-	if err := writeJSONArtifact(policyPath, draft); err != nil {
+	if err := writeArtifact(policyPath, draft); err != nil {
 		return "", "", err
 	}
-	if err := writeJSONArtifact(filepath.Join(outDir, "mcp_quarantine_plan.json"), plan); err != nil {
+	if err := writeArtifact(filepath.Join(outDir, "mcp_quarantine_plan.json"), plan); err != nil {
 		return "", "", err
 	}
 	return inv.Grade.Letter, policyPath, nil
 }
 
+func marshalSetupJSONArtifact(value any) ([]byte, error) {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
 func installSetupMCP(opts setupOptions, bin string) error {
 	switch opts.Target {
 	case "claude-code":
-		return setupExecCommand("claude", "mcp", "add", "--transport", "stdio", "--scope", opts.Scope, setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
+		claude, err := resolveSetupClaudeCodeBinary()
+		if err != nil {
+			return err
+		}
+		return setupExecCommand(claude, "mcp", "add", "--transport", "stdio", "--scope", opts.Scope, setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio", "--data-dir", opts.DataDir)
 	case "codex":
 		if opts.Scope == "project" {
-			return upsertCodexProjectMCP(setupClientConfigPath(opts), bin)
+			return upsertCodexProjectMCP(setupClientConfigPath(opts), bin, opts.DataDir)
 		}
-		return setupExecCommand("codex", "mcp", "add", setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
+		return setupExecCommand("codex", "mcp", "add", setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio", "--data-dir", opts.DataDir)
 	default:
 		return fmt.Errorf("unsupported target %q", opts.Target)
 	}
@@ -378,10 +714,14 @@ func installSetupMCP(opts setupOptions, bin string) error {
 func removeSetupMCP(opts setupOptions) error {
 	switch opts.Target {
 	case "claude-code":
-		return setupExecCommand("claude", "mcp", "remove", "--scope", opts.Scope, setupMCPServerName)
+		claude, err := resolveSetupClaudeCodeBinary()
+		if err != nil {
+			return err
+		}
+		return setupExecCommand(claude, "mcp", "remove", "--scope", opts.Scope, setupMCPServerName)
 	case "codex":
 		if opts.Scope == "project" {
-			return removeCodexProjectMCP(setupClientConfigPath(opts))
+			return removeCodexProjectMCP(setupClientConfigPath(opts), opts.DataDir)
 		}
 		return setupExecCommand("codex", "mcp", "remove", setupMCPServerName)
 	default:
@@ -390,22 +730,49 @@ func removeSetupMCP(opts setupOptions) error {
 }
 
 func installSetupHook(opts setupOptions, bin string) error {
-	return upsertHookConfig(setupHookConfigPath(opts), setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
+	return upsertOwnedSetupHookConfig(setupHookConfigPath(opts), setupHookMatcher(opts.Target), setupHookCommand(opts, bin), opts.Target)
 }
 
 func removeSetupHook(opts setupOptions, bin string) error {
-	return removeHookConfig(setupHookConfigPath(opts), setupHookCommand(opts, bin))
+	return removeOwnedSetupHookConfig(setupHookConfigPath(opts), opts.Target, setupHookCommand(opts, bin))
 }
 
-func setupMCPInstalled(opts setupOptions, path string) bool {
-	if opts.Target == "claude-code" && opts.Scope == "user" {
-		return fileContains(path, setupMCPServerName)
+func setupMCPConfigured(opts setupOptions, path, bin string) bool {
+	if opts.Target != "codex" {
+		// The external Claude Code CLI owns its config serialization. Until that
+		// exact schema is inspected rather than guessed, configuration is not
+		// reported as observed.
+		return false
 	}
-	return fileContains(path, setupMCPServerName)
+	server, ok, err := readCodexMCPServer(path)
+	if err != nil || !ok {
+		return false
+	}
+	return isOwnedCodexMCPServer(server) && server.Command == bin && sameSetupStringSlice(server.Args, setupMCPServerArgs(opts.DataDir))
 }
 
-func setupHookInstalled(opts setupOptions, path, bin string) bool {
-	return fileContains(path, setupHookCommand(opts, bin))
+func setupHookConfigured(opts setupOptions, path, bin string) bool {
+	if opts.Target == "codex" && opts.Scope == "project" {
+		source, err := inspectCodexProjectHookSourcePath(setupClientConfigPath(opts))
+		if err != nil || source.HooksDisabled || source.InlineHooks {
+			return false
+		}
+	}
+	_, pre, err := readSetupHookConfig(path)
+	if err != nil {
+		return false
+	}
+	for _, entry := range pre {
+		if !isStrictOwnedSetupHookEntryForCommand(entry, opts.Target, setupHookCommand(opts, bin)) {
+			continue
+		}
+		group := entry.(map[string]any)
+		hooks := group["hooks"].([]any)
+		if hookCommandFromAny(hooks[0]) == setupHookCommand(opts, bin) {
+			return true
+		}
+	}
+	return false
 }
 
 func setupQuickstartProfile(target string) string {
@@ -460,6 +827,22 @@ func setupHookCommand(opts setupOptions, bin string) string {
 	return shellQuote(bin) + " hook pre-tool --client " + opts.Target + " --data-dir " + shellQuote(opts.DataDir)
 }
 
+func setupMCPServerArgs(dataDir string) []string {
+	return []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}
+}
+
+func sameSetupStringSlice(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
 func upsertHookConfig(path, matcher, command string) error {
 	root, err := readJSONObject(path)
 	if err != nil {
@@ -486,16 +869,122 @@ func upsertHookConfig(path, matcher, command string) error {
 	return writeJSONObject(path, root)
 }
 
-func removeHookConfig(path, command string) error {
-	root, err := readJSONObject(path)
-	if os.IsNotExist(err) {
+func upsertOwnedSetupHookConfig(path, matcher, command, target string) error {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return err
+	}
+	next, err := buildUpsertOwnedSetupHookState(state, matcher, command, target)
+	if err != nil {
+		return err
+	}
+	return restoreSetupFileState(next)
+}
+
+func removeOwnedSetupHookConfig(path, target, expectedCommand string) error {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return err
+	}
+	next, err := buildRemoveOwnedSetupHookState(state, target, expectedCommand)
+	if err != nil {
+		return err
+	}
+	if sameSetupFileState(state, next) {
 		return nil
 	}
+	return restoreSetupFileState(next)
+}
+
+func buildUpsertOwnedSetupHookState(state setupFileState, matcher, command, target string) (setupFileState, error) {
+	root, pre, err := parseSetupHookConfig(state.Data)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	if err := requireMutableSetupHookEntries(pre, target, command); err != nil {
+		return setupFileState{}, err
+	}
+	filtered := make([]any, 0, len(pre)+1)
+	for _, existing := range pre {
+		if !isStrictOwnedSetupHookEntryForCommand(existing, target, command) {
+			filtered = append(filtered, existing)
+		}
+	}
+	entry := map[string]any{
+		"matcher": matcher,
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       command,
+				"timeout":       float64(30),
+				"statusMessage": setupHookOwnershipStatus,
+			},
+		},
+	}
+	if err := setSetupPreToolUse(root, append(filtered, entry)); err != nil {
+		return setupFileState{}, err
+	}
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return setupFileState{}, err
+	}
+	return setupFileState{Path: state.Path, Exists: true, Data: append(data, '\n')}, nil
+}
+
+func buildRemoveOwnedSetupHookState(state setupFileState, target, expectedCommand string) (setupFileState, error) {
+	if !state.Exists {
+		return state, nil
+	}
+	root, pre, err := parseSetupHookConfig(state.Data)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	if err := requireMutableSetupHookEntries(pre, target, expectedCommand); err != nil {
+		return setupFileState{}, err
+	}
+	filtered := make([]any, 0, len(pre))
+	found := false
+	for _, entry := range pre {
+		if isStrictOwnedSetupHookEntryForCommand(entry, target, expectedCommand) {
+			found = true
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	if !found {
+		return state, nil
+	}
+	if err := setSetupPreToolUse(root, filtered); err != nil {
+		return setupFileState{}, err
+	}
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return setupFileState{}, err
+	}
+	return setupFileState{Path: state.Path, Exists: true, Data: append(data, '\n')}, nil
+}
+
+func removeHookConfig(path string, remove func(hook any) bool) error {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return err
+	}
+	if !state.Exists {
+		return nil
+	}
+	root, err := readJSONObject(path)
 	if err != nil {
 		return err
 	}
 	hooks := objectValue(root, "hooks")
 	pre := arrayValue(hooks, "PreToolUse")
+	filtered := filterHookEntries(pre, remove)
+	hooks["PreToolUse"] = filtered
+	root["hooks"] = hooks
+	return writeJSONObject(path, root)
+}
+
+func filterHookEntries(pre []any, remove func(hook any) bool) []any {
 	filtered := make([]any, 0, len(pre))
 	for _, item := range pre {
 		obj, ok := item.(map[string]any)
@@ -509,9 +998,9 @@ func removeHookConfig(path, command string) error {
 			continue
 		}
 		keptHooks := make([]any, 0, len(hookItems))
-		for _, h := range hookItems {
-			if hookCommandFromAny(h) != command {
-				keptHooks = append(keptHooks, h)
+		for _, hook := range hookItems {
+			if !remove(hook) {
+				keptHooks = append(keptHooks, hook)
 			}
 		}
 		if len(keptHooks) > 0 {
@@ -519,24 +1008,86 @@ func removeHookConfig(path, command string) error {
 			filtered = append(filtered, obj)
 		}
 	}
-	hooks["PreToolUse"] = filtered
-	root["hooks"] = hooks
-	return writeJSONObject(path, root)
+	return filtered
+}
+
+func isOwnedSetupHook(hook any, target string) bool {
+	status := hookStatusMessageFromAny(hook)
+	switch status {
+	case setupHookOwnershipStatus:
+		return isSetupHookCommandShape(hookCommandFromAny(hook), target)
+	case setupLegacyHookStatus:
+		return isSetupHookCommandShape(hookCommandFromAny(hook), target)
+	default:
+		return false
+	}
+}
+
+func hasUnownedMatchingSetupHook(pre []any, command, target string) bool {
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooks, ok := obj["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, hook := range hooks {
+			if hookCommandFromAny(hook) == command && !isOwnedSetupHook(hook, target) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isSetupHookCommandShape(command, target string) bool {
+	separator := " hook pre-tool --client " + target + " --data-dir "
+	parts := strings.SplitN(command, separator, 2)
+	if len(parts) != 2 || !strings.HasPrefix(parts[0], "'") || !strings.HasSuffix(parts[0], "'") {
+		return false
+	}
+	if !isHELMKernelExecutable(strings.Trim(parts[0], "'")) {
+		return false
+	}
+	return strings.HasPrefix(parts[1], "'") && strings.HasSuffix(parts[1], "'")
+}
+
+// setupHookDataDirArgument returns the exact shell-quoted data-dir argument
+// emitted by setupHookCommand. Keeping it lexical avoids treating a differently
+// quoted or extended shell fragment as equivalent ownership.
+func setupHookDataDirArgument(command, target string) (string, bool) {
+	if !isSetupHookCommandShape(command, target) {
+		return "", false
+	}
+	separator := " hook pre-tool --client " + target + " --data-dir "
+	parts := strings.SplitN(command, separator, 2)
+	if len(parts) != 2 {
+		return "", false
+	}
+	return parts[1], true
+}
+
+func sameSetupHookDataDirArgument(current, expected, target string) bool {
+	currentArg, currentOK := setupHookDataDirArgument(current, target)
+	expectedArg, expectedOK := setupHookDataDirArgument(expected, target)
+	return currentOK && expectedOK && currentArg == expectedArg
 }
 
 func readJSONObject(path string) (map[string]any, error) {
-	raw, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return map[string]any{}, nil
-	}
+	state, err := readSetupFileState(path)
 	if err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(string(raw)) == "" {
+	if !state.Exists {
+		return map[string]any{}, nil
+	}
+	if strings.TrimSpace(string(state.Data)) == "" {
 		return map[string]any{}, nil
 	}
 	var root map[string]any
-	if err := json.Unmarshal(raw, &root); err != nil {
+	if err := json.Unmarshal(state.Data, &root); err != nil {
 		return nil, err
 	}
 	if root == nil {
@@ -546,14 +1097,11 @@ func readJSONObject(path string) (map[string]any, error) {
 }
 
 func writeJSONObject(path string, root map[string]any) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
-	}
 	data, err := json.MarshalIndent(root, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o600)
+	return writeSetupPrivateFile(path, append(data, '\n'))
 }
 
 func objectValue(root map[string]any, key string) map[string]any {
@@ -570,6 +1118,144 @@ func arrayValue(root map[string]any, key string) []any {
 		return arr
 	}
 	return []any{}
+}
+
+// readSetupHookConfig validates the concrete JSON shape before any mutation.
+// Missing hooks are initializable; an existing value of the wrong type is
+// user state and must never be coerced into a replacement object or array.
+func readSetupHookConfig(path string) (map[string]any, []any, error) {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return parseSetupHookConfig(state.Data)
+}
+
+func parseSetupHookConfig(raw []byte) (map[string]any, []any, error) {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return map[string]any{}, []any{}, nil
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, nil, err
+	}
+	if root == nil {
+		return map[string]any{}, []any{}, nil
+	}
+	rawHooks, hasHooks := root["hooks"]
+	if !hasHooks {
+		return root, []any{}, nil
+	}
+	hooks, ok := rawHooks.(map[string]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("hooks must be an object when present")
+	}
+	rawPreToolUse, hasPreToolUse := hooks["PreToolUse"]
+	if !hasPreToolUse {
+		return root, []any{}, nil
+	}
+	preToolUse, ok := rawPreToolUse.([]any)
+	if !ok {
+		return nil, nil, fmt.Errorf("hooks.PreToolUse must be an array when present")
+	}
+	return root, preToolUse, nil
+}
+
+func setSetupPreToolUse(root map[string]any, entries []any) error {
+	rawHooks, hasHooks := root["hooks"]
+	var hooks map[string]any
+	if !hasHooks {
+		hooks = map[string]any{}
+	} else {
+		var ok bool
+		hooks, ok = rawHooks.(map[string]any)
+		if !ok {
+			return fmt.Errorf("hooks must be an object when present")
+		}
+	}
+	hooks["PreToolUse"] = entries
+	root["hooks"] = hooks
+	return nil
+}
+
+func exactSetupObjectKeys(obj map[string]any, want ...string) bool {
+	if len(obj) != len(want) {
+		return false
+	}
+	for _, key := range want {
+		if _, ok := obj[key]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func isStrictOwnedSetupHookEntry(entry any, target string) bool {
+	group, ok := entry.(map[string]any)
+	if !ok || !exactSetupObjectKeys(group, "matcher", "hooks") {
+		return false
+	}
+	matcher, _ := group["matcher"].(string)
+	if matcher != setupHookMatcher(target) {
+		return false
+	}
+	hooks, ok := group["hooks"].([]any)
+	return ok && len(hooks) == 1 && isStrictOwnedSetupHook(hooks[0], target)
+}
+
+// isStrictOwnedSetupHookEntryForCommand preserves automatic binary upgrades
+// while making the selected Kernel state directory part of HELM ownership. A
+// changed data-dir changes the scope of local state and must be treated as
+// user-managed rather than silently rewritten or removed.
+func isStrictOwnedSetupHookEntryForCommand(entry any, target, expectedCommand string) bool {
+	if !isStrictOwnedSetupHookEntry(entry, target) {
+		return false
+	}
+	group := entry.(map[string]any)
+	hooks := group["hooks"].([]any)
+	return sameSetupHookDataDirArgument(hookCommandFromAny(hooks[0]), expectedCommand, target)
+}
+
+func isStrictOwnedSetupHook(hook any, target string) bool {
+	obj, ok := hook.(map[string]any)
+	if !ok || !exactSetupObjectKeys(obj, "type", "command", "timeout", "statusMessage") {
+		return false
+	}
+	typ, _ := obj["type"].(string)
+	command, _ := obj["command"].(string)
+	status, _ := obj["statusMessage"].(string)
+	timeout, ok := obj["timeout"].(float64)
+	return typ == "command" && timeout == 30 && status == setupHookOwnershipStatus && isSetupHookCommandShape(command, target) && ok
+}
+
+func isHELMSetupHookCandidate(entry any, target string) bool {
+	group, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	hooks, ok := group["hooks"].([]any)
+	if !ok {
+		return false
+	}
+	for _, hook := range hooks {
+		status := hookStatusMessageFromAny(hook)
+		if status == setupHookOwnershipStatus || status == setupLegacyHookStatus || isSetupHookCommandShape(hookCommandFromAny(hook), target) {
+			return true
+		}
+	}
+	return false
+}
+
+func requireMutableSetupHookEntries(entries []any, target, expectedCommand string) error {
+	if _, ok := setupHookDataDirArgument(expectedCommand, target); !ok {
+		return fmt.Errorf("invalid expected HELM hook command")
+	}
+	for _, entry := range entries {
+		if isHELMSetupHookCandidate(entry, target) && !isStrictOwnedSetupHookEntryForCommand(entry, target, expectedCommand) {
+			return fmt.Errorf("Codex hook has user-managed fields or an unproven HELM ownership marker; refusing automatic mutation")
+		}
+	}
+	return nil
 }
 
 func hookCommandPresent(pre []any, command string) bool {
@@ -600,36 +1286,372 @@ func hookCommandFromAny(v any) string {
 	return command
 }
 
-func upsertCodexProjectMCP(path, bin string) error {
-	current := ""
-	if raw, err := os.ReadFile(path); err == nil {
-		current = string(raw)
-	} else if !os.IsNotExist(err) {
+func hookStatusMessageFromAny(v any) string {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return ""
+	}
+	statusMessage, _ := obj["statusMessage"].(string)
+	return statusMessage
+}
+
+func hasOwnedSetupHookInBytes(raw []byte, target, expectedCommand string) (bool, error) {
+	_, pre, err := parseSetupHookConfig(raw)
+	if err != nil {
+		return false, fmt.Errorf("parse hook config: %w", err)
+	}
+	if err := requireMutableSetupHookEntries(pre, target, expectedCommand); err != nil {
+		return false, err
+	}
+	for _, entry := range pre {
+		if isStrictOwnedSetupHookEntryForCommand(entry, target, expectedCommand) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+type codexMCPServerConfig struct {
+	Command         string   `toml:"command"`
+	Args            []string `toml:"args"`
+	UnmanagedKeys   []string `toml:"-"`
+	OwnershipMarker bool     `toml:"-"`
+}
+
+func readCodexMCPServer(path string) (codexMCPServerConfig, bool, error) {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return codexMCPServerConfig{}, false, err
+	}
+	if !state.Exists {
+		return codexMCPServerConfig{}, false, nil
+	}
+	server, err := readCodexMCPServerFromBytes(state.Data)
+	if err != nil {
+		return codexMCPServerConfig{}, false, err
+	}
+	if server == nil {
+		return codexMCPServerConfig{}, false, nil
+	}
+	return *server, true, nil
+}
+
+func readCodexMCPServerFromBytes(raw []byte) (*codexMCPServerConfig, error) {
+	var config struct {
+		MCPServers map[string]codexMCPServerConfig `toml:"mcp_servers"`
+	}
+	metadata, err := toml.Decode(string(raw), &config)
+	if err != nil {
+		return nil, fmt.Errorf("parse Codex MCP config: %w", err)
+	}
+	server, ok := config.MCPServers[setupMCPServerName]
+	if !ok {
+		return nil, nil
+	}
+	for _, key := range metadata.Undecoded() {
+		if len(key) > 2 && key[0] == "mcp_servers" && key[1] == setupMCPServerName {
+			server.UnmanagedKeys = append(server.UnmanagedKeys, key.String())
+		}
+	}
+	server.OwnershipMarker = hasCodexMCPOwnershipMarker(raw)
+	return &server, nil
+}
+
+type codexProjectHookSource struct {
+	HooksDisabled bool
+	InlineHooks   bool
+}
+
+// inspectCodexProjectHookSource checks the project config layer only. It does
+// not claim anything about trusted user/system/plugin layers; those still need
+// a real Codex client session. Within the project layer, however, mixed inline
+// and hooks.json sources or a disabled feature make this local setup unsafe.
+func inspectCodexProjectHookSource(raw []byte) (codexProjectHookSource, error) {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return codexProjectHookSource{}, nil
+	}
+	var config map[string]any
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		return codexProjectHookSource{}, fmt.Errorf("parse Codex config: %w", err)
+	}
+	source := codexProjectHookSource{}
+	if _, present := config["hooks"]; present {
+		source.InlineHooks = true
+	}
+	featuresRaw, hasFeatures := config["features"]
+	if !hasFeatures {
+		return source, nil
+	}
+	features, ok := featuresRaw.(map[string]any)
+	if !ok {
+		return codexProjectHookSource{}, fmt.Errorf("Codex features must be a table")
+	}
+	hooks, hasHooks, err := codexHookFeatureValue(features, "hooks")
+	if err != nil {
+		return codexProjectHookSource{}, err
+	}
+	legacy, hasLegacy, err := codexHookFeatureValue(features, "codex_hooks")
+	if err != nil {
+		return codexProjectHookSource{}, err
+	}
+	if hasHooks && hasLegacy && hooks != legacy {
+		return codexProjectHookSource{}, fmt.Errorf("Codex hooks and codex_hooks feature values conflict")
+	}
+	source.HooksDisabled = (hasHooks && !hooks) || (hasLegacy && !legacy)
+	return source, nil
+}
+
+func codexHookFeatureValue(features map[string]any, key string) (bool, bool, error) {
+	raw, ok := features[key]
+	if !ok {
+		return false, false, nil
+	}
+	value, ok := raw.(bool)
+	if !ok {
+		return false, false, fmt.Errorf("Codex features.%s must be a boolean", key)
+	}
+	return value, true, nil
+}
+
+func inspectCodexProjectHookSourcePath(path string) (codexProjectHookSource, error) {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return codexProjectHookSource{}, err
+	}
+	return inspectCodexProjectHookSource(state.Data)
+}
+
+func requireCodexProjectHookSourceForInstall(raw []byte) error {
+	source, err := inspectCodexProjectHookSource(raw)
+	if err != nil {
 		return err
 	}
-	current = removeTOMLTable(current, "[mcp_servers."+setupMCPServerName+"]")
-	block := fmt.Sprintf("[mcp_servers.%s]\ncommand = %q\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\"]\n", setupMCPServerName, bin)
+	if source.HooksDisabled {
+		return fmt.Errorf("Codex hooks are disabled in project config; refusing to install an inactive hook")
+	}
+	if source.InlineHooks {
+		return fmt.Errorf("Codex project config already defines inline hooks; refusing to mix config.toml and hooks.json sources")
+	}
+	return nil
+}
+
+func requireCodexProjectHookSourceForRemoval(raw []byte) error {
+	source, err := inspectCodexProjectHookSource(raw)
+	if err != nil {
+		return err
+	}
+	if source.InlineHooks {
+		return fmt.Errorf("Codex project config defines inline hooks; refusing automatic removal across mixed hook sources")
+	}
+	return nil
+}
+
+func hasCodexMCPOwnershipMarker(raw []byte) bool {
+	insideServer := false
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			insideServer = trimmed == "[mcp_servers."+setupMCPServerName+"]"
+			continue
+		}
+		if insideServer && trimmed == "# "+setupMCPOwnershipMarker {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCodexProjectOwnedConfig(clientConfigPath, hookConfigPath, expectedDataDir, expectedHookCommand string) (bool, error) {
+	clientState, err := readSetupFileState(clientConfigPath)
+	if err != nil {
+		return false, err
+	}
+	if err := requireCodexProjectHookSourceForRemoval(clientState.Data); err != nil {
+		return false, err
+	}
+	mcp, hasMCP, err := readCodexMCPServer(clientConfigPath)
+	if err != nil {
+		return false, err
+	}
+	if hasMCP {
+		if err := requireSafeCodexMCPRemoval(&mcp, expectedDataDir); err != nil {
+			return false, err
+		}
+	}
+	hookState, err := readSetupFileState(hookConfigPath)
+	if err != nil {
+		return false, err
+	}
+	hasHook := false
+	if hookState.Exists {
+		hasHook, err = hasOwnedSetupHookInBytes(hookState.Data, "codex", expectedHookCommand)
+		if err != nil {
+			return false, err
+		}
+	}
+	return (hasMCP && isOwnedCodexMCPServerForDataDir(mcp, expectedDataDir)) || hasHook, nil
+}
+
+func upsertCodexProjectMCP(path, bin, dataDir string) error {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return err
+	}
+	next, err := buildUpsertCodexProjectMCPState(state, bin, dataDir)
+	if err != nil {
+		return err
+	}
+	return restoreSetupFileState(next)
+}
+
+func removeCodexProjectMCP(path, expectedDataDir string) error {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return err
+	}
+	next, err := buildRemoveCodexProjectMCPState(state, expectedDataDir)
+	if err != nil {
+		return err
+	}
+	if sameSetupFileState(state, next) {
+		return nil
+	}
+	return restoreSetupFileState(next)
+}
+
+func buildUpsertCodexProjectMCPState(state setupFileState, bin, dataDir string) (setupFileState, error) {
+	if err := requireCodexProjectHookSourceForInstall(state.Data); err != nil {
+		return setupFileState{}, err
+	}
+	existing, err := readCodexMCPServerFromBytes(state.Data)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	if err := requireMutableCodexMCPServer(existing, dataDir); err != nil {
+		return setupFileState{}, err
+	}
+	current := removeTOMLTable(string(state.Data), "[mcp_servers."+setupMCPServerName+"]")
+	block := fmt.Sprintf("[mcp_servers.%s]\n# %s\ncommand = %q\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", %q]\n", setupMCPServerName, setupMCPOwnershipMarker, bin, dataDir)
 	next := strings.TrimRight(current, "\n")
 	if next != "" {
 		next += "\n\n"
 	}
 	next += block
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(next), 0o600)
+	return setupFileState{Path: state.Path, Exists: true, Data: []byte(next)}, nil
 }
 
-func removeCodexProjectMCP(path string) error {
-	raw, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
+func buildRemoveCodexProjectMCPState(state setupFileState, expectedDataDir string) (setupFileState, error) {
+	return buildRemoveCodexProjectMCPStateForBinary(state, expectedDataDir, "")
+}
+
+func buildRemoveCodexProjectMCPStateForBinary(state setupFileState, expectedDataDir, expectedBinary string) (setupFileState, error) {
+	if !state.Exists {
+		return state, nil
+	}
+	if err := requireCodexProjectHookSourceForRemoval(state.Data); err != nil {
+		return setupFileState{}, err
+	}
+	existing, err := readCodexMCPServerFromBytes(state.Data)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	owned := existing != nil && isOwnedCodexMCPServerForDataDir(*existing, expectedDataDir)
+	if owned && expectedBinary != "" {
+		owned = existing.Command == expectedBinary
+	}
+	if !owned {
+		if existing != nil && isHELMCodexMCPServerCore(*existing) {
+			if expectedBinary != "" && existing.Command != expectedBinary {
+				return setupFileState{}, fmt.Errorf("Codex MCP server %q points at a different Kernel binary; refusing to remove it", setupMCPServerName)
+			}
+			if !existing.OwnershipMarker {
+				return setupFileState{}, fmt.Errorf("Codex MCP server %q has no HELM ownership marker; refusing to remove it", setupMCPServerName)
+			}
+			if isHELMCodexMCPServerCore(*existing) && !sameSetupStringSlice(existing.Args, setupMCPServerArgs(expectedDataDir)) {
+				return setupFileState{}, fmt.Errorf("Codex MCP server %q has a user-managed data-dir; refusing to remove it", setupMCPServerName)
+			}
+			return setupFileState{}, fmt.Errorf("Codex MCP server %q has user-managed fields (%s); refusing to remove it", setupMCPServerName, strings.Join(existing.UnmanagedKeys, ", "))
+		}
+		return state, nil
+	}
+	next := removeTOMLTable(string(state.Data), "[mcp_servers."+setupMCPServerName+"]")
+	return setupFileState{Path: state.Path, Exists: true, Data: []byte(strings.TrimRight(next, "\n") + "\n")}, nil
+}
+
+func isOwnedCodexMCPServer(server codexMCPServerConfig) bool {
+	return server.OwnershipMarker && isHELMCodexMCPServerCore(server) && len(server.UnmanagedKeys) == 0
+}
+
+func isOwnedCodexMCPServerForDataDir(server codexMCPServerConfig, expectedDataDir string) bool {
+	return isOwnedCodexMCPServer(server) && sameSetupStringSlice(server.Args, setupMCPServerArgs(expectedDataDir))
+}
+
+func isOwnedCodexMCPServerForBinaryAndDataDir(server codexMCPServerConfig, expectedBinary, expectedDataDir string) bool {
+	return server.Command == expectedBinary && isOwnedCodexMCPServerForDataDir(server, expectedDataDir)
+}
+
+func isHELMCodexMCPServerCore(server codexMCPServerConfig) bool {
+	return isHELMKernelExecutable(server.Command) && isOwnedCodexMCPArgs(server.Args)
+}
+
+func requireMutableCodexMCPServer(server *codexMCPServerConfig, expectedDataDir string) error {
+	if server == nil {
 		return nil
 	}
-	if err != nil {
-		return err
+	if !isHELMCodexMCPServerCore(*server) {
+		return fmt.Errorf("Codex MCP server %q exists but is not HELM-owned; refusing to replace it", setupMCPServerName)
 	}
-	next := removeTOMLTable(string(raw), "[mcp_servers."+setupMCPServerName+"]")
-	return os.WriteFile(path, []byte(strings.TrimRight(next, "\n")+"\n"), 0o600)
+	if !server.OwnershipMarker {
+		return fmt.Errorf("Codex MCP server %q has no HELM ownership marker; refusing to replace it", setupMCPServerName)
+	}
+	if len(server.UnmanagedKeys) > 0 {
+		return fmt.Errorf("Codex MCP server %q has user-managed fields (%s); refusing to replace it", setupMCPServerName, strings.Join(server.UnmanagedKeys, ", "))
+	}
+	if !sameSetupStringSlice(server.Args, setupMCPServerArgs(expectedDataDir)) {
+		return fmt.Errorf("Codex MCP server %q has a user-managed data-dir; refusing to replace it", setupMCPServerName)
+	}
+	return nil
+}
+
+// Removal may coexist with an unrelated user-owned server of the same name
+// while removing a separately owned hook. Only a HELM-shaped server without
+// provenance or with extra fields is ambiguous enough to block automatic
+// removal.
+func requireSafeCodexMCPRemoval(server *codexMCPServerConfig, expectedDataDir string) error {
+	if server == nil || !isHELMCodexMCPServerCore(*server) {
+		return nil
+	}
+	if !server.OwnershipMarker {
+		return fmt.Errorf("Codex MCP server %q has no HELM ownership marker; refusing automatic removal", setupMCPServerName)
+	}
+	if len(server.UnmanagedKeys) > 0 {
+		return fmt.Errorf("Codex MCP server %q has user-managed fields (%s); refusing automatic removal", setupMCPServerName, strings.Join(server.UnmanagedKeys, ", "))
+	}
+	if !sameSetupStringSlice(server.Args, setupMCPServerArgs(expectedDataDir)) {
+		return fmt.Errorf("Codex MCP server %q has a user-managed data-dir; refusing automatic removal", setupMCPServerName)
+	}
+	return nil
+}
+
+func isOwnedCodexMCPArgs(args []string) bool {
+	const prefixLength = 5
+	if len(args) != prefixLength+1 {
+		return false
+	}
+	for index, want := range []string{"mcp", "serve", "--transport", "stdio", "--data-dir"} {
+		if args[index] != want {
+			return false
+		}
+	}
+	return filepath.IsAbs(args[5])
+}
+
+func isHELMKernelExecutable(path string) bool {
+	if !filepath.IsAbs(path) {
+		return false
+	}
+	base := strings.TrimSuffix(filepath.Base(path), ".exe")
+	return base == "helm-ai-kernel" || base == "helm-ai-kernel.test"
 }
 
 func removeTOMLTable(input, table string) string {

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -2,13 +2,22 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
 )
 
 func TestSetupNoArgsPrintsChooser(t *testing.T) {
@@ -135,10 +144,38 @@ func TestSetupDryRunJSONSummary(t *testing.T) {
 	}
 }
 
+func TestSetupCodexProjectDryRunCreatesNoConfigOrLifecycleState(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--dry-run", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("dry-run exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	for _, path := range []string{
+		filepath.Join(tmp, ".codex", "config.toml"),
+		filepath.Join(tmp, ".codex", "hooks.json"),
+		filepath.Join(dataDir, "root.key"),
+		filepath.Join(dataDir, "helm.db"),
+	} {
+		if _, err := os.Stat(path); !errorsIsNotExist(err) {
+			t.Fatalf("dry-run created %s: %v", path, err)
+		}
+	}
+}
+
 func TestSetupInstallClaudeWritesHookAndRunsQuickstart(t *testing.T) {
 	tmp := t.TempDir()
 	home := filepath.Join(tmp, "home")
 	t.Setenv("HOME", home)
+	claude := writeSetupExecutable(t, filepath.Join(tmp, "claude"))
+	t.Setenv(setupClaudeCodeBinaryEnv, claude)
 	restore := stubSetupSideEffects(t)
 
 	var stdout, stderr bytes.Buffer
@@ -147,8 +184,8 @@ func TestSetupInstallClaudeWritesHookAndRunsQuickstart(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("setup exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
 	}
-	if len(restore.execCalls) != 1 || !strings.Contains(strings.Join(restore.execCalls[0], " "), "claude mcp add") {
-		t.Fatalf("exec calls = %#v, want claude mcp add", restore.execCalls)
+	if len(restore.execCalls) != 1 || restore.execCalls[0][0] != claude || !strings.Contains(strings.Join(restore.execCalls[0], " "), " mcp add") {
+		t.Fatalf("exec calls = %#v, want %s mcp add", restore.execCalls, claude)
 	}
 	if strings.Join(restore.quickstartArgs, " ") != "--profile claude --data-dir "+filepath.Join(dataDir, "quickstart") {
 		t.Fatalf("quickstart args = %#v", restore.quickstartArgs)
@@ -166,14 +203,14 @@ func TestSetupInstallClaudeWritesHookAndRunsQuickstart(t *testing.T) {
 	}
 }
 
-func TestSetupInstallJSONKeepsQuickstartOutputOffStdout(t *testing.T) {
+func TestSetupCodexProjectJSONReturnsWithoutStartingUnrelatedQuickstart(t *testing.T) {
 	tmp := t.TempDir()
 	oldWD, _ := os.Getwd()
 	if err := os.Chdir(tmp); err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldWD) })
-	stubSetupSideEffects(t)
+	restore := stubSetupSideEffects(t)
 
 	var stdout, stderr bytes.Buffer
 	dataDir := filepath.Join(tmp, "helm")
@@ -190,8 +227,8 @@ func TestSetupInstallJSONKeepsQuickstartOutputOffStdout(t *testing.T) {
 	if err := dec.Decode(&extra); err != io.EOF {
 		t.Fatalf("stdout should contain only one JSON value, extra=%#v err=%v stdout=%s", extra, err, stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "quickstart ready") {
-		t.Fatalf("quickstart output should move to stderr in JSON mode, stderr=%s", stderr.String())
+	if len(restore.quickstartArgs) != 0 {
+		t.Fatalf("Codex project setup unexpectedly started a quickstart server: %#v", restore.quickstartArgs)
 	}
 }
 
@@ -221,6 +258,10 @@ func TestSetupCodexProjectRemoveUndoLocalConfig(t *testing.T) {
 	if !strings.Contains(string(raw), "[mcp_servers.helm-ai-kernel-governance]") {
 		t.Fatalf("codex config missing MCP table:\n%s", string(raw))
 	}
+	server := decodeCodexProjectMCP(t, raw)
+	if got, want := server.Args, []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}; !equalSetupStrings(got, want) {
+		t.Fatalf("Codex MCP args = %#v, want %#v", got, want)
+	}
 	hookConfig := filepath.Join(tmp, ".codex", "hooks.json")
 	raw, err = os.ReadFile(hookConfig)
 	if err != nil {
@@ -249,6 +290,1916 @@ func TestSetupCodexProjectRemoveUndoLocalConfig(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "hook pre-tool --client codex") {
 		t.Fatalf("hook config still contains HELM command:\n%s", string(raw))
+	}
+}
+
+func TestUpsertCodexProjectMCPRefusesOwnedDataDirChange(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".codex", "config.toml")
+	firstDataDir := filepath.Join(tmp, "helm-first")
+	secondDataDir := filepath.Join(tmp, "helm-second")
+	if err := upsertCodexProjectMCP(configPath, "/tmp/helm-ai-kernel", firstDataDir); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(configPath, "/tmp/helm-ai-kernel", secondDataDir); err == nil {
+		t.Fatal("upsert unexpectedly replaced a HELM-owned MCP server with a different data-dir")
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(raw), "[mcp_servers."+setupMCPServerName+"]"); got != 1 {
+		t.Fatalf("HELM MCP table count = %d, want 1:\n%s", got, raw)
+	}
+	if !bytes.Equal(raw, before) {
+		t.Fatalf("data-dir mismatch changed Codex MCP config:\n%s", raw)
+	}
+	server := decodeCodexProjectMCP(t, raw)
+	if got, want := server.Args, []string{"mcp", "serve", "--transport", "stdio", "--data-dir", firstDataDir}; !equalSetupStrings(got, want) {
+		t.Fatalf("Codex MCP args = %#v, want %#v", got, want)
+	}
+}
+
+func TestSetupCodexProjectRefusesChangedOwnedDataDirOnInstallAndRemove(t *testing.T) {
+	for _, surface := range []string{"hook", "mcp"} {
+		t.Run(surface, func(t *testing.T) {
+			tmp := t.TempDir()
+			oldWD, _ := os.Getwd()
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			stubSetupSideEffects(t)
+
+			dataDir := filepath.Join(tmp, "helm")
+			wrongDataDir := filepath.Join(tmp, "user-managed-state")
+			args := []string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}
+			var stdout, stderr bytes.Buffer
+			if code := Run(args, &stdout, &stderr); code != 0 {
+				t.Fatalf("initial setup exit = %d stderr=%s", code, stderr.String())
+			}
+
+			clientPath := filepath.Join(tmp, ".codex", "config.toml")
+			hookPath := filepath.Join(tmp, ".codex", "hooks.json")
+			if surface == "hook" {
+				raw, err := os.ReadFile(hookPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				mutated := strings.Replace(string(raw), shellQuote(dataDir), shellQuote(wrongDataDir), 1)
+				if mutated == string(raw) {
+					t.Fatal("test fixture did not change owned hook data-dir")
+				}
+				if err := os.WriteFile(hookPath, []byte(mutated), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				raw, err := os.ReadFile(clientPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				mutated := strings.Replace(string(raw), strconv.Quote(dataDir), strconv.Quote(wrongDataDir), 1)
+				if mutated == string(raw) {
+					t.Fatal("test fixture did not change owned MCP data-dir")
+				}
+				if err := os.WriteFile(clientPath, []byte(mutated), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			clientBefore, err := os.ReadFile(clientPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			hookBefore, err := os.ReadFile(hookPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run(args, &stdout, &stderr); code != 1 {
+				t.Fatalf("setup with changed %s data-dir exit = %d, want 1 stderr=%s", surface, code, stderr.String())
+			}
+			assertSetupConfigBytesUnchanged(t, clientPath, clientBefore, hookPath, hookBefore)
+
+			stdout.Reset()
+			stderr.Reset()
+			removeArgs := []string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}
+			if code := Run(removeArgs, &stdout, &stderr); code != 1 {
+				t.Fatalf("remove with changed %s data-dir exit = %d, want 1 stderr=%s", surface, code, stderr.String())
+			}
+			assertSetupConfigBytesUnchanged(t, clientPath, clientBefore, hookPath, hookBefore)
+		})
+	}
+}
+
+func TestStrictOwnedSetupHookRequiresExactQuotedDataDir(t *testing.T) {
+	dataDir := "/tmp/helm's state"
+	command := shellQuote("/tmp/helm-ai-kernel") + " hook pre-tool --client codex --data-dir " + shellQuote(dataDir)
+	entry := map[string]any{
+		"matcher": setupHookMatcher("codex"),
+		"hooks": []any{map[string]any{
+			"type":          "command",
+			"command":       command,
+			"timeout":       float64(30),
+			"statusMessage": setupHookOwnershipStatus,
+		}},
+	}
+	if !isStrictOwnedSetupHookEntryForCommand(entry, "codex", command) {
+		t.Fatal("exact quoted data-dir was not recognized as owned")
+	}
+	if isStrictOwnedSetupHookEntryForCommand(entry, "codex", setupHookCommand(setupOptions{Target: "codex", DataDir: "/tmp/other"}, "/tmp/helm-ai-kernel")) {
+		t.Fatal("different data-dir was recognized as owned")
+	}
+	injected := command + " ; echo injected"
+	if isStrictOwnedSetupHookEntryForCommand(entry, "codex", injected) {
+		t.Fatal("extended shell command was recognized as owned")
+	}
+}
+
+func TestUpsertCodexProjectMCPRefusesUnownedSameNameServer(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".codex", "config.toml")
+	original := []byte("[mcp_servers.helm-ai-kernel-governance]\ncommand = \"/usr/local/bin/user-owned-server\"\nargs = [\"serve\"]\n")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(configPath, "/tmp/helm-ai-kernel", filepath.Join(tmp, "helm")); err == nil {
+		t.Fatal("upsert unexpectedly replaced a same-named user-owned MCP server")
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, original) {
+		t.Fatalf("unowned MCP config changed:\n%s", after)
+	}
+}
+
+func TestSetupCodexProjectRefusesUnownedSameNameServerWithoutRewritingIt(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	configPath := filepath.Join(tmp, ".codex", "config.toml")
+	original := []byte("[mcp_servers.helm-ai-kernel-governance]\ncommand = \"/usr/local/bin/user-owned-server\"\nargs = [\"serve\"]\n")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	after, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, original) || !os.SameFile(before, after) {
+		t.Fatalf("refused install rewrote user-owned config:\n%s", raw)
+	}
+	if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+		t.Fatalf("refused install created Kernel state: %v", err)
+	}
+}
+
+func TestSetupCodexProjectRefusesMalformedTOMLWithoutRewritingIt(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	configPath := filepath.Join(tmp, ".codex", "config.toml")
+	original := []byte("[mcp_servers.helm-ai-kernel-governance\ncommand = \"/tmp/helm-ai-kernel\"\n")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	after, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, original) || !os.SameFile(before, after) {
+		t.Fatalf("malformed Codex TOML was rewritten:\n%s", raw)
+	}
+	if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+		t.Fatalf("malformed-config refusal created Kernel state: %v", err)
+	}
+}
+
+func TestSetupCodexProjectRefusesSymlinkedConfig(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	target := filepath.Join(tmp, "user-owned.toml")
+	original := []byte("[mcp_servers.unrelated]\ncommand = \"/tmp/user-server\"\n")
+	if err := os.WriteFile(target, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(tmp, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	info, err := os.Lstat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("setup replaced a user-owned config symlink: mode=%v", info.Mode())
+	}
+	raw, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(raw, original) {
+		t.Fatalf("setup changed symlink target:\n%s", raw)
+	}
+	if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+		t.Fatalf("symlink refusal created Kernel state: %v", err)
+	}
+}
+
+func TestSetupCodexProjectRefusesSymlinkedConfigParent(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	externalDir := filepath.Join(tmp, "external-codex")
+	if err := os.MkdirAll(externalDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalDir, filepath.Join(tmp, ".codex")); err != nil {
+		t.Fatal(err)
+	}
+	dataDir := filepath.Join(tmp, "helm")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	info, err := os.Lstat(filepath.Join(tmp, ".codex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("setup replaced a symlinked config parent: mode=%v", info.Mode())
+	}
+	if _, err := os.Stat(filepath.Join(externalDir, "config.toml")); !errorsIsNotExist(err) {
+		t.Fatalf("setup wrote through symlinked config parent: %v", err)
+	}
+	if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+		t.Fatalf("symlink-parent refusal created Kernel state: %v", err)
+	}
+}
+
+func TestSetupCodexProjectRefusesExtendedOwnedMCPConfigWithoutRewrite(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := append(raw, []byte("\n[mcp_servers."+setupMCPServerName+".env]\nUSER_ADDED = \"keep-me\"\n")...)
+	if err := os.WriteFile(summary.ClientConfigPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	after, err := os.Stat(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(current, original) || !os.SameFile(before, after) {
+		t.Fatalf("setup rewrote extended HELM MCP config:\n%s", current)
+	}
+	if !strings.Contains(stderr.String(), "user-managed fields") {
+		t.Fatalf("setup did not explain extended MCP refusal: %s", stderr.String())
+	}
+}
+
+func TestSetupCodexProjectRemoveRefusesExtendedOwnedMCPConfigWithoutCorruption(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := append(raw, []byte("\n[mcp_servers."+setupMCPServerName+".env]\nUSER_ADDED = \"keep-me\"\n")...)
+	if err := os.WriteFile(summary.ClientConfigPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("remove exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	after, err := os.Stat(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(current, original) || !os.SameFile(before, after) {
+		t.Fatalf("remove corrupted extended HELM MCP config:\n%s", current)
+	}
+	if !strings.Contains(stderr.String(), "user-managed fields") {
+		t.Fatalf("remove did not explain extended MCP refusal: %s", stderr.String())
+	}
+}
+
+func TestSetupCodexProjectLifecycleIsSignedAndDoesNotClaimClientLoad(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	t.Setenv("HELM_RECEIPT_PROFILE", "")
+	stubSetupSideEffects(t)
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("setup exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatalf("decode setup summary: %v\n%s", err, stdout.String())
+	}
+	if !summary.MCPConfigured || !summary.HookConfigured || !summary.LocalConfigVerified {
+		t.Fatalf("setup did not report exact local config: %#v", summary)
+	}
+	if summary.Configured || summary.ClientLoadObserved {
+		t.Fatalf("setup must not claim an unobserved Codex integration: %#v", summary)
+	}
+	if !summary.SyntheticDenialVerified || summary.LifecycleReceiptID == "" {
+		t.Fatalf("missing verified synthetic denial lifecycle receipt: %#v", summary)
+	}
+	if summary.LifecycleEvidencePath == "" {
+		t.Fatalf("missing retained lifecycle evidence path: %#v", summary)
+	}
+
+	db, _, receiptStore, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	receipt, err := receiptStore.GetByReceiptID(context.Background(), summary.LifecycleReceiptID)
+	if err != nil {
+		t.Fatalf("read lifecycle receipt: %v", err)
+	}
+	if receipt.Status != "DENY" || receipt.EffectID != "mcp.tools.call/file_write" || receipt.OutputHash == "" || receipt.ArgsHash == "" {
+		t.Fatalf("unexpected install lifecycle receipt: %#v", receipt)
+	}
+	if got, _ := receipt.Metadata["client_load_observed"].(bool); got {
+		t.Fatalf("receipt must not claim a Codex load: %#v", receipt.Metadata)
+	}
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := helmcrypto.NewEd25519Verifier(signer.PublicKeyBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := verifier.VerifyReceipt(receipt); err != nil || !ok {
+		t.Fatalf("lifecycle receipt signature invalid: ok=%v err=%v", ok, err)
+	}
+	evidence, err := verifySetupLifecycleEvidence(dataDir, receipt)
+	if err != nil {
+		t.Fatalf("verify retained lifecycle evidence: %v", err)
+	}
+	if !evidence.Observation.MCPConfigured || !evidence.Observation.HookConfigured || evidence.Observation.ClientLoadObserved || evidence.Observation.KernelDispatchObserved || evidence.Observation.SyntheticDenial == nil || !evidence.Observation.SyntheticDenial.Verified || evidence.Observation.SyntheticDenial.Dispatched {
+		t.Fatalf("unexpected signed lifecycle observation: %#v", evidence.Observation)
+	}
+	for _, mutate := range []func(*contracts.Receipt){
+		func(r *contracts.Receipt) { r.ArgsHash = "tampered" },
+		func(r *contracts.Receipt) { r.OutputHash = "tampered" },
+		func(r *contracts.Receipt) { r.Status = "ALLOW" },
+		func(r *contracts.Receipt) { r.PrevHash = "tampered" },
+	} {
+		tampered := *receipt
+		mutate(&tampered)
+		if ok, err := verifier.VerifyReceipt(&tampered); err == nil && ok {
+			t.Fatalf("tampered signed lifecycle field unexpectedly verified: %#v", tampered)
+		}
+	}
+	if err := os.WriteFile(summary.LifecycleEvidencePath, []byte(`{"tampered":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifySetupLifecycleEvidence(dataDir, receipt); err == nil {
+		t.Fatal("tampered lifecycle evidence unexpectedly verified")
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "install binding evidence") {
+		t.Fatalf("tampered install evidence did not block automatic removal: code=%d stderr=%s", code, stderr.String())
+	}
+	originalEvidence, err := canonicalize.JCS(evidence)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(summary.LifecycleEvidencePath, originalEvidence, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "synthetic-denial")); !errorsIsNotExist(err) {
+		t.Fatalf("synthetic denial probe directory was retained: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("remove exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	var removal setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &removal); err != nil {
+		t.Fatalf("decode removal summary: %v\n%s", err, stdout.String())
+	}
+	if removal.MCPConfigured || removal.HookConfigured || removal.LocalConfigVerified || removal.Configured {
+		t.Fatalf("remove still reports configuration: %#v", removal)
+	}
+	if removal.ClientLoadObserved {
+		t.Fatalf("remove must not claim a client load: %#v", removal)
+	}
+	if removal.LifecycleReceiptID == "" {
+		t.Fatalf("remove did not issue a lifecycle receipt: %#v", removal)
+	}
+	removeReceipt, err := receiptStore.GetByReceiptID(context.Background(), removal.LifecycleReceiptID)
+	if err != nil {
+		t.Fatalf("read remove lifecycle receipt: %v", err)
+	}
+	installChainHash, err := contracts.ReceiptChainHash(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removeReceipt.Status != "REVOKED" || removeReceipt.PrevHash != installChainHash || removeReceipt.LamportClock != receipt.LamportClock+1 {
+		t.Fatalf("unexpected remove lifecycle receipt: %#v", removeReceipt)
+	}
+	if ok, err := verifier.VerifyReceipt(removeReceipt); err != nil || !ok {
+		t.Fatalf("remove lifecycle receipt signature invalid: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCodexLifecycleRemovalSurvivesReceiptProfileDrift(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		installProfile string
+		removeProfile  string
+	}{
+		{name: "hybrid install classical remove", installProfile: "hybrid", removeProfile: ""},
+		{name: "classical install hybrid remove", installProfile: "", removeProfile: "hybrid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := chdirTempDir(t)
+			dataDir := filepath.Join(tmp, "helm")
+			t.Setenv("HELM_RECEIPT_PROFILE", tc.installProfile)
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+				t.Fatalf("install exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			t.Setenv("HELM_RECEIPT_PROFILE", tc.removeProfile)
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+				t.Fatalf("remove exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+		})
+	}
+}
+
+func TestSetupCodexProjectInstallRequiresDurableRecoveryWhenLifecycleReceiptFails(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	clientPath := filepath.Join(tmp, ".codex", "config.toml")
+	hookPath := filepath.Join(tmp, ".codex", "hooks.json")
+	const userSentinel = "user-config-secret-must-not-enter-journal"
+	clientBefore := []byte("[mcp_servers.unrelated]\ncommand = \"/tmp/" + userSentinel + "\"\n")
+	hookBefore := []byte(`{"hooks":{"PreToolUse":[{"matcher":"^Bash$","hooks":[{"type":"command","command":"echo ` + userSentinel + `","statusMessage":"user"}]}]}}` + "\n")
+	if err := os.MkdirAll(filepath.Dir(clientPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(clientPath, clientBefore, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hookPath, hookBefore, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousRecord := recordCodexProjectSetupLifecycleFn
+	recordCodexProjectSetupLifecycleFn = func(setupOptions, setupSummary, string) (setupLifecycleResult, error) {
+		return setupLifecycleResult{}, errors.New("receipt store unavailable")
+	}
+	t.Cleanup(func() { recordCodexProjectSetupLifecycleFn = previousRecord })
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	journal, err := readSetupRecoveryJournal(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if journal == nil {
+		t.Fatal("failed setup did not retain a durable recovery journal")
+	}
+	journalRaw, err := os.ReadFile(setupRecoveryJournalPath(dataDir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(journalRaw), userSentinel) {
+		t.Fatalf("recovery journal persisted user config bytes: %s", journalRaw)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("pending recovery did not block MCP startup: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("pending recovery status exit = %d stderr=%s", code, stderr.String())
+	}
+	var pendingStatus setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &pendingStatus); err != nil {
+		t.Fatal(err)
+	}
+	if !pendingStatus.RecoveryRequired {
+		t.Fatalf("pending recovery status did not expose recovery_required: %#v", pendingStatus)
+	}
+
+	recordCodexProjectSetupLifecycleFn = previousRecord
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recovery exit = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("recovery journal remained after a completed recovery: pending=%v err=%v", pending, err)
+	}
+	clientAfter, err := os.ReadFile(clientPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookAfter, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(clientAfter), userSentinel) || !strings.Contains(string(hookAfter), userSentinel) || !strings.Contains(string(clientAfter), setupMCPServerName) || !strings.Contains(string(hookAfter), setupHookOwnershipStatus) {
+		t.Fatalf("recovery did not preserve user state and complete HELM configuration:\nclient=%s\nhook=%s", clientAfter, hookAfter)
+	}
+}
+
+func TestSetupCodexProjectRecoveryWithoutReceiptRejectsInvalidProfileBeforeConfigMutation(t *testing.T) {
+	tmp := chdirTempDir(t)
+	stubSetupSideEffects(t)
+	dataDir := filepath.Join(tmp, "helm")
+	previousRecord := recordCodexProjectSetupLifecycleFn
+	recordCodexProjectSetupLifecycleFn = func(setupOptions, setupSummary, string) (setupLifecycleResult, error) {
+		return setupLifecycleResult{}, errors.New("injected pre-receipt lifecycle failure")
+	}
+	t.Cleanup(func() { recordCodexProjectSetupLifecycleFn = previousRecord })
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("pre-receipt lifecycle failure did not retain recovery journal: pending=%v err=%v", pending, err)
+	}
+	for _, path := range []string{filepath.Join(tmp, ".codex", "config.toml"), filepath.Join(tmp, ".codex", "hooks.json")} {
+		if err := os.Remove(path); err != nil {
+			t.Fatalf("restore recorded before-state %s: %v", path, err)
+		}
+	}
+	recordCodexProjectSetupLifecycleFn = previousRecord
+	t.Setenv("HELM_RECEIPT_PROFILE", "invalid-profile")
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "validate receipt profile before resumable config mutation") {
+		t.Fatalf("invalid-profile recovery exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, path := range []string{
+		filepath.Join(tmp, ".codex", "config.toml"),
+		filepath.Join(tmp, ".codex", "hooks.json"),
+		filepath.Join(dataDir, "root.key"),
+		filepath.Join(dataDir, "root.mldsa65.key"),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("invalid-profile recovery mutated %s: %v", path, err)
+		}
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("invalid-profile recovery did not retain journal: pending=%v err=%v", pending, err)
+	}
+}
+
+func TestSetupCodexProjectRecoveryDoesNotDuplicateCommittedReceipt(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	previousFinalize := finalizeCodexProjectRecoveryJournal
+	finalizeCodexProjectRecoveryJournal = func(string, *setupRecoveryJournal) error {
+		return errors.New("injected journal-finalize failure")
+	}
+	t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr=%s", code, stderr.String())
+	}
+	journal, err := readSetupRecoveryJournal(dataDir)
+	if err != nil || journal == nil {
+		t.Fatalf("missing journal after finalization failure: journal=%#v err=%v", journal, err)
+	}
+	db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var before int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM receipts WHERE receipt_id = ?`, journal.LifecycleReceiptID).Scan(&before); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if before != 1 {
+		t.Fatalf("prepared receipt count = %d, want 1", before)
+	}
+
+	finalizeCodexProjectRecoveryJournal = previousFinalize
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recovery exit = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	db, _, _, err = setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var after int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM receipts WHERE receipt_id = ?`, journal.LifecycleReceiptID).Scan(&after); err != nil {
+		t.Fatal(err)
+	}
+	if after != 1 {
+		t.Fatalf("recovery appended duplicate lifecycle receipt: count=%d", after)
+	}
+}
+
+func TestSetupCodexProjectRecoveryUsesPersistedReceiptProfileWithoutNewAuthority(t *testing.T) {
+	cases := []struct {
+		name              string
+		initialProfile    string
+		recoveryProfile   string
+		assertNoMLDSARoot bool
+	}{
+		{
+			name:              "classical_to_hybrid",
+			initialProfile:    "classical",
+			recoveryProfile:   "hybrid",
+			assertNoMLDSARoot: true,
+		},
+		{
+			name:            "hybrid_to_classical",
+			initialProfile:  "hybrid",
+			recoveryProfile: "classical",
+		},
+		{
+			name:              "classical_to_invalid_profile",
+			initialProfile:    "classical",
+			recoveryProfile:   "invalid-profile",
+			assertNoMLDSARoot: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			oldWD, _ := os.Getwd()
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			stubSetupSideEffects(t)
+			t.Setenv("HELM_RECEIPT_PROFILE", tc.initialProfile)
+
+			previousFinalize := finalizeCodexProjectRecoveryJournal
+			finalizeCodexProjectRecoveryJournal = func(string, *setupRecoveryJournal) error {
+				return errors.New("injected journal-finalize failure")
+			}
+			t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+
+			dataDir := filepath.Join(tmp, "helm")
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+				t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			journal, err := readSetupRecoveryJournal(dataDir)
+			if err != nil || journal == nil {
+				t.Fatalf("missing journal after finalization failure: journal=%#v err=%v", journal, err)
+			}
+
+			t.Setenv("HELM_RECEIPT_PROFILE", tc.recoveryProfile)
+			finalizeCodexProjectRecoveryJournal = previousFinalize
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+				t.Fatalf("recovery exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+				t.Fatalf("recovery journal remained after persisted-profile recovery: pending=%v err=%v", pending, err)
+			}
+			db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var count int
+			if err := db.QueryRow(`SELECT COUNT(1) FROM receipts WHERE receipt_id = ?`, journal.LifecycleReceiptID).Scan(&count); err != nil {
+				_ = db.Close()
+				t.Fatal(err)
+			}
+			if err := db.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 {
+				t.Fatalf("persisted-profile recovery appended duplicate lifecycle receipt: count=%d", count)
+			}
+			if tc.assertNoMLDSARoot {
+				if _, err := os.Stat(filepath.Join(dataDir, "root.mldsa65.key")); !os.IsNotExist(err) {
+					t.Fatalf("recovery generated an ML-DSA key from current profile: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestSetupCodexProjectFailedLifecycleCleansNewSignerAndReceiptStoreState(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+	t.Setenv("HELM_RECEIPT_PROFILE", "invalid-profile")
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	for _, path := range []string{
+		filepath.Join(tmp, ".codex", "config.toml"),
+		filepath.Join(tmp, ".codex", "hooks.json"),
+		filepath.Join(dataDir, "root.key"),
+		filepath.Join(dataDir, "root.pub"),
+		filepath.Join(dataDir, "root.mldsa65.key"),
+		filepath.Join(dataDir, "helm.db"),
+		filepath.Join(dataDir, "helm.db-wal"),
+		filepath.Join(dataDir, "helm.db-shm"),
+		filepath.Join(dataDir, "helm.db-journal"),
+		filepath.Join(dataDir, "autoconfigure", "inventory.json"),
+		filepath.Join(dataDir, "autoconfigure", "policy.draft.json"),
+		filepath.Join(dataDir, "autoconfigure", "mcp_quarantine_plan.json"),
+	} {
+		if _, err := os.Stat(path); !errorsIsNotExist(err) {
+			t.Fatalf("failed lifecycle left durable state %s: %v", path, err)
+		}
+	}
+}
+
+func TestSetupCodexProjectRetainsRecoveryJournalAfterKnownAbortedReceiptAppend(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	previousPrepared := setupLifecycleStorePrepared
+	setupLifecycleStorePrepared = func(db *sql.DB) error {
+		_, err := db.Exec(`CREATE TRIGGER helm_setup_abort BEFORE INSERT ON receipts BEGIN SELECT RAISE(ABORT, 'injected setup receipt failure'); END;`)
+		return err
+	}
+	t.Cleanup(func() { setupLifecycleStorePrepared = previousPrepared })
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr=%s", code, stderr.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("known-aborted receipt append did not retain recovery state: pending=%v err=%v", pending, err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("pending aborted receipt recovery did not block MCP startup: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "helm.db")); err != nil {
+		t.Fatalf("known-aborted receipt path did not retain its SQLite state for recovery: %v", err)
+	}
+	journal, err := readSetupRecoveryJournal(dataDir)
+	if err != nil || journal == nil {
+		t.Fatalf("known-aborted receipt append did not retain its journal: journal=%#v err=%v", journal, err)
+	}
+
+	setupLifecycleStorePrepared = previousPrepared
+	db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`DROP TRIGGER helm_setup_abort`); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("known-aborted receipt recovery exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("known-aborted receipt recovery remained pending=%v err=%v", pending, err)
+	}
+	db, _, _, err = setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(1) FROM receipts WHERE receipt_id = ?`, journal.LifecycleReceiptID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("known-aborted receipt recovery appended %d receipts, want 1", count)
+	}
+}
+
+func TestSetupCodexProjectDryRunAcceptsStandardTempRoot(t *testing.T) {
+	for _, root := range []string{"/tmp", "/var/tmp"} {
+		t.Run(root, func(t *testing.T) {
+			tmp, err := os.MkdirTemp(root, "helm-setup-data-dir-")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(tmp) })
+			workdir := t.TempDir()
+			oldWD, _ := os.Getwd()
+			if err := os.Chdir(workdir); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--dry-run", "--data-dir", filepath.Join(tmp, "state")}, &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("setup dry-run under %s exit = %d, want 0 stderr=%s", root, code, stderr.String())
+			}
+		})
+	}
+}
+
+func TestNormalizeSetupDataDirRejectsChildSymlinkUnderStandardTempRoot(t *testing.T) {
+	tmp, err := os.MkdirTemp("/tmp", "helm-setup-data-dir-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmp) })
+	external := t.TempDir()
+	link := filepath.Join(tmp, "user-link")
+	if err := os.Symlink(external, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := normalizeSetupDataDir(filepath.Join(link, "state")); err == nil {
+		t.Fatal("normalizer accepted a descendant symlink below a standard temp root")
+	}
+}
+
+func TestSetupCodexProjectRejectsDataDirSymlinksBeforeAnyWrite(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		dataDirRel string
+	}{
+		{name: "final", dataDirRel: "state-link"},
+		{name: "ancestor", dataDirRel: filepath.Join("state-parent", "helm")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			oldWD, _ := os.Getwd()
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			stubSetupSideEffects(t)
+
+			external := filepath.Join(tmp, "external")
+			if err := os.MkdirAll(external, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			link := filepath.Join(tmp, "state-link")
+			if tc.name == "ancestor" {
+				link = filepath.Join(tmp, "state-parent")
+			}
+			if err := os.Symlink(external, link); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", filepath.Join(tmp, tc.dataDirRel)}, &stdout, &stderr)
+			if code != 2 {
+				t.Fatalf("setup exit = %d, want 2 stderr = %s", code, stderr.String())
+			}
+			entries, err := os.ReadDir(external)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(entries) != 0 {
+				t.Fatalf("setup wrote through data-dir symlink: %#v", entries)
+			}
+			if _, err := os.Stat(filepath.Join(tmp, ".codex")); !errorsIsNotExist(err) {
+				t.Fatalf("data-dir refusal wrote client config: %v", err)
+			}
+		})
+	}
+}
+
+func TestSetupCodexProjectRejectsSymlinkedEnvironmentDataDirRoots(t *testing.T) {
+	for _, variable := range []string{"TMPDIR", "HOME"} {
+		t.Run(variable, func(t *testing.T) {
+			base := t.TempDir()
+			workdir := t.TempDir()
+			oldWD, _ := os.Getwd()
+			if err := os.Chdir(workdir); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			stubSetupSideEffects(t)
+
+			external := filepath.Join(base, "external")
+			envRootTarget := filepath.Join(external, "real-root")
+			if err := os.MkdirAll(envRootTarget, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			link := filepath.Join(base, strings.ToLower(variable)+"-link")
+			if err := os.Symlink(external, link); err != nil {
+				t.Fatal(err)
+			}
+			// Keep the other environment-derived candidate real but outside the
+			// data path, so the test proves the selected symlinked root is not
+			// accepted as a traversal boundary.
+			envRoot := filepath.Join(link, "real-root")
+			if variable == "TMPDIR" {
+				t.Setenv("HOME", workdir)
+			} else {
+				t.Setenv("TMPDIR", workdir)
+			}
+			t.Setenv(variable, envRoot)
+
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", filepath.Join(envRoot, "helm")}, &stdout, &stderr)
+			if code != 2 {
+				t.Fatalf("setup exit = %d, want 2 stderr=%s", code, stderr.String())
+			}
+			if _, err := os.Stat(filepath.Join(envRootTarget, "helm")); !errorsIsNotExist(err) {
+				t.Fatalf("setup wrote through %s symlink root: %v", variable, err)
+			}
+		})
+	}
+}
+
+func TestSetupCodexProjectRefusesUnmarkedSameShapeMCPServer(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("[mcp_servers." + setupMCPServerName + "]\ncommand = " + strconv.Quote(summary.BinaryPath) + "\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n")
+	if err := os.MkdirAll(filepath.Dir(summary.ClientConfigPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(summary.ClientConfigPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "no HELM ownership marker") {
+		t.Fatalf("setup did not refuse unmarked same-shape MCP: exit=%d stderr=%s", code, stderr.String())
+	}
+	after, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, original) {
+		t.Fatalf("setup rewrote unmarked same-shape MCP config:\n%s", after)
+	}
+	if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+		t.Fatalf("unmarked MCP refusal created Kernel state: %v", err)
+	}
+}
+
+func TestSetupCodexProjectRefusesMutatedOwnedHookWithoutRewrite(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	raw, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatal(err)
+	}
+	hook := root["hooks"].(map[string]any)["PreToolUse"].([]any)[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)
+	hook["timeout"] = float64(31)
+	mutated, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutated = append(mutated, '\n')
+	if err := os.WriteFile(summary.HookConfigPath, mutated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "user-managed fields") {
+		t.Fatalf("setup did not refuse mutated owned hook: exit=%d stderr=%s", code, stderr.String())
+	}
+	after, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, mutated) {
+		t.Fatalf("setup rewrote user-mutated hook:\n%s", after)
+	}
+	if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+		t.Fatalf("mutated hook refusal created Kernel state: %v", err)
+	}
+}
+
+func TestSetupCodexProjectRefusesMalformedHookJSONWithoutRewrite(t *testing.T) {
+	for _, raw := range [][]byte{
+		[]byte(`{"hooks":"user-owned"}` + "\n"),
+		[]byte(`{"hooks":{"PreToolUse":{}}}` + "\n"),
+	} {
+		t.Run(string(raw), func(t *testing.T) {
+			tmp := t.TempDir()
+			oldWD, _ := os.Getwd()
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			stubSetupSideEffects(t)
+
+			hookPath := filepath.Join(tmp, ".codex", "hooks.json")
+			if err := os.MkdirAll(filepath.Dir(hookPath), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(hookPath, raw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			dataDir := filepath.Join(tmp, "helm")
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+			if code != 1 || !strings.Contains(stderr.String(), "hook config") {
+				t.Fatalf("setup did not reject malformed hook JSON: exit=%d stderr=%s", code, stderr.String())
+			}
+			after, err := os.ReadFile(hookPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, raw) {
+				t.Fatalf("setup rewrote malformed hook config:\n%s", after)
+			}
+			if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+				t.Fatalf("malformed hook refusal created Kernel state: %v", err)
+			}
+		})
+	}
+}
+
+func TestSetupCodexProjectRefusesInactiveOrMixedProjectHookSource(t *testing.T) {
+	for name, config := range map[string][]byte{
+		"hooks-disabled": []byte("[features]\nhooks = false\n"),
+		"inline-hooks":   []byte("[[hooks.PreToolUse]]\nmatcher = \"^Bash$\"\n\n[[hooks.PreToolUse.hooks]]\ntype = \"command\"\ncommand = \"echo user-owned\"\n"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			tmp := t.TempDir()
+			oldWD, _ := os.Getwd()
+			if err := os.Chdir(tmp); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chdir(oldWD) })
+			stubSetupSideEffects(t)
+
+			configPath := filepath.Join(tmp, ".codex", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(configPath, config, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			dataDir := filepath.Join(tmp, "helm")
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("setup exit = %d, want 1 stderr=%s", code, stderr.String())
+			}
+			after, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(after, config) {
+				t.Fatalf("setup rewrote %s config:\n%s", name, after)
+			}
+			if _, err := os.Stat(filepath.Join(tmp, ".codex", "hooks.json")); !errorsIsNotExist(err) {
+				t.Fatalf("setup wrote hooks.json beside %s config: %v", name, err)
+			}
+			if _, err := os.Stat(dataDir); !errorsIsNotExist(err) {
+				t.Fatalf("%s refusal created Kernel state: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestCodexProjectTransactionRepeatsHookSourceChecks(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: filepath.Join(tmp, "helm")}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := preflightCodexProjectSetup(opts, summary); err != nil {
+		t.Fatalf("empty project preflight: %v", err)
+	}
+	inline := []byte("[[hooks.PreToolUse]]\nmatcher = \"^Bash$\"\n")
+	if err := os.MkdirAll(filepath.Dir(summary.ClientConfigPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(summary.ClientConfigPath, inline, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err == nil {
+		t.Fatal("journaled install preparation accepted inline hook config written after preflight")
+	}
+	afterInstall, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(afterInstall, inline) {
+		t.Fatalf("install rewrote post-preflight inline config:\n%s", afterInstall)
+	}
+
+	// Removal must make the same decision before it deletes either owned file.
+	if err := os.Remove(summary.ClientConfigPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, opts.DataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+	clientBefore, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientBefore = append(clientBefore, inline...)
+	if err := os.WriteFile(summary.ClientConfigPath, clientBefore, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	hookBefore, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryRemove(opts, summary); err == nil {
+		t.Fatal("journaled removal preparation accepted inline hook config")
+	}
+	clientAfter, _ := os.ReadFile(summary.ClientConfigPath)
+	hookAfter, _ := os.ReadFile(summary.HookConfigPath)
+	if !bytes.Equal(clientAfter, clientBefore) || !bytes.Equal(hookAfter, hookBefore) {
+		t.Fatalf("remove mutated config across mixed hook sources:\nclient=%s\nhook=%s", clientAfter, hookAfter)
+	}
+}
+
+func TestCodexProjectConfigTransactionRefusesConcurrentPreWriteChange(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: filepath.Join(tmp, "helm")}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := beginCodexProjectConfigTransaction(summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userConfig := []byte("[mcp_servers.user]\ncommand = \"echo\"\n")
+	if err := os.MkdirAll(filepath.Dir(summary.ClientConfigPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(summary.ClientConfigPath, userConfig, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	next, err := buildUpsertCodexProjectMCPState(tx.clientBefore(), summary.BinaryPath, opts.DataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.replaceClientState(next); err == nil {
+		t.Fatal("transaction overwrote a config changed after its snapshot")
+	}
+	after, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, userConfig) {
+		t.Fatalf("transaction overwrote concurrent pre-write config:\n%s", after)
+	}
+}
+
+func TestSetupCodexProjectRecoveryRefusesToOverwriteConcurrentConfigChange(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	dataDir := filepath.Join(tmp, "helm")
+	previousRecord := recordCodexProjectSetupLifecycleFn
+	recordCodexProjectSetupLifecycleFn = func(_ setupOptions, summary setupSummary, _ string) (setupLifecycleResult, error) {
+		if err := os.WriteFile(summary.ClientConfigPath, []byte("# user changed this after HELM wrote it\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return setupLifecycleResult{}, errors.New("receipt store unavailable")
+	}
+	t.Cleanup(func() { recordCodexProjectSetupLifecycleFn = previousRecord })
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("setup exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "local recovery is required") {
+		t.Fatalf("setup did not report retained recovery: %s", stderr.String())
+	}
+	raw, err := os.ReadFile(filepath.Join(tmp, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "# user changed this after HELM wrote it\n" {
+		t.Fatalf("setup overwrote concurrent user config:\n%s", raw)
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("concurrent change did not retain recovery journal: pending=%v err=%v", pending, err)
+	}
+
+	recordCodexProjectSetupLifecycleFn = previousRecord
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "conflict") {
+		t.Fatalf("recovery did not refuse concurrent user config: code=%d stderr=%s", code, stderr.String())
+	}
+	raw, err = os.ReadFile(filepath.Join(tmp, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != "# user changed this after HELM wrote it\n" {
+		t.Fatalf("recovery overwrote concurrent user config:\n%s", raw)
+	}
+}
+
+func TestSetupCodexProjectRemoveRequiresRecoveryWhenLifecycleReceiptFails(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	stubSetupSideEffects(t)
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	previousRecord := recordCodexProjectSetupLifecycleFn
+	recordCodexProjectSetupLifecycleFn = func(setupOptions, setupSummary, string) (setupLifecycleResult, error) {
+		return setupLifecycleResult{}, errors.New("receipt store unavailable")
+	}
+	t.Cleanup(func() { recordCodexProjectSetupLifecycleFn = previousRecord })
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("remove exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("failed revoke did not retain recovery journal: pending=%v err=%v", pending, err)
+	}
+
+	recordCodexProjectSetupLifecycleFn = previousRecord
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("remove recovery exit = %d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("remove recovery journal remained: pending=%v err=%v", pending, err)
+	}
+	clientAfter, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookAfter, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(clientAfter), setupMCPServerName) || strings.Contains(string(hookAfter), setupHookOwnershipStatus) {
+		t.Fatalf("remove recovery left owned config:\nclient=%s\nhook=%s", clientAfter, hookAfter)
+	}
+}
+
+func TestSetupCodexProjectRemoveNoOpDoesNotCreateLifecycleState(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("no-op remove exit = %d stderr = %s", code, stderr.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.LifecycleReceiptID != "" || summary.LifecycleEvidencePath != "" {
+		t.Fatalf("no-op remove unexpectedly issued lifecycle evidence: %#v", summary)
+	}
+	for _, stateFile := range []string{filepath.Join(dataDir, "root.key"), filepath.Join(dataDir, "helm.db")} {
+		if _, err := os.Stat(stateFile); !errorsIsNotExist(err) {
+			t.Fatalf("no-op remove created local state %s: %v", stateFile, err)
+		}
+	}
+}
+
+func TestSetupCodexProjectRemovePartialMCPDoesNotCreateEmptyHookConfig(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(summary.HookConfigPath); !errorsIsNotExist(err) {
+		t.Fatalf("fixture unexpectedly has a hook config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "no prior HELM install binding") {
+		t.Fatalf("unproven partial config removal must fail closed: code=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(summary.HookConfigPath); !errorsIsNotExist(err) {
+		t.Fatalf("remove created an empty hook config: %v", err)
+	}
+	clientAfter, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil || !strings.Contains(string(clientAfter), setupMCPServerName) {
+		t.Fatalf("unproven partial config was changed: %q err=%v", clientAfter, err)
+	}
+}
+
+func TestSetupCodexProjectRemoveDryRunReportsCurrentConfigWithoutState(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--dry-run", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("remove dry-run exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	var dryRun setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &dryRun); err != nil {
+		t.Fatal(err)
+	}
+	if !dryRun.MCPConfigured || !dryRun.HookConfigured || !dryRun.LocalConfigVerified || dryRun.Configured {
+		t.Fatalf("remove dry-run did not distinguish local config from client integration: %#v", dryRun)
+	}
+	for _, stateFile := range []string{filepath.Join(dataDir, "root.key"), filepath.Join(dataDir, "helm.db")} {
+		if _, err := os.Stat(stateFile); !errorsIsNotExist(err) {
+			t.Fatalf("remove dry-run created local state %s: %v", stateFile, err)
+		}
+	}
+}
+
+func TestSetupCodexProjectRemovePreservesUnownedSameNameMCPServer(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("[mcp_servers.helm-ai-kernel-governance]\ncommand = \"/usr/local/bin/user-owned-server\"\nargs = [\"serve\"]\n")
+	if err := os.MkdirAll(filepath.Dir(summary.ClientConfigPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(summary.ClientConfigPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "not a proven HELM installation") {
+		t.Fatalf("remove must fail closed across ambiguous MCP/hook ownership: code=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	after, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, original) {
+		t.Fatalf("remove changed a same-named user-owned MCP server:\n%s", after)
+	}
+	rawHook, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(rawHook), setupHookOwnershipStatus) {
+		t.Fatalf("ambiguous removal changed the hook:\n%s", rawHook)
+	}
+}
+
+func TestSetupStatusReportsConfiguredNotClientLoadedWithoutCreatingState(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("status exit = %d, want 1 stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	var status setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatalf("decode status summary: %v\n%s", err, stdout.String())
+	}
+	if !status.MCPConfigured || !status.HookConfigured || !status.LocalConfigVerified {
+		t.Fatalf("status did not report exact local config: %#v", status)
+	}
+	if status.Configured || status.ClientLoadObserved {
+		t.Fatalf("status must not turn config presence into a Codex integration claim: %#v", status)
+	}
+	for _, stateFile := range []string{filepath.Join(dataDir, "root.key"), filepath.Join(dataDir, "helm.db")} {
+		if _, err := os.Stat(stateFile); !errorsIsNotExist(err) {
+			t.Fatalf("status created local state %s: %v", stateFile, err)
+		}
+	}
+}
+
+func TestSetupStatusRefusesToCallExtendedCodexMCPConfigExact(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw = append(raw, []byte("\n[mcp_servers."+setupMCPServerName+".env]\nUSER_ADDED = \"keep-me\"\n")...)
+	if err := os.WriteFile(summary.ClientConfigPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("status exit = %d, want 1 stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	var status setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.MCPConfigured || !status.HookConfigured || status.LocalConfigVerified || status.Configured {
+		t.Fatalf("extended MCP table was reported as exact local configuration: %#v", status)
+	}
+}
+
+func TestSetupStatusRefusesToCallWrongCodexHookMatcherExact(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, "^Bash$", setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("status exit = %d, want 1 stderr = %s stdout = %s", code, stderr.String(), stdout.String())
+	}
+	var status setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if !status.MCPConfigured || status.HookConfigured || status.LocalConfigVerified || status.Configured {
+		t.Fatalf("wrong hook matcher was reported as exact local configuration: %#v", status)
+	}
+}
+
+func TestRemoveSetupHookRevokesStaleOwnedCodexCommand(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: filepath.Join(tmp, "helm")}
+	staleCommand := shellQuote("/old/helm-ai-kernel") + " hook pre-tool --client codex --data-dir " + shellQuote(opts.DataDir)
+	hookPath := setupHookConfigPath(opts)
+	if err := upsertOwnedSetupHookConfig(hookPath, setupHookMatcher(opts.Target), staleCommand, opts.Target); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeSetupHook(opts, "/new/helm-ai-kernel"); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "hook pre-tool --client codex --data-dir") {
+		t.Fatalf("stale owned Codex hook survived removal:\n%s", raw)
+	}
+}
+
+func TestInstallSetupHookReplacesStaleOwnedEntryWithoutRemovingUserHook(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: filepath.Join(tmp, "helm")}
+	hookPath := setupHookConfigPath(opts)
+	if err := writeJSONObject(hookPath, map[string]any{"hooks": map[string]any{"PreToolUse": []any{map[string]any{
+		"matcher": "^Bash$",
+		"hooks": []any{map[string]any{
+			"type":          "command",
+			"command":       "echo user-owned",
+			"timeout":       float64(30),
+			"statusMessage": "user-owned",
+		}},
+	}}}}); err != nil {
+		t.Fatal(err)
+	}
+	staleCommand := setupHookCommand(opts, "/old/helm-ai-kernel")
+	if err := upsertOwnedSetupHookConfig(hookPath, setupHookMatcher(opts.Target), staleCommand, opts.Target); err != nil {
+		t.Fatal(err)
+	}
+	if err := installSetupHook(opts, "/new/helm-ai-kernel"); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(raw), setupHookOwnershipStatus) != 1 {
+		t.Fatalf("owned hook was duplicated instead of replaced:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "/old/helm-ai-kernel") || !strings.Contains(string(raw), "/new/helm-ai-kernel") {
+		t.Fatalf("owned hook did not migrate to current binary:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "echo user-owned") {
+		t.Fatalf("updating HELM hook removed user hook:\n%s", raw)
+	}
+}
+
+func TestInstallSetupHookRefusesToReplaceUnownedMatchingCommand(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: filepath.Join(tmp, "helm")}
+	hookPath := setupHookConfigPath(opts)
+	command := setupHookCommand(opts, "/tmp/helm-ai-kernel")
+	original := []byte(`{"hooks":{"PreToolUse":[{"matcher":"^Bash$","hooks":[{"type":"command","command":` + strconv.Quote(command) + `,"statusMessage":"user-owned"}]}]}}` + "\n")
+	if err := os.MkdirAll(filepath.Dir(hookPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hookPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := installSetupHook(opts, "/tmp/helm-ai-kernel"); err == nil {
+		t.Fatal("install unexpectedly replaced an unowned matching hook")
+	}
+	after, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, original) {
+		t.Fatalf("unowned matching hook changed:\n%s", after)
+	}
+}
+
+func TestSetupStatusRejectsWrongCodexDataDirInsteadOfSubstringMatch(t *testing.T) {
+	tmp := t.TempDir()
+	oldWD, _ := os.Getwd()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	dataDir := filepath.Join(tmp, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, filepath.Join(tmp, "wrong-state")); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("status exit = %d, want 1 stderr = %s", code, stderr.String())
+	}
+	var status setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.MCPConfigured || !status.HookConfigured || status.LocalConfigVerified || status.Configured {
+		t.Fatalf("wrong data-dir was reported as configured: %#v", status)
 	}
 }
 
@@ -297,4 +2248,56 @@ func containsSetupString(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func decodeCodexProjectMCP(t *testing.T, raw []byte) struct {
+	Command string   `toml:"command"`
+	Args    []string `toml:"args"`
+} {
+	t.Helper()
+	var config struct {
+		MCPServers map[string]struct {
+			Command string   `toml:"command"`
+			Args    []string `toml:"args"`
+		} `toml:"mcp_servers"`
+	}
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		t.Fatalf("decode Codex TOML: %v\n%s", err, raw)
+	}
+	server, ok := config.MCPServers[setupMCPServerName]
+	if !ok {
+		t.Fatalf("Codex TOML has no %q server: %#v", setupMCPServerName, config.MCPServers)
+	}
+	return server
+}
+
+func equalSetupStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func assertSetupConfigBytesUnchanged(t *testing.T, clientPath string, clientWant []byte, hookPath string, hookWant []byte) {
+	t.Helper()
+	clientGot, err := os.ReadFile(clientPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookGot, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(clientGot, clientWant) || !bytes.Equal(hookGot, hookWant) {
+		t.Fatalf("setup changed config despite ownership conflict:\nclient=%s\nhook=%s", clientGot, hookGot)
+	}
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && os.IsNotExist(err)
 }

--- a/core/cmd/helm-ai-kernel/setup_codex_binding.go
+++ b/core/cmd/helm-ai-kernel/setup_codex_binding.go
@@ -1,0 +1,450 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+const (
+	setupCodexProjectBindingSchema = "helm.native-client.install-binding/v1"
+	setupCodexProjectBindingFile   = "codex-project-binding.json"
+)
+
+// setupCodexProjectBinding is a local pointer to a signed install receipt and
+// its exact configuration snapshots. It contains hashes, not user-owned
+// configuration bytes. Automatic removal only acts when this binding and its
+// signed evidence prove that the exact currently-installed configuration was
+// installed by this Kernel state.
+type setupCodexProjectBinding struct {
+	SchemaVersion           string `json:"schema_version"`
+	WorkspacePathHash       string `json:"workspace_path_hash"`
+	DataDirPathHash         string `json:"data_dir_path_hash"`
+	ConfiguredBinaryPath    string `json:"configured_binary_path"`
+	BinaryContentHash       string `json:"binary_content_hash"`
+	InstallReceiptID        string `json:"install_receipt_id"`
+	ClientConfigContentHash string `json:"client_config_content_hash"`
+	HookConfigContentHash   string `json:"hook_config_content_hash"`
+}
+
+type setupLifecycleStatePresence uint8
+
+const (
+	setupLifecycleStateAbsent setupLifecycleStatePresence = iota
+	setupLifecycleStateComplete
+)
+
+func setupCodexProjectBindingPath(dataDir string) string {
+	return currentCodexProjectPaths(dataDir).BindingPath
+}
+
+func inspectSetupLifecycleStatePresence(dataDir string) (setupLifecycleStatePresence, error) {
+	securedDataDir, err := requireSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return setupLifecycleStateAbsent, err
+	}
+	dataDir = securedDataDir
+	rootKey, err := readSetupExistingPrivateFile(filepath.Join(dataDir, "root.key"))
+	if err != nil {
+		return setupLifecycleStateAbsent, err
+	}
+	database, err := inspectSetupRegularFile(filepath.Join(dataDir, "helm.db"))
+	if err != nil {
+		return setupLifecycleStateAbsent, err
+	}
+	if !rootKey.Exists && !database.Exists {
+		return setupLifecycleStateAbsent, nil
+	}
+	if !rootKey.Exists || !database.Exists {
+		return setupLifecycleStateAbsent, fmt.Errorf("incomplete local lifecycle state; root.key and helm.db must either both exist or both be absent")
+	}
+	return setupLifecycleStateComplete, nil
+}
+
+// loadExistingSetupLifecycleSignerForSignature chooses verification authority
+// from the persisted signature envelope, never from HELM_RECEIPT_PROFILE.
+// The environment controls new receipt issuance only; using it to verify an
+// existing installation makes a valid hybrid proof unverifiable after a
+// profile rollout or rollback.
+func loadExistingSetupLifecycleSignerForSignature(dataDir, signature string) (helmcrypto.Signer, error) {
+	presence, err := inspectSetupLifecycleStatePresence(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	if presence != setupLifecycleStateComplete {
+		return nil, fmt.Errorf("no existing local lifecycle signer and receipt store")
+	}
+	edSigner, err := loadExistingEd25519Root(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	if helmcrypto.ReceiptSignatureProfile(signature) != helmcrypto.ReceiptProfileHybrid {
+		return edSigner, nil
+	}
+	mldsaSigner, err := loadExistingMLDSARoot(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	return helmcrypto.NewHybridSignerFromSigners(edSigner, mldsaSigner, "root")
+}
+
+func validateSetupCodexProjectBinding(binding *setupCodexProjectBinding) error {
+	if binding == nil || binding.SchemaVersion != setupCodexProjectBindingSchema {
+		return fmt.Errorf("unsupported Codex project install binding")
+	}
+	if !isSetupSHA256(binding.WorkspacePathHash) || !isSetupSHA256(binding.DataDirPathHash) || !isSetupSHA256(binding.BinaryContentHash) || !isSetupSHA256(binding.ClientConfigContentHash) || !isSetupSHA256(binding.HookConfigContentHash) {
+		return fmt.Errorf("Codex project install binding has invalid hashes")
+	}
+	if !isSetupLifecycleReceiptID(binding.InstallReceiptID) || !filepath.IsAbs(binding.ConfiguredBinaryPath) || strings.ContainsRune(binding.ConfiguredBinaryPath, '\x00') {
+		return fmt.Errorf("Codex project install binding has invalid receipt or Kernel binary path")
+	}
+	return nil
+}
+
+func readSetupCodexProjectBinding(dataDir string) (*setupCodexProjectBinding, error) {
+	stateExists, err := inspectCodexProjectStateAuthority(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("inspect Codex project binding authority state: %w", err)
+	}
+	if !stateExists {
+		return nil, nil
+	}
+	return readSetupCodexProjectBindingAtPath(setupCodexProjectBindingPath(dataDir))
+}
+
+// readSetupCodexProjectBindingAtPath keeps the parser independent from the
+// current v1 namespace so the explicit legacy migration path can validate an
+// old binding before it is copied into active state. Callers must never use it
+// as a runtime fallback: an unscoped path is not project authority.
+func readSetupCodexProjectBindingAtPath(path string) (*setupCodexProjectBinding, error) {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return nil, err
+	}
+	if !state.Exists {
+		return nil, nil
+	}
+	var binding setupCodexProjectBinding
+	if err := decodeCanonicalSetupJSON(state.Data, &binding); err != nil {
+		return nil, fmt.Errorf("decode Codex project install binding: %w", err)
+	}
+	if err := validateSetupCodexProjectBinding(&binding); err != nil {
+		return nil, err
+	}
+	return &binding, nil
+}
+
+func decodeCanonicalSetupJSON(data []byte, value any) error {
+	if err := jsonUnmarshalSetup(data, value); err != nil {
+		return err
+	}
+	canonical, err := canonicalize.JCS(value)
+	if err != nil {
+		return err
+	}
+	if string(canonical) != string(data) {
+		return fmt.Errorf("JSON is not canonical")
+	}
+	return nil
+}
+
+// jsonUnmarshalSetup is a narrow seam for canonical local-state parsing. It
+// keeps the binding's strict JCS check self-contained without accepting a
+// duplicate-key or whitespace-normalized representation.
+var jsonUnmarshalSetup = func(data []byte, value any) error {
+	return json.Unmarshal(data, value)
+}
+
+func buildSetupCodexProjectBinding(opts setupOptions, summary setupSummary, receiptID string, clientState, hookState setupFileState) (setupCodexProjectBinding, error) {
+	if !clientState.Exists || !hookState.Exists {
+		return setupCodexProjectBinding{}, fmt.Errorf("Codex project install binding requires both local configuration files")
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		return setupCodexProjectBinding{}, err
+	}
+	identity, err := inspectSetupKernelBinary(summary.BinaryPath)
+	if err != nil {
+		return setupCodexProjectBinding{}, err
+	}
+	if !isSetupLifecycleReceiptID(receiptID) {
+		return setupCodexProjectBinding{}, fmt.Errorf("invalid Codex project install receipt id")
+	}
+	return setupCodexProjectBinding{
+		SchemaVersion:           setupCodexProjectBindingSchema,
+		WorkspacePathHash:       workspacePathHash,
+		DataDirPathHash:         canonicalize.HashBytes([]byte(opts.DataDir)),
+		ConfiguredBinaryPath:    identity.Path,
+		BinaryContentHash:       identity.ContentHash,
+		InstallReceiptID:        receiptID,
+		ClientConfigContentHash: canonicalize.HashBytes(clientState.Data),
+		HookConfigContentHash:   canonicalize.HashBytes(hookState.Data),
+	}, nil
+}
+
+func marshalSetupCodexProjectBinding(binding setupCodexProjectBinding) ([]byte, error) {
+	if err := validateSetupCodexProjectBinding(&binding); err != nil {
+		return nil, err
+	}
+	return canonicalize.JCS(binding)
+}
+
+type setupCodexProjectInstallProof struct {
+	Binding  *setupCodexProjectBinding
+	Binary   setupKernelBinaryIdentity
+	Receipt  *contracts.Receipt
+	Evidence setupLifecycleEvidence
+	Signer   helmcrypto.Signer
+}
+
+// loadCodexProjectInstallProof verifies the signed install record without
+// looking at a mutable live config. Recovery needs this distinction: after a
+// crash, one config file may already be in its journaled removal state while
+// the binding correctly describes the pre-removal install state.
+func loadCodexProjectInstallProof(opts setupOptions) (setupCodexProjectInstallProof, error) {
+	binding, err := readSetupCodexProjectBinding(opts.DataDir)
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	if binding == nil {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("no prior HELM install binding proves this Codex project configuration; refusing automatic removal")
+	}
+	return validateCodexProjectInstallProof(opts, binding)
+}
+
+func validateCodexProjectInstallProof(opts setupOptions, binding *setupCodexProjectBinding) (setupCodexProjectInstallProof, error) {
+	if err := validateSetupCodexProjectBinding(binding); err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	presence, err := inspectSetupLifecycleStatePresence(opts.DataDir)
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	if presence != setupLifecycleStateComplete {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("no prior HELM lifecycle state proves this Codex project configuration; refusing automatic removal")
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	if binding.WorkspacePathHash != workspacePathHash || binding.DataDirPathHash != canonicalize.HashBytes([]byte(opts.DataDir)) {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("Codex project install binding is for a different workspace or data-dir")
+	}
+	identity, err := inspectSetupKernelBinary(binding.ConfiguredBinaryPath)
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	if identity.ContentHash != binding.BinaryContentHash {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("configured Kernel binary no longer matches its proven install binding")
+	}
+
+	receipt, err := readSetupLifecycleReceiptReadOnly(context.Background(), opts.DataDir, binding.InstallReceiptID)
+	if err != nil {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("read proven Codex install receipt: %w", err)
+	}
+	signer, err := loadExistingSetupLifecycleSignerForSignature(opts.DataDir, receipt.Signature)
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	if receipt.ReceiptID != binding.InstallReceiptID ||
+		receipt.DecisionID != "decision/native-client/install/"+binding.InstallReceiptID ||
+		receipt.EffectID != "mcp.tools.call/file_write" ||
+		receipt.Status != "DENY" ||
+		receipt.ExternalReferenceID != "codex-project:"+workspacePathHash ||
+		receipt.ExecutorID != "codex-project:"+workspacePathHash ||
+		receipt.Metadata["evidence_schema"] != setupCodexProjectLifecycleSchema ||
+		receipt.Metadata["lifecycle_operation"] != "install" {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("install binding receipt is not an exact Codex install lifecycle receipt")
+	}
+	verified, err := verifySetupLifecycleReceiptWithSigner(signer, receipt)
+	if err != nil || !verified {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("install binding receipt signature does not verify under local lifecycle authority")
+	}
+	evidence, err := verifySetupLifecycleEvidence(opts.DataDir, receipt)
+	if err != nil {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("verify Codex install binding evidence: %w", err)
+	}
+	clientPath, err := filepath.Abs(setupClientConfigPath(opts))
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	hookPath, err := filepath.Abs(setupHookConfigPath(opts))
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	if evidence.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Descriptor.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Observation.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Descriptor.Client != "codex" ||
+		evidence.Descriptor.Scope != "project" ||
+		evidence.Descriptor.Operation != "install" ||
+		evidence.Observation.Operation != "install" ||
+		evidence.Descriptor.WorkspacePathHash != binding.WorkspacePathHash ||
+		evidence.Descriptor.DataDirPathHash != binding.DataDirPathHash ||
+		evidence.Descriptor.KernelBinaryPath != binding.ConfiguredBinaryPath ||
+		evidence.Descriptor.KernelBinaryContentHash != binding.BinaryContentHash ||
+		!evidence.Descriptor.ExpectedMCP || !evidence.Descriptor.ExpectedHook ||
+		!evidence.Observation.MCPConfigured || !evidence.Observation.HookConfigured ||
+		!evidence.Observation.ClientConfig.Exists || !evidence.Observation.HookConfig.Exists ||
+		evidence.Observation.ClientConfig.PathHash != canonicalize.HashBytes([]byte(clientPath)) ||
+		evidence.Observation.HookConfig.PathHash != canonicalize.HashBytes([]byte(hookPath)) ||
+		evidence.Observation.ClientConfig.ContentHash != binding.ClientConfigContentHash ||
+		evidence.Observation.HookConfig.ContentHash != binding.HookConfigContentHash ||
+		evidence.Observation.SyntheticDenial == nil || !evidence.Observation.SyntheticDenial.Verified || evidence.Observation.SyntheticDenial.Dispatched || !evidence.Observation.SyntheticDenial.SentinelAbsent {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("Codex install binding evidence is incomplete")
+	}
+	return setupCodexProjectInstallProof{Binding: binding, Binary: identity, Receipt: receipt, Evidence: evidence, Signer: signer}, nil
+}
+
+func validateCodexProjectInstallBindingForCurrentConfig(opts setupOptions, clientState, hookState setupFileState) (setupCodexProjectInstallProof, error) {
+	proof, err := loadCodexProjectInstallProof(opts)
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	return validateCodexProjectInstallProofForCurrentConfig(opts, proof, clientState, hookState)
+}
+
+// validateCodexProjectInstallProofForCurrentConfig is shared by ordinary
+// provenance checks and the explicit legacy-binding migration. It accepts an
+// already-verified proof so migration can prove the source binding before it
+// publishes any v1 state.
+func validateCodexProjectInstallProofForCurrentConfig(opts setupOptions, proof setupCodexProjectInstallProof, clientState, hookState setupFileState) (setupCodexProjectInstallProof, error) {
+	if proof.Binding == nil {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("Codex project install proof has no binding")
+	}
+	if !clientState.Exists || !hookState.Exists ||
+		canonicalize.HashBytes(clientState.Data) != proof.Binding.ClientConfigContentHash ||
+		canonicalize.HashBytes(hookState.Data) != proof.Binding.HookConfigContentHash {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("Codex project config differs from its proven install binding; refusing automatic removal")
+	}
+	server, err := readCodexMCPServerFromBytes(clientState.Data)
+	if err != nil || server == nil {
+		if err != nil {
+			return setupCodexProjectInstallProof{}, err
+		}
+		return setupCodexProjectInstallProof{}, fmt.Errorf("Codex project install binding has no configured MCP server")
+	}
+	if server.Command != proof.Binding.ConfiguredBinaryPath || !isOwnedCodexMCPServerForDataDir(*server, opts.DataDir) {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("Codex MCP server does not match its proven install binding")
+	}
+	hasHook, err := hasOwnedSetupHookInBytes(hookState.Data, opts.Target, setupHookCommand(opts, proof.Binary.Path))
+	if err != nil {
+		return setupCodexProjectInstallProof{}, err
+	}
+	if !hasHook {
+		return setupCodexProjectInstallProof{}, fmt.Errorf("Codex hook does not match its proven install binding")
+	}
+	return proof, nil
+}
+
+func validateCodexProjectRemovalProvenance(opts setupOptions, summary setupSummary, clientState, hookState setupFileState) (string, error) {
+	proof, err := validateCodexProjectInstallBindingForCurrentConfig(opts, clientState, hookState)
+	if err != nil {
+		return "", err
+	}
+	if summary.BinaryPath != proof.Binary.Path {
+		return "", fmt.Errorf("current Kernel executable path does not match the proven Codex install binding")
+	}
+	return proof.Binary.Path, nil
+}
+
+// validateStagedCodexProjectInstallBinding makes the staged artifact part of
+// the transaction contract before any shared config is touched. A staged file
+// is not authority merely because its hash appears in a mutable journal.
+func validateStagedCodexProjectInstallBinding(opts setupOptions, journal *setupRecoveryJournal) (*setupCodexProjectBinding, error) {
+	if err := validateSetupRecoveryJournal(journal); err != nil {
+		return nil, err
+	}
+	if journal.Operation != "install" {
+		return nil, fmt.Errorf("staged install binding requires an install recovery journal")
+	}
+	bindingPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileBinding)
+	if err != nil {
+		return nil, err
+	}
+	stagePath, err := setupRecoverySafeStagePath(opts.DataDir, bindingPlan.StageFile)
+	if err != nil {
+		return nil, err
+	}
+	state, err := readSetupFileState(stagePath)
+	if err != nil {
+		return nil, err
+	}
+	if !state.Exists || !setupRecoveryFingerprintMatchesState(bindingPlan.After, state) {
+		return nil, fmt.Errorf("staged Codex project binding does not match its recovery fingerprint")
+	}
+	var binding setupCodexProjectBinding
+	if err := decodeCanonicalSetupJSON(state.Data, &binding); err != nil {
+		return nil, fmt.Errorf("decode staged Codex project binding: %w", err)
+	}
+	if err := validateSetupCodexProjectBindingAgainstJournal(opts, journal, &binding); err != nil {
+		return nil, err
+	}
+	return &binding, nil
+}
+
+func validateSetupCodexProjectBindingAgainstJournal(opts setupOptions, journal *setupRecoveryJournal, binding *setupCodexProjectBinding) error {
+	if err := validateSetupCodexProjectBinding(binding); err != nil {
+		return err
+	}
+	if binding.InstallReceiptID != journal.LifecycleReceiptID ||
+		binding.WorkspacePathHash != journal.WorkspacePathHash ||
+		binding.DataDirPathHash != journal.DataDirPathHash ||
+		binding.ConfiguredBinaryPath != journal.BinaryPath ||
+		binding.BinaryContentHash != journal.BinaryContentHash ||
+		binding.DataDirPathHash != canonicalize.HashBytes([]byte(opts.DataDir)) {
+		return fmt.Errorf("staged Codex project binding does not match its recovery identity")
+	}
+	mcpPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileMCP)
+	if err != nil {
+		return err
+	}
+	hookPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileHook)
+	if err != nil {
+		return err
+	}
+	if !mcpPlan.After.Exists || !hookPlan.After.Exists ||
+		mcpPlan.After.ContentHash != binding.ClientConfigContentHash ||
+		hookPlan.After.ContentHash != binding.HookConfigContentHash {
+		return fmt.Errorf("staged Codex project binding does not match the deterministic post-install config plans")
+	}
+	return nil
+}
+
+// validateStagedCodexProjectInstallBindingForCurrentConfig is called only
+// after the lifecycle receipt has been recorded. It proves the same staged
+// binding against that signed receipt/evidence and the exact post-install
+// config before the binding is published to its durable final path.
+func validateStagedCodexProjectInstallBindingForCurrentConfig(opts setupOptions, journal *setupRecoveryJournal) (*setupCodexProjectBinding, error) {
+	binding, err := validateStagedCodexProjectInstallBinding(opts, journal)
+	if err != nil {
+		return nil, err
+	}
+	clientState, err := readSetupFileState(setupClientConfigPath(opts))
+	if err != nil {
+		return nil, err
+	}
+	hookState, err := readSetupFileState(setupHookConfigPath(opts))
+	if err != nil {
+		return nil, err
+	}
+	if !clientState.Exists || !hookState.Exists ||
+		canonicalize.HashBytes(clientState.Data) != binding.ClientConfigContentHash ||
+		canonicalize.HashBytes(hookState.Data) != binding.HookConfigContentHash {
+		return nil, fmt.Errorf("post-install Codex config does not match the staged binding")
+	}
+	proof, err := validateCodexProjectInstallProof(opts, binding)
+	if err != nil {
+		return nil, err
+	}
+	if proof.Binary.Path != binding.ConfiguredBinaryPath || proof.Receipt.ReceiptID != journal.LifecycleReceiptID {
+		return nil, fmt.Errorf("staged Codex project binding proof does not match the recovered lifecycle receipt")
+	}
+	return binding, nil
+}

--- a/core/cmd/helm-ai-kernel/setup_codex_lifecycle.go
+++ b/core/cmd/helm-ai-kernel/setup_codex_lifecycle.go
@@ -1,0 +1,682 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	cryptorand "crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+)
+
+const setupCodexProjectLifecycleSchema = "helm.native-client.setup/v1"
+
+var recordCodexProjectSetupLifecycleFn = recordCodexProjectSetupLifecycle
+
+// setupLifecycleStorePrepared is a narrow deterministic test seam. Production
+// uses the no-op default; tests can install a SQLite trigger after the store is
+// initialized to prove cleanup behavior for an actual append failure.
+var setupLifecycleStorePrepared = func(_ *sql.DB) error { return nil }
+
+func validateSetupLifecycleReceiptProfile() error {
+	switch profile := os.Getenv("HELM_RECEIPT_PROFILE"); profile {
+	case "", helmcrypto.ReceiptProfileClassical, helmcrypto.ReceiptProfileHybrid:
+		return nil
+	default:
+		return fmt.Errorf("unknown HELM_RECEIPT_PROFILE %q (expected %q or %q)", profile, helmcrypto.ReceiptProfileClassical, helmcrypto.ReceiptProfileHybrid)
+	}
+}
+
+type setupLifecycleResult struct {
+	ReceiptID               string
+	EvidencePath            string
+	SyntheticDenialVerified bool
+}
+
+type setupFileSnapshot struct {
+	PathHash    string `json:"path_hash"`
+	Exists      bool   `json:"exists"`
+	ContentHash string `json:"content_hash,omitempty"`
+}
+
+type setupSyntheticDenial struct {
+	Verified            bool   `json:"verified"`
+	Dispatched          bool   `json:"dispatched"`
+	SentinelAbsent      bool   `json:"sentinel_absent"`
+	ResponseContentHash string `json:"response_content_hash"`
+}
+
+type setupLifecycleDescriptor struct {
+	SchemaVersion           string `json:"schema_version"`
+	Client                  string `json:"client"`
+	Scope                   string `json:"scope"`
+	Operation               string `json:"operation"`
+	WorkspacePathHash       string `json:"workspace_path_hash"`
+	DataDirPathHash         string `json:"data_dir_path_hash"`
+	KernelBinaryPath        string `json:"kernel_binary_path"`
+	KernelBinaryContentHash string `json:"kernel_binary_content_hash"`
+	ExpectedMCP             bool   `json:"expected_mcp_configured"`
+	ExpectedHook            bool   `json:"expected_hook_configured"`
+}
+
+type setupLifecycleObservation struct {
+	SchemaVersion          string                `json:"schema_version"`
+	Operation              string                `json:"operation"`
+	MCPConfigured          bool                  `json:"mcp_configured"`
+	HookConfigured         bool                  `json:"hook_configured"`
+	ClientLoadObserved     bool                  `json:"client_load_observed"`
+	ClientConfig           setupFileSnapshot     `json:"client_config"`
+	HookConfig             setupFileSnapshot     `json:"hook_config"`
+	SyntheticDenial        *setupSyntheticDenial `json:"synthetic_denial,omitempty"`
+	KernelDispatchObserved bool                  `json:"kernel_dispatch_observed"`
+	WorkspacePathHash      string                `json:"workspace_path_hash"`
+	DataDirPathHash        string                `json:"data_dir_path_hash"`
+}
+
+type setupLifecycleEvidence struct {
+	SchemaVersion string                    `json:"schema_version"`
+	ReceiptID     string                    `json:"receipt_id"`
+	Descriptor    setupLifecycleDescriptor  `json:"descriptor"`
+	Observation   setupLifecycleObservation `json:"observation"`
+}
+
+// preflightCodexProjectSetup validates only local ownership and syntax before
+// setup creates Kernel state or scans the workspace. The mutating helpers
+// repeat these checks inside the transaction because the files can change
+// between this preflight and the write.
+func preflightCodexProjectSetup(opts setupOptions, summary setupSummary) error {
+	clientState, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return fmt.Errorf("inspect Codex project config: %w", err)
+	}
+	if err := requireCodexProjectHookSourceForInstall(clientState.Data); err != nil {
+		return err
+	}
+	mcp, hasMCP, err := readCodexMCPServer(summary.ClientConfigPath)
+	if err != nil {
+		return fmt.Errorf("inspect Codex MCP config: %w", err)
+	}
+	if hasMCP {
+		if err := requireMutableCodexMCPServer(&mcp, opts.DataDir); err != nil {
+			return err
+		}
+	}
+	_, pre, err := readSetupHookConfig(summary.HookConfigPath)
+	if err != nil {
+		return fmt.Errorf("inspect Codex hook config: %w", err)
+	}
+	if err := requireMutableSetupHookEntries(pre, opts.Target, setupHookCommand(opts, summary.BinaryPath)); err != nil {
+		return err
+	}
+	if hasMCP && isOwnedCodexMCPServerForDataDir(mcp, opts.DataDir) {
+		hookState, err := readSetupFileState(summary.HookConfigPath)
+		if err != nil {
+			return fmt.Errorf("inspect Codex hook binding: %w", err)
+		}
+		if _, err := validateCodexProjectRemovalProvenance(opts, summary, clientState, hookState); err != nil {
+			return fmt.Errorf("verify existing Codex project install provenance before replacement: %w", err)
+		}
+	}
+	return nil
+}
+
+func refreshSetupConfiguration(opts setupOptions, summary *setupSummary) {
+	summary.MCPConfigured = setupMCPConfigured(opts, summary.ClientConfigPath, summary.BinaryPath)
+	summary.HookConfigured = setupHookConfigured(opts, summary.HookConfigPath, summary.BinaryPath)
+	summary.LocalConfigVerified = summary.MCPConfigured && summary.HookConfigured
+	// A project file is only a candidate client configuration. Codex can skip
+	// it until the project and hooks are trusted, so integration remains false
+	// until a sterile client session observes the configured server loaded.
+	summary.Configured = summary.LocalConfigVerified && summary.ClientLoadObserved
+}
+
+// reconcilePersistedSetupLifecycleReceipt completes the post-append recovery
+// boundary without issuing a new receipt or using HELM_RECEIPT_PROFILE. A
+// recovery journal may outlive a profile rollout, rollback, or an invalid
+// environment override; the persisted receipt envelope is the only valid
+// source for selecting its verification authority.
+func reconcilePersistedSetupLifecycleReceipt(dataDir, receiptID, workspacePathHash, operation string, summary setupSummary, descriptor setupLifecycleDescriptor, clientConfig, hookConfig setupFileSnapshot, receipt *contracts.Receipt) (setupLifecycleResult, error) {
+	if receipt == nil {
+		return setupLifecycleResult{}, fmt.Errorf("persisted lifecycle receipt is required")
+	}
+	signer, err := loadExistingSetupLifecycleSignerForSignature(dataDir, receipt.Signature)
+	if err != nil {
+		return setupLifecycleResult{}, fmt.Errorf("load persisted lifecycle verification authority: %w", err)
+	}
+	evidence, err := verifySetupLifecycleEvidence(dataDir, receipt)
+	if err != nil {
+		return setupLifecycleResult{}, fmt.Errorf("verify persisted lifecycle evidence: %w", err)
+	}
+	if evidence.Descriptor != descriptor {
+		return setupLifecycleResult{}, fmt.Errorf("persisted lifecycle descriptor does not match the recovered setup")
+	}
+	observation := evidence.Observation
+	if observation.Operation != operation ||
+		observation.MCPConfigured != summary.MCPConfigured ||
+		observation.HookConfigured != summary.HookConfigured ||
+		observation.ClientLoadObserved ||
+		observation.ClientConfig != clientConfig ||
+		observation.HookConfig != hookConfig ||
+		observation.WorkspacePathHash != descriptor.WorkspacePathHash ||
+		observation.DataDirPathHash != descriptor.DataDirPathHash {
+		return setupLifecycleResult{}, fmt.Errorf("persisted lifecycle observation does not match the recovered setup")
+	}
+	if operation == "install" {
+		if observation.SyntheticDenial == nil || !observation.SyntheticDenial.Verified || !observation.SyntheticDenial.SentinelAbsent || observation.SyntheticDenial.Dispatched || observation.KernelDispatchObserved {
+			return setupLifecycleResult{}, fmt.Errorf("persisted install lifecycle evidence has no valid synthetic denial")
+		}
+	} else if observation.SyntheticDenial != nil || observation.KernelDispatchObserved {
+		return setupLifecycleResult{}, fmt.Errorf("persisted removal lifecycle evidence has unexpected synthetic denial state")
+	}
+	descriptorHash, err := canonicalize.CanonicalHash(descriptor)
+	if err != nil {
+		return setupLifecycleResult{}, fmt.Errorf("hash recovered lifecycle descriptor: %w", err)
+	}
+	outputHash, err := canonicalize.CanonicalHash(observation)
+	if err != nil {
+		return setupLifecycleResult{}, fmt.Errorf("hash persisted lifecycle observation: %w", err)
+	}
+	if err := validatePersistedSetupLifecycleReceipt(signer, receipt, receiptID, descriptorHash, outputHash, workspacePathHash, operation); err != nil {
+		return setupLifecycleResult{}, err
+	}
+	return setupLifecycleResult{
+		ReceiptID:               receiptID,
+		EvidencePath:            setupLifecycleEvidencePath(dataDir, receiptID),
+		SyntheticDenialVerified: observation.SyntheticDenial != nil && observation.SyntheticDenial.Verified,
+	}, nil
+}
+
+// recordCodexProjectSetupLifecycle records only a local Kernel observation.
+// It intentionally does not claim that Codex trusted, loaded, or invoked the
+// configured MCP server; that must be certified from a sterile client session.
+func recordCodexProjectSetupLifecycle(opts setupOptions, summary setupSummary, operation string) (result setupLifecycleResult, returnErr error) {
+	if opts.Target != "codex" || opts.Scope != "project" {
+		return result, fmt.Errorf("Codex project lifecycle requires target codex with project scope")
+	}
+	if operation != "install" && operation != "remove" {
+		return result, fmt.Errorf("unsupported Codex project lifecycle operation %q", operation)
+	}
+	if operation == "install" && !summary.LocalConfigVerified {
+		return result, fmt.Errorf("Codex project config is incomplete after install")
+	}
+	if operation == "remove" && (summary.MCPConfigured || summary.HookConfigured) {
+		return result, fmt.Errorf("owned Codex project config remains after remove")
+	}
+	stateTracker, err := beginSetupLifecycleStateTracker(opts.DataDir)
+	if err != nil {
+		return result, fmt.Errorf("snapshot lifecycle state: %w", err)
+	}
+	var evidencePath string
+	cleanupLifecycleState := true
+	defer func() {
+		if returnErr == nil {
+			return
+		}
+		if opts.lifecycleRecoveryManaged {
+			// A prepared recovery journal owns this lifecycle attempt. Retain
+			// signer, SQLite, and evidence state so a resumed transaction can
+			// prove or finish the same receipt without tearing down an uncertain
+			// post-append boundary.
+			return
+		}
+		if evidencePath != "" {
+			if err := os.Remove(evidencePath); err != nil && !os.IsNotExist(err) {
+				returnErr = fmt.Errorf("%w; remove lifecycle evidence: %v", returnErr, err)
+			}
+			if err := os.Remove(filepath.Dir(evidencePath)); err != nil && !os.IsNotExist(err) {
+				returnErr = fmt.Errorf("%w; remove empty lifecycle evidence dir: %v", returnErr, err)
+			}
+		}
+		if !cleanupLifecycleState {
+			return
+		}
+		if err := stateTracker.cleanupCreated(); err != nil {
+			returnErr = fmt.Errorf("%w; cleanup newly-created lifecycle state: %v", returnErr, err)
+		}
+	}()
+
+	workspacePath, err := filepath.Abs(".")
+	if err != nil {
+		return result, fmt.Errorf("resolve workspace: %w", err)
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(workspacePath); resolveErr == nil {
+		workspacePath = resolved
+	}
+	workspacePathHash := canonicalize.HashBytes([]byte(workspacePath))
+	dataDirPathHash := canonicalize.HashBytes([]byte(opts.DataDir))
+	binaryIdentity, err := inspectSetupKernelBinary(summary.BinaryPath)
+	if err != nil {
+		return result, fmt.Errorf("inspect lifecycle Kernel binary: %w", err)
+	}
+
+	clientConfig, err := snapshotSetupFile(summary.ClientConfigPath)
+	if err != nil {
+		return result, fmt.Errorf("snapshot client config: %w", err)
+	}
+	hookConfig, err := snapshotSetupFile(summary.HookConfigPath)
+	if err != nil {
+		return result, fmt.Errorf("snapshot hook config: %w", err)
+	}
+
+	descriptor := setupLifecycleDescriptor{
+		SchemaVersion:           setupCodexProjectLifecycleSchema,
+		Client:                  "codex",
+		Scope:                   "project",
+		Operation:               operation,
+		WorkspacePathHash:       workspacePathHash,
+		DataDirPathHash:         dataDirPathHash,
+		KernelBinaryPath:        binaryIdentity.Path,
+		KernelBinaryContentHash: binaryIdentity.ContentHash,
+		ExpectedMCP:             operation == "install",
+		ExpectedHook:            operation == "install",
+	}
+	descriptorHash, err := canonicalize.CanonicalHash(descriptor)
+	if err != nil {
+		return result, fmt.Errorf("hash lifecycle descriptor: %w", err)
+	}
+
+	receiptID := opts.lifecycleReceiptID
+	if receiptID == "" {
+		var receiptErr error
+		receiptID, receiptErr = newSetupLifecycleReceiptID()
+		if receiptErr != nil {
+			return result, receiptErr
+		}
+	}
+	if opts.lifecycleReceiptID != "" {
+		stored, persisted, inspectErr := inspectSetupLifecycleReceiptReadOnly(context.Background(), opts.DataDir, receiptID)
+		if inspectErr != nil {
+			return result, fmt.Errorf("inspect recovered lifecycle receipt: %w", inspectErr)
+		}
+		if persisted {
+			return reconcilePersistedSetupLifecycleReceipt(opts.DataDir, receiptID, workspacePathHash, operation, summary, descriptor, clientConfig, hookConfig, stored)
+		}
+	}
+
+	signer, signerErr := loadOrGenerateSignerWithDataDir(opts.DataDir)
+	if captureErr := stateTracker.captureCreated(); captureErr != nil {
+		return result, captureErr
+	}
+	if signerErr != nil {
+		return result, fmt.Errorf("load lifecycle signer: %w", signerErr)
+	}
+
+	var synthetic *setupSyntheticDenial
+	if operation == "install" {
+		denial, err := verifyCodexProjectSyntheticDenial(opts.DataDir, signer)
+		if err != nil {
+			return result, err
+		}
+		synthetic = &denial
+	}
+
+	observation := setupLifecycleObservation{
+		SchemaVersion:          setupCodexProjectLifecycleSchema,
+		Operation:              operation,
+		MCPConfigured:          summary.MCPConfigured,
+		HookConfigured:         summary.HookConfigured,
+		ClientLoadObserved:     false,
+		ClientConfig:           clientConfig,
+		HookConfig:             hookConfig,
+		SyntheticDenial:        synthetic,
+		KernelDispatchObserved: synthetic != nil && synthetic.Dispatched,
+		WorkspacePathHash:      workspacePathHash,
+		DataDirPathHash:        dataDirPathHash,
+	}
+	outputHash, err := canonicalize.CanonicalHash(observation)
+	if err != nil {
+		return result, fmt.Errorf("hash lifecycle observation: %w", err)
+	}
+
+	evidencePath, err = writeSetupLifecycleEvidence(opts.DataDir, setupLifecycleEvidence{
+		SchemaVersion: setupCodexProjectLifecycleSchema,
+		ReceiptID:     receiptID,
+		Descriptor:    descriptor,
+		Observation:   observation,
+	})
+	if err != nil {
+		return result, fmt.Errorf("write lifecycle evidence: %w", err)
+	}
+
+	ctx := context.Background()
+	db, _, receiptStore, storeErr := setupLiteModeWithDataDir(ctx, opts.DataDir)
+	if captureErr := stateTracker.captureCreated(); captureErr != nil {
+		return result, captureErr
+	}
+	if storeErr != nil {
+		return result, fmt.Errorf("open lifecycle receipt store: %w", storeErr)
+	}
+	defer func() { _ = db.Close() }()
+	if err := setupLifecycleStorePrepared(db); err != nil {
+		return result, fmt.Errorf("prepare lifecycle receipt store: %w", err)
+	}
+	if opts.lifecycleReceiptID != "" {
+		persisted, inspectErr := setupLifecycleReceiptPersisted(ctx, db, receiptID)
+		if inspectErr != nil {
+			return result, fmt.Errorf("inspect recovered lifecycle receipt: %w", inspectErr)
+		}
+		if persisted {
+			stored, lookupErr := receiptStore.GetByReceiptID(ctx, receiptID)
+			if lookupErr != nil {
+				return result, fmt.Errorf("read recovered lifecycle receipt: %w", lookupErr)
+			}
+			return reconcilePersistedSetupLifecycleReceipt(opts.DataDir, receiptID, workspacePathHash, operation, summary, descriptor, clientConfig, hookConfig, stored)
+		}
+	}
+
+	sessionID := "codex-project:" + workspacePathHash
+	status := "DENY"
+	effectID := "mcp.tools.call/file_write"
+	reasonCode := "ERR_SYNTHETIC_FILE_WRITE_DENIED"
+	toolName := "file_write"
+	if operation == "remove" {
+		status = "REVOKED"
+		effectID = "native_client.setup/codex-project/remove"
+		reasonCode = "CONFIG_REMOVED"
+		toolName = ""
+	}
+
+	appendErr := receiptStore.AppendCausal(ctx, sessionID, func(_ *contracts.Receipt, lamport uint64, prevHash string) (*contracts.Receipt, error) {
+		receipt := &contracts.Receipt{
+			ReceiptID:           receiptID,
+			DecisionID:          "decision/native-client/" + operation + "/" + receiptID,
+			EffectID:            effectID,
+			ExternalReferenceID: sessionID,
+			Status:              status,
+			OutputHash:          outputHash,
+			Timestamp:           time.Now().UTC(),
+			ExecutorID:          sessionID,
+			PrevHash:            prevHash,
+			LamportClock:        lamport,
+			ArgsHash:            descriptorHash,
+			Type:                "native_client_setup_lifecycle",
+			Action:              operation,
+			Verdict:             status,
+			ToolName:            toolName,
+			ReasonCode:          reasonCode,
+			Metadata: map[string]any{
+				"evidence_schema":     setupCodexProjectLifecycleSchema,
+				"lifecycle_operation": operation,
+			},
+		}
+		if err := signer.SignReceipt(receipt); err != nil {
+			return nil, fmt.Errorf("sign lifecycle receipt: %w", err)
+		}
+		return receipt, nil
+	})
+	if appendErr != nil {
+		persisted, inspectErr := setupLifecycleReceiptPersisted(ctx, db, receiptID)
+		if inspectErr != nil {
+			cleanupLifecycleState = false
+			return result, fmt.Errorf("append lifecycle receipt: %w; receipt outcome is unknown and local recovery is required: %v", appendErr, inspectErr)
+		}
+		if !persisted {
+			if captureErr := stateTracker.captureCreated(); captureErr != nil {
+				return result, fmt.Errorf("append lifecycle receipt: %w; snapshot rollback state: %v", appendErr, captureErr)
+			}
+			return result, fmt.Errorf("append lifecycle receipt: %w", appendErr)
+		}
+		stored, lookupErr := receiptStore.GetByReceiptID(ctx, receiptID)
+		verificationSigner, verifierErr := loadExistingSetupLifecycleSignerForSignature(opts.DataDir, func() string {
+			if stored == nil {
+				return ""
+			}
+			return stored.Signature
+		}())
+		if lookupErr != nil || verifierErr != nil || validatePersistedSetupLifecycleReceipt(verificationSigner, stored, receiptID, descriptorHash, outputHash, workspacePathHash, operation) != nil {
+			cleanupLifecycleState = false
+			return result, fmt.Errorf("append lifecycle receipt returned an error but receipt state needs recovery review")
+		}
+	}
+
+	stored, lookupErr := receiptStore.GetByReceiptID(ctx, receiptID)
+	if lookupErr != nil {
+		cleanupLifecycleState = false
+		return result, fmt.Errorf("read appended lifecycle receipt: %w", lookupErr)
+	}
+	verificationSigner, verifierErr := loadExistingSetupLifecycleSignerForSignature(opts.DataDir, stored.Signature)
+	if verifierErr != nil {
+		cleanupLifecycleState = false
+		return result, fmt.Errorf("load appended lifecycle verification authority: %w", verifierErr)
+	}
+	if err := validatePersistedSetupLifecycleReceipt(verificationSigner, stored, receiptID, descriptorHash, outputHash, workspacePathHash, operation); err != nil {
+		cleanupLifecycleState = false
+		return result, fmt.Errorf("appended lifecycle receipt failed verification: %w", err)
+	}
+
+	return setupLifecycleResult{
+		ReceiptID:               receiptID,
+		EvidencePath:            evidencePath,
+		SyntheticDenialVerified: synthetic != nil && synthetic.Verified,
+	}, nil
+}
+
+func validatePersistedSetupLifecycleReceipt(signer helmcrypto.Signer, receipt *contracts.Receipt, receiptID, descriptorHash, outputHash, workspacePathHash, operation string) error {
+	if receipt == nil || receipt.ReceiptID != receiptID || receipt.ArgsHash != descriptorHash || receipt.OutputHash != outputHash {
+		return fmt.Errorf("receipt identity or signed hashes differ from the prepared lifecycle observation")
+	}
+	sessionID := "codex-project:" + workspacePathHash
+	if receipt.DecisionID != "decision/native-client/"+operation+"/"+receiptID || receipt.ExternalReferenceID != sessionID || receipt.ExecutorID != sessionID {
+		return fmt.Errorf("receipt lifecycle identity does not match the prepared operation")
+	}
+	if receipt.Metadata["evidence_schema"] != setupCodexProjectLifecycleSchema || receipt.Metadata["lifecycle_operation"] != operation {
+		return fmt.Errorf("receipt lifecycle metadata is incomplete")
+	}
+	switch operation {
+	case "install":
+		if receipt.Status != "DENY" || receipt.EffectID != "mcp.tools.call/file_write" {
+			return fmt.Errorf("install lifecycle receipt has unexpected status or effect")
+		}
+	case "remove":
+		if receipt.Status != "REVOKED" || receipt.EffectID != "native_client.setup/codex-project/remove" {
+			return fmt.Errorf("remove lifecycle receipt has unexpected status or effect")
+		}
+	default:
+		return fmt.Errorf("unsupported lifecycle operation %q", operation)
+	}
+	verified, err := verifySetupLifecycleReceiptWithSigner(signer, receipt)
+	if err != nil {
+		return err
+	}
+	if !verified {
+		return fmt.Errorf("receipt signature does not verify under the local lifecycle authority")
+	}
+	return nil
+}
+
+func verifySetupLifecycleReceiptWithSigner(signer helmcrypto.Signer, receipt *contracts.Receipt) (bool, error) {
+	if signer == nil || receipt == nil {
+		return false, fmt.Errorf("lifecycle signer and receipt are required")
+	}
+	payload := []byte(helmcrypto.CanonicalizeReceipt(receipt.ReceiptID, receipt.DecisionID, receipt.EffectID, receipt.Status, receipt.OutputHash, receipt.PrevHash, receipt.LamportClock, receipt.ArgsHash))
+	switch typed := signer.(type) {
+	case *helmcrypto.HybridSigner:
+		return typed.Verify(payload, receipt.Signature)
+	default:
+		verifier, err := helmcrypto.NewEd25519Verifier(signer.PublicKeyBytes())
+		if err != nil {
+			return false, err
+		}
+		return verifier.VerifyReceipt(receipt)
+	}
+}
+
+func setupLifecycleReceiptPersisted(ctx context.Context, db *sql.DB, receiptID string) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(1) FROM receipts WHERE receipt_id = ?", receiptID).Scan(&count); err != nil {
+		return false, err
+	}
+	return count == 1, nil
+}
+
+func writeSetupLifecycleEvidence(dataDir string, evidence setupLifecycleEvidence) (string, error) {
+	if !isSetupLifecycleReceiptID(evidence.ReceiptID) {
+		return "", fmt.Errorf("lifecycle evidence receipt id is invalid")
+	}
+	securedDataDir, err := ensureSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return "", err
+	}
+	dataDir = securedDataDir
+	if err := ensureSetupAuthoritySubdirectory(dataDir, "lifecycle-evidence"); err != nil {
+		return "", fmt.Errorf("prepare lifecycle evidence directory: %w", err)
+	}
+	data, err := canonicalize.JCS(evidence)
+	if err != nil {
+		return "", err
+	}
+	path := setupLifecycleEvidencePath(dataDir, evidence.ReceiptID)
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return "", err
+	}
+	if state.Exists {
+		if bytes.Equal(state.Data, data) {
+			return path, nil
+		}
+		return "", fmt.Errorf("existing lifecycle evidence does not match the prepared receipt")
+	}
+	if err := writeSetupPrivateFile(path, data); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func setupLifecycleEvidencePath(dataDir, receiptID string) string {
+	return filepath.Join(dataDir, "lifecycle-evidence", receiptID+".json")
+}
+
+func verifySetupLifecycleEvidence(dataDir string, receipt *contracts.Receipt) (setupLifecycleEvidence, error) {
+	if receipt == nil || !isSetupLifecycleReceiptID(receipt.ReceiptID) {
+		return setupLifecycleEvidence{}, fmt.Errorf("receipt id is required")
+	}
+	securedDataDir, err := requireSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return setupLifecycleEvidence{}, err
+	}
+	dataDir = securedDataDir
+	if _, err := requireSetupAuthoritySubdirectory(dataDir, "lifecycle-evidence"); err != nil {
+		return setupLifecycleEvidence{}, fmt.Errorf("inspect lifecycle evidence directory: %w", err)
+	}
+	state, err := readSetupFileState(setupLifecycleEvidencePath(dataDir, receipt.ReceiptID))
+	if err != nil {
+		return setupLifecycleEvidence{}, err
+	}
+	if !state.Exists {
+		return setupLifecycleEvidence{}, fmt.Errorf("lifecycle evidence does not exist")
+	}
+	var evidence setupLifecycleEvidence
+	if err := decodeCanonicalSetupJSON(state.Data, &evidence); err != nil {
+		return setupLifecycleEvidence{}, fmt.Errorf("decode lifecycle evidence: %w", err)
+	}
+	if evidence.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Descriptor.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Observation.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.ReceiptID != receipt.ReceiptID {
+		return setupLifecycleEvidence{}, fmt.Errorf("evidence receipt id does not match signed receipt")
+	}
+	argsHash, err := canonicalize.CanonicalHash(evidence.Descriptor)
+	if err != nil {
+		return setupLifecycleEvidence{}, fmt.Errorf("hash lifecycle evidence descriptor: %w", err)
+	}
+	if argsHash != receipt.ArgsHash {
+		return setupLifecycleEvidence{}, fmt.Errorf("lifecycle evidence descriptor hash does not match signed receipt")
+	}
+	outputHash, err := canonicalize.CanonicalHash(evidence.Observation)
+	if err != nil {
+		return setupLifecycleEvidence{}, fmt.Errorf("hash lifecycle evidence observation: %w", err)
+	}
+	if outputHash != receipt.OutputHash {
+		return setupLifecycleEvidence{}, fmt.Errorf("lifecycle evidence observation hash does not match signed receipt")
+	}
+	return evidence, nil
+}
+
+func snapshotSetupFile(path string) (setupFileSnapshot, error) {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return setupFileSnapshot{}, err
+	}
+	snapshot := setupFileSnapshot{PathHash: canonicalize.HashBytes([]byte(state.Path))}
+	if !state.Exists {
+		return snapshot, nil
+	}
+	snapshot.Exists = true
+	snapshot.ContentHash = canonicalize.HashBytes(state.Data)
+	return snapshot, nil
+}
+
+func verifyCodexProjectSyntheticDenial(dataDir string, signer helmcrypto.Signer) (setupSyntheticDenial, error) {
+	probeID, err := newSetupLifecycleReceiptID()
+	if err != nil {
+		return setupSyntheticDenial{}, err
+	}
+	probeDir := filepath.Join(dataDir, "synthetic-denial")
+	if err := ensureSetupAuthoritySubdirectory(dataDir, "synthetic-denial"); err != nil {
+		return setupSyntheticDenial{}, fmt.Errorf("create synthetic denial probe dir: %w", err)
+	}
+	defer func() { _ = os.Remove(probeDir) }()
+	sentinel := filepath.Join(probeDir, probeID+".sentinel")
+	if _, err := os.Lstat(sentinel); err == nil {
+		return setupSyntheticDenial{}, fmt.Errorf("synthetic denial sentinel already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return setupSyntheticDenial{}, fmt.Errorf("inspect synthetic denial sentinel: %w", err)
+	}
+
+	dispatched := false
+	_, executor, err := newLocalMCPRuntimeWithSignerAndHandler(signer, func(ctx context.Context, req mcppkg.ToolExecutionRequest) (mcppkg.ToolExecutionResponse, error) {
+		dispatched = true
+		return runLocalMCPTool(ctx, req)
+	})
+	if err != nil {
+		return setupSyntheticDenial{}, fmt.Errorf("start local MCP runtime for synthetic denial: %w", err)
+	}
+	response, err := executor(context.Background(), mcppkg.ToolExecutionRequest{
+		ToolName:  "file_write",
+		SessionID: "setup-codex-project-synthetic-denial",
+		Arguments: map[string]any{
+			"path":    sentinel,
+			"content": "must-not-exist",
+		},
+	})
+	if err != nil {
+		return setupSyntheticDenial{}, fmt.Errorf("run synthetic file_write: %w", err)
+	}
+	if _, err := os.Lstat(sentinel); err == nil {
+		_ = os.Remove(sentinel)
+		return setupSyntheticDenial{}, fmt.Errorf("synthetic file_write reached the executor; sentinel removed")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return setupSyntheticDenial{}, fmt.Errorf("inspect synthetic denial sentinel after execution: %w", err)
+	}
+	if !response.Evaluated || !response.IsError || !strings.HasPrefix(response.Content, "Access Denied:") {
+		return setupSyntheticDenial{}, fmt.Errorf("synthetic file_write did not produce an evaluated firewall denial")
+	}
+	if dispatched {
+		return setupSyntheticDenial{}, fmt.Errorf("synthetic file_write reached the executor")
+	}
+
+	return setupSyntheticDenial{
+		Verified:            true,
+		Dispatched:          dispatched,
+		SentinelAbsent:      true,
+		ResponseContentHash: canonicalize.HashBytes([]byte(response.Content)),
+	}, nil
+}
+
+func newSetupLifecycleReceiptID() (string, error) {
+	var random [16]byte
+	if _, err := cryptorand.Read(random[:]); err != nil {
+		return "", fmt.Errorf("generate lifecycle receipt id: %w", err)
+	}
+	return "rcpt_native_client_" + hex.EncodeToString(random[:]), nil
+}

--- a/core/cmd/helm-ai-kernel/setup_codex_project_paths.go
+++ b/core/cmd/helm-ai-kernel/setup_codex_project_paths.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+const setupCodexProjectStateLayout = "v1"
+
+// setupCodexProjectPaths separates project-scoped native-client state from
+// the shared local authority (root keys, receipt DB, and evidence). A single
+// data-dir may intentionally serve multiple Codex projects; their install
+// bindings, recovery journals, and generated discovery artifacts must never
+// overwrite one another.
+type setupCodexProjectPaths struct {
+	WorkspacePathHash string
+	StateRoot         string
+	BindingPath       string
+	RecoveryRoot      string
+	ArtifactsDir      string
+}
+
+func newSetupCodexProjectPaths(opts setupOptions) (setupCodexProjectPaths, error) {
+	if opts.Target != "codex" || opts.Scope != "project" {
+		return setupCodexProjectPaths{}, fmt.Errorf("Codex project state paths require target codex with project scope")
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		return setupCodexProjectPaths{}, fmt.Errorf("resolve Codex project workspace identity: %w", err)
+	}
+	if !isSetupSHA256(workspacePathHash) {
+		return setupCodexProjectPaths{}, fmt.Errorf("invalid Codex project workspace identity")
+	}
+	stateRoot := filepath.Join(opts.DataDir, "native-client", "codex-projects", setupCodexProjectStateLayout, workspacePathHash)
+	return setupCodexProjectPaths{
+		WorkspacePathHash: workspacePathHash,
+		StateRoot:         stateRoot,
+		BindingPath:       filepath.Join(stateRoot, setupCodexProjectBindingFile),
+		RecoveryRoot:      filepath.Join(stateRoot, setupRecoveryDirectory),
+		ArtifactsDir:      filepath.Join(stateRoot, "autoconfigure"),
+	}, nil
+}
+
+// currentCodexProjectPaths is deliberately a convenience only for helpers
+// whose existing signature predates project namespaces. All external command
+// paths validate through buildSetupSummary/newSetupCodexProjectPaths before a
+// mutation; the sentinel makes an unexpected getwd failure non-colliding in
+// direct test/helper calls rather than falling back to a shared root.
+func currentCodexProjectPaths(dataDir string) setupCodexProjectPaths {
+	paths, err := newSetupCodexProjectPaths(setupOptions{Target: "codex", Scope: "project", DataDir: dataDir})
+	if err == nil {
+		return paths
+	}
+	stateRoot := filepath.Join(dataDir, "native-client", "codex-projects", setupCodexProjectStateLayout, "workspace-unavailable")
+	return setupCodexProjectPaths{
+		StateRoot:    stateRoot,
+		BindingPath:  filepath.Join(stateRoot, setupCodexProjectBindingFile),
+		RecoveryRoot: filepath.Join(stateRoot, setupRecoveryDirectory),
+		ArtifactsDir: filepath.Join(stateRoot, "autoconfigure"),
+	}
+}
+
+func setupCodexProjectArtifactsDir(dataDir string) string {
+	return currentCodexProjectPaths(dataDir).ArtifactsDir
+}
+
+// setupCodexProjectStateAuthorityRelativePath derives the entire
+// project-scoped state tree below dataDir. Keeping the relative path explicit
+// makes it possible to validate every existing native-client ancestor before
+// a binding, recovery journal, or generated artifact is trusted.
+func setupCodexProjectStateAuthorityRelativePath(dataDir string) (string, error) {
+	normalized, err := normalizeSetupDataDir(dataDir)
+	if err != nil {
+		return "", err
+	}
+	paths, err := newSetupCodexProjectPaths(setupOptions{Target: "codex", Scope: "project", DataDir: normalized})
+	if err != nil {
+		return "", err
+	}
+	relativePath, err := filepath.Rel(normalized, paths.StateRoot)
+	if err != nil || relativePath == "." || filepath.IsAbs(relativePath) || relativePath == ".." {
+		return "", fmt.Errorf("resolve Codex project state authority path")
+	}
+	return relativePath, nil
+}
+
+func ensureCodexProjectStateAuthority(dataDir string) error {
+	relativePath, err := setupCodexProjectStateAuthorityRelativePath(dataDir)
+	if err != nil {
+		return err
+	}
+	return ensureSetupAuthoritySubdirectory(dataDir, relativePath)
+}
+
+func inspectCodexProjectStateAuthority(dataDir string) (bool, error) {
+	relativePath, err := setupCodexProjectStateAuthorityRelativePath(dataDir)
+	if err != nil {
+		return false, err
+	}
+	return inspectSetupAuthoritySubdirectory(dataDir, relativePath)
+}
+
+func requireCodexProjectStateAuthority(dataDir string) error {
+	relativePath, err := setupCodexProjectStateAuthorityRelativePath(dataDir)
+	if err != nil {
+		return err
+	}
+	_, err = requireSetupAuthoritySubdirectory(dataDir, relativePath)
+	return err
+}
+
+// legacyCodexProjectBindingPath and legacyCodexProjectArtifactsDir name the
+// pre-v1 locations that existed before project namespacing. They are only
+// used by the explicit migration/recovery path; normal runtime admission must
+// never silently fall back to them because one shared data-dir could contain
+// state from a different project.
+func legacyCodexProjectBindingPath(dataDir string) string {
+	return filepath.Join(dataDir, "native-client", setupCodexProjectBindingFile)
+}
+
+func legacyCodexProjectArtifactsDir(dataDir string) string {
+	return filepath.Join(dataDir, "autoconfigure")
+}
+
+// legacySetupRecoveryRoot names the pre-v1 unscoped recovery location. It is
+// never used to mutate current project state; detecting it is fail-closed so a
+// pre-upgrade pending transaction cannot be made invisible by namespacing.
+func legacySetupRecoveryRoot(dataDir string) string {
+	return filepath.Join(dataDir, setupRecoveryDirectory)
+}

--- a/core/cmd/helm-ai-kernel/setup_config_transaction.go
+++ b/core/cmd/helm-ai-kernel/setup_config_transaction.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// setupFileState is an in-memory, private backup used only to compensate a
+// failed local configuration transaction. It is never written into Kernel
+// state because client configuration may contain user-owned sensitive data.
+type setupFileState struct {
+	Path   string
+	Exists bool
+	Data   []byte
+}
+
+// setupRegularFileState is a metadata-only view of a setup-owned file. It is
+// intentionally separate from setupFileState: callers which only need to
+// establish that a SQLite database exists must not read the full database into
+// memory before opening it read-only.
+type setupRegularFileState struct {
+	Path   string
+	Exists bool
+	Info   os.FileInfo
+}
+
+type codexProjectConfigTransaction struct {
+	client setupTransactionFile
+	hook   setupTransactionFile
+}
+
+// setupTransactionFile carries an exact before/after pair for one file. The
+// mutator verifies that the bytes it is about to replace are still the bytes
+// captured at transaction start. It must never infer that a user change was
+// made by HELM merely because before and after differ.
+type setupTransactionFile struct {
+	before  setupFileState
+	after   setupFileState
+	mutated bool
+}
+
+func beginCodexProjectConfigTransaction(summary setupSummary) (*codexProjectConfigTransaction, error) {
+	clientBefore, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot Codex project config: %w", err)
+	}
+	hookBefore, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot Codex project hook config: %w", err)
+	}
+	return &codexProjectConfigTransaction{
+		client: setupTransactionFile{before: clientBefore, after: clientBefore},
+		hook:   setupTransactionFile{before: hookBefore, after: hookBefore},
+	}, nil
+}
+
+func (tx *codexProjectConfigTransaction) clientBefore() setupFileState {
+	return tx.client.before
+}
+
+func (tx *codexProjectConfigTransaction) hookBefore() setupFileState {
+	return tx.hook.before
+}
+
+func (tx *codexProjectConfigTransaction) replaceClient(data []byte) error {
+	return tx.replaceClientState(setupFileState{
+		Path:   tx.client.before.Path,
+		Exists: true,
+		Data:   append([]byte(nil), data...),
+	})
+}
+
+func (tx *codexProjectConfigTransaction) removeClient() error {
+	return tx.replaceClientState(setupFileState{Path: tx.client.before.Path})
+}
+
+func (tx *codexProjectConfigTransaction) replaceClientState(next setupFileState) error {
+	next.Path = tx.client.before.Path
+	next.Data = append([]byte(nil), next.Data...)
+	return tx.replace(&tx.client, next)
+}
+
+func (tx *codexProjectConfigTransaction) replaceHook(data []byte) error {
+	return tx.replaceHookState(setupFileState{
+		Path:   tx.hook.before.Path,
+		Exists: true,
+		Data:   append([]byte(nil), data...),
+	})
+}
+
+func (tx *codexProjectConfigTransaction) removeHook() error {
+	return tx.replaceHookState(setupFileState{Path: tx.hook.before.Path})
+}
+
+func (tx *codexProjectConfigTransaction) replaceHookState(next setupFileState) error {
+	next.Path = tx.hook.before.Path
+	next.Data = append([]byte(nil), next.Data...)
+	return tx.replace(&tx.hook, next)
+}
+
+func (tx *codexProjectConfigTransaction) replace(file *setupTransactionFile, next setupFileState) error {
+	current, err := readSetupFileState(file.before.Path)
+	if err != nil {
+		return err
+	}
+	if !sameSetupFileState(current, file.before) {
+		return fmt.Errorf("setup config changed concurrently before HELM could modify it")
+	}
+	if sameSetupFileState(file.before, next) {
+		file.after = file.before
+		return nil
+	}
+	if err := restoreSetupFileState(next); err != nil {
+		return err
+	}
+	file.after = next
+	file.mutated = true
+	return nil
+}
+
+func (tx *codexProjectConfigTransaction) hasOwnedConfig(expectedDataDir, expectedHookCommand string) (bool, error) {
+	if err := requireCodexProjectHookSourceForRemoval(tx.client.before.Data); err != nil {
+		return false, err
+	}
+	mcp, err := readCodexMCPServerFromBytes(tx.client.before.Data)
+	if err != nil {
+		return false, err
+	}
+	if mcp != nil {
+		if err := requireSafeCodexMCPRemoval(mcp, expectedDataDir); err != nil {
+			return false, err
+		}
+	}
+	hasHook, err := hasOwnedSetupHookInBytes(tx.hook.before.Data, "codex", expectedHookCommand)
+	if err != nil {
+		return false, err
+	}
+	return (mcp != nil && isOwnedCodexMCPServerForDataDir(*mcp, expectedDataDir)) || hasHook, nil
+}
+
+func (tx *codexProjectConfigTransaction) rollback() error {
+	if tx == nil {
+		return nil
+	}
+	var rollbackErrors []error
+	if err := rollbackSetupTransactionFile(tx.hook, "hook config"); err != nil {
+		rollbackErrors = append(rollbackErrors, err)
+	}
+	if err := rollbackSetupTransactionFile(tx.client, "Codex project config"); err != nil {
+		rollbackErrors = append(rollbackErrors, err)
+	}
+	return errors.Join(rollbackErrors...)
+}
+
+func rollbackSetupTransactionFile(file setupTransactionFile, label string) error {
+	if !file.mutated {
+		return nil
+	}
+	current, err := readSetupFileState(file.before.Path)
+	if err != nil {
+		return fmt.Errorf("read %s before rollback: %w", label, err)
+	}
+	if !sameSetupFileState(current, file.after) {
+		return fmt.Errorf("%s changed concurrently; refusing to overwrite user state", label)
+	}
+	if err := restoreSetupFileState(file.before); err != nil {
+		return fmt.Errorf("restore %s: %w", label, err)
+	}
+	return nil
+}
+
+func readSetupFileState(path string) (setupFileState, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	if err := rejectSetupConfigParentSymlink(absPath); err != nil {
+		return setupFileState{}, err
+	}
+	state := setupFileState{Path: absPath}
+	info, err := os.Lstat(absPath)
+	if os.IsNotExist(err) {
+		return state, nil
+	}
+	if err != nil {
+		return setupFileState{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return setupFileState{}, fmt.Errorf("refusing to modify symlinked setup config %s", absPath)
+	}
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	state.Exists = true
+	state.Data = append([]byte(nil), data...)
+	return state, nil
+}
+
+// inspectSetupRegularFile performs the same static path/symlink checks as a
+// setup file read, but deliberately returns metadata only. It is appropriate
+// for large durable state such as helm.db, where os.ReadFile would turn a
+// provenance check into an avoidable local-memory denial of service.
+func inspectSetupRegularFile(path string) (setupRegularFileState, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return setupRegularFileState{}, err
+	}
+	if err := rejectSetupConfigParentSymlink(absPath); err != nil {
+		return setupRegularFileState{}, err
+	}
+	state := setupRegularFileState{Path: absPath}
+	info, err := os.Lstat(absPath)
+	if os.IsNotExist(err) {
+		return state, nil
+	}
+	if err != nil {
+		return setupRegularFileState{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return setupRegularFileState{}, fmt.Errorf("refusing to inspect symlinked setup file %s", absPath)
+	}
+	if !info.Mode().IsRegular() {
+		return setupRegularFileState{}, fmt.Errorf("setup file is not a regular file: %s", absPath)
+	}
+	state.Exists = true
+	state.Info = info
+	return state, nil
+}
+
+// readSetupExistingPrivateFile accepts only an existing, regular, private
+// local-authority file. Root signing keys are an authority boundary: loading a
+// group/world-readable key would allow another local principal to forge the
+// lifecycle receipts that recovery treats as proof.
+func readSetupExistingPrivateFile(path string) (setupFileState, error) {
+	metadata, err := inspectSetupRegularFile(path)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	state := setupFileState{Path: metadata.Path}
+	if !metadata.Exists {
+		return state, nil
+	}
+	mode := metadata.Info.Mode()
+	if mode.Perm() != 0o600 || mode&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		return setupFileState{}, fmt.Errorf("setup private file must have exact mode 0600: %s", metadata.Path)
+	}
+	if err := requireSetupPrivateFileOwner(metadata.Path, metadata.Info); err != nil {
+		return setupFileState{}, err
+	}
+	data, err := os.ReadFile(metadata.Path)
+	if err != nil {
+		return setupFileState{}, err
+	}
+	state.Exists = true
+	state.Data = append([]byte(nil), data...)
+	return state, nil
+}
+
+func sameSetupFileState(left, right setupFileState) bool {
+	return left.Path == right.Path && left.Exists == right.Exists && bytes.Equal(left.Data, right.Data)
+}
+
+func restoreSetupFileState(state setupFileState) error {
+	if state.Exists {
+		return writeSetupPrivateFile(state.Path, state.Data)
+	}
+	if err := os.Remove(state.Path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return syncSetupParentDirectory(state.Path)
+}
+
+func writeSetupPrivateFile(path string, data []byte) (err error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	path = absPath
+	if err := rejectSetupConfigParentSymlink(path); err != nil {
+		return err
+	}
+	if err := rejectSetupFileSymlink(path); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	if err := rejectSetupConfigParentSymlink(path); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".helm-setup-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := rejectSetupFileSymlink(path); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	return syncSetupParentDirectory(path)
+}
+
+// writeSetupPrivateFileIfAbsent publishes a new private authority file without
+// ever replacing one produced by another local process. The temporary file is
+// fully written and synced before Link gives it a durable final name, so a
+// concurrent first-use process either wins with a complete key or reloads the
+// complete key chosen by the winner.
+func writeSetupPrivateFileIfAbsent(path string, data []byte) (bool, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false, err
+	}
+	path = absPath
+	if err := rejectSetupConfigParentSymlink(path); err != nil {
+		return false, err
+	}
+	if err := rejectSetupFileSymlink(path); err != nil {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return false, err
+	}
+	if err := rejectSetupConfigParentSymlink(path); err != nil {
+		return false, err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".helm-setup-*")
+	if err != nil {
+		return false, err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return false, err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return false, err
+	}
+	if err := tmp.Sync(); err != nil {
+		return false, err
+	}
+	if err := tmp.Close(); err != nil {
+		return false, err
+	}
+	if err := rejectSetupFileSymlink(path); err != nil {
+		return false, err
+	}
+	if err := os.Link(tmpPath, path); err != nil {
+		if os.IsExist(err) {
+			if symlinkErr := rejectSetupFileSymlink(path); symlinkErr != nil {
+				return false, symlinkErr
+			}
+			return false, nil
+		}
+		return false, err
+	}
+	if err := syncSetupParentDirectory(path); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// syncSetupParentDirectory makes the rename/removal boundary durable on the
+// Unix platforms that run the local Kernel. Windows does not expose durable
+// directory fsync through os.File, so it keeps the atomic replacement but does
+// not claim the stronger crash-durability boundary there.
+func syncSetupParentDirectory(path string) error {
+	return syncSetupDirectory(filepath.Dir(path))
+}
+
+func syncSetupDirectory(path string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	dir, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = dir.Close() }()
+	return dir.Sync()
+}
+
+func rejectSetupFileSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to replace symlinked setup config %s", path)
+	}
+	return nil
+}
+
+func rejectSetupConfigParentSymlink(path string) error {
+	parent := filepath.Dir(path)
+	info, err := os.Lstat(parent)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to modify setup config through symlinked parent %s", parent)
+	}
+	return nil
+}

--- a/core/cmd/helm-ai-kernel/setup_data_dir.go
+++ b/core/cmd/helm-ai-kernel/setup_data_dir.go
@@ -1,0 +1,320 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// normalizeSetupDataDir rejects a final data-dir symlink and symlinks below a
+// caller-local trusted root before setup writes. It deliberately preserves the
+// user's lexical path: macOS commonly exposes TMPDIR through /var, so silently
+// canonicalizing that platform alias would change the path stored in config.
+func normalizeSetupDataDir(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	root := trustedSetupDataDirRoot(absPath)
+	rel, err := filepath.Rel(root, absPath)
+	if err != nil || rel == ".." || len(rel) >= 3 && rel[:3] == ".."+string(filepath.Separator) {
+		return "", fmt.Errorf("--data-dir must be below its trusted root: %s", absPath)
+	}
+	current := root
+	if rel == "." {
+		return absPath, rejectSetupDataDirSymlink(current)
+	}
+	for _, component := range splitSetupPath(rel) {
+		current = filepath.Join(current, component)
+		if err := rejectSetupDataDirSymlink(current); err != nil {
+			return "", err
+		}
+	}
+	return absPath, nil
+}
+
+// ensureSetupAuthorityDataDir creates (when necessary) and validates the root
+// of the local authority state. A private root.key is not sufficient when the
+// directory holding it is writable by another local principal: that principal
+// can replace the key, database, binding, or evidence between ordinary path
+// checks. We deliberately keep this separate from normalizeSetupDataDir so
+// dry-run/status parsing remains non-mutating.
+func ensureSetupAuthorityDataDir(path string) (string, error) {
+	normalized, err := normalizeSetupDataDir(path)
+	if err != nil {
+		return "", err
+	}
+	if err := ensureSetupAuthorityDirectory(normalized); err != nil {
+		return "", fmt.Errorf("secure local authority data dir: %w", err)
+	}
+	return normalized, nil
+}
+
+// requireSetupAuthorityDataDir validates an already-existing authority root
+// without creating it. Runtime admission uses this form so a missing or
+// unsafe state directory never becomes a fresh authority implicitly.
+func requireSetupAuthorityDataDir(path string) (string, error) {
+	normalized, err := normalizeSetupDataDir(path)
+	if err != nil {
+		return "", err
+	}
+	if err := requireSetupAuthorityDirectory(normalized); err != nil {
+		return "", fmt.Errorf("secure local authority data dir: %w", err)
+	}
+	return normalized, nil
+}
+
+// validateSetupAuthorityDataDirIfPresent preserves setup's preflight
+// no-side-effect contract. A fresh install may have no local authority state
+// yet, but an existing root must already meet the same ownership and mode
+// requirements as runtime authority. Callers that are about to write state
+// must still use ensureSetupAuthorityDataDir after all user-owned config
+// preflight checks have passed.
+func validateSetupAuthorityDataDirIfPresent(path string) (string, error) {
+	normalized, err := normalizeSetupDataDir(path)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Lstat(normalized); os.IsNotExist(err) {
+		return normalized, nil
+	} else if err != nil {
+		return "", err
+	}
+	if err := requireSetupAuthorityDirectory(normalized); err != nil {
+		return "", fmt.Errorf("secure local authority data dir: %w", err)
+	}
+	return normalized, nil
+}
+
+// inspectSetupAuthoritySubdirectory validates each existing setup-owned
+// component without creating one. A missing root or descendant is reported as
+// absent so preflight/status paths remain non-mutating; an unsafe existing
+// ancestor is never treated as absent state.
+func inspectSetupAuthoritySubdirectory(dataDir, relativePath string) (bool, error) {
+	normalized, err := normalizeSetupDataDir(dataDir)
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Lstat(normalized); os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	if err := requireSetupAuthorityDirectory(normalized); err != nil {
+		return false, fmt.Errorf("secure local authority data dir: %w", err)
+	}
+	clean := filepath.Clean(relativePath)
+	if clean == "." {
+		return true, nil
+	}
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return false, fmt.Errorf("authority subdirectory must be relative to data dir: %s", relativePath)
+	}
+	current := normalized
+	for _, component := range splitSetupPath(clean) {
+		current = filepath.Join(current, component)
+		if _, err := os.Lstat(current); os.IsNotExist(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+		if err := requireSetupAuthorityDirectory(current); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// ensureSetupAuthoritySubdirectory creates a setup-owned directory beneath a
+// validated authority root. Every component is re-checked: an old
+// world-writable native-client/ or lifecycle-evidence/ directory would
+// otherwise let another local principal replace a binding or proof even if
+// dataDir itself is private.
+func ensureSetupAuthoritySubdirectory(dataDir, relativePath string) error {
+	normalized, err := ensureSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return err
+	}
+	clean := filepath.Clean(relativePath)
+	if clean == "." {
+		return nil
+	}
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("authority subdirectory must be relative to data dir: %s", relativePath)
+	}
+	current := normalized
+	for _, component := range splitSetupPath(clean) {
+		current = filepath.Join(current, component)
+		if err := ensureSetupAuthorityDirectory(current); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// requireSetupAuthoritySubdirectory validates a previously-created
+// setup-owned directory without creating it. Evidence and bindings are proof
+// inputs during runtime admission, so a missing directory is handled by its
+// caller as absent state while an unsafe existing directory is never read as
+// authority.
+func requireSetupAuthoritySubdirectory(dataDir, relativePath string) (string, error) {
+	normalized, err := requireSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return "", err
+	}
+	clean := filepath.Clean(relativePath)
+	if clean == "." {
+		return normalized, nil
+	}
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("authority subdirectory must be relative to data dir: %s", relativePath)
+	}
+	current := normalized
+	for _, component := range splitSetupPath(clean) {
+		current = filepath.Join(current, component)
+		if err := requireSetupAuthorityDirectory(current); err != nil {
+			return "", err
+		}
+	}
+	return current, nil
+}
+
+func ensureSetupAuthorityDirectory(path string) error {
+	if err := ensureSetupDirectory(path, 0o700); err != nil {
+		return err
+	}
+	return requireSetupAuthorityDirectory(path)
+}
+
+func requireSetupAuthorityDirectory(path string) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Lstat(absPath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("authority state is not a real directory: %s", absPath)
+	}
+	if info.Mode().Perm()&0o022 != 0 || info.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		return fmt.Errorf("authority state directory must not be group/world-writable or special: %s", absPath)
+	}
+	if err := requireSetupAuthorityDirectoryOwner(absPath, info); err != nil {
+		return err
+	}
+	return nil
+}
+
+func trustedSetupDataDirRoot(path string) string {
+	candidates := []string{os.TempDir(), homeDirOrDot()}
+	if cwd, err := os.Getwd(); err == nil {
+		candidates = append(candidates, cwd)
+	}
+	// These are platform roots rather than user-controlled intermediate links.
+	// They avoid treating macOS's /var and /tmp aliases as a setup escape.
+	candidates = append(candidates, string(filepath.Separator), "/tmp", "/var", "/private/var")
+	best := string(filepath.Separator)
+	for _, candidate := range candidates {
+		absCandidate, err := filepath.Abs(candidate)
+		if err != nil || !safeSetupDataDirAnchor(absCandidate) || !pathWithinSetupRoot(absCandidate, path) {
+			continue
+		}
+		if len(absCandidate) > len(best) {
+			best = absCandidate
+		}
+	}
+	return best
+}
+
+func safeSetupDataDirAnchor(path string) bool {
+	// The filesystem root is the final fallback. Every other caller or
+	// environment-derived candidate must itself be a real directory before we
+	// use it as an unchecked traversal boundary.
+	if path == string(filepath.Separator) {
+		return true
+	}
+	if isAcceptedPlatformSetupAlias(path) {
+		return true
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	return err == nil && resolved == canonicalPlatformSetupPath(path)
+}
+
+func isAcceptedPlatformSetupAlias(path string) bool {
+	canonical := canonicalPlatformSetupPath(path)
+	if canonical == path {
+		return false
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	return err == nil && resolved == canonical
+}
+
+func canonicalPlatformSetupPath(path string) string {
+	// macOS exposes /var and /tmp as stable public aliases of /private/var and
+	// /private/tmp. These are the only aliases accepted for an anchor; every
+	// other resolved difference denotes a user-controlled symlink traversal.
+	if runtime.GOOS != "darwin" {
+		return path
+	}
+	for _, alias := range []struct{ from, to string }{
+		{from: "/var", to: "/private/var"},
+		{from: "/tmp", to: "/private/tmp"},
+	} {
+		if path == alias.from {
+			return alias.to
+		}
+		if strings.HasPrefix(path, alias.from+string(filepath.Separator)) {
+			return alias.to + strings.TrimPrefix(path, alias.from)
+		}
+	}
+	return path
+}
+
+func pathWithinSetupRoot(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && (len(rel) < 3 || rel[:3] != ".."+string(filepath.Separator))
+}
+
+func splitSetupPath(rel string) []string {
+	if rel == "." || rel == "" {
+		return nil
+	}
+	parts := make([]string, 0)
+	for current := rel; current != "." && current != ""; {
+		parent := filepath.Dir(current)
+		parts = append(parts, filepath.Base(current))
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	for left, right := 0, len(parts)-1; left < right; left, right = left+1, right-1 {
+		parts[left], parts[right] = parts[right], parts[left]
+	}
+	return parts
+}
+
+func rejectSetupDataDirSymlink(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		if isAcceptedPlatformSetupAlias(path) {
+			return nil
+		}
+		return fmt.Errorf("--data-dir must not traverse a symlink: %s", path)
+	}
+	return nil
+}

--- a/core/cmd/helm-ai-kernel/setup_legacy_migration.go
+++ b/core/cmd/helm-ai-kernel/setup_legacy_migration.go
@@ -1,0 +1,874 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const setupLegacyMigrationTemporaryPrefix = ".helm-setup-migrate-"
+
+var (
+	renameLegacyCodexProjectMigration     = os.Rename
+	syncLegacyCodexProjectMigrationParent = syncSetupParentDirectory
+	writeLegacyCodexProjectMigrationFile  = writeSetupPrivateFile
+	removeLegacyCodexProjectMigrationTree = os.RemoveAll
+	afterLegacyRecoveryMigrationPreflight = func() {}
+	afterLegacyBindingMigrationPreflight  = func() {}
+)
+
+// runSetupMigrateCmd is intentionally explicit: normal setup and runtime
+// admission must never silently treat one shared pre-v1 state directory as
+// authority for an arbitrary project. Migration validates the exact current
+// project before moving only owned state into its namespaced v1 location.
+func runSetupMigrateCmd(args []string, stdout, stderr io.Writer) int {
+	opts, code := parseSetupInspectArgs("setup migrate", args, stderr, true)
+	if code != 0 {
+		return code
+	}
+	if opts.Target != "codex" || opts.Scope != "project" {
+		fmt.Fprintln(stderr, "setup migrate: migration is available only for Codex project scope")
+		return 2
+	}
+	if !opts.Yes && !opts.DryRun {
+		fmt.Fprintln(stderr, "setup migrate: pass --yes to migrate validated legacy local state, or --dry-run to inspect it")
+		return 2
+	}
+	securedDataDir, err := requireSetupAuthorityDataDir(opts.DataDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup migrate: unsafe Codex project authority state: %v\n", err)
+		return 1
+	}
+	opts.DataDir = securedDataDir
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup migrate: %v\n", err)
+		return 2
+	}
+	if !opts.DryRun {
+		lifecycleLock, lockErr := acquireSetupCodexProjectLifecycleLock(opts.DataDir)
+		if lockErr != nil {
+			fmt.Fprintf(stderr, "setup migrate: acquire Codex project lifecycle lock: %v\n", lockErr)
+			return 1
+		}
+		defer func() { _ = lifecycleLock.Close() }()
+	}
+	migration, err := inspectLegacyCodexProjectMigration(opts, summary)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup migrate: %v\n", err)
+		return 1
+	}
+	if opts.DryRun {
+		fmt.Fprintf(stderr, "setup migrate: validated legacy %s state; rerun with --yes to move it into the current project namespace\n", migration.kind)
+		printSetupSummary(stdout, summary, opts.JSON)
+		return 0
+	}
+	applyResult, err := applyLegacyCodexProjectMigration(opts, summary, migration)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup migrate: %v\n", err)
+		return 1
+	}
+	if applyResult.cleanupWarning != "" {
+		fmt.Fprintf(stderr, "setup migrate: migration completed, but %s\n", applyResult.cleanupWarning)
+	}
+	refreshSetupConfiguration(opts, &summary)
+	if migration.kind == "recovery" {
+		summary.RecoveryRequired = true
+	}
+	printSetupSummary(stdout, summary, opts.JSON)
+	return 0
+}
+
+type legacyCodexProjectMigration struct {
+	kind        string
+	recovery    *legacyCodexProjectRecoveryMigration
+	bindingPlan *legacyCodexProjectBindingMigrationPlan
+}
+
+type legacyCodexProjectMigrationApplyResult struct {
+	cleanupWarning string
+}
+
+type legacyCodexProjectRecoveryMigration struct {
+	journal *setupRecoveryJournal
+}
+
+type legacyCodexProjectMigrationFile struct {
+	name       string
+	sourcePath string
+	data       []byte
+}
+
+type legacyCodexProjectBindingMigrationPlan struct {
+	dataDir             string
+	binding             *setupCodexProjectBinding
+	bindingData         []byte
+	bindingSourcePath   string
+	artifacts           []legacyCodexProjectMigrationFile
+	paths               setupCodexProjectPaths
+	destinationComplete bool
+}
+
+func (plan legacyCodexProjectBindingMigrationPlan) sourceFiles() []legacyCodexProjectMigrationFile {
+	files := make([]legacyCodexProjectMigrationFile, 0, len(plan.artifacts)+1)
+	files = append(files, legacyCodexProjectMigrationFile{
+		name:       setupCodexProjectBindingFile,
+		sourcePath: plan.bindingSourcePath,
+		data:       plan.bindingData,
+	})
+	files = append(files, plan.artifacts...)
+	return files
+}
+
+func inspectLegacyCodexProjectMigration(opts setupOptions, summary setupSummary) (legacyCodexProjectMigration, error) {
+	legacyRoot := legacySetupRecoveryRoot(opts.DataDir)
+	legacyInfo, err := os.Lstat(legacyRoot)
+	if err == nil {
+		if legacyInfo.Mode()&os.ModeSymlink != 0 || !legacyInfo.IsDir() {
+			return legacyCodexProjectMigration{}, fmt.Errorf("legacy unscoped recovery state is not a real directory")
+		}
+		recovery, err := inspectLegacyCodexProjectRecoveryMigration(opts, summary)
+		if err != nil {
+			return legacyCodexProjectMigration{}, err
+		}
+		return legacyCodexProjectMigration{kind: "recovery", recovery: recovery}, nil
+	}
+	if !os.IsNotExist(err) {
+		return legacyCodexProjectMigration{}, fmt.Errorf("inspect legacy recovery state: %w", err)
+	}
+
+	plan, err := inspectLegacyCodexProjectBindingMigration(opts, summary)
+	if err != nil {
+		return legacyCodexProjectMigration{}, err
+	}
+	return legacyCodexProjectMigration{kind: "binding", bindingPlan: plan}, nil
+}
+
+func inspectLegacyCodexProjectRecoveryMigration(opts setupOptions, summary setupSummary) (*legacyCodexProjectRecoveryMigration, error) {
+	legacyRoot := legacySetupRecoveryRoot(opts.DataDir)
+	if _, err := requireSetupAuthoritySubdirectory(opts.DataDir, setupRecoveryDirectory); err != nil {
+		return nil, fmt.Errorf("inspect legacy recovery authority state: %w", err)
+	}
+	stageExists, nonTemporaryEntries, err := inspectLegacySetupRecoveryDirectory(legacyRoot)
+	if err != nil {
+		return nil, fmt.Errorf("inspect legacy recovery contents: %w", err)
+	}
+	journal, err := readSetupRecoveryJournalAtPath(filepath.Join(legacyRoot, setupRecoveryJournalFile))
+	if err != nil {
+		return nil, fmt.Errorf("read legacy recovery journal: %w", err)
+	}
+	preparing, err := readSetupRecoveryMarkerAtPath(filepath.Join(legacyRoot, setupRecoveryPreparingFile), setupRecoveryPreparingFile)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy recovery preparing marker: %w", err)
+	}
+	committed, err := readSetupRecoveryMarkerAtPath(filepath.Join(legacyRoot, setupRecoveryCommittedFile), setupRecoveryCommittedFile)
+	if err != nil {
+		return nil, fmt.Errorf("read legacy recovery committed marker: %w", err)
+	}
+	if journal != nil {
+		if _, err := validateCodexProjectRecoveryJournal(opts, summary, journal); err != nil {
+			return nil, fmt.Errorf("validate legacy recovery journal: %w", err)
+		}
+		if !stageExists {
+			return nil, fmt.Errorf("prepared legacy recovery journal has no staging directory")
+		}
+	} else if committed != nil {
+		// A marker-only legacy residue cannot prove a v1 binding before migration.
+		// Do not relocate it and then discover an unresumable state after writes.
+		return nil, fmt.Errorf("legacy committed recovery marker has no resumable journal")
+	} else if preparing == nil && !stageExists && nonTemporaryEntries != 0 {
+		return nil, fmt.Errorf("unclassifiable legacy recovery state")
+	}
+	if err := requireLegacyRecoveryDestinationAbsent(opts.DataDir); err != nil {
+		return nil, err
+	}
+	return &legacyCodexProjectRecoveryMigration{journal: journal}, nil
+}
+
+func inspectLegacySetupRecoveryDirectory(root string) (stageExists bool, nonTemporaryEntries int, err error) {
+	if err := requireSetupAuthorityDirectory(root); err != nil {
+		return false, 0, err
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false, 0, err
+	}
+	known := map[string]bool{
+		setupRecoveryJournalFile:   true,
+		setupRecoveryStagingDir:    true,
+		setupRecoveryPreparingFile: true,
+		setupRecoveryCommittedFile: true,
+	}
+	for _, entry := range entries {
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return false, 0, err
+		}
+		entryPath := filepath.Join(root, entry.Name())
+		if isSetupRecoveryTemporaryName(entry.Name()) {
+			if err := validateSetupRecoveryTemporaryEntry(entryPath, entryInfo); err != nil {
+				return false, 0, err
+			}
+			continue
+		}
+		if !known[entry.Name()] {
+			return false, 0, fmt.Errorf("unexpected setup recovery entry %q", entry.Name())
+		}
+		nonTemporaryEntries++
+		if entryInfo.Mode()&os.ModeSymlink != 0 {
+			return false, 0, fmt.Errorf("refusing setup recovery through symlinked entry %q", entry.Name())
+		}
+		if entry.Name() == setupRecoveryStagingDir {
+			if !entryInfo.IsDir() {
+				return false, 0, fmt.Errorf("setup recovery staging entry is not a directory")
+			}
+			if err := requireSetupAuthorityDirectory(entryPath); err != nil {
+				return false, 0, err
+			}
+		} else if !entryInfo.Mode().IsRegular() {
+			return false, 0, fmt.Errorf("setup recovery entry %q is not a regular file", entry.Name())
+		}
+	}
+	stageExists, err = inspectLegacySetupRecoveryStageDirectory(filepath.Join(root, setupRecoveryStagingDir))
+	return stageExists, nonTemporaryEntries, err
+}
+
+func inspectLegacySetupRecoveryStageDirectory(stageDir string) (bool, error) {
+	info, err := os.Lstat(stageDir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return false, fmt.Errorf("invalid setup recovery staging directory %s", stageDir)
+	}
+	if err := requireSetupAuthorityDirectory(stageDir); err != nil {
+		return false, err
+	}
+	entries, err := os.ReadDir(stageDir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return false, err
+		}
+		entryPath := filepath.Join(stageDir, entry.Name())
+		if isSetupRecoveryTemporaryName(entry.Name()) {
+			if err := validateSetupRecoveryTemporaryEntry(entryPath, entryInfo); err != nil {
+				return false, err
+			}
+			continue
+		}
+		if !setupRecoveryAllowedStageFile(entry.Name()) {
+			return false, fmt.Errorf("unexpected setup recovery staged entry %q", entry.Name())
+		}
+		if entryInfo.Mode()&os.ModeSymlink != 0 || !entryInfo.Mode().IsRegular() {
+			return false, fmt.Errorf("invalid setup recovery staged entry %q", entry.Name())
+		}
+	}
+	return true, nil
+}
+
+func inspectLegacyCodexProjectBindingMigration(opts setupOptions, summary setupSummary) (*legacyCodexProjectBindingMigrationPlan, error) {
+	if _, err := requireSetupAuthoritySubdirectory(opts.DataDir, "native-client"); err != nil {
+		return nil, fmt.Errorf("inspect legacy binding authority state: %w", err)
+	}
+	legacyBindingPath := legacyCodexProjectBindingPath(opts.DataDir)
+	legacyBindingState, err := readSetupExistingPrivateFile(legacyBindingPath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect legacy Codex binding: %w", err)
+	}
+	if !legacyBindingState.Exists {
+		return nil, fmt.Errorf("no legacy unscoped Codex recovery or install binding exists")
+	}
+	var binding setupCodexProjectBinding
+	if err := decodeCanonicalSetupJSON(legacyBindingState.Data, &binding); err != nil {
+		return nil, fmt.Errorf("read legacy Codex binding: %w", err)
+	}
+	if err := validateSetupCodexProjectBinding(&binding); err != nil {
+		return nil, fmt.Errorf("read legacy Codex binding: %w", err)
+	}
+	if err := validateLegacyCodexProjectBindingProof(opts, summary, &binding); err != nil {
+		return nil, err
+	}
+	paths, err := newSetupCodexProjectPaths(opts)
+	if err != nil {
+		return nil, err
+	}
+	artifacts, err := inspectLegacyCodexProjectArtifacts(opts.DataDir, paths)
+	if err != nil {
+		return nil, err
+	}
+	plan := &legacyCodexProjectBindingMigrationPlan{
+		dataDir:           opts.DataDir,
+		binding:           &binding,
+		bindingData:       append([]byte(nil), legacyBindingState.Data...),
+		bindingSourcePath: legacyBindingPath,
+		artifacts:         artifacts,
+		paths:             paths,
+	}
+	if err := inspectLegacyCodexProjectBindingDestination(plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func validateLegacyCodexProjectBindingProof(opts setupOptions, summary setupSummary, binding *setupCodexProjectBinding) error {
+	proof, err := validateCodexProjectInstallProof(opts, binding)
+	if err != nil {
+		return fmt.Errorf("validate legacy Codex install proof: %w", err)
+	}
+	clientState, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return err
+	}
+	hookState, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return err
+	}
+	if _, err := validateCodexProjectInstallProofForCurrentConfig(opts, proof, clientState, hookState); err != nil {
+		return fmt.Errorf("legacy Codex install proof does not match current config: %w", err)
+	}
+	currentBinary, err := inspectSetupKernelBinary(summary.BinaryPath)
+	if err != nil {
+		return err
+	}
+	if proof.Binary.Path != currentBinary.Path || proof.Binary.ContentHash != currentBinary.ContentHash {
+		return fmt.Errorf("legacy Codex install proof is pinned to a different running Kernel binary; reinstall with this binary before migration")
+	}
+	return nil
+}
+
+func inspectLegacyCodexProjectArtifacts(dataDir string, paths setupCodexProjectPaths) ([]legacyCodexProjectMigrationFile, error) {
+	legacyDir := legacyCodexProjectArtifactsDir(dataDir)
+	info, err := os.Lstat(legacyDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil, fmt.Errorf("legacy autoconfigure state is not a real directory")
+	}
+	if _, err := requireSetupAuthoritySubdirectory(dataDir, "autoconfigure"); err != nil {
+		return nil, fmt.Errorf("inspect legacy autoconfigure authority state: %w", err)
+	}
+	entries, err := os.ReadDir(legacyDir)
+	if err != nil {
+		return nil, err
+	}
+	allowed := map[string]bool{
+		"inventory.json":           true,
+		"policy.draft.json":        true,
+		"mcp_quarantine_plan.json": true,
+	}
+	for _, entry := range entries {
+		if !allowed[entry.Name()] {
+			return nil, fmt.Errorf("legacy autoconfigure state contains unsupported entry %q", entry.Name())
+		}
+	}
+	artifacts := make([]legacyCodexProjectMigrationFile, 0, len(allowed))
+	for _, filename := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json"} {
+		sourcePath := filepath.Join(legacyDir, filename)
+		state, err := readSetupExistingPrivateFile(sourcePath)
+		if err != nil {
+			return nil, fmt.Errorf("read legacy %s: %w", filename, err)
+		}
+		if !state.Exists {
+			continue
+		}
+		artifacts = append(artifacts, legacyCodexProjectMigrationFile{
+			name:       filename,
+			sourcePath: sourcePath,
+			data:       append([]byte(nil), state.Data...),
+		})
+	}
+	return artifacts, nil
+}
+
+func inspectLegacyCodexProjectBindingDestination(plan *legacyCodexProjectBindingMigrationPlan) error {
+	stateExists, err := inspectCodexProjectStateAuthority(plan.dataDir)
+	if err != nil {
+		return fmt.Errorf("inspect project migration destination authority: %w", err)
+	}
+	if !stateExists {
+		plan.destinationComplete = false
+		return nil
+	}
+	bindingState, err := readSetupExistingPrivateFile(plan.paths.BindingPath)
+	if err != nil {
+		return fmt.Errorf("read current project binding: %w", err)
+	}
+	if !bindingState.Exists || !bytes.Equal(bindingState.Data, plan.bindingData) {
+		return fmt.Errorf("current project binding differs from the validated legacy binding")
+	}
+	if len(plan.artifacts) == 0 {
+		plan.destinationComplete = true
+		return nil
+	}
+	info, err := os.Lstat(plan.paths.ArtifactsDir)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("current project is missing validated legacy autoconfigure artifacts")
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("current project autoconfigure state is not a real directory")
+	}
+	relativeArtifactsDir, err := filepath.Rel(plan.dataDir, plan.paths.ArtifactsDir)
+	if err != nil || filepath.IsAbs(relativeArtifactsDir) || relativeArtifactsDir == ".." {
+		return fmt.Errorf("resolve current project autoconfigure authority path")
+	}
+	if _, err := requireSetupAuthoritySubdirectory(plan.dataDir, relativeArtifactsDir); err != nil {
+		return fmt.Errorf("inspect current project autoconfigure authority state: %w", err)
+	}
+	for _, artifact := range plan.artifacts {
+		state, err := readSetupExistingPrivateFile(filepath.Join(plan.paths.ArtifactsDir, artifact.name))
+		if err != nil {
+			return err
+		}
+		if !state.Exists || !bytes.Equal(state.Data, artifact.data) {
+			return fmt.Errorf("current project %s differs from the validated legacy artifact", artifact.name)
+		}
+	}
+	plan.destinationComplete = true
+	return nil
+}
+
+func validateLegacyCodexProjectBindingMigrationPlan(opts setupOptions, summary setupSummary, plan *legacyCodexProjectBindingMigrationPlan) error {
+	if plan == nil || plan.binding == nil || plan.dataDir != opts.DataDir {
+		return fmt.Errorf("invalid legacy Codex binding migration plan")
+	}
+	if err := validateLegacyCodexProjectBindingProof(opts, summary, plan.binding); err != nil {
+		return err
+	}
+	if _, err := requireSetupAuthoritySubdirectory(opts.DataDir, "native-client"); err != nil {
+		return fmt.Errorf("revalidate legacy binding authority state: %w", err)
+	}
+	if len(plan.artifacts) > 0 {
+		if _, err := requireSetupAuthoritySubdirectory(opts.DataDir, "autoconfigure"); err != nil {
+			return fmt.Errorf("revalidate legacy autoconfigure authority state: %w", err)
+		}
+	}
+	for _, source := range plan.sourceFiles() {
+		state, err := readSetupExistingPrivateFile(source.sourcePath)
+		if err != nil {
+			return fmt.Errorf("read legacy %s before migration: %w", source.name, err)
+		}
+		if !state.Exists || !bytes.Equal(state.Data, source.data) {
+			return fmt.Errorf("legacy %s changed during migration", source.name)
+		}
+	}
+	wasComplete := plan.destinationComplete
+	if err := inspectLegacyCodexProjectBindingDestination(plan); err != nil {
+		return err
+	}
+	if plan.destinationComplete != wasComplete {
+		return fmt.Errorf("current project migration destination changed during preflight")
+	}
+	return nil
+}
+
+func applyLegacyCodexProjectMigration(opts setupOptions, summary setupSummary, migration legacyCodexProjectMigration) (legacyCodexProjectMigrationApplyResult, error) {
+	switch migration.kind {
+	case "recovery":
+		if migration.recovery == nil {
+			return legacyCodexProjectMigrationApplyResult{}, fmt.Errorf("legacy recovery migration plan is required")
+		}
+		return legacyCodexProjectMigrationApplyResult{}, migrateLegacyCodexProjectRecovery(opts, summary, migration.recovery.journal)
+	case "binding":
+		return migrateLegacyCodexProjectBinding(opts, summary, migration.bindingPlan)
+	default:
+		return legacyCodexProjectMigrationApplyResult{}, fmt.Errorf("unsupported legacy migration kind %q", migration.kind)
+	}
+}
+
+func requireLegacyRecoveryDestinationAbsent(dataDir string) error {
+	if _, err := inspectCodexProjectStateAuthority(dataDir); err != nil {
+		return fmt.Errorf("inspect current project recovery authority state: %w", err)
+	}
+	currentRoot := setupRecoveryRoot(dataDir)
+	if _, err := os.Lstat(currentRoot); err == nil {
+		return fmt.Errorf("current project recovery state already exists; refusing to overwrite it")
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func migrateLegacyCodexProjectRecovery(opts setupOptions, summary setupSummary, journal *setupRecoveryJournal) error {
+	// Repeat the complete read-only preflight while the caller holds the
+	// lifecycle lock. This closes the window between --dry-run/initial inspect
+	// and the no-overwrite rename below.
+	preflight, err := inspectLegacyCodexProjectRecoveryMigration(opts, summary)
+	if err != nil {
+		return err
+	}
+	afterLegacyRecoveryMigrationPreflight()
+	preflight, err = inspectLegacyCodexProjectRecoveryMigration(opts, summary)
+	if err != nil {
+		return err
+	}
+	if (preflight.journal == nil) != (journal == nil) {
+		return fmt.Errorf("legacy recovery journal presence changed during migration")
+	}
+	if preflight.journal != nil {
+		before, err := setupRecoveryJournalHash(journal)
+		if err != nil {
+			return err
+		}
+		after, err := setupRecoveryJournalHash(preflight.journal)
+		if err != nil {
+			return err
+		}
+		if before != after {
+			return fmt.Errorf("legacy recovery journal changed during migration")
+		}
+	}
+	if err := requireLegacyRecoveryDestinationAbsent(opts.DataDir); err != nil {
+		return err
+	}
+	if err := ensureCodexProjectStateAuthority(opts.DataDir); err != nil {
+		return fmt.Errorf("create project migration destination: %w", err)
+	}
+	if err := requireLegacyRecoveryDestinationAbsent(opts.DataDir); err != nil {
+		return err
+	}
+	legacyRoot := legacySetupRecoveryRoot(opts.DataDir)
+	currentRoot := setupRecoveryRoot(opts.DataDir)
+	if err := renameLegacyCodexProjectMigration(legacyRoot, currentRoot); err != nil {
+		return fmt.Errorf("move legacy recovery state into project namespace: %w", err)
+	}
+	if err := syncLegacyCodexProjectMigrationParent(currentRoot); err != nil {
+		rollbackErr := rollbackLegacyCodexProjectRecoveryMove(currentRoot, legacyRoot)
+		if rollbackErr != nil {
+			return errors.Join(fmt.Errorf("sync migrated recovery state: %w", err), fmt.Errorf("rollback migrated recovery state: %w", rollbackErr))
+		}
+		return fmt.Errorf("sync migrated recovery state: %w", err)
+	}
+	inspection, inspectErr := inspectSetupRecovery(opts.DataDir)
+	if inspectErr == nil && inspection.State == setupRecoveryStateAbsent {
+		inspectErr = fmt.Errorf("migrated recovery state disappeared during validation")
+	}
+	if inspectErr != nil {
+		rollbackErr := rollbackLegacyCodexProjectRecoveryMove(currentRoot, legacyRoot)
+		if rollbackErr != nil {
+			return errors.Join(fmt.Errorf("validate migrated recovery state: %w", inspectErr), fmt.Errorf("rollback migrated recovery state: %w", rollbackErr))
+		}
+		return fmt.Errorf("validate migrated recovery state: %w", inspectErr)
+	}
+	return nil
+}
+
+func rollbackLegacyCodexProjectRecoveryMove(currentRoot, legacyRoot string) error {
+	if err := renameLegacyCodexProjectMigration(currentRoot, legacyRoot); err != nil {
+		return err
+	}
+	return syncLegacyCodexProjectMigrationParent(legacyRoot)
+}
+
+func migrateLegacyCodexProjectBinding(opts setupOptions, summary setupSummary, plan *legacyCodexProjectBindingMigrationPlan) (legacyCodexProjectMigrationApplyResult, error) {
+	afterLegacyBindingMigrationPreflight()
+	if err := validateLegacyCodexProjectBindingMigrationPlan(opts, summary, plan); err != nil {
+		return legacyCodexProjectMigrationApplyResult{}, err
+	}
+	published, err := publishLegacyCodexProjectBindingDestination(plan)
+	if err != nil {
+		return legacyCodexProjectMigrationApplyResult{}, err
+	}
+	sourceMove, err := moveLegacyCodexProjectMigrationSources(plan)
+	if err != nil {
+		// A failed rollback leaves a sealed source backup behind. The v1
+		// destination contains the complete, durably published state, so removing
+		// it would turn a recoverable cleanup condition into data loss.
+		if sourceMove.preservePublishedDestination {
+			return legacyCodexProjectMigrationApplyResult{cleanupWarning: sourceMove.cleanupWarning}, nil
+		}
+		if !published {
+			return legacyCodexProjectMigrationApplyResult{}, err
+		}
+		rollbackErr := rollbackPublishedLegacyCodexProjectBindingDestination(plan)
+		if rollbackErr != nil {
+			return legacyCodexProjectMigrationApplyResult{}, errors.Join(err, fmt.Errorf("rollback project-scoped binding destination: %w", rollbackErr))
+		}
+		return legacyCodexProjectMigrationApplyResult{}, err
+	}
+	return legacyCodexProjectMigrationApplyResult{cleanupWarning: sourceMove.cleanupWarning}, nil
+}
+
+func publishLegacyCodexProjectBindingDestination(plan *legacyCodexProjectBindingMigrationPlan) (bool, error) {
+	if plan.destinationComplete {
+		return false, nil
+	}
+	stateExists, err := inspectCodexProjectStateAuthority(plan.dataDir)
+	if err != nil {
+		return false, err
+	}
+	if stateExists {
+		return false, fmt.Errorf("current project migration destination appeared during publication")
+	}
+	parentRelativePath := filepath.Join("native-client", "codex-projects", setupCodexProjectStateLayout)
+	if err := ensureSetupAuthoritySubdirectory(plan.dataDir, parentRelativePath); err != nil {
+		return false, fmt.Errorf("create project migration parent: %w", err)
+	}
+	stateParent := filepath.Dir(plan.paths.StateRoot)
+	stagingRoot, err := os.MkdirTemp(stateParent, setupLegacyMigrationTemporaryPrefix)
+	if err != nil {
+		return false, err
+	}
+	cleanupStaging := true
+	defer func() {
+		if cleanupStaging {
+			_ = removeLegacyCodexProjectMigrationTemporaryDirectory(stagingRoot)
+		}
+	}()
+	if err := os.Chmod(stagingRoot, 0o700); err != nil {
+		return false, err
+	}
+	if err := requireSetupAuthorityDirectory(stagingRoot); err != nil {
+		return false, err
+	}
+	if err := writeLegacyCodexProjectMigrationFile(filepath.Join(stagingRoot, setupCodexProjectBindingFile), plan.bindingData); err != nil {
+		return false, fmt.Errorf("stage project-scoped Codex binding: %w", err)
+	}
+	if len(plan.artifacts) > 0 {
+		artifactsDir := filepath.Join(stagingRoot, "autoconfigure")
+		if err := os.Mkdir(artifactsDir, 0o700); err != nil {
+			return false, err
+		}
+		if err := requireSetupAuthorityDirectory(artifactsDir); err != nil {
+			return false, err
+		}
+		for _, artifact := range plan.artifacts {
+			if err := writeLegacyCodexProjectMigrationFile(filepath.Join(artifactsDir, artifact.name), artifact.data); err != nil {
+				return false, fmt.Errorf("stage project-scoped %s: %w", artifact.name, err)
+			}
+		}
+	}
+	stagedPlan := *plan
+	stagedPlan.paths.StateRoot = stagingRoot
+	stagedPlan.paths.BindingPath = filepath.Join(stagingRoot, setupCodexProjectBindingFile)
+	stagedPlan.paths.ArtifactsDir = filepath.Join(stagingRoot, "autoconfigure")
+	if err := validatePublishedLegacyCodexProjectBindingDestination(&stagedPlan); err != nil {
+		return false, fmt.Errorf("verify staged project migration state: %w", err)
+	}
+	stateExists, err = inspectCodexProjectStateAuthority(plan.dataDir)
+	if err != nil {
+		return false, err
+	}
+	if stateExists {
+		return false, fmt.Errorf("current project migration destination appeared during publication")
+	}
+	if err := renameLegacyCodexProjectMigration(stagingRoot, plan.paths.StateRoot); err != nil {
+		return false, fmt.Errorf("publish project-scoped migration state: %w", err)
+	}
+	cleanupStaging = false
+	if err := syncLegacyCodexProjectMigrationParent(plan.paths.StateRoot); err != nil {
+		rollbackErr := renameLegacyCodexProjectMigration(plan.paths.StateRoot, stagingRoot)
+		if rollbackErr == nil {
+			rollbackErr = syncLegacyCodexProjectMigrationParent(stagingRoot)
+		}
+		if rollbackErr != nil {
+			return false, errors.Join(fmt.Errorf("sync published project migration state: %w", err), fmt.Errorf("rollback published project migration state: %w", rollbackErr))
+		}
+		cleanupStaging = true
+		return false, fmt.Errorf("sync published project migration state: %w", err)
+	}
+	return true, nil
+}
+
+func validatePublishedLegacyCodexProjectBindingDestination(plan *legacyCodexProjectBindingMigrationPlan) error {
+	if err := requireSetupAuthorityDirectory(plan.paths.StateRoot); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(plan.paths.StateRoot)
+	if err != nil {
+		return err
+	}
+	allowedRootEntries := map[string]bool{setupCodexProjectBindingFile: true}
+	if len(plan.artifacts) > 0 {
+		allowedRootEntries["autoconfigure"] = true
+	}
+	for _, entry := range entries {
+		if !allowedRootEntries[entry.Name()] {
+			return fmt.Errorf("unexpected project migration entry %q", entry.Name())
+		}
+	}
+	binding, err := readSetupExistingPrivateFile(plan.paths.BindingPath)
+	if err != nil {
+		return err
+	}
+	if !binding.Exists || !bytes.Equal(binding.Data, plan.bindingData) {
+		return fmt.Errorf("project-scoped binding does not match staged legacy binding")
+	}
+	if len(plan.artifacts) == 0 {
+		return nil
+	}
+	if err := requireSetupAuthorityDirectory(plan.paths.ArtifactsDir); err != nil {
+		return err
+	}
+	expected := make(map[string][]byte, len(plan.artifacts))
+	for _, artifact := range plan.artifacts {
+		expected[artifact.name] = artifact.data
+	}
+	artifactEntries, err := os.ReadDir(plan.paths.ArtifactsDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range artifactEntries {
+		if _, ok := expected[entry.Name()]; !ok {
+			return fmt.Errorf("unexpected project migration artifact %q", entry.Name())
+		}
+	}
+	for name, data := range expected {
+		state, err := readSetupExistingPrivateFile(filepath.Join(plan.paths.ArtifactsDir, name))
+		if err != nil {
+			return err
+		}
+		if !state.Exists || !bytes.Equal(state.Data, data) {
+			return fmt.Errorf("project migration artifact %s does not match legacy state", name)
+		}
+	}
+	return nil
+}
+
+func rollbackPublishedLegacyCodexProjectBindingDestination(plan *legacyCodexProjectBindingMigrationPlan) error {
+	if err := validatePublishedLegacyCodexProjectBindingDestination(plan); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(plan.paths.StateRoot); err != nil {
+		return err
+	}
+	return syncLegacyCodexProjectMigrationParent(plan.paths.StateRoot)
+}
+
+type legacyCodexProjectMigrationSourceMoveResult struct {
+	cleanupWarning               string
+	preservePublishedDestination bool
+}
+
+func moveLegacyCodexProjectMigrationSources(plan *legacyCodexProjectBindingMigrationPlan) (legacyCodexProjectMigrationSourceMoveResult, error) {
+	temporaryRoot, err := os.MkdirTemp(plan.dataDir, setupLegacyMigrationTemporaryPrefix)
+	if err != nil {
+		return legacyCodexProjectMigrationSourceMoveResult{}, err
+	}
+	cleanupTemporaryRoot := true
+	defer func() {
+		if cleanupTemporaryRoot {
+			_ = removeLegacyCodexProjectMigrationTemporaryDirectory(temporaryRoot)
+		}
+	}()
+	if err := os.Chmod(temporaryRoot, 0o700); err != nil {
+		return legacyCodexProjectMigrationSourceMoveResult{}, err
+	}
+	if err := requireSetupAuthorityDirectory(temporaryRoot); err != nil {
+		return legacyCodexProjectMigrationSourceMoveResult{}, err
+	}
+	type movedSource struct {
+		source legacyCodexProjectMigrationFile
+		backup string
+	}
+	moved := make([]movedSource, 0, len(plan.sourceFiles()))
+	rollback := func() error {
+		var rollbackErrors []error
+		for index := len(moved) - 1; index >= 0; index-- {
+			item := moved[index]
+			backup, err := readSetupExistingPrivateFile(item.backup)
+			if err != nil {
+				rollbackErrors = append(rollbackErrors, err)
+				continue
+			}
+			if !backup.Exists || !bytes.Equal(backup.Data, item.source.data) {
+				rollbackErrors = append(rollbackErrors, fmt.Errorf("migration backup for %s changed during rollback", item.source.name))
+				continue
+			}
+			current, err := readSetupFileState(item.source.sourcePath)
+			if err != nil {
+				rollbackErrors = append(rollbackErrors, err)
+				continue
+			}
+			if current.Exists {
+				rollbackErrors = append(rollbackErrors, fmt.Errorf("legacy %s reappeared during rollback", item.source.name))
+				continue
+			}
+			if err := renameLegacyCodexProjectMigration(item.backup, item.source.sourcePath); err != nil {
+				rollbackErrors = append(rollbackErrors, err)
+				continue
+			}
+			if err := syncLegacyCodexProjectMigrationParent(item.source.sourcePath); err != nil {
+				rollbackErrors = append(rollbackErrors, err)
+			}
+		}
+		return errors.Join(rollbackErrors...)
+	}
+	rollbackOrPreservePublishedDestination := func(cause error) (legacyCodexProjectMigrationSourceMoveResult, error) {
+		rollbackErr := rollback()
+		if rollbackErr == nil {
+			return legacyCodexProjectMigrationSourceMoveResult{}, cause
+		}
+		// The published v1 namespace is already complete and durable. Retain it
+		// and the private transaction directory rather than deleting both the
+		// authoritative copy and a source backup whose rollback could not finish.
+		cleanupTemporaryRoot = false
+		return legacyCodexProjectMigrationSourceMoveResult{
+			cleanupWarning:               fmt.Sprintf("legacy source retirement could not be completed or fully rolled back after v1 publication (%v; %v); retained sealed source state at %s and the v1 project state remains active", cause, rollbackErr, temporaryRoot),
+			preservePublishedDestination: true,
+		}, errors.Join(cause, fmt.Errorf("rollback legacy source moves: %w", rollbackErr))
+	}
+	for index, source := range plan.sourceFiles() {
+		state, err := readSetupExistingPrivateFile(source.sourcePath)
+		if err != nil {
+			return rollbackOrPreservePublishedDestination(fmt.Errorf("read legacy %s before move: %w", source.name, err))
+		}
+		if !state.Exists || !bytes.Equal(state.Data, source.data) {
+			return rollbackOrPreservePublishedDestination(fmt.Errorf("legacy %s changed during migration", source.name))
+		}
+		backupPath := filepath.Join(temporaryRoot, fmt.Sprintf("%02d-%s", index, source.name))
+		if err := renameLegacyCodexProjectMigration(source.sourcePath, backupPath); err != nil {
+			return rollbackOrPreservePublishedDestination(fmt.Errorf("move legacy %s into migration transaction: %w", source.name, err))
+		}
+		moved = append(moved, movedSource{source: source, backup: backupPath})
+		if err := syncLegacyCodexProjectMigrationParent(source.sourcePath); err != nil {
+			return rollbackOrPreservePublishedDestination(fmt.Errorf("sync migrated legacy %s: %w", source.name, err))
+		}
+	}
+	// Every source now lives in a secure retired-source directory and the v1
+	// destination was already durably published. That is the transaction commit
+	// point. Cleanup is best effort: returning an error here would make the
+	// caller roll back the only active state after the legacy names disappeared.
+	if err := removeLegacyCodexProjectMigrationTree(temporaryRoot); err != nil {
+		cleanupTemporaryRoot = false
+		return legacyCodexProjectMigrationSourceMoveResult{cleanupWarning: fmt.Sprintf("a sealed retired-source cleanup remains at %s; it is not active project authority", temporaryRoot)}, nil
+	}
+	cleanupTemporaryRoot = false
+	if err := syncLegacyCodexProjectMigrationParent(temporaryRoot); err != nil {
+		return legacyCodexProjectMigrationSourceMoveResult{cleanupWarning: fmt.Sprintf("retired-source cleanup completed but parent-directory durability could not be confirmed for %s", filepath.Dir(temporaryRoot))}, nil
+	}
+	return legacyCodexProjectMigrationSourceMoveResult{}, nil
+}
+
+func removeLegacyCodexProjectMigrationTemporaryDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() || filepath.Base(path) == "" || len(filepath.Base(path)) <= len(setupLegacyMigrationTemporaryPrefix) || filepath.Base(path)[:len(setupLegacyMigrationTemporaryPrefix)] != setupLegacyMigrationTemporaryPrefix {
+		return fmt.Errorf("refusing to remove invalid legacy migration temporary directory %s", path)
+	}
+	if err := removeLegacyCodexProjectMigrationTree(path); err != nil {
+		return err
+	}
+	return syncLegacyCodexProjectMigrationParent(path)
+}

--- a/core/cmd/helm-ai-kernel/setup_lifecycle_lock.go
+++ b/core/cmd/helm-ai-kernel/setup_lifecycle_lock.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const setupCodexProjectLifecycleLockFile = ".helm-setup-codex-project.lock"
+
+// setupCodexProjectLifecycleLock serializes mutating Codex project lifecycle
+// commands for one secure data directory. Recovery journals make an interrupted
+// transaction resumable; this lock prevents two live same-user processes from
+// replacing each other's project namespace between preflight and publication.
+type setupCodexProjectLifecycleLock struct {
+	file *os.File
+}
+
+func acquireSetupCodexProjectLifecycleLock(dataDir string) (*setupCodexProjectLifecycleLock, error) {
+	securedDataDir, err := ensureSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(securedDataDir, setupCodexProjectLifecycleLockFile)
+	state, err := readSetupExistingPrivateFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if !state.Exists {
+		created, err := writeSetupPrivateFileIfAbsent(path, nil)
+		if err != nil {
+			return nil, err
+		}
+		if !created {
+			state, err = readSetupExistingPrivateFile(path)
+			if err != nil {
+				return nil, err
+			}
+			if !state.Exists {
+				return nil, fmt.Errorf("Codex project lifecycle lock disappeared during creation")
+			}
+		}
+	}
+	file, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+	if err := lockSetupCodexProjectLifecycleFile(file); err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	return &setupCodexProjectLifecycleLock{file: file}, nil
+}
+
+func (lock *setupCodexProjectLifecycleLock) Close() error {
+	if lock == nil || lock.file == nil {
+		return nil
+	}
+	unlockErr := unlockSetupCodexProjectLifecycleFile(lock.file)
+	closeErr := lock.file.Close()
+	lock.file = nil
+	if unlockErr != nil {
+		return unlockErr
+	}
+	return closeErr
+}

--- a/core/cmd/helm-ai-kernel/setup_lifecycle_lock_other.go
+++ b/core/cmd/helm-ai-kernel/setup_lifecycle_lock_other.go
@@ -1,0 +1,14 @@
+//go:build !darwin && !linux && !freebsd && !openbsd && !netbsd && !dragonfly && !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func lockSetupCodexProjectLifecycleFile(_ *os.File) error {
+	return fmt.Errorf("safe cross-process Codex project lifecycle locking is unavailable on this platform")
+}
+
+func unlockSetupCodexProjectLifecycleFile(_ *os.File) error { return nil }

--- a/core/cmd/helm-ai-kernel/setup_lifecycle_lock_unix.go
+++ b/core/cmd/helm-ai-kernel/setup_lifecycle_lock_unix.go
@@ -1,0 +1,20 @@
+//go:build darwin || linux || freebsd || openbsd || netbsd || dragonfly
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func lockSetupCodexProjectLifecycleFile(file *os.File) error {
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return fmt.Errorf("another Codex project lifecycle operation is already in progress: %w", err)
+	}
+	return nil
+}
+
+func unlockSetupCodexProjectLifecycleFile(file *os.File) error {
+	return syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+}

--- a/core/cmd/helm-ai-kernel/setup_lifecycle_lock_windows.go
+++ b/core/cmd/helm-ai-kernel/setup_lifecycle_lock_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// The portable standard library does not expose a Windows equivalent of the
+// advisory Unix flock used by the local authority lifecycle. Failing closed is
+// preferable to claiming cross-process transaction serialization we cannot
+// establish.
+func lockSetupCodexProjectLifecycleFile(_ *os.File) error {
+	return fmt.Errorf("safe cross-process Codex project lifecycle locking is unavailable on Windows")
+}
+
+func unlockSetupCodexProjectLifecycleFile(_ *os.File) error { return nil }

--- a/core/cmd/helm-ai-kernel/setup_lifecycle_readonly.go
+++ b/core/cmd/helm-ai-kernel/setup_lifecycle_readonly.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// readSetupLifecycleReceiptReadOnly opens only an already-existing receipt
+// store. Provenance checks must not run migrations, enable WAL, create a
+// database, or otherwise change local authority state merely because a user
+// asks whether automatic removal is safe.
+func readSetupLifecycleReceiptReadOnly(ctx context.Context, dataDir, receiptID string) (*contracts.Receipt, error) {
+	receipt, exists, err := inspectSetupLifecycleReceiptReadOnly(ctx, dataDir, receiptID)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("lifecycle receipt %q was not found", receiptID)
+	}
+	return receipt, nil
+}
+
+// inspectSetupLifecycleReceiptReadOnly distinguishes a genuinely absent
+// receipt from corrupted, legacy, or unreadable durable state. Recovery uses
+// it before issuing any signer: a receipt that already exists must be
+// re-verified from its own signature profile without opening SQLite writable
+// or generating a key for the current environment profile.
+func inspectSetupLifecycleReceiptReadOnly(ctx context.Context, dataDir, receiptID string) (*contracts.Receipt, bool, error) {
+	if !isSetupLifecycleReceiptID(receiptID) {
+		return nil, false, fmt.Errorf("lifecycle receipt id is invalid")
+	}
+	securedDataDir, err := requireSetupAuthorityDataDir(dataDir)
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect lifecycle receipt authority state: %w", err)
+	}
+	database, err := inspectSetupRegularFile(filepath.Join(securedDataDir, "helm.db"))
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect lifecycle receipt database: %w", err)
+	}
+	if !database.Exists {
+		return nil, false, nil
+	}
+
+	// modernc SQLite accepts a file URI. mode=ro ensures this path rejects a
+	// missing or legacy database instead of creating or migrating it. Build it
+	// as a URI so spaces, #, and query-like characters in a user path cannot
+	// change SQLite's connection options.
+	uri := (&url.URL{Scheme: "file", Path: filepath.ToSlash(database.Path), RawQuery: "mode=ro"}).String()
+	db, err := sql.Open("sqlite", uri)
+	if err != nil {
+		return nil, false, fmt.Errorf("open lifecycle receipt database read-only: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	defer func() { _ = db.Close() }()
+	if err := db.PingContext(ctx); err != nil {
+		return nil, false, fmt.Errorf("open lifecycle receipt database read-only: %w", err)
+	}
+
+	var envelope string
+	err = db.QueryRowContext(ctx, `SELECT receipt_envelope FROM receipts WHERE receipt_id = ?`, receiptID).Scan(&envelope)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("read canonical lifecycle receipt envelope: %w", err)
+	}
+	if envelope == "" {
+		return nil, false, fmt.Errorf("lifecycle receipt %q predates canonical durable receipt envelopes; automatic provenance is unavailable until it is re-established", receiptID)
+	}
+	decoder := json.NewDecoder(strings.NewReader(envelope))
+	decoder.UseNumber()
+	var receipt contracts.Receipt
+	if err := decoder.Decode(&receipt); err != nil {
+		return nil, false, fmt.Errorf("decode canonical lifecycle receipt envelope: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return nil, false, fmt.Errorf("canonical lifecycle receipt envelope has trailing JSON")
+		}
+		return nil, false, fmt.Errorf("read canonical lifecycle receipt envelope: %w", err)
+	}
+	canonical, err := canonicalize.JCS(&receipt)
+	if err != nil {
+		return nil, false, fmt.Errorf("canonicalize lifecycle receipt envelope: %w", err)
+	}
+	if !bytes.Equal(canonical, []byte(envelope)) {
+		return nil, false, fmt.Errorf("lifecycle receipt envelope is not canonical")
+	}
+	if receipt.ReceiptID != receiptID {
+		return nil, false, fmt.Errorf("lifecycle receipt envelope id does not match its database row")
+	}
+	return &receipt, true, nil
+}

--- a/core/cmd/helm-ai-kernel/setup_lifecycle_state.go
+++ b/core/cmd/helm-ai-kernel/setup_lifecycle_state.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// setupLifecycleStateTracker only removes state files that did not exist when
+// the setup attempt began and whose exact bytes still match the file created
+// during that attempt. That prevents a failed setup from deleting a concurrent
+// user change while cleaning up a newly generated signer or SQLite store.
+type setupLifecycleStateTracker struct {
+	before  map[string]setupFileState
+	created map[string]setupFileState
+}
+
+func beginSetupLifecycleStateTracker(dataDir string) (*setupLifecycleStateTracker, error) {
+	absDataDir, err := filepath.Abs(dataDir)
+	if err != nil {
+		return nil, err
+	}
+	tracker := &setupLifecycleStateTracker{
+		before:  make(map[string]setupFileState),
+		created: make(map[string]setupFileState),
+	}
+	for _, path := range []string{
+		filepath.Join(absDataDir, "root.key"),
+		filepath.Join(absDataDir, "root.pub"),
+		filepath.Join(absDataDir, "root.mldsa65.key"),
+		filepath.Join(absDataDir, "helm.db"),
+		filepath.Join(absDataDir, "helm.db-wal"),
+		filepath.Join(absDataDir, "helm.db-shm"),
+		filepath.Join(absDataDir, "helm.db-journal"),
+	} {
+		state, err := readSetupFileState(path)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot lifecycle state %s: %w", path, err)
+		}
+		tracker.before[path] = state
+	}
+	return tracker, nil
+}
+
+func (tracker *setupLifecycleStateTracker) captureCreated() error {
+	if tracker == nil {
+		return nil
+	}
+	for path, before := range tracker.before {
+		if before.Exists {
+			continue
+		}
+		state, err := readSetupFileState(path)
+		if err != nil {
+			return fmt.Errorf("snapshot newly-created lifecycle state %s: %w", path, err)
+		}
+		if state.Exists {
+			tracker.created[path] = state
+		}
+	}
+	return nil
+}
+
+func (tracker *setupLifecycleStateTracker) cleanupCreated() error {
+	if tracker == nil {
+		return nil
+	}
+	var cleanupErrors []error
+	for path, created := range tracker.created {
+		current, err := readSetupFileState(path)
+		if err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("read lifecycle state %s before cleanup: %w", path, err))
+			continue
+		}
+		if !current.Exists {
+			continue
+		}
+		if !sameSetupFileState(current, created) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("lifecycle state %s changed concurrently; refusing to delete it", path))
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			cleanupErrors = append(cleanupErrors, fmt.Errorf("remove newly-created lifecycle state %s: %w", path, err))
+		}
+	}
+	return errors.Join(cleanupErrors...)
+}

--- a/core/cmd/helm-ai-kernel/setup_private_file_owner_other.go
+++ b/core/cmd/helm-ai-kernel/setup_private_file_owner_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux && !freebsd && !openbsd && !netbsd && !dragonfly && !windows
+
+package main
+
+import "os"
+
+// Platforms without the POSIX ownership API still receive strict regular-file,
+// symlink, and 0600 checks from readSetupExistingPrivateFile.
+func requireSetupPrivateFileOwner(_ string, _ os.FileInfo) error { return nil }

--- a/core/cmd/helm-ai-kernel/setup_private_file_owner_unix.go
+++ b/core/cmd/helm-ai-kernel/setup_private_file_owner_unix.go
@@ -1,0 +1,24 @@
+//go:build darwin || linux || freebsd || openbsd || netbsd || dragonfly
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// requireSetupPrivateFileOwner rejects a private key owned by another local
+// account on POSIX hosts. Mode 0600 alone is insufficient when a different
+// account owns the file and can later replace it.
+func requireSetupPrivateFileOwner(path string, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("cannot determine setup private file ownership: %s", path)
+	}
+	uid := os.Getuid()
+	if uid >= 0 && stat.Uid != uint32(uid) {
+		return fmt.Errorf("setup private file is not owned by the current user: %s", path)
+	}
+	return nil
+}

--- a/core/cmd/helm-ai-kernel/setup_private_file_owner_windows.go
+++ b/core/cmd/helm-ai-kernel/setup_private_file_owner_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package main
+
+import "os"
+
+// Windows ownership and ACL verification requires a security-descriptor
+// implementation. Keep the portable mode/symlink checks above and avoid
+// asserting a POSIX ownership guarantee on this platform.
+func requireSetupPrivateFileOwner(_ string, _ os.FileInfo) error { return nil }

--- a/core/cmd/helm-ai-kernel/setup_recovery_apply.go
+++ b/core/cmd/helm-ai-kernel/setup_recovery_apply.go
@@ -1,0 +1,732 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+const (
+	setupRecoveryFileMCP               = "mcp"
+	setupRecoveryFileHook              = "hook"
+	setupRecoveryFileInventory         = "artifact.inventory"
+	setupRecoveryFilePolicyDraft       = "artifact.policy_draft"
+	setupRecoveryFileMCPQuarantinePlan = "artifact.mcp_quarantine_plan"
+	setupRecoveryFileBinding           = "binding"
+)
+
+type codexProjectRecoveryPreparation struct {
+	journal *setupRecoveryJournal
+	summary setupSummary
+}
+
+var finalizeCodexProjectRecoveryJournal = removeSetupRecoveryJournal
+
+func prepareCodexProjectRecoveryInstall(opts setupOptions, summary setupSummary) (*codexProjectRecoveryPreparation, error) {
+	if err := validateSetupLifecycleReceiptProfile(); err != nil {
+		return nil, err
+	}
+	if err := preflightCodexProjectSetup(opts, summary); err != nil {
+		return nil, err
+	}
+	clientBefore, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	hookBefore, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	clientAfter, err := buildUpsertCodexProjectMCPState(clientBefore, summary.BinaryPath, opts.DataDir)
+	if err != nil {
+		return nil, err
+	}
+	hookAfter, err := buildUpsertOwnedSetupHookState(hookBefore, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target)
+	if err != nil {
+		return nil, err
+	}
+	if err := prepareSetupRecoveryDirectory(opts.DataDir); err != nil {
+		return nil, err
+	}
+	artifactsDir := setupCodexProjectArtifactsDir(opts.DataDir)
+	grade, policyPath, err := stageSetupAutoconfigure(opts.DataDir)
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	inventoryBefore, err := readSetupFileState(filepath.Join(artifactsDir, "inventory.json"))
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	policyBefore, err := readSetupFileState(filepath.Join(artifactsDir, "policy.draft.json"))
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	quarantineBefore, err := readSetupFileState(filepath.Join(artifactsDir, "mcp_quarantine_plan.json"))
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	bindingBefore, err := readSetupFileState(setupCodexProjectBindingPath(opts.DataDir))
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	inventoryAfter, err := readSetupFileState(setupRecoveryStagePath(opts.DataDir, "inventory.json"))
+	if err != nil || !inventoryAfter.Exists {
+		if err == nil {
+			err = fmt.Errorf("staged inventory is missing")
+		}
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	policyAfter, err := readSetupFileState(setupRecoveryStagePath(opts.DataDir, "policy.draft.json"))
+	if err != nil || !policyAfter.Exists {
+		if err == nil {
+			err = fmt.Errorf("staged policy draft is missing")
+		}
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	quarantineAfter, err := readSetupFileState(setupRecoveryStagePath(opts.DataDir, "mcp_quarantine_plan.json"))
+	if err != nil || !quarantineAfter.Exists {
+		if err == nil {
+			err = fmt.Errorf("staged MCP quarantine plan is missing")
+		}
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	txnID, err := newSetupRecoveryTransactionID()
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	receiptID, err := newSetupLifecycleReceiptID()
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	binding, err := buildSetupCodexProjectBinding(opts, summary, receiptID, clientAfter, hookAfter)
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	bindingData, err := marshalSetupCodexProjectBinding(binding)
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	bindingStagePath, err := setupRecoverySafeStagePath(opts.DataDir, setupCodexProjectBindingFile)
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	if err := writeSetupPrivateFile(bindingStagePath, bindingData); err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	bindingAfter, err := readSetupFileState(bindingStagePath)
+	if err != nil || !bindingAfter.Exists {
+		if err == nil {
+			err = fmt.Errorf("staged Codex project install binding is missing")
+		}
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	summary.ScanGrade = grade
+	summary.DraftPolicyPath = policyPath
+
+	journal, err := newCodexProjectRecoveryJournal(opts, summary, "install", txnID, receiptID, []setupRecoveryFilePlan{
+		setupRecoveryPlanForStates(setupRecoveryFileInventory, inventoryBefore, inventoryAfter, "inventory.json"),
+		setupRecoveryPlanForStates(setupRecoveryFilePolicyDraft, policyBefore, policyAfter, "policy.draft.json"),
+		setupRecoveryPlanForStates(setupRecoveryFileMCPQuarantinePlan, quarantineBefore, quarantineAfter, "mcp_quarantine_plan.json"),
+		setupRecoveryPlanForStates(setupRecoveryFileHook, hookBefore, hookAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileMCP, clientBefore, clientAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileBinding, bindingBefore, bindingAfter, setupCodexProjectBindingFile),
+	})
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	if err := writeSetupRecoveryJournal(opts.DataDir, *journal); err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	if err := removeSetupRecoveryMarker(opts.DataDir, setupRecoveryPreparingFile); err != nil {
+		return nil, fmt.Errorf("publish prepared Codex project recovery journal: %w", err)
+	}
+	return &codexProjectRecoveryPreparation{journal: journal, summary: summary}, nil
+}
+
+func prepareCodexProjectRecoveryRemove(opts setupOptions, summary setupSummary) (*codexProjectRecoveryPreparation, error) {
+	if err := validateSetupLifecycleReceiptProfile(); err != nil {
+		return nil, err
+	}
+	clientBefore, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	hookBefore, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireCodexProjectHookSourceForRemoval(clientBefore.Data); err != nil {
+		return nil, err
+	}
+	mcp, err := readCodexMCPServerFromBytes(clientBefore.Data)
+	if err != nil {
+		return nil, err
+	}
+	if mcp == nil {
+		if strings.Contains(string(hookBefore.Data), setupHookOwnershipStatus) {
+			return nil, fmt.Errorf("Codex hook looks HELM-managed but no MCP install binding can prove automatic removal")
+		}
+		refreshSetupConfiguration(opts, &summary)
+		return &codexProjectRecoveryPreparation{summary: summary}, nil
+	}
+	if !isHELMCodexMCPServerCore(*mcp) {
+		if strings.Contains(string(hookBefore.Data), setupHookOwnershipStatus) {
+			return nil, fmt.Errorf("Codex hook looks HELM-managed but its MCP server is not a proven HELM installation")
+		}
+		refreshSetupConfiguration(opts, &summary)
+		return &codexProjectRecoveryPreparation{summary: summary}, nil
+	}
+	if err := requireSafeCodexMCPRemoval(mcp, opts.DataDir); err != nil {
+		return nil, err
+	}
+	provenBinary, err := validateCodexProjectRemovalProvenance(opts, summary, clientBefore, hookBefore)
+	if err != nil {
+		return nil, err
+	}
+	summary.BinaryPath = provenBinary
+	hookAfter, err := buildRemoveOwnedSetupHookState(hookBefore, opts.Target, setupHookCommand(opts, summary.BinaryPath))
+	if err != nil {
+		return nil, err
+	}
+	clientAfter, err := buildRemoveCodexProjectMCPStateForBinary(clientBefore, opts.DataDir, summary.BinaryPath)
+	if err != nil {
+		return nil, err
+	}
+	bindingBefore, err := readSetupFileState(setupCodexProjectBindingPath(opts.DataDir))
+	if err != nil {
+		return nil, err
+	}
+	if err := prepareSetupRecoveryDirectory(opts.DataDir); err != nil {
+		return nil, err
+	}
+	txnID, err := newSetupRecoveryTransactionID()
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	receiptID, err := newSetupLifecycleReceiptID()
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	journal, err := newCodexProjectRecoveryJournal(opts, summary, "remove", txnID, receiptID, []setupRecoveryFilePlan{
+		setupRecoveryPlanForStates(setupRecoveryFileMCP, clientBefore, clientAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileHook, hookBefore, hookAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileBinding, bindingBefore, setupFileState{Path: bindingBefore.Path}, ""),
+	})
+	if err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	if err := writeSetupRecoveryJournal(opts.DataDir, *journal); err != nil {
+		return nil, discardUncommittedSetupRecoveryDirectory(opts.DataDir, err)
+	}
+	if err := removeSetupRecoveryMarker(opts.DataDir, setupRecoveryPreparingFile); err != nil {
+		return nil, fmt.Errorf("publish prepared Codex project removal journal: %w", err)
+	}
+	return &codexProjectRecoveryPreparation{journal: journal, summary: summary}, nil
+}
+
+func newCodexProjectRecoveryJournal(opts setupOptions, summary setupSummary, operation, transactionID, receiptID string, files []setupRecoveryFilePlan) (*setupRecoveryJournal, error) {
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		return nil, err
+	}
+	identity, err := inspectSetupKernelBinary(summary.BinaryPath)
+	if err != nil {
+		return nil, err
+	}
+	return &setupRecoveryJournal{
+		SchemaVersion:      setupRecoverySchema,
+		TransactionID:      transactionID,
+		Operation:          operation,
+		Target:             opts.Target,
+		Scope:              opts.Scope,
+		WorkspacePathHash:  workspacePathHash,
+		DataDirPathHash:    canonicalize.HashBytes([]byte(opts.DataDir)),
+		BinaryPath:         identity.Path,
+		BinaryContentHash:  identity.ContentHash,
+		LifecycleReceiptID: receiptID,
+		ScanGrade:          summary.ScanGrade,
+		Phase:              setupRecoveryPhasePrepared,
+		Files:              files,
+	}, nil
+}
+
+func setupRecoveryWorkspacePathHash() (string, error) {
+	workspacePath, err := filepath.Abs(".")
+	if err != nil {
+		return "", err
+	}
+	if resolved, resolveErr := filepath.EvalSymlinks(workspacePath); resolveErr == nil {
+		workspacePath = resolved
+	}
+	return canonicalize.HashBytes([]byte(workspacePath)), nil
+}
+
+func setupRecoveryPlanForStates(id string, before, after setupFileState, stageFile string) setupRecoveryFilePlan {
+	return setupRecoveryFilePlan{
+		ID:        id,
+		Before:    setupRecoveryFingerprintForState(before),
+		After:     setupRecoveryFingerprintForState(after),
+		StageFile: stageFile,
+	}
+}
+
+func stageSetupAutoconfigure(dataDir string) (string, string, error) {
+	artifactsDir := setupCodexProjectArtifactsDir(dataDir)
+	writer := func(finalPath string, value any) error {
+		data, err := marshalSetupJSONArtifact(value)
+		if err != nil {
+			return err
+		}
+		return writeSetupPrivateFile(setupRecoveryStagePath(dataDir, filepath.Base(finalPath)), data)
+	}
+	return runSetupAutoconfigureTo(artifactsDir, writer)
+}
+
+func discardUncommittedSetupRecoveryDirectory(dataDir string, cause error) error {
+	if cleanupErr := cleanupIncompleteSetupRecoveryDirectory(dataDir); cleanupErr != nil {
+		return fmt.Errorf("%w; preserve incomplete setup recovery state: %v", cause, cleanupErr)
+	}
+	return cause
+}
+
+func validateCodexProjectRecoveryJournal(opts setupOptions, summary setupSummary, journal *setupRecoveryJournal) (setupKernelBinaryIdentity, error) {
+	if err := validateSetupRecoveryJournal(journal); err != nil {
+		return setupKernelBinaryIdentity{}, err
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		return setupKernelBinaryIdentity{}, err
+	}
+	if journal.Target != "codex" || journal.Scope != "project" || opts.Target != journal.Target || opts.Scope != journal.Scope {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("setup recovery journal does not match the requested Codex project scope")
+	}
+	if journal.WorkspacePathHash != workspacePathHash || journal.DataDirPathHash != canonicalize.HashBytes([]byte(opts.DataDir)) {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("setup recovery journal is bound to a different workspace or data-dir")
+	}
+	journalBinary, err := inspectSetupKernelBinary(journal.BinaryPath)
+	if err != nil {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("setup recovery journal Kernel binary is unavailable: %w", err)
+	}
+	// A recovery journal is itself untrusted crash residue. It must name the
+	// canonical executable path that was pinned at prepare time, rather than a
+	// symlink which happens to resolve to it today. Otherwise a journal could
+	// redirect a resumed transaction through a mutable alternate pathname.
+	if journalBinary.Path != journal.BinaryPath {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("setup recovery journal Kernel executable path does not match its resolved pinned path")
+	}
+	if journalBinary.ContentHash != journal.BinaryContentHash {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("setup recovery journal Kernel binary no longer matches its pinned content hash")
+	}
+	currentBinary, err := inspectSetupKernelBinary(summary.BinaryPath)
+	if err != nil {
+		return setupKernelBinaryIdentity{}, err
+	}
+	if currentBinary.ContentHash != journal.BinaryContentHash {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("current Kernel binary does not match the prepared recovery transaction")
+	}
+	if currentBinary.Path != journalBinary.Path {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("current Kernel executable path does not match the prepared recovery transaction")
+	}
+	if summary.ClientConfigPath == "" || summary.HookConfigPath == "" {
+		return setupKernelBinaryIdentity{}, fmt.Errorf("setup recovery paths are incomplete")
+	}
+	return journalBinary, nil
+}
+
+func resumeCodexProjectRecovery(opts setupOptions, summary setupSummary, journal *setupRecoveryJournal) (setupLifecycleResult, setupSummary, error) {
+	journalBinary, err := validateCodexProjectRecoveryJournal(opts, summary, journal)
+	if err != nil {
+		return setupLifecycleResult{}, summary, err
+	}
+	_, persistedReceipt, receiptErr := inspectSetupLifecycleReceiptReadOnly(context.Background(), opts.DataDir, journal.LifecycleReceiptID)
+	if receiptErr != nil {
+		return setupLifecycleResult{}, summary, fmt.Errorf("inspect recovered lifecycle receipt before config mutation: %w", receiptErr)
+	}
+	if !persistedReceipt {
+		if err := validateSetupLifecycleReceiptProfile(); err != nil {
+			return setupLifecycleResult{}, summary, fmt.Errorf("validate receipt profile before resumable config mutation: %w", err)
+		}
+	}
+	summary.BinaryPath = journalBinary.Path
+	if journal.Operation == "remove" {
+		if err := validateCodexProjectRemoveRecoveryProvenance(opts, summary, journal, journalBinary); err != nil {
+			return setupLifecycleResult{}, summary, fmt.Errorf("verify recovered Codex project removal provenance: %w", err)
+		}
+	}
+	if journal.Operation == "install" {
+		if _, err := validateStagedCodexProjectInstallBinding(opts, journal); err != nil {
+			return setupLifecycleResult{}, summary, fmt.Errorf("verify staged Codex project install binding: %w", err)
+		}
+		artifactsDir := setupCodexProjectArtifactsDir(opts.DataDir)
+		for _, id := range []string{setupRecoveryFileInventory, setupRecoveryFilePolicyDraft, setupRecoveryFileMCPQuarantinePlan} {
+			if err := applyStagedSetupRecoveryFile(opts.DataDir, journal, id, filepath.Join(artifactsDir, stageFileForRecoveryID(id))); err != nil {
+				return setupLifecycleResult{}, summary, err
+			}
+		}
+		if err := applyCodexRecoveryHook(opts, summary, journal, true); err != nil {
+			return setupLifecycleResult{}, summary, err
+		}
+		if err := applyCodexRecoveryMCP(opts, summary, journal, true); err != nil {
+			return setupLifecycleResult{}, summary, err
+		}
+		summary.ScanGrade = journal.ScanGrade
+		summary.DraftPolicyPath = filepath.Join(artifactsDir, "policy.draft.json")
+	} else {
+		if err := applyCodexRecoveryMCP(opts, summary, journal, false); err != nil {
+			return setupLifecycleResult{}, summary, err
+		}
+		if err := applyCodexRecoveryHook(opts, summary, journal, false); err != nil {
+			return setupLifecycleResult{}, summary, err
+		}
+	}
+
+	refreshSetupConfiguration(opts, &summary)
+	if journal.Operation == "install" && !summary.LocalConfigVerified {
+		return setupLifecycleResult{}, summary, fmt.Errorf("recovered Codex project config is not exact")
+	}
+	if journal.Operation == "remove" && (summary.MCPConfigured || summary.HookConfigured) {
+		return setupLifecycleResult{}, summary, fmt.Errorf("recovered Codex project removal left owned config")
+	}
+	recordOpts := opts
+	recordOpts.lifecycleReceiptID = journal.LifecycleReceiptID
+	recordOpts.lifecycleRecoveryManaged = true
+	lifecycle, err := recordCodexProjectSetupLifecycleFn(recordOpts, summary, journal.Operation)
+	if err != nil {
+		return setupLifecycleResult{}, summary, fmt.Errorf("record recovered lifecycle: %w", err)
+	}
+	if journal.Operation == "install" {
+		if _, err := validateStagedCodexProjectInstallBindingForCurrentConfig(opts, journal); err != nil {
+			return setupLifecycleResult{}, summary, fmt.Errorf("verify signed Codex project install binding before publication: %w", err)
+		}
+		if err := applyStagedSetupRecoveryFile(opts.DataDir, journal, setupRecoveryFileBinding, setupCodexProjectBindingPath(opts.DataDir)); err != nil {
+			return setupLifecycleResult{}, summary, fmt.Errorf("publish proven Codex project install binding: %w", err)
+		}
+	} else {
+		if err := applySetupRecoveryFilePlan(opts.DataDir, journal, setupRecoveryFileBinding, setupCodexProjectBindingPath(opts.DataDir)); err != nil {
+			return setupLifecycleResult{}, summary, fmt.Errorf("remove Codex project install binding: %w", err)
+		}
+	}
+	if err := finalizeCodexProjectRecoveryJournal(opts.DataDir, journal); err != nil {
+		inspection, inspectErr := inspectSetupRecovery(opts.DataDir)
+		if inspectErr == nil && inspection.State == setupRecoveryStateCommitted {
+			summary.RecoveryCleanupPending = true
+			return lifecycle, summary, nil
+		}
+		return setupLifecycleResult{}, summary, fmt.Errorf("finalize recovered setup journal: %w", err)
+	}
+	return lifecycle, summary, nil
+}
+
+// validateCodexProjectRemoveRecoveryProvenance replays only a removal that is
+// causally anchored to a signed install binding. A recovery journal is an
+// integrity record, not authority by itself: it may be damaged or forged while
+// a process is down. The binding proves the pre-removal configs; the journal
+// must then describe exactly the deterministic removal of those configs.
+func validateCodexProjectRemoveRecoveryProvenance(opts setupOptions, summary setupSummary, journal *setupRecoveryJournal, journalBinary setupKernelBinaryIdentity) error {
+	bindingState, err := readSetupFileState(setupCodexProjectBindingPath(opts.DataDir))
+	if err != nil {
+		return err
+	}
+	if !bindingState.Exists {
+		return validateCodexProjectCompletedRemoveRecovery(opts, summary, journal, journalBinary, bindingState)
+	}
+	proof, err := loadCodexProjectInstallProof(opts)
+	if err != nil {
+		return err
+	}
+	if proof.Binary.Path != journalBinary.Path || proof.Binary.ContentHash != journalBinary.ContentHash || summary.BinaryPath != proof.Binary.Path {
+		return fmt.Errorf("recovery journal Kernel binary does not match the proven install binding")
+	}
+
+	mcpPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileMCP)
+	if err != nil {
+		return err
+	}
+	hookPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileHook)
+	if err != nil {
+		return err
+	}
+	bindingPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileBinding)
+	if err != nil {
+		return err
+	}
+	if !mcpPlan.Before.Exists || mcpPlan.Before.ContentHash != proof.Binding.ClientConfigContentHash ||
+		!hookPlan.Before.Exists || hookPlan.Before.ContentHash != proof.Binding.HookConfigContentHash ||
+		bindingPlan.After.Exists {
+		return fmt.Errorf("recovery journal does not preserve the proven Codex install binding state")
+	}
+	bindingData, err := marshalSetupCodexProjectBinding(*proof.Binding)
+	if err != nil {
+		return err
+	}
+	if !bindingPlan.Before.Exists || bindingPlan.Before.ContentHash != canonicalize.HashBytes(bindingData) {
+		return fmt.Errorf("recovery journal binding plan does not match the proven install binding")
+	}
+
+	clientState, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return err
+	}
+	hookState, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return err
+	}
+	if err := validateRemoveRecoveryConfigPlan(mcpPlan, clientState, func(before setupFileState) (setupFileState, error) {
+		return buildRemoveCodexProjectMCPStateForBinary(before, opts.DataDir, proof.Binary.Path)
+	}); err != nil {
+		return fmt.Errorf("Codex MCP recovery plan: %w", err)
+	}
+	if err := validateRemoveRecoveryConfigPlan(hookPlan, hookState, func(before setupFileState) (setupFileState, error) {
+		return buildRemoveOwnedSetupHookState(before, opts.Target, setupHookCommand(opts, proof.Binary.Path))
+	}); err != nil {
+		return fmt.Errorf("Codex hook recovery plan: %w", err)
+	}
+	if setupRecoveryFingerprintMatchesState(bindingPlan.After, bindingState) {
+		return nil
+	}
+	if !setupRecoveryFingerprintMatchesState(bindingPlan.Before, bindingState) {
+		return fmt.Errorf("Codex project binding changed outside the recorded removal")
+	}
+	return nil
+}
+
+// validateCodexProjectCompletedRemoveRecovery handles the narrow crash window
+// after an already-signed REVOKED lifecycle receipt has been persisted and the
+// install binding has been deleted, but before the terminal marker is durable.
+// The missing binding is never accepted on the strength of a journal alone:
+// this branch is cleanup-only and requires the signed post-removal receipt,
+// evidence, and exact post-removal file snapshots before resume may continue.
+func validateCodexProjectCompletedRemoveRecovery(opts setupOptions, summary setupSummary, journal *setupRecoveryJournal, journalBinary setupKernelBinaryIdentity, bindingState setupFileState) error {
+	if bindingState.Exists {
+		return fmt.Errorf("completed Codex removal recovery requires an absent install binding")
+	}
+	mcpPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileMCP)
+	if err != nil {
+		return err
+	}
+	hookPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileHook)
+	if err != nil {
+		return err
+	}
+	bindingPlan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileBinding)
+	if err != nil {
+		return err
+	}
+	if !bindingPlan.Before.Exists || bindingPlan.After.Exists {
+		return fmt.Errorf("missing install binding is not an exact recorded removal state")
+	}
+	clientState, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return err
+	}
+	hookState, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return err
+	}
+	if !setupRecoveryFingerprintMatchesState(mcpPlan.After, clientState) || !setupRecoveryFingerprintMatchesState(hookPlan.After, hookState) || !setupRecoveryFingerprintMatchesState(bindingPlan.After, bindingState) {
+		return fmt.Errorf("post-removal Codex project state differs from the recorded recovery plan")
+	}
+
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		return err
+	}
+	receipt, err := readSetupLifecycleReceiptReadOnly(context.Background(), opts.DataDir, journal.LifecycleReceiptID)
+	if err != nil {
+		return fmt.Errorf("read signed completed Codex removal receipt: %w", err)
+	}
+	signer, err := loadExistingSetupLifecycleSignerForSignature(opts.DataDir, receipt.Signature)
+	if err != nil {
+		return err
+	}
+	evidence, err := verifySetupLifecycleEvidence(opts.DataDir, receipt)
+	if err != nil {
+		return fmt.Errorf("verify completed Codex removal evidence: %w", err)
+	}
+	descriptorHash, err := canonicalize.CanonicalHash(evidence.Descriptor)
+	if err != nil {
+		return err
+	}
+	observationHash, err := canonicalize.CanonicalHash(evidence.Observation)
+	if err != nil {
+		return err
+	}
+	if err := validatePersistedSetupLifecycleReceipt(signer, receipt, journal.LifecycleReceiptID, descriptorHash, observationHash, workspacePathHash, "remove"); err != nil {
+		return fmt.Errorf("completed Codex removal receipt is not an exact signed lifecycle record: %w", err)
+	}
+	if evidence.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Descriptor.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Observation.SchemaVersion != setupCodexProjectLifecycleSchema ||
+		evidence.Descriptor.Client != "codex" || evidence.Descriptor.Scope != "project" || evidence.Descriptor.Operation != "remove" ||
+		evidence.Descriptor.WorkspacePathHash != workspacePathHash || evidence.Descriptor.DataDirPathHash != canonicalize.HashBytes([]byte(opts.DataDir)) ||
+		evidence.Descriptor.KernelBinaryPath != journalBinary.Path || evidence.Descriptor.KernelBinaryContentHash != journalBinary.ContentHash ||
+		evidence.Descriptor.ExpectedMCP || evidence.Descriptor.ExpectedHook ||
+		evidence.Observation.Operation != "remove" || evidence.Observation.MCPConfigured || evidence.Observation.HookConfigured ||
+		evidence.Observation.ClientLoadObserved || evidence.Observation.KernelDispatchObserved || evidence.Observation.SyntheticDenial != nil ||
+		evidence.Observation.WorkspacePathHash != workspacePathHash || evidence.Observation.DataDirPathHash != canonicalize.HashBytes([]byte(opts.DataDir)) {
+		return fmt.Errorf("completed Codex removal evidence is incomplete or does not match the recorded transaction")
+	}
+	if ok, err := setupLifecycleSnapshotMatchesCurrent(evidence.Observation.ClientConfig, summary.ClientConfigPath); err != nil || !ok {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("completed Codex removal client config snapshot changed after revocation")
+	}
+	if ok, err := setupLifecycleSnapshotMatchesCurrent(evidence.Observation.HookConfig, summary.HookConfigPath); err != nil || !ok {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("completed Codex removal hook config snapshot changed after revocation")
+	}
+	refreshSetupConfiguration(opts, &summary)
+	if summary.MCPConfigured || summary.HookConfigured {
+		return fmt.Errorf("completed Codex removal still exposes owned configuration")
+	}
+	return nil
+}
+
+func validateRemoveRecoveryConfigPlan(plan setupRecoveryFilePlan, current setupFileState, transform func(setupFileState) (setupFileState, error)) error {
+	if setupRecoveryFingerprintMatchesState(plan.After, current) {
+		return nil
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.Before, current) {
+		return fmt.Errorf("config differs from both the proven pre-removal and recorded post-removal state")
+	}
+	next, err := transform(current)
+	if err != nil {
+		return err
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.After, next) {
+		return fmt.Errorf("deterministic removal transformation differs from the recorded post-removal state")
+	}
+	return nil
+}
+
+func applyStagedSetupRecoveryFile(dataDir string, journal *setupRecoveryJournal, id, finalPath string) error {
+	plan, err := lookupSetupRecoveryFilePlan(journal, id)
+	if err != nil {
+		return err
+	}
+	current, err := readSetupFileState(finalPath)
+	if err != nil {
+		return err
+	}
+	if setupRecoveryFingerprintMatchesState(plan.After, current) {
+		return nil
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.Before, current) {
+		return fmt.Errorf("setup recovery conflict: %s changed outside HELM", id)
+	}
+	stagePath, err := setupRecoverySafeStagePath(dataDir, plan.StageFile)
+	if err != nil {
+		return err
+	}
+	staged, err := readSetupFileState(stagePath)
+	if err != nil {
+		return err
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.After, staged) {
+		return fmt.Errorf("setup recovery staged artifact does not match its journal: %s", id)
+	}
+	staged.Path = finalPath
+	return restoreSetupFileState(staged)
+}
+
+func applySetupRecoveryFilePlan(dataDir string, journal *setupRecoveryJournal, id, finalPath string) error {
+	plan, err := lookupSetupRecoveryFilePlan(journal, id)
+	if err != nil {
+		return err
+	}
+	current, err := readSetupFileState(finalPath)
+	if err != nil {
+		return err
+	}
+	if setupRecoveryFingerprintMatchesState(plan.After, current) {
+		return nil
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.Before, current) {
+		return fmt.Errorf("setup recovery conflict: %s changed outside HELM", id)
+	}
+	if plan.After.Exists {
+		return fmt.Errorf("setup recovery non-staged plan %s unexpectedly creates a file", id)
+	}
+	return restoreSetupFileState(setupFileState{Path: finalPath, Exists: plan.After.Exists})
+}
+
+func applyCodexRecoveryHook(opts setupOptions, summary setupSummary, journal *setupRecoveryJournal, install bool) error {
+	plan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileHook)
+	if err != nil {
+		return err
+	}
+	current, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return err
+	}
+	if setupRecoveryFingerprintMatchesState(plan.After, current) {
+		return nil
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.Before, current) {
+		return fmt.Errorf("setup recovery conflict: hook config changed outside HELM")
+	}
+	var next setupFileState
+	if install {
+		next, err = buildUpsertOwnedSetupHookState(current, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target)
+	} else {
+		next, err = buildRemoveOwnedSetupHookState(current, opts.Target, setupHookCommand(opts, summary.BinaryPath))
+	}
+	if err != nil {
+		return err
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.After, next) {
+		return fmt.Errorf("setup recovery hook transformation differs from its prepared journal")
+	}
+	return restoreSetupFileState(next)
+}
+
+func applyCodexRecoveryMCP(opts setupOptions, summary setupSummary, journal *setupRecoveryJournal, install bool) error {
+	plan, err := lookupSetupRecoveryFilePlan(journal, setupRecoveryFileMCP)
+	if err != nil {
+		return err
+	}
+	current, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return err
+	}
+	if setupRecoveryFingerprintMatchesState(plan.After, current) {
+		return nil
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.Before, current) {
+		return fmt.Errorf("setup recovery conflict: Codex MCP config changed outside HELM")
+	}
+	var next setupFileState
+	if install {
+		next, err = buildUpsertCodexProjectMCPState(current, summary.BinaryPath, opts.DataDir)
+	} else {
+		next, err = buildRemoveCodexProjectMCPStateForBinary(current, opts.DataDir, summary.BinaryPath)
+	}
+	if err != nil {
+		return err
+	}
+	if !setupRecoveryFingerprintMatchesState(plan.After, next) {
+		return fmt.Errorf("setup recovery MCP transformation differs from its prepared journal")
+	}
+	return restoreSetupFileState(next)
+}
+
+func stageFileForRecoveryID(id string) string {
+	switch id {
+	case setupRecoveryFileInventory:
+		return "inventory.json"
+	case setupRecoveryFilePolicyDraft:
+		return "policy.draft.json"
+	case setupRecoveryFileMCPQuarantinePlan:
+		return "mcp_quarantine_plan.json"
+	case setupRecoveryFileBinding:
+		return setupCodexProjectBindingFile
+	default:
+		return ""
+	}
+}

--- a/core/cmd/helm-ai-kernel/setup_recovery_journal.go
+++ b/core/cmd/helm-ai-kernel/setup_recovery_journal.go
@@ -1,0 +1,876 @@
+package main
+
+import (
+	"bytes"
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+const (
+	setupRecoverySchema               = "helm.codex-project-recovery/v1"
+	setupRecoveryMarkerSchema         = "helm.codex-project-recovery-marker/v1"
+	setupRecoveryDirectory            = ".helm-setup-recovery"
+	setupRecoveryJournalFile          = "journal.json"
+	setupRecoveryStagingDir           = "staged"
+	setupRecoveryPreparingFile        = "PREPARING"
+	setupRecoveryCommittedFile        = "COMMITTED"
+	setupRecoveryPhasePrepared        = "prepared"
+	setupRecoveryMarkerStatePreparing = "preparing"
+	setupRecoveryMarkerStateCommitted = "committed"
+	setupRecoveryTemporaryPrefix      = ".helm-setup-"
+)
+
+// setupRecoveryFingerprint intentionally records only existence plus a
+// content hash. It never persists user-owned TOML or JSON bytes in Kernel
+// state. A resumed transaction can only move a file from its exact recorded
+// before state to a reproducible after state; any third state is a conflict.
+type setupRecoveryFingerprint struct {
+	Exists      bool   `json:"exists"`
+	ContentHash string `json:"content_hash,omitempty"`
+}
+
+type setupRecoveryFilePlan struct {
+	ID        string                   `json:"id"`
+	Before    setupRecoveryFingerprint `json:"before"`
+	After     setupRecoveryFingerprint `json:"after"`
+	StageFile string                   `json:"stage_file,omitempty"`
+}
+
+type setupRecoveryJournal struct {
+	SchemaVersion      string                  `json:"schema_version"`
+	TransactionID      string                  `json:"transaction_id"`
+	Operation          string                  `json:"operation"`
+	Target             string                  `json:"target"`
+	Scope              string                  `json:"scope"`
+	WorkspacePathHash  string                  `json:"workspace_path_hash"`
+	DataDirPathHash    string                  `json:"data_dir_path_hash"`
+	BinaryPath         string                  `json:"binary_path"`
+	BinaryContentHash  string                  `json:"binary_content_hash"`
+	LifecycleReceiptID string                  `json:"lifecycle_receipt_id"`
+	ScanGrade          string                  `json:"scan_grade,omitempty"`
+	Phase              string                  `json:"phase"`
+	Files              []setupRecoveryFilePlan `json:"files"`
+}
+
+// setupRecoveryMarker is deliberately much smaller than the journal. It
+// makes the two otherwise-unobservable crash windows explicit: preparation
+// before a journal is durable, and completion before its directory cleanup is
+// durable. Markers contain no user-owned configuration bytes.
+type setupRecoveryMarker struct {
+	SchemaVersion      string `json:"schema_version"`
+	State              string `json:"state"`
+	TransactionID      string `json:"transaction_id,omitempty"`
+	LifecycleReceiptID string `json:"lifecycle_receipt_id,omitempty"`
+	JournalHash        string `json:"journal_hash,omitempty"`
+	Operation          string `json:"operation,omitempty"`
+	Target             string `json:"target,omitempty"`
+	Scope              string `json:"scope,omitempty"`
+	WorkspacePathHash  string `json:"workspace_path_hash,omitempty"`
+	DataDirPathHash    string `json:"data_dir_path_hash,omitempty"`
+	BinaryPath         string `json:"binary_path,omitempty"`
+	BinaryContentHash  string `json:"binary_content_hash,omitempty"`
+	Signature          string `json:"signature,omitempty"`
+}
+
+type setupRecoveryState uint8
+
+const (
+	setupRecoveryStateAbsent setupRecoveryState = iota
+	setupRecoveryStatePrepared
+	setupRecoveryStatePending
+	setupRecoveryStateCommitted
+)
+
+type setupRecoveryInspection struct {
+	State   setupRecoveryState
+	Journal *setupRecoveryJournal
+}
+
+type setupRecoveryPlanSpec struct {
+	ID        string
+	StageFile string
+}
+
+func setupRecoveryRoot(dataDir string) string {
+	return currentCodexProjectPaths(dataDir).RecoveryRoot
+}
+
+func setupRecoveryJournalPath(dataDir string) string {
+	return filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryJournalFile)
+}
+
+func setupRecoveryMarkerPath(dataDir, filename string) string {
+	return filepath.Join(setupRecoveryRoot(dataDir), filename)
+}
+
+func setupRecoveryStagePath(dataDir, stageFile string) string {
+	return filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir, stageFile)
+}
+
+func setupRecoveryFingerprintForState(state setupFileState) setupRecoveryFingerprint {
+	fingerprint := setupRecoveryFingerprint{Exists: state.Exists}
+	if state.Exists {
+		fingerprint.ContentHash = canonicalize.HashBytes(state.Data)
+	}
+	return fingerprint
+}
+
+func sameSetupRecoveryFingerprint(left, right setupRecoveryFingerprint) bool {
+	return left.Exists == right.Exists && left.ContentHash == right.ContentHash
+}
+
+func setupRecoveryFingerprintMatchesState(fingerprint setupRecoveryFingerprint, state setupFileState) bool {
+	return sameSetupRecoveryFingerprint(fingerprint, setupRecoveryFingerprintForState(state))
+}
+
+func newSetupRecoveryTransactionID() (string, error) {
+	var random [16]byte
+	if _, err := cryptorand.Read(random[:]); err != nil {
+		return "", fmt.Errorf("generate recovery transaction id: %w", err)
+	}
+	return "txn_native_client_" + hex.EncodeToString(random[:]), nil
+}
+
+func isSetupRecoveryTransactionID(value string) bool {
+	return isSetupOpaqueID(value, "txn_native_client_")
+}
+
+func isSetupLifecycleReceiptID(value string) bool {
+	return isSetupOpaqueID(value, "rcpt_native_client_")
+}
+
+func isSetupOpaqueID(value, prefix string) bool {
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+32 {
+		return false
+	}
+	for _, char := range value[len(prefix):] {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSetupSHA256(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, char := range value {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+func expectedSetupRecoveryPlans(operation string) ([]setupRecoveryPlanSpec, error) {
+	switch operation {
+	case "install":
+		return []setupRecoveryPlanSpec{
+			{ID: setupRecoveryFileInventory, StageFile: "inventory.json"},
+			{ID: setupRecoveryFilePolicyDraft, StageFile: "policy.draft.json"},
+			{ID: setupRecoveryFileMCPQuarantinePlan, StageFile: "mcp_quarantine_plan.json"},
+			{ID: setupRecoveryFileHook},
+			{ID: setupRecoveryFileMCP},
+			{ID: setupRecoveryFileBinding, StageFile: "codex-project-binding.json"},
+		}, nil
+	case "remove":
+		return []setupRecoveryPlanSpec{
+			{ID: setupRecoveryFileMCP},
+			{ID: setupRecoveryFileHook},
+			{ID: setupRecoveryFileBinding},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported setup recovery operation %q", operation)
+	}
+}
+
+func validateSetupRecoveryFingerprint(fingerprint setupRecoveryFingerprint) error {
+	if !fingerprint.Exists && fingerprint.ContentHash != "" {
+		return fmt.Errorf("absent recovery file fingerprint must not include a content hash")
+	}
+	if fingerprint.Exists && !isSetupSHA256(fingerprint.ContentHash) {
+		return fmt.Errorf("present recovery file fingerprint requires a SHA-256 content hash")
+	}
+	return nil
+}
+
+func validateSetupRecoveryJournal(journal *setupRecoveryJournal) error {
+	if journal == nil {
+		return fmt.Errorf("setup recovery journal is required")
+	}
+	if journal.SchemaVersion != setupRecoverySchema || journal.Phase != setupRecoveryPhasePrepared {
+		return fmt.Errorf("unsupported or incomplete setup recovery journal")
+	}
+	if !isSetupRecoveryTransactionID(journal.TransactionID) || !isSetupLifecycleReceiptID(journal.LifecycleReceiptID) {
+		return fmt.Errorf("setup recovery journal has invalid transaction or lifecycle receipt id")
+	}
+	if journal.Target != "codex" || journal.Scope != "project" {
+		return fmt.Errorf("setup recovery journal has unsupported target or scope")
+	}
+	if !isSetupSHA256(journal.WorkspacePathHash) || !isSetupSHA256(journal.DataDirPathHash) || !isSetupSHA256(journal.BinaryContentHash) {
+		return fmt.Errorf("setup recovery journal has invalid path or binary hash")
+	}
+	if !filepath.IsAbs(journal.BinaryPath) || filepath.Clean(journal.BinaryPath) != journal.BinaryPath || strings.ContainsRune(journal.BinaryPath, '\x00') {
+		return fmt.Errorf("setup recovery journal has invalid Kernel binary path")
+	}
+	expected, err := expectedSetupRecoveryPlans(journal.Operation)
+	if err != nil {
+		return err
+	}
+	if len(journal.Files) != len(expected) {
+		return fmt.Errorf("setup recovery journal has an unexpected recovery plan count")
+	}
+	for index, spec := range expected {
+		plan := journal.Files[index]
+		if plan.ID != spec.ID || plan.StageFile != spec.StageFile {
+			return fmt.Errorf("setup recovery journal plan %d is not the expected %s plan", index, spec.ID)
+		}
+		if err := validateSetupRecoveryFingerprint(plan.Before); err != nil {
+			return fmt.Errorf("setup recovery %s plan before fingerprint: %w", spec.ID, err)
+		}
+		if err := validateSetupRecoveryFingerprint(plan.After); err != nil {
+			return fmt.Errorf("setup recovery %s plan after fingerprint: %w", spec.ID, err)
+		}
+	}
+	return nil
+}
+
+func readSetupRecoveryJournal(dataDir string) (*setupRecoveryJournal, error) {
+	return readSetupRecoveryJournalAtPath(setupRecoveryJournalPath(dataDir))
+}
+
+// readSetupRecoveryJournalAtPath keeps the canonical parser reusable for the
+// explicit v0-to-v1 migration path. It parses only a caller-validated private
+// file; it is never a fallback for normal recovery.
+func readSetupRecoveryJournalAtPath(path string) (*setupRecoveryJournal, error) {
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return nil, err
+	}
+	if !state.Exists {
+		return nil, nil
+	}
+	var journal setupRecoveryJournal
+	if err := json.Unmarshal(state.Data, &journal); err != nil {
+		return nil, fmt.Errorf("decode setup recovery journal: %w", err)
+	}
+	canonical, err := canonicalize.JCS(journal)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize setup recovery journal: %w", err)
+	}
+	if !bytes.Equal(state.Data, canonical) {
+		return nil, fmt.Errorf("setup recovery journal is not canonical")
+	}
+	if err := validateSetupRecoveryJournal(&journal); err != nil {
+		return nil, err
+	}
+	return &journal, nil
+}
+
+func writeSetupRecoveryJournal(dataDir string, journal setupRecoveryJournal) error {
+	if err := validateSetupRecoveryJournal(&journal); err != nil {
+		return err
+	}
+	data, err := canonicalize.JCS(journal)
+	if err != nil {
+		return err
+	}
+	if err := writeSetupPrivateFile(setupRecoveryJournalPath(dataDir), data); err != nil {
+		return err
+	}
+	// writeSetupPrivateFile fsyncs the recovery directory. The recovery-root
+	// entry itself is synced when it is created below, so this journal is
+	// durable before any shared configuration mutation can begin.
+	return nil
+}
+
+func validateSetupRecoveryMarker(marker *setupRecoveryMarker) error {
+	if marker == nil || marker.SchemaVersion != setupRecoveryMarkerSchema {
+		return fmt.Errorf("unsupported setup recovery marker")
+	}
+	switch marker.State {
+	case setupRecoveryMarkerStatePreparing:
+		if marker.TransactionID != "" || marker.LifecycleReceiptID != "" || marker.JournalHash != "" || marker.Operation != "" || marker.Target != "" || marker.Scope != "" || marker.WorkspacePathHash != "" || marker.DataDirPathHash != "" || marker.BinaryPath != "" || marker.BinaryContentHash != "" || marker.Signature != "" {
+			return fmt.Errorf("preparing setup recovery marker must not contain transaction state")
+		}
+	case setupRecoveryMarkerStateCommitted:
+		if !isSetupRecoveryTransactionID(marker.TransactionID) || !isSetupLifecycleReceiptID(marker.LifecycleReceiptID) {
+			return fmt.Errorf("committed setup recovery marker has invalid transaction state")
+		}
+		if !setupRecoveryMarkerHasTerminalProof(marker) {
+			// Older/incomplete markers are deliberately readable so a live
+			// journal remains resumable. They are never terminal authority.
+			if marker.JournalHash != "" || marker.Operation != "" || marker.Target != "" || marker.Scope != "" || marker.WorkspacePathHash != "" || marker.DataDirPathHash != "" || marker.BinaryPath != "" || marker.BinaryContentHash != "" || marker.Signature != "" {
+				return fmt.Errorf("committed setup recovery marker has incomplete terminal proof")
+			}
+			return nil
+		}
+		if !isSetupSHA256(marker.JournalHash) || !isSetupSHA256(marker.WorkspacePathHash) || !isSetupSHA256(marker.DataDirPathHash) || !isSetupSHA256(marker.BinaryContentHash) || marker.Target != "codex" || marker.Scope != "project" || strings.ContainsRune(marker.BinaryPath, '\x00') || !filepath.IsAbs(marker.BinaryPath) {
+			return fmt.Errorf("committed setup recovery marker has invalid terminal proof")
+		}
+		if _, err := expectedSetupRecoveryPlans(marker.Operation); err != nil {
+			return fmt.Errorf("committed setup recovery marker has invalid operation: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown setup recovery marker state %q", marker.State)
+	}
+	return nil
+}
+
+func setupRecoveryMarkerHasTerminalProof(marker *setupRecoveryMarker) bool {
+	return setupRecoveryMarkerHasTerminalPayload(marker) && marker.Signature != ""
+}
+
+func setupRecoveryMarkerHasTerminalPayload(marker *setupRecoveryMarker) bool {
+	if marker == nil {
+		return false
+	}
+	return marker.JournalHash != "" && marker.Operation != "" && marker.Target != "" && marker.Scope != "" && marker.WorkspacePathHash != "" && marker.DataDirPathHash != "" && marker.BinaryPath != "" && marker.BinaryContentHash != ""
+}
+
+func readSetupRecoveryMarker(dataDir, filename string) (*setupRecoveryMarker, error) {
+	return readSetupRecoveryMarkerAtPath(setupRecoveryMarkerPath(dataDir, filename), filename)
+}
+
+// readSetupRecoveryMarkerAtPath keeps canonical marker parsing independent of
+// the active v1 recovery root so explicit legacy migration can reject malformed
+// source state during dry-run before it moves a directory.
+func readSetupRecoveryMarkerAtPath(path, filename string) (*setupRecoveryMarker, error) {
+	state, err := readSetupExistingPrivateFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if !state.Exists {
+		return nil, nil
+	}
+	var marker setupRecoveryMarker
+	if err := json.Unmarshal(state.Data, &marker); err != nil {
+		return nil, fmt.Errorf("decode setup recovery marker %s: %w", filename, err)
+	}
+	canonical, err := canonicalize.JCS(marker)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize setup recovery marker %s: %w", filename, err)
+	}
+	if !bytes.Equal(state.Data, canonical) {
+		return nil, fmt.Errorf("setup recovery marker %s is not canonical", filename)
+	}
+	if err := validateSetupRecoveryMarker(&marker); err != nil {
+		return nil, err
+	}
+	return &marker, nil
+}
+
+func writeSetupRecoveryMarker(dataDir, filename string, marker setupRecoveryMarker) error {
+	if err := validateSetupRecoveryMarker(&marker); err != nil {
+		return err
+	}
+	data, err := canonicalize.JCS(marker)
+	if err != nil {
+		return err
+	}
+	return writeSetupPrivateFile(setupRecoveryMarkerPath(dataDir, filename), data)
+}
+
+func removeSetupRecoveryMarker(dataDir, filename string) error {
+	path := setupRecoveryMarkerPath(dataDir, filename)
+	state, err := readSetupFileState(path)
+	if err != nil {
+		return err
+	}
+	if !state.Exists {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return syncSetupParentDirectory(path)
+}
+
+func setupRecoveryAllowedStageFile(name string) bool {
+	switch name {
+	case "inventory.json", "policy.draft.json", "mcp_quarantine_plan.json", "codex-project-binding.json":
+		return true
+	default:
+		return false
+	}
+}
+
+// isSetupRecoveryTemporaryName accepts only the exact shape emitted by
+// os.CreateTemp(dir, ".helm-setup-*") in writeSetupPrivateFile. Crash residue
+// is deliberately allowlisted only in the private recovery root and its
+// direct staged child; this must never become a generic cleanup rule.
+func isSetupRecoveryTemporaryName(name string) bool {
+	if !strings.HasPrefix(name, setupRecoveryTemporaryPrefix) {
+		return false
+	}
+	suffix := strings.TrimPrefix(name, setupRecoveryTemporaryPrefix)
+	if suffix == "" {
+		return false
+	}
+	for _, char := range suffix {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func validateSetupRecoveryTemporaryEntry(path string, info os.FileInfo) error {
+	if !isSetupRecoveryTemporaryName(filepath.Base(path)) {
+		return fmt.Errorf("invalid setup recovery temporary entry %q", filepath.Base(path))
+	}
+	mode := info.Mode()
+	if mode&os.ModeSymlink != 0 || !mode.IsRegular() || mode.Perm() != 0o600 || mode&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		return fmt.Errorf("invalid setup recovery temporary entry %q", filepath.Base(path))
+	}
+	if err := requireSetupPrivateFileOwner(path, info); err != nil {
+		return fmt.Errorf("invalid setup recovery temporary entry %q: %w", filepath.Base(path), err)
+	}
+	return nil
+}
+
+func setupRecoverySafeStagePath(dataDir, stageFile string) (string, error) {
+	if !setupRecoveryAllowedStageFile(stageFile) || filepath.Base(stageFile) != stageFile {
+		return "", fmt.Errorf("invalid setup recovery staged file %q", stageFile)
+	}
+	return setupRecoveryStagePath(dataDir, stageFile), nil
+}
+
+func inspectSetupRecoveryStageDirectory(dataDir string) (bool, error) {
+	stageDir := filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir)
+	info, err := os.Lstat(stageDir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return false, fmt.Errorf("invalid setup recovery staging directory %s", stageDir)
+	}
+	entries, err := os.ReadDir(stageDir)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return false, err
+		}
+		entryPath := filepath.Join(stageDir, entry.Name())
+		if isSetupRecoveryTemporaryName(entry.Name()) {
+			if err := validateSetupRecoveryTemporaryEntry(entryPath, entryInfo); err != nil {
+				return false, err
+			}
+			continue
+		}
+		if !setupRecoveryAllowedStageFile(entry.Name()) {
+			return false, fmt.Errorf("unexpected setup recovery staged entry %q", entry.Name())
+		}
+		if entryInfo.Mode()&os.ModeSymlink != 0 || !entryInfo.Mode().IsRegular() {
+			return false, fmt.Errorf("invalid setup recovery staged entry %q", entry.Name())
+		}
+	}
+	return true, nil
+}
+
+func inspectSetupRecovery(dataDir string) (setupRecoveryInspection, error) {
+	projectStateExists, authorityErr := inspectCodexProjectStateAuthority(dataDir)
+	if authorityErr != nil {
+		return setupRecoveryInspection{}, fmt.Errorf("inspect Codex project authority state: %w", authorityErr)
+	}
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	legacyInfo, legacyErr := os.Lstat(legacyRoot)
+	if legacyErr == nil {
+		if legacyInfo.Mode()&os.ModeSymlink != 0 || !legacyInfo.IsDir() {
+			return setupRecoveryInspection{}, fmt.Errorf("legacy unscoped Codex recovery state is invalid and must be inspected before native setup can continue")
+		}
+		return setupRecoveryInspection{}, fmt.Errorf("legacy unscoped Codex recovery state is present; migrate or resolve it before native setup can continue")
+	}
+	if !os.IsNotExist(legacyErr) {
+		return setupRecoveryInspection{}, legacyErr
+	}
+	if !projectStateExists {
+		return setupRecoveryInspection{State: setupRecoveryStateAbsent}, nil
+	}
+	root := setupRecoveryRoot(dataDir)
+	info, err := os.Lstat(root)
+	if os.IsNotExist(err) {
+		return setupRecoveryInspection{State: setupRecoveryStateAbsent}, nil
+	}
+	if err != nil {
+		return setupRecoveryInspection{}, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return setupRecoveryInspection{}, fmt.Errorf("invalid setup recovery directory %s", root)
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return setupRecoveryInspection{}, err
+	}
+	known := map[string]bool{
+		setupRecoveryJournalFile:   true,
+		setupRecoveryStagingDir:    true,
+		setupRecoveryPreparingFile: true,
+		setupRecoveryCommittedFile: true,
+	}
+	nonTemporaryEntries := 0
+	for _, entry := range entries {
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return setupRecoveryInspection{}, err
+		}
+		entryPath := filepath.Join(root, entry.Name())
+		if isSetupRecoveryTemporaryName(entry.Name()) {
+			if err := validateSetupRecoveryTemporaryEntry(entryPath, entryInfo); err != nil {
+				return setupRecoveryInspection{}, err
+			}
+			continue
+		}
+		if !known[entry.Name()] {
+			return setupRecoveryInspection{}, fmt.Errorf("unexpected setup recovery entry %q", entry.Name())
+		}
+		nonTemporaryEntries++
+		if entryInfo.Mode()&os.ModeSymlink != 0 {
+			return setupRecoveryInspection{}, fmt.Errorf("refusing setup recovery through symlinked entry %q", entry.Name())
+		}
+		if entry.Name() == setupRecoveryStagingDir {
+			if !entryInfo.IsDir() {
+				return setupRecoveryInspection{}, fmt.Errorf("setup recovery staging entry is not a directory")
+			}
+		} else if !entryInfo.Mode().IsRegular() {
+			return setupRecoveryInspection{}, fmt.Errorf("setup recovery entry %q is not a regular file", entry.Name())
+		}
+	}
+
+	stageExists, err := inspectSetupRecoveryStageDirectory(dataDir)
+	if err != nil {
+		return setupRecoveryInspection{}, err
+	}
+	journal, err := readSetupRecoveryJournal(dataDir)
+	if err != nil {
+		return setupRecoveryInspection{}, err
+	}
+	preparing, err := readSetupRecoveryMarker(dataDir, setupRecoveryPreparingFile)
+	if err != nil {
+		return setupRecoveryInspection{}, err
+	}
+	committed, err := readSetupRecoveryMarker(dataDir, setupRecoveryCommittedFile)
+	if err != nil {
+		return setupRecoveryInspection{}, err
+	}
+
+	if committed != nil {
+		terminal, terminalErr := verifyCommittedSetupRecoveryTerminal(dataDir, committed, journal)
+		if terminalErr != nil {
+			if journal == nil {
+				return setupRecoveryInspection{}, fmt.Errorf("committed setup recovery marker cannot be verified: %w", terminalErr)
+			}
+			// A journal is still present, so an unsigned or damaged marker must
+			// never discard the resumable transaction or open the runtime gate.
+			// Treat it as pending and let a real resume write a new signed marker.
+		} else if terminal {
+			return setupRecoveryInspection{State: setupRecoveryStateCommitted, Journal: journal}, nil
+		} else if journal == nil {
+			return setupRecoveryInspection{}, fmt.Errorf("committed setup recovery marker has no terminal proof")
+		}
+	}
+	if journal != nil {
+		if !stageExists {
+			return setupRecoveryInspection{}, fmt.Errorf("prepared setup recovery journal has no staging directory")
+		}
+		return setupRecoveryInspection{State: setupRecoveryStatePending, Journal: journal}, nil
+	}
+	if preparing != nil || stageExists || nonTemporaryEntries == 0 {
+		// Before a journal is durable, no shared client configuration has been
+		// touched. This is still surfaced as recovery-required so a caller must
+		// use `setup recover --yes` to remove only this known private residue.
+		return setupRecoveryInspection{State: setupRecoveryStatePrepared}, nil
+	}
+	return setupRecoveryInspection{}, fmt.Errorf("unclassifiable setup recovery state")
+}
+
+func setupRecoveryRequired(dataDir string) (bool, error) {
+	inspection, err := inspectSetupRecovery(dataDir)
+	if err != nil {
+		return false, err
+	}
+	return inspection.State == setupRecoveryStatePrepared || inspection.State == setupRecoveryStatePending, nil
+}
+
+func ensureSetupDirectory(path string, mode os.FileMode) error {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	var missing []string
+	for current := absPath; ; current = filepath.Dir(current) {
+		info, statErr := os.Lstat(current)
+		if statErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+				return fmt.Errorf("refusing to create setup state beneath invalid directory %s", current)
+			}
+			break
+		}
+		if !os.IsNotExist(statErr) {
+			return statErr
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return fmt.Errorf("cannot find an existing parent for setup directory %s", absPath)
+		}
+		missing = append(missing, current)
+	}
+	for index := len(missing) - 1; index >= 0; index-- {
+		dir := missing[index]
+		if err := os.Mkdir(dir, mode); err != nil && !os.IsExist(err) {
+			return err
+		}
+		info, err := os.Lstat(dir)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return fmt.Errorf("setup directory is not a real directory: %s", dir)
+		}
+		if err := syncSetupDirectory(filepath.Dir(dir)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func createSetupRecoveryDirectory(path string, mode os.FileMode) error {
+	if err := os.Mkdir(path, mode); err != nil {
+		return err
+	}
+	return syncSetupDirectory(filepath.Dir(path))
+}
+
+func prepareSetupRecoveryDirectory(dataDir string) error {
+	if err := ensureCodexProjectStateAuthority(dataDir); err != nil {
+		return err
+	}
+	inspection, err := inspectSetupRecovery(dataDir)
+	if err != nil {
+		return err
+	}
+	switch inspection.State {
+	case setupRecoveryStateCommitted:
+		if err := cleanupCommittedSetupRecoveryDirectory(dataDir); err != nil {
+			return fmt.Errorf("clean completed setup recovery residue: %w", err)
+		}
+	case setupRecoveryStatePrepared, setupRecoveryStatePending:
+		return fmt.Errorf("setup recovery is pending; run `helm-ai-kernel setup recover codex --scope project --yes` before starting a new transaction")
+	}
+
+	root := setupRecoveryRoot(dataDir)
+	if err := createSetupRecoveryDirectory(root, 0o700); err != nil {
+		return err
+	}
+	if err := createSetupRecoveryDirectory(filepath.Join(root, setupRecoveryStagingDir), 0o700); err != nil {
+		return err
+	}
+	// Persist this marker immediately. A crash before it appears leaves only
+	// an empty owned root/staging shape, which inspectSetupRecovery classifies
+	// as prepared and recovery can clean without touching shared config.
+	return writeSetupRecoveryMarker(dataDir, setupRecoveryPreparingFile, setupRecoveryMarker{
+		SchemaVersion: setupRecoveryMarkerSchema,
+		State:         setupRecoveryMarkerStatePreparing,
+	})
+}
+
+func removeSetupRecoveryKnownFile(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return fmt.Errorf("refusing to remove invalid setup recovery file %s", path)
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return syncSetupParentDirectory(path)
+}
+
+func removeSetupRecoveryKnownDirectory(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("refusing to remove invalid setup recovery directory %s", path)
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return syncSetupParentDirectory(path)
+}
+
+// removeSetupRecoveryTemporaryEntries removes only exact writer-shaped crash
+// residue from a direct child directory. It intentionally does not recurse:
+// any nested or malformed entry remains an invalid recovery state for a human
+// to inspect instead of being silently deleted.
+func removeSetupRecoveryTemporaryEntries(directory string) error {
+	info, err := os.Lstat(directory)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("invalid setup recovery temporary directory %s", directory)
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if !isSetupRecoveryTemporaryName(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(directory, entry.Name())
+		entryInfo, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if err := validateSetupRecoveryTemporaryEntry(path, entryInfo); err != nil {
+			return err
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		if err := syncSetupParentDirectory(path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func cleanupSetupRecoveryDirectory(dataDir string, terminal bool) error {
+	inspection, err := inspectSetupRecovery(dataDir)
+	if err != nil {
+		return err
+	}
+	if terminal {
+		if inspection.State == setupRecoveryStateAbsent {
+			return nil
+		}
+		if inspection.State != setupRecoveryStateCommitted {
+			return fmt.Errorf("setup recovery transaction is not committed")
+		}
+	} else {
+		if inspection.State == setupRecoveryStateAbsent {
+			return nil
+		}
+		if inspection.State != setupRecoveryStatePrepared {
+			return fmt.Errorf("setup recovery journal is durable; resume it instead of discarding it")
+		}
+	}
+	stageDir := filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir)
+	if err := removeSetupRecoveryTemporaryEntries(stageDir); err != nil {
+		return err
+	}
+	if err := removeSetupRecoveryTemporaryEntries(setupRecoveryRoot(dataDir)); err != nil {
+		return err
+	}
+
+	for _, stageFile := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json", "codex-project-binding.json"} {
+		stagePath, err := setupRecoverySafeStagePath(dataDir, stageFile)
+		if err != nil {
+			return err
+		}
+		if err := removeSetupRecoveryKnownFile(stagePath); err != nil {
+			return err
+		}
+	}
+	if err := removeSetupRecoveryKnownDirectory(stageDir); err != nil {
+		return err
+	}
+	if terminal {
+		if err := removeSetupRecoveryMarker(dataDir, setupRecoveryPreparingFile); err != nil {
+			return err
+		}
+		if err := removeSetupRecoveryKnownFile(setupRecoveryJournalPath(dataDir)); err != nil {
+			return err
+		}
+	}
+	if err := removeSetupRecoveryMarker(dataDir, setupRecoveryPreparingFile); err != nil {
+		return err
+	}
+	if terminal {
+		if err := removeSetupRecoveryMarker(dataDir, setupRecoveryCommittedFile); err != nil {
+			return err
+		}
+	}
+	return removeSetupRecoveryKnownDirectory(setupRecoveryRoot(dataDir))
+}
+
+func cleanupIncompleteSetupRecoveryDirectory(dataDir string) error {
+	return cleanupSetupRecoveryDirectory(dataDir, false)
+}
+
+func cleanupCommittedSetupRecoveryDirectory(dataDir string) error {
+	return cleanupSetupRecoveryDirectory(dataDir, true)
+}
+
+func removeSetupRecoveryJournal(dataDir string, journal *setupRecoveryJournal) error {
+	if journal == nil {
+		return nil
+	}
+	if err := validateSetupRecoveryJournal(journal); err != nil {
+		return err
+	}
+	inspection, err := inspectSetupRecovery(dataDir)
+	if err != nil {
+		return err
+	}
+	if inspection.State == setupRecoveryStateAbsent {
+		return nil
+	}
+	if inspection.State != setupRecoveryStateCommitted {
+		if inspection.Journal == nil || inspection.Journal.TransactionID != journal.TransactionID || inspection.Journal.LifecycleReceiptID != journal.LifecycleReceiptID {
+			return fmt.Errorf("setup recovery journal changed before finalization")
+		}
+		marker, err := newSignedSetupRecoveryCommittedMarker(dataDir, journal)
+		if err != nil {
+			return err
+		}
+		if err := writeSetupRecoveryMarker(dataDir, setupRecoveryCommittedFile, marker); err != nil {
+			return err
+		}
+	}
+	// Once COMMITTED is durable, config and lifecycle evidence have completed.
+	// A process death in cleanup is terminal, not a new rollback/replay state;
+	// the next setup/recover safely retries only this allowlisted cleanup.
+	return cleanupCommittedSetupRecoveryDirectory(dataDir)
+}
+
+func lookupSetupRecoveryFilePlan(journal *setupRecoveryJournal, id string) (setupRecoveryFilePlan, error) {
+	if err := validateSetupRecoveryJournal(journal); err != nil {
+		return setupRecoveryFilePlan{}, err
+	}
+	for _, plan := range journal.Files {
+		if plan.ID == id {
+			return plan, nil
+		}
+	}
+	return setupRecoveryFilePlan{}, fmt.Errorf("setup recovery journal has no %s plan", id)
+}

--- a/core/cmd/helm-ai-kernel/setup_recovery_security_test.go
+++ b/core/cmd/helm-ai-kernel/setup_recovery_security_test.go
@@ -1,0 +1,2094 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+func writeSetupSecurityPendingJournal(t *testing.T, dataDir, operation string, plans []setupRecoveryFilePlan) *setupRecoveryJournal {
+	t.Helper()
+	if err := prepareSetupRecoveryDirectory(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if plans == nil {
+		specs, err := expectedSetupRecoveryPlans(operation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		plans = make([]setupRecoveryFilePlan, 0, len(specs))
+		for _, spec := range specs {
+			plans = append(plans, setupRecoveryFilePlan{ID: spec.ID, StageFile: spec.StageFile})
+		}
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := inspectSetupKernelBinary(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	txnID, err := newSetupRecoveryTransactionID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptID, err := newSetupLifecycleReceiptID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := &setupRecoveryJournal{
+		SchemaVersion:      setupRecoverySchema,
+		TransactionID:      txnID,
+		Operation:          operation,
+		Target:             "codex",
+		Scope:              "project",
+		WorkspacePathHash:  workspacePathHash,
+		DataDirPathHash:    canonicalize.HashBytes([]byte(dataDir)),
+		BinaryPath:         identity.Path,
+		BinaryContentHash:  identity.ContentHash,
+		LifecycleReceiptID: receiptID,
+		Phase:              setupRecoveryPhasePrepared,
+		Files:              plans,
+	}
+	if err := writeSetupRecoveryJournal(dataDir, *journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeSetupRecoveryMarker(dataDir, setupRecoveryPreparingFile); err != nil {
+		t.Fatal(err)
+	}
+	return journal
+}
+
+func writeSetupRecoveryCrashTemp(t *testing.T, directory, suffix string) string {
+	t.Helper()
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, setupRecoveryTemporaryPrefix+suffix)
+	if err := os.WriteFile(path, []byte("incomplete private write"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSetupRecoveryPreparedResidueFailsClosedThenRecovers(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	if err := os.MkdirAll(filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeSetupRecoveryCrashTemp(t, setupRecoveryRoot(dataDir), "101")
+	writeSetupRecoveryCrashTemp(t, filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir), "102")
+
+	pending, err := setupRecoveryRequired(dataDir)
+	if err != nil || !pending {
+		t.Fatalf("pre-journal residue pending=%v err=%v", pending, err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("status exit=%d stderr=%s", code, stderr.String())
+	}
+	var status setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil || !status.RecoveryRequired {
+		t.Fatalf("prepared residue status=%#v err=%v", status, err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("pending hook did not deny safely: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, path := range []string{filepath.Join(dataDir, "root.key"), filepath.Join(dataDir, "receipts", "hooks")} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("pending hook created state %s: %v", path, err)
+		}
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("prepared residue did not block MCP: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover prepared residue exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("recover retained pre-journal residue: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("fresh setup stayed blocked after residue cleanup: code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestSetupRecoveryUnexpectedResidueIsPreservedAndFailsClosed(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	root := setupRecoveryRoot(dataDir)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	unknown := filepath.Join(root, "not-owned")
+	if err := os.WriteFile(unknown, []byte("user-data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "unexpected") {
+		t.Fatalf("status did not fail closed: code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "unexpected") {
+		t.Fatalf("recover accepted unknown residue: code=%d stderr=%s", code, stderr.String())
+	}
+	if raw, err := os.ReadFile(unknown); err != nil || string(raw) != "user-data" {
+		t.Fatalf("recover modified unknown residue: raw=%q err=%v", raw, err)
+	}
+}
+
+func TestSetupRecoveryPendingJournalToleratesOnlyWriterShapedCrashTemps(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	previousRecord := recordCodexProjectSetupLifecycleFn
+	recordCodexProjectSetupLifecycleFn = func(setupOptions, setupSummary, string) (setupLifecycleResult, error) {
+		return setupLifecycleResult{}, errors.New("injected lifecycle failure")
+	}
+	t.Cleanup(func() { recordCodexProjectSetupLifecycleFn = previousRecord })
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("setup with injected lifecycle failure exit=%d stderr=%s", code, stderr.String())
+	}
+	if inspection, err := inspectSetupRecovery(dataDir); err != nil || inspection.State != setupRecoveryStatePending {
+		t.Fatalf("initial pending recovery inspection=%#v err=%v", inspection, err)
+	}
+	writeSetupRecoveryCrashTemp(t, setupRecoveryRoot(dataDir), "201")
+	writeSetupRecoveryCrashTemp(t, filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir), "202")
+	if inspection, err := inspectSetupRecovery(dataDir); err != nil || inspection.State != setupRecoveryStatePending {
+		t.Fatalf("pending recovery rejected writer-shaped temps: inspection=%#v err=%v", inspection, err)
+	}
+
+	recordCodexProjectSetupLifecycleFn = previousRecord
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("pending recovery with crash temps exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("pending recovery left temporary residue: %v", err)
+	}
+
+	db, _, receiptStore, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var count int
+	if err := db.QueryRow("SELECT COUNT(1) FROM receipts WHERE status = 'DENY'").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("recovered install wrote %d lifecycle receipts, want one", count)
+	}
+	if _, err := receiptStore.GetByReceiptID(context.Background(), func() string {
+		var id string
+		if err := db.QueryRow("SELECT receipt_id FROM receipts WHERE status = 'DENY' LIMIT 1").Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}()); err != nil {
+		t.Fatalf("recovered lifecycle receipt unreadable: %v", err)
+	}
+}
+
+func TestSetupRecoveryRejectsMalformedTemporaryResidueWithoutDeletingIt(t *testing.T) {
+	cases := []struct {
+		name   string
+		stage  bool
+		create func(t *testing.T, path string, external string)
+	}{
+		{
+			name: "unknown root file",
+			create: func(t *testing.T, path string, _ string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("user-data"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "temporary-shaped staged symlink",
+			stage: true,
+			create: func(t *testing.T, path string, external string) {
+				t.Helper()
+				if err := os.Symlink(external, path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "temporary-shaped root directory",
+			create: func(t *testing.T, path string, _ string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "temporary-shaped staged wrong mode",
+			stage: true,
+			create: func(t *testing.T, path string, _ string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("must-remain"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(path, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := chdirTempDir(t)
+			dataDir := filepath.Join(dir, "helm")
+			root := setupRecoveryRoot(dataDir)
+			stageDir := filepath.Join(root, setupRecoveryStagingDir)
+			if err := os.MkdirAll(stageDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			directory := root
+			name := "not-owned"
+			if tc.stage {
+				directory = stageDir
+				name = setupRecoveryTemporaryPrefix + "303"
+			} else if strings.Contains(tc.name, "temporary-shaped") {
+				name = setupRecoveryTemporaryPrefix + "304"
+			}
+			path := filepath.Join(directory, name)
+			external := filepath.Join(dir, "external")
+			if err := os.WriteFile(external, []byte("outside"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			tc.create(t, path, external)
+
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr); code != 2 {
+				t.Fatalf("status accepted malformed temporary residue: code=%d stderr=%s", code, stderr.String())
+			}
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+				t.Fatalf("recover accepted malformed temporary residue: code=%d stderr=%s", code, stderr.String())
+			}
+			if _, err := os.Lstat(path); err != nil {
+				t.Fatalf("recover removed malformed temporary residue: %v", err)
+			}
+			if got, err := os.ReadFile(external); err != nil || string(got) != "outside" {
+				t.Fatalf("recover touched symlink target: got=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestForgedCodexRemovalJournalCannotAlterUnprovenConfig(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+	clientBefore, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookBefore, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientAfter, err := buildRemoveCodexProjectMCPStateForBinary(clientBefore, dataDir, summary.BinaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookAfter, err := buildRemoveOwnedSetupHookState(hookBefore, opts.Target, setupHookCommand(opts, summary.BinaryPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSetupSecurityPendingJournal(t, dataDir, "remove", []setupRecoveryFilePlan{
+		setupRecoveryPlanForStates(setupRecoveryFileMCP, clientBefore, clientAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileHook, hookBefore, hookAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileBinding, setupFileState{Path: setupCodexProjectBindingPath(dataDir)}, setupFileState{Path: setupCodexProjectBindingPath(dataDir)}, ""),
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "provenance") {
+		t.Fatalf("forged removal journal was not rejected: code=%d stderr=%s", code, stderr.String())
+	}
+	clientAfterAttempt, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil || !bytes.Equal(clientAfterAttempt, clientBefore.Data) {
+		t.Fatalf("forged removal journal changed MCP config: %q err=%v", clientAfterAttempt, err)
+	}
+	hookAfterAttempt, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil || !bytes.Equal(hookAfterAttempt, hookBefore.Data) {
+		t.Fatalf("forged removal journal changed hook config: %q err=%v", hookAfterAttempt, err)
+	}
+	for _, path := range []string{filepath.Join(dataDir, "root.key"), filepath.Join(dataDir, "helm.db")} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("forged removal journal created lifecycle state %s: %v", path, err)
+		}
+	}
+}
+
+func TestCodexRemovalRecoveryCompletesAfterBindingDeletedBeforeTerminalMarker(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+
+	previousFinalize := finalizeCodexProjectRecoveryJournal
+	finalizeCodexProjectRecoveryJournal = func(_ string, _ *setupRecoveryJournal) error {
+		return errors.New("injected pre-marker finalization failure")
+	}
+	t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("remove with injected finalization failure exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(setupCodexProjectBindingPath(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("binding survived the intended post-revocation crash boundary: %v", err)
+	}
+	if inspection, err := inspectSetupRecovery(dataDir); err != nil || inspection.State != setupRecoveryStatePending {
+		t.Fatalf("post-binding-delete recovery inspection=%#v err=%v", inspection, err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("pending post-binding-delete recovery did not block MCP: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("pending post-binding-delete recovery did not deny hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var revokedBefore int
+	if err := db.QueryRow("SELECT COUNT(1) FROM receipts WHERE status = 'REVOKED'").Scan(&revokedBefore); err != nil {
+		t.Fatal(err)
+	}
+	if revokedBefore != 1 {
+		t.Fatalf("post-binding-delete state has %d revoked receipts, want one", revokedBefore)
+	}
+
+	finalizeCodexProjectRecoveryJournal = previousFinalize
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recover after binding delete exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("completed removal recovery left recovery root: %v", err)
+	}
+	var revokedAfter int
+	if err := db.QueryRow("SELECT COUNT(1) FROM receipts WHERE status = 'REVOKED'").Scan(&revokedAfter); err != nil {
+		t.Fatal(err)
+	}
+	if revokedAfter != 1 {
+		t.Fatalf("completed removal recovery duplicated revoked receipt: before=%d after=%d", revokedBefore, revokedAfter)
+	}
+	refreshSetupConfiguration(opts, &summary)
+	if summary.MCPConfigured || summary.HookConfigured {
+		t.Fatalf("completed removal recovery restored owned config: %#v", summary)
+	}
+}
+
+func TestCodexRemovalRecoveryAfterBindingDeleteRefusesChangedConfig(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	previousFinalize := finalizeCodexProjectRecoveryJournal
+	finalizeCodexProjectRecoveryJournal = func(_ string, _ *setupRecoveryJournal) error {
+		return errors.New("injected pre-marker finalization failure")
+	}
+	t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("remove with injected finalization failure exit=%d stderr=%s", code, stderr.String())
+	}
+	const userChange = "# user changed this after HELM removed its MCP\n"
+	if err := os.WriteFile(summary.ClientConfigPath, []byte(userChange), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	finalizeCodexProjectRecoveryJournal = previousFinalize
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "post-removal") {
+		t.Fatalf("recovery accepted a post-revocation config edit: code=%d stderr=%s", code, stderr.String())
+	}
+	if got, err := os.ReadFile(summary.ClientConfigPath); err != nil || string(got) != userChange {
+		t.Fatalf("recovery overwrote user config after binding deletion: got=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatalf("recovery discarded journal after a concurrent edit: %v", err)
+	}
+}
+
+func TestBindingAbsentRemovalJournalWithoutSignedRevocationCannotMutateConfig(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	clientBefore, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookBefore, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparation, err := prepareCodexProjectRecoveryRemove(opts, summary)
+	if err != nil || preparation.journal == nil {
+		t.Fatalf("prepare removal journal err=%v preparation=%#v", err, preparation)
+	}
+	if err := os.Remove(setupCodexProjectBindingPath(dataDir)); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("binding-absent journal without signed revocation recovered: code=%d stderr=%s", code, stderr.String())
+	}
+	if got, err := os.ReadFile(summary.ClientConfigPath); err != nil || !bytes.Equal(got, clientBefore) {
+		t.Fatalf("unsigned binding-absent journal changed MCP config: got=%q err=%v", got, err)
+	}
+	if got, err := os.ReadFile(summary.HookConfigPath); err != nil || !bytes.Equal(got, hookBefore) {
+		t.Fatalf("unsigned binding-absent journal changed hook config: got=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatalf("unsigned binding-absent journal was discarded: %v", err)
+	}
+}
+
+func TestCodexProjectsShareAuthorityStateWithoutSharingBindingsRecoveryOrArtifacts(t *testing.T) {
+	root := t.TempDir()
+	projectA := filepath.Join(root, "project-a")
+	projectB := filepath.Join(root, "project-b")
+	for _, project := range []string{projectA, projectB} {
+		if err := os.MkdirAll(project, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	enterProject := func(project string) {
+		t.Helper()
+		if err := os.Chdir(project); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stubSetupSideEffects(t)
+	dataDir := filepath.Join(root, "shared-kernel-state")
+	setup := func(project string) setupCodexProjectPaths {
+		t.Helper()
+		enterProject(project)
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+			t.Fatalf("setup %s exit=%d stderr=%s stdout=%s", project, code, stderr.String(), stdout.String())
+		}
+		paths, err := newSetupCodexProjectPaths(setupOptions{Target: "codex", Scope: "project", DataDir: dataDir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return paths
+	}
+	pathsA := setup(projectA)
+	pathsB := setup(projectB)
+	if pathsA.StateRoot == pathsB.StateRoot || pathsA.BindingPath == pathsB.BindingPath || pathsA.RecoveryRoot == pathsB.RecoveryRoot || pathsA.ArtifactsDir == pathsB.ArtifactsDir {
+		t.Fatalf("project state namespaces collided: A=%#v B=%#v", pathsA, pathsB)
+	}
+	for _, path := range []string{pathsA.BindingPath, filepath.Join(pathsA.ArtifactsDir, "policy.draft.json"), pathsB.BindingPath, filepath.Join(pathsB.ArtifactsDir, "policy.draft.json")} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("missing project-scoped native state %s: %v", path, err)
+		}
+	}
+
+	enterProject(projectA)
+	if _, configured, err := admitCodexProjectRuntime(dataDir); err != nil || !configured {
+		t.Fatalf("project A lost runtime admission after project B setup: configured=%v err=%v", configured, err)
+	}
+	if err := prepareSetupRecoveryDirectory(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("project A prepared recovery was not project-local pending state: pending=%v err=%v", pending, err)
+	}
+
+	enterProject(projectB)
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("project A recovery incorrectly blocked project B: pending=%v err=%v", pending, err)
+	}
+	if _, configured, err := admitCodexProjectRuntime(dataDir); err != nil || !configured {
+		t.Fatalf("project B runtime admission failed while A recovery was pending: configured=%v err=%v", configured, err)
+	}
+
+	enterProject(projectA)
+	if err := cleanupIncompleteSetupRecoveryDirectory(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("remove project A exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(pathsA.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("removing project A retained its binding: %v", err)
+	}
+
+	enterProject(projectB)
+	if _, err := os.Stat(pathsB.BindingPath); err != nil {
+		t.Fatalf("removing project A altered project B binding: %v", err)
+	}
+	if _, configured, err := admitCodexProjectRuntime(dataDir); err != nil || !configured {
+		t.Fatalf("project B lost runtime admission after A removal: configured=%v err=%v", configured, err)
+	}
+}
+
+func TestLegacyUnscopedRecoveryStateBlocksNamespacedCodexEntrypoints(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.MkdirAll(filepath.Join(legacyRoot, setupRecoveryStagingDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, setupRecoveryJournalFile), []byte(`{"schema_version":"helm.codex-project-recovery/v1"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr); code != 2 || !strings.Contains(stderr.String(), "legacy unscoped") {
+		t.Fatalf("status ignored legacy recovery state: code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "legacy unscoped") {
+		t.Fatalf("setup ignored legacy recovery state: code=%d stderr=%s", code, stderr.String())
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "legacy unscoped") {
+		t.Fatalf("MCP ignored legacy recovery state: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("hook ignored legacy recovery state: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "root.key")); !os.IsNotExist(err) {
+		t.Fatalf("legacy-blocked entrypoint created new lifecycle authority: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(legacyRoot, setupRecoveryJournalFile)); err != nil {
+		t.Fatalf("legacy-blocked entrypoint altered recovery journal: %v", err)
+	}
+}
+
+func TestForgedCommittedMarkerKeepsLiveJournalPending(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	journal := writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+	if err := writeSetupRecoveryMarker(dataDir, setupRecoveryCommittedFile, setupRecoveryMarker{
+		SchemaVersion:      setupRecoveryMarkerSchema,
+		State:              setupRecoveryMarkerStateCommitted,
+		TransactionID:      journal.TransactionID,
+		LifecycleReceiptID: journal.LifecycleReceiptID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := setupRecoveryRequired(dataDir)
+	if err != nil || !pending {
+		t.Fatalf("forged committed marker unblocked recovery: pending=%v err=%v", pending, err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("forged committed marker unblocked MCP: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("forged committed marker unblocked hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatalf("forged marker discarded live journal: %v", err)
+	}
+}
+
+func TestStagedCodexBindingCannotBeReplayedBeforeConfigMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparation, err := prepareCodexProjectRecoveryInstall(opts, summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindingPath, err := setupRecoverySafeStagePath(dataDir, setupCodexProjectBindingFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := readSetupFileState(bindingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var binding setupCodexProjectBinding
+	if err := decodeCanonicalSetupJSON(state.Data, &binding); err != nil {
+		t.Fatal(err)
+	}
+	binding.InstallReceiptID, err = newSetupLifecycleReceiptID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered, err := canonicalize.JCS(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(bindingPath, tampered); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := resumeCodexProjectRecovery(opts, preparation.summary, preparation.journal); err == nil || !strings.Contains(err.Error(), "staged") {
+		t.Fatalf("replayed staged binding was accepted: %v", err)
+	}
+	for _, path := range []string{summary.ClientConfigPath, summary.HookConfigPath, setupCodexProjectBindingPath(dataDir)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("invalid staged binding changed durable config %s: %v", path, err)
+		}
+	}
+}
+
+func TestLifecycleReceiptReadBackRejectsAfterInsertMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	previousPrepared := setupLifecycleStorePrepared
+	setupLifecycleStorePrepared = func(db *sql.DB) error {
+		_, err := db.Exec(`CREATE TRIGGER helm_setup_tamper AFTER INSERT ON receipts BEGIN UPDATE receipts SET signature = '00' WHERE receipt_id = NEW.receipt_id; END;`)
+		return err
+	}
+	t.Cleanup(func() { setupLifecycleStorePrepared = previousPrepared })
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || (!strings.Contains(stderr.String(), "failed verification") && !strings.Contains(stderr.String(), "receipt envelope does not match")) {
+		t.Fatalf("tampered appended receipt was accepted: code=%d stderr=%s", code, stderr.String())
+	}
+	pending, err := setupRecoveryRequired(dataDir)
+	if err != nil || !pending {
+		t.Fatalf("tampered receipt did not retain recovery: pending=%v err=%v", pending, err)
+	}
+	if _, err := os.Stat(setupCodexProjectBindingPath(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("tampered receipt published install binding: %v", err)
+	}
+}
+
+func TestRemovalProvenanceFailureDoesNotMutateReceiptStore(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientBefore, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientTampered := append(append([]byte(nil), clientBefore...), []byte("# user-owned change\n")...)
+	if err := writeSetupPrivateFile(summary.ClientConfigPath, clientTampered); err != nil {
+		t.Fatal(err)
+	}
+	dbBefore, err := os.ReadFile(filepath.Join(dataDir, "helm.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	walPath := filepath.Join(dataDir, "helm.db-wal")
+	walBefore, walBeforeErr := os.ReadFile(walPath)
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "differs from its proven install binding") {
+		t.Fatalf("tampered config removal did not fail provenance: code=%d stderr=%s", code, stderr.String())
+	}
+	dbAfter, err := os.ReadFile(filepath.Join(dataDir, "helm.db"))
+	if err != nil || !bytes.Equal(dbAfter, dbBefore) {
+		t.Fatalf("failed provenance check changed lifecycle DB: equal=%v err=%v", bytes.Equal(dbAfter, dbBefore), err)
+	}
+	walAfter, walAfterErr := os.ReadFile(walPath)
+	if (walBeforeErr == nil) != (walAfterErr == nil) || walBeforeErr == nil && !bytes.Equal(walAfter, walBefore) {
+		t.Fatalf("failed provenance check changed lifecycle WAL: beforeErr=%v afterErr=%v", walBeforeErr, walAfterErr)
+	}
+	clientAfter, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil || !bytes.Equal(clientAfter, clientTampered) {
+		t.Fatalf("failed provenance check changed user config: %q err=%v", clientAfter, err)
+	}
+}
+
+func TestLifecycleEvidenceRejectsSymlinkAndDuplicateJSON(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := readSetupLifecycleReceiptReadOnly(context.Background(), dataDir, summary.LifecycleReceiptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Type != "native_client_setup_lifecycle" || receipt.Action != "install" || receipt.Verdict != "DENY" || receipt.ToolName != "file_write" || receipt.ReasonCode != "ERR_SYNTHETIC_FILE_WRITE_DENIED" || receipt.SignatureProfile == "" || receipt.SignatureAlgorithm == "" || receipt.KeyID == "" {
+		t.Fatalf("read-only lifecycle proof lost canonical receipt fields: %#v", receipt)
+	}
+	original, err := os.ReadFile(summary.LifecycleEvidencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(dir, "external-evidence.json")
+	if err := os.WriteFile(external, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(summary.LifecycleEvidencePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, summary.LifecycleEvidencePath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifySetupLifecycleEvidence(dataDir, receipt); err == nil {
+		t.Fatal("symlinked lifecycle evidence unexpectedly verified")
+	}
+	if err := os.Remove(summary.LifecycleEvidencePath); err != nil {
+		t.Fatal(err)
+	}
+	needle := `"receipt_id":"` + summary.LifecycleReceiptID + `"`
+	duplicate := strings.Replace(string(original), needle, `"receipt_id":"tampered","receipt_id":"`+summary.LifecycleReceiptID+`"`, 1)
+	if duplicate == string(original) {
+		t.Fatal("fixture did not locate receipt_id in canonical evidence")
+	}
+	if err := writeSetupPrivateFile(summary.LifecycleEvidencePath, []byte(duplicate)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifySetupLifecycleEvidence(dataDir, receipt); err == nil {
+		t.Fatal("duplicate-key lifecycle evidence unexpectedly verified")
+	}
+	db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`UPDATE receipts SET receipt_envelope = '' WHERE receipt_id = ?`, summary.LifecycleReceiptID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readSetupLifecycleReceiptReadOnly(context.Background(), dataDir, summary.LifecycleReceiptID); err == nil || !strings.Contains(err.Error(), "predates canonical durable receipt envelopes") {
+		t.Fatalf("legacy receipt projection was accepted as native lifecycle authority: %v", err)
+	}
+}
+
+func TestLifecycleSignerRejectsMalformedAndSymlinkedRootKey(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rootPath := filepath.Join(dataDir, "root.key")
+	if err := writeSetupPrivateFile(rootPath, []byte("00")); err != nil {
+		t.Fatal(err)
+	}
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("malformed root.key panicked: %v", recovered)
+			}
+		}()
+		if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "seed size") {
+			t.Fatalf("malformed root.key error=%v", err)
+		}
+	}()
+	if err := os.Remove(rootPath); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(dir, "external-root.key")
+	if err := os.WriteFile(external, []byte("00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, rootPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlinked root.key error=%v", err)
+	}
+}
+
+func TestLifecycleSignerRejectsInsecureExistingPrivateKeyModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX 0600 boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	rootPath := filepath.Join(dataDir, "root.key")
+	if err := os.Chmod(rootPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadExistingEd25519Root(dataDir); err == nil || !strings.Contains(err.Error(), "exact mode 0600") {
+		t.Fatalf("insecure root.key mode accepted: %v", err)
+	}
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "exact mode 0600") {
+		t.Fatalf("load-or-generate accepted insecure root.key mode: %v", err)
+	}
+	if err := os.Chmod(rootPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HELM_RECEIPT_PROFILE", "hybrid")
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	mlDSAPath := filepath.Join(dataDir, "root.mldsa65.key")
+	if err := os.Chmod(mlDSAPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadExistingMLDSARoot(dataDir); err == nil || !strings.Contains(err.Error(), "exact mode 0600") {
+		t.Fatalf("insecure ML-DSA root mode accepted: %v", err)
+	}
+}
+
+func TestLifecycleSignerRejectsInvalidProfileBeforeAuthorityStateCreation(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "fresh-authority")
+	t.Setenv("HELM_RECEIPT_PROFILE", "invalid-profile")
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "unknown HELM_RECEIPT_PROFILE") {
+		t.Fatalf("invalid receipt profile was accepted: %v", err)
+	}
+	for _, path := range []string{
+		dataDir,
+		filepath.Join(dataDir, "root.key"),
+		filepath.Join(dataDir, "root.mldsa65.key"),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("invalid receipt profile created authority state %s: %v", path, err)
+		}
+	}
+}
+
+func TestCodexProjectSetupRejectsWorldWritableAuthorityDataDirBeforeConfigMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "shared-authority")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dataDir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dataDir, 0o700) })
+	stubSetupSideEffects(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "unsafe Codex project authority state") || !strings.Contains(stderr.String(), "group/world-writable") {
+		t.Fatalf("unsafe authority setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, path := range []string{
+		filepath.Join(dir, ".codex", "config.toml"),
+		filepath.Join(dir, ".codex", "hooks.json"),
+		filepath.Join(dataDir, "root.key"),
+		setupRecoveryRoot(dataDir),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("unsafe authority setup mutated %s: %v", path, err)
+		}
+	}
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("signer accepted world-writable authority data dir: %v", err)
+	}
+}
+
+func TestAuthoritySubdirectoryRejectsExistingWorldWritableStateComponent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dataDir := filepath.Join(t.TempDir(), "authority")
+	if _, err := ensureSetupAuthorityDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	unsafe := filepath.Join(dataDir, "native-client")
+	if err := os.MkdirAll(unsafe, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unsafe, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+	if err := ensureSetupAuthoritySubdirectory(dataDir, filepath.Join("native-client", "codex-projects")); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("unsafe authority subdirectory accepted: %v", err)
+	}
+}
+
+func TestCodexProjectSetupRejectsUnsafeProjectStateAncestorBeforeConfigMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "shared-authority")
+	if _, err := ensureSetupAuthorityDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	unsafe := filepath.Join(dataDir, "native-client")
+	if err := os.MkdirAll(unsafe, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unsafe, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+	stubSetupSideEffects(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "inspect Codex project recovery state") || !strings.Contains(stderr.String(), "group/world-writable") {
+		t.Fatalf("unsafe project state ancestor setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, path := range []string{
+		filepath.Join(dir, ".codex", "config.toml"),
+		filepath.Join(dir, ".codex", "hooks.json"),
+		filepath.Join(dataDir, "root.key"),
+		setupRecoveryRoot(dataDir),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("unsafe project state ancestor setup mutated %s: %v", path, err)
+		}
+	}
+}
+
+func TestConfiguredCodexRuntimeRejectsUnsafeProjectStateAuthority(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dataDir, _ := setupProvenNativeCodexProjectForRuntime(t)
+	unsafe := filepath.Join(dataDir, "native-client")
+	if err := os.Chmod(unsafe, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+
+	if _, _, err := newLocalMCPRuntimeWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("configured runtime admitted unsafe project authority: %v", err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("stdio runtime admitted unsafe project authority: %v", err)
+	}
+}
+
+func moveCurrentCodexProjectBindingToLegacyForTest(t *testing.T, dataDir string) setupCodexProjectPaths {
+	t.Helper()
+	paths := currentCodexProjectPaths(dataDir)
+	bindingData, err := os.ReadFile(paths.BindingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(legacyCodexProjectBindingPath(dataDir), bindingData); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(paths.BindingPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSetupAuthoritySubdirectory(dataDir, "autoconfigure"); err != nil {
+		t.Fatal(err)
+	}
+	for _, filename := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json"} {
+		source := filepath.Join(paths.ArtifactsDir, filename)
+		data, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writeSetupPrivateFile(filepath.Join(legacyCodexProjectArtifactsDir(dataDir), filename), data); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(source); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Remove(paths.ArtifactsDir); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.Remove(paths.StateRoot); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return paths
+}
+
+func TestSetupMigrateCodexProjectBindingMovesOnlyValidatedLegacyState(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	if _, err := os.Stat(legacyBinding); err != nil {
+		t.Fatalf("legacy fixture binding is missing: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("current binding survived fixture migration: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--json", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("migration dry-run exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyBinding); err != nil {
+		t.Fatalf("migration dry-run changed legacy binding: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("migration dry-run created current binding: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyBinding); !os.IsNotExist(err) {
+		t.Fatalf("migration retained legacy binding: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); err != nil {
+		t.Fatalf("migration did not publish current binding: %v", err)
+	}
+	for _, filename := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json"} {
+		if _, err := os.Stat(filepath.Join(paths.ArtifactsDir, filename)); err != nil {
+			t.Fatalf("migration did not publish %s: %v", filename, err)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("removal after binding migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRefusesWrongWorkspaceWithoutMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	binding, err := readSetupCodexProjectBindingAtPath(legacyBinding)
+	if err != nil || binding == nil {
+		t.Fatalf("read legacy fixture binding: binding=%#v err=%v", binding, err)
+	}
+	binding.WorkspacePathHash = strings.Repeat("0", 64)
+	data, err := marshalSetupCodexProjectBinding(*binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(legacyBinding, data); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "different workspace") {
+		t.Fatalf("wrong-workspace migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyBinding); err != nil {
+		t.Fatalf("wrong-workspace migration removed legacy binding: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("wrong-workspace migration wrote current binding: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryMovesValidatedJournalThenRecovers(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparation, err := prepareCodexProjectRecoveryInstall(opts, summary)
+	if err != nil || preparation == nil || preparation.journal == nil {
+		t.Fatalf("prepare current recovery fixture: preparation=%#v err=%v", preparation, err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncSetupParentDirectory(legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recovery migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); !os.IsNotExist(err) {
+		t.Fatalf("recovery migration retained legacy root: %v", err)
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("migrated recovery was not pending: pending=%v err=%v", pending, err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recovery after migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("migrated recovery remained pending: pending=%v err=%v", pending, err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRejectsUnsafeLegacyArtifactsBeforeDryRunOrApply(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyArtifacts := legacyCodexProjectArtifactsDir(dataDir)
+	beforeBinding, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeArtifact, err := os.ReadFile(filepath.Join(legacyArtifacts, "inventory.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(legacyArtifacts, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(legacyArtifacts, 0o700) })
+
+	for _, args := range [][]string{
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "autoconfigure authority") {
+			t.Fatalf("unsafe artifact migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if got, err := os.ReadFile(legacyBinding); err != nil || !bytes.Equal(got, beforeBinding) {
+			t.Fatalf("unsafe artifact migration changed legacy binding: equal=%v err=%v", bytes.Equal(got, beforeBinding), err)
+		}
+		if got, err := os.ReadFile(filepath.Join(legacyArtifacts, "inventory.json")); err != nil || !bytes.Equal(got, beforeArtifact) {
+			t.Fatalf("unsafe artifact migration changed legacy artifact: equal=%v err=%v", bytes.Equal(got, beforeArtifact), err)
+		}
+		if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+			t.Fatalf("unsafe artifact migration created current binding: %v", err)
+		}
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRollsBackSecondArtifactStageFailure(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyArtifacts := legacyCodexProjectArtifactsDir(dataDir)
+	beforeBinding, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeArtifacts := make(map[string][]byte)
+	for _, filename := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json"} {
+		data, err := os.ReadFile(filepath.Join(legacyArtifacts, filename))
+		if err != nil {
+			t.Fatal(err)
+		}
+		beforeArtifacts[filename] = data
+	}
+	previousWrite := writeLegacyCodexProjectMigrationFile
+	writeLegacyCodexProjectMigrationFile = func(path string, data []byte) error {
+		if filepath.Base(path) == "policy.draft.json" && strings.Contains(path, setupLegacyMigrationTemporaryPrefix) {
+			return errors.New("injected second artifact stage failure")
+		}
+		return previousWrite(path, data)
+	}
+	t.Cleanup(func() { writeLegacyCodexProjectMigrationFile = previousWrite })
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "injected second artifact") {
+		t.Fatalf("injected migration failure exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if got, err := os.ReadFile(legacyBinding); err != nil || !bytes.Equal(got, beforeBinding) {
+		t.Fatalf("second artifact failure changed legacy binding: equal=%v err=%v", bytes.Equal(got, beforeBinding), err)
+	}
+	for filename, before := range beforeArtifacts {
+		if got, err := os.ReadFile(filepath.Join(legacyArtifacts, filename)); err != nil || !bytes.Equal(got, before) {
+			t.Fatalf("second artifact failure changed %s: equal=%v err=%v", filename, bytes.Equal(got, before), err)
+		}
+	}
+	if _, err := os.Stat(paths.StateRoot); !os.IsNotExist(err) {
+		t.Fatalf("second artifact failure retained current project state: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRejectsDestinationArtifactConflictWithoutMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyArtifact := filepath.Join(legacyCodexProjectArtifactsDir(dataDir), "inventory.json")
+	legacyBindingData, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyArtifactData, err := os.ReadFile(legacyArtifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureCodexProjectStateAuthority(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(paths.BindingPath, legacyBindingData); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(paths.ArtifactsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(filepath.Join(paths.ArtifactsDir, "inventory.json"), []byte("different-current-artifact")); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "differs from the validated legacy artifact") {
+			t.Fatalf("artifact-conflict migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if got, err := os.ReadFile(legacyBinding); err != nil || !bytes.Equal(got, legacyBindingData) {
+			t.Fatalf("artifact-conflict migration changed legacy binding: equal=%v err=%v", bytes.Equal(got, legacyBindingData), err)
+		}
+		if got, err := os.ReadFile(legacyArtifact); err != nil || !bytes.Equal(got, legacyArtifactData) {
+			t.Fatalf("artifact-conflict migration changed legacy artifact: equal=%v err=%v", bytes.Equal(got, legacyArtifactData), err)
+		}
+		if got, err := os.ReadFile(filepath.Join(paths.ArtifactsDir, "inventory.json")); err != nil || string(got) != "different-current-artifact" {
+			t.Fatalf("artifact-conflict migration changed current artifact: got=%q err=%v", got, err)
+		}
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryRejectsUnsafeDestinationAndMalformedSourceDuringDryRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	t.Run("unsafe destination ancestor", func(t *testing.T) {
+		dir := chdirTempDir(t)
+		dataDir := filepath.Join(dir, "kernel-state")
+		opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+		summary, err := buildSetupSummary(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+			t.Fatal(err)
+		}
+		paths := currentCodexProjectPaths(dataDir)
+		legacyRoot := legacySetupRecoveryRoot(dataDir)
+		if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+			t.Fatal(err)
+		}
+		unsafe := filepath.Join(dataDir, "native-client", "codex-projects")
+		if err := os.Chmod(unsafe, 0o777); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+		for _, args := range [][]string{
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+		} {
+			var stdout, stderr bytes.Buffer
+			if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "group/world-writable") {
+				t.Fatalf("unsafe destination migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if _, err := os.Stat(legacyRoot); err != nil {
+				t.Fatalf("unsafe destination migration moved legacy recovery: %v", err)
+			}
+			if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+				t.Fatalf("unsafe destination migration created current recovery: %v", err)
+			}
+		}
+	})
+	t.Run("malformed source staging", func(t *testing.T) {
+		dir := chdirTempDir(t)
+		dataDir := filepath.Join(dir, "kernel-state")
+		opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+		summary, err := buildSetupSummary(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+			t.Fatal(err)
+		}
+		paths := currentCodexProjectPaths(dataDir)
+		legacyRoot := legacySetupRecoveryRoot(dataDir)
+		if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(legacyRoot, setupRecoveryStagingDir, "unexpected"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+		} {
+			var stdout, stderr bytes.Buffer
+			if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "unexpected setup recovery staged entry") {
+				t.Fatalf("malformed source migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if _, err := os.Stat(legacyRoot); err != nil {
+				t.Fatalf("malformed source migration moved legacy recovery: %v", err)
+			}
+			if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+				t.Fatalf("malformed source migration created current recovery: %v", err)
+			}
+		}
+	})
+}
+
+func TestSetupMigrateCodexProjectRecoverySyncFailureRestoresLegacySource(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+		t.Fatal(err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	previousSync := syncLegacyCodexProjectMigrationParent
+	syncLegacyCodexProjectMigrationParent = func(path string) error {
+		if path == paths.RecoveryRoot {
+			return errors.New("injected migrated recovery sync failure")
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncLegacyCodexProjectMigrationParent = previousSync })
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "injected migrated recovery sync failure") {
+		t.Fatalf("sync-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); err != nil {
+		t.Fatalf("sync-failure migration did not restore legacy recovery: %v", err)
+	}
+	if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+		t.Fatalf("sync-failure migration retained current recovery: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryReportsRollbackFailure(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+		t.Fatal(err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	previousSync := syncLegacyCodexProjectMigrationParent
+	previousRename := renameLegacyCodexProjectMigration
+	syncLegacyCodexProjectMigrationParent = func(path string) error {
+		if path == paths.RecoveryRoot {
+			return errors.New("injected migrated recovery sync failure")
+		}
+		return previousSync(path)
+	}
+	renameLegacyCodexProjectMigration = func(oldPath, newPath string) error {
+		if oldPath == paths.RecoveryRoot && newPath == legacyRoot {
+			return errors.New("injected recovery rollback rename failure")
+		}
+		return previousRename(oldPath, newPath)
+	}
+	t.Cleanup(func() {
+		syncLegacyCodexProjectMigrationParent = previousSync
+		renameLegacyCodexProjectMigration = previousRename
+	})
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "rollback migrated recovery state") || !strings.Contains(stderr.String(), "injected recovery rollback rename failure") {
+		t.Fatalf("rollback-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); !os.IsNotExist(err) {
+		t.Fatalf("rollback-failure migration unexpectedly restored legacy recovery: %v", err)
+	}
+	if _, err := os.Stat(paths.RecoveryRoot); err != nil {
+		t.Fatalf("rollback-failure migration hid current recovery state: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryRejectsJournalPresenceChangeUnderLock(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+		t.Fatal(err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	previousAfterPreflight := afterLegacyRecoveryMigrationPreflight
+	afterLegacyRecoveryMigrationPreflight = func() {
+		if err := os.Remove(filepath.Join(legacyRoot, setupRecoveryJournalFile)); err != nil {
+			t.Fatalf("remove legacy journal during interleaving test: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterLegacyRecoveryMigrationPreflight = previousAfterPreflight })
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "journal presence changed") {
+		t.Fatalf("journal-presence migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); err != nil {
+		t.Fatalf("journal-presence migration moved legacy recovery: %v", err)
+	}
+	if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+		t.Fatalf("journal-presence migration created current recovery: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRevalidatesLegacyAuthorityBeforePublish(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyArtifacts := legacyCodexProjectArtifactsDir(dataDir)
+	previousAfterPreflight := afterLegacyBindingMigrationPreflight
+	afterLegacyBindingMigrationPreflight = func() {
+		if err := os.Chmod(legacyArtifacts, 0o777); err != nil {
+			t.Fatalf("make legacy authority unsafe during interleaving test: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		afterLegacyBindingMigrationPreflight = previousAfterPreflight
+		_ = os.Chmod(legacyArtifacts, 0o700)
+	})
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "revalidate legacy autoconfigure authority") {
+		t.Fatalf("legacy-authority interleaving migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy-authority interleaving migration published target binding: %v", err)
+	}
+	if _, err := os.Stat(legacyCodexProjectBindingPath(dataDir)); err != nil {
+		t.Fatalf("legacy-authority interleaving migration moved source binding: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingKeepsPublishedStateWhenRetiredSourceCleanupFails(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	previousRemoveTree := removeLegacyCodexProjectMigrationTree
+	removeLegacyCodexProjectMigrationTree = func(path string) error {
+		if strings.HasPrefix(filepath.Base(path), setupLegacyMigrationTemporaryPrefix) && filepath.Dir(path) == dataDir {
+			return errors.New("injected retired-source cleanup failure")
+		}
+		return previousRemoveTree(path)
+	}
+	t.Cleanup(func() { removeLegacyCodexProjectMigrationTree = previousRemoveTree })
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 || !strings.Contains(stderr.String(), "migration completed") || !strings.Contains(stderr.String(), "retired-source cleanup remains") {
+		t.Fatalf("cleanup-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(paths.BindingPath); err != nil {
+		t.Fatalf("cleanup-failure migration rolled back published target binding: %v", err)
+	}
+	if _, err := os.Stat(legacyCodexProjectBindingPath(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("cleanup-failure migration retained active legacy binding: %v", err)
+	}
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundRetiredSource := false
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), setupLegacyMigrationTemporaryPrefix) {
+			foundRetiredSource = true
+			break
+		}
+	}
+	if !foundRetiredSource {
+		t.Fatal("cleanup-failure migration lost retired source instead of retaining it safely")
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingKeepsPublishedStateWhenSourceRollbackFails(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyInventory := filepath.Join(legacyCodexProjectArtifactsDir(dataDir), "inventory.json")
+	beforeBinding, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousRename := renameLegacyCodexProjectMigration
+	renameLegacyCodexProjectMigration = func(oldPath, newPath string) error {
+		if oldPath == legacyInventory && strings.HasPrefix(filepath.Base(filepath.Dir(newPath)), setupLegacyMigrationTemporaryPrefix) {
+			return errors.New("injected second source move failure")
+		}
+		if newPath == legacyBinding && strings.HasPrefix(filepath.Base(filepath.Dir(oldPath)), setupLegacyMigrationTemporaryPrefix) {
+			return errors.New("injected source rollback rename failure")
+		}
+		return previousRename(oldPath, newPath)
+	}
+	t.Cleanup(func() { renameLegacyCodexProjectMigration = previousRename })
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 || !strings.Contains(stderr.String(), "could not be completed or fully rolled back") || !strings.Contains(stderr.String(), "injected source rollback rename failure") {
+		t.Fatalf("rollback-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if got, err := os.ReadFile(paths.BindingPath); err != nil || !bytes.Equal(got, beforeBinding) {
+		t.Fatalf("rollback-failure migration lost published target binding: equal=%v err=%v", bytes.Equal(got, beforeBinding), err)
+	}
+	if _, err := os.Stat(legacyBinding); !os.IsNotExist(err) {
+		t.Fatalf("rollback-failure migration restored an ambiguous active legacy binding: %v", err)
+	}
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundSealedBackup := false
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), setupLegacyMigrationTemporaryPrefix) {
+			continue
+		}
+		backup := filepath.Join(dataDir, entry.Name(), "00-"+setupCodexProjectBindingFile)
+		if got, err := os.ReadFile(backup); err == nil && bytes.Equal(got, beforeBinding) {
+			foundSealedBackup = true
+			break
+		}
+	}
+	if !foundSealedBackup {
+		t.Fatal("rollback-failure migration did not retain the sealed source backup")
+	}
+}
+
+func TestSetupCodexProjectLifecycleLockRejectsConcurrentMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("safe cross-process lifecycle lock intentionally fails closed on Windows")
+	}
+	dataDir := filepath.Join(t.TempDir(), "kernel-state")
+	first, err := acquireSetupCodexProjectLifecycleLock(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second, err := acquireSetupCodexProjectLifecycleLock(dataDir)
+	if second != nil {
+		_ = second.Close()
+		t.Fatal("second lifecycle lock unexpectedly succeeded")
+	}
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("second lifecycle lock error=%v", err)
+	}
+}
+
+func TestConcurrentFirstUseChoosesOneDurableLifecycleRoot(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "shared-kernel-state")
+	const workers = 16
+	start := make(chan struct{})
+	results := make(chan []byte, workers)
+	errors := make(chan error, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+			if err != nil {
+				errors <- err
+				return
+			}
+			results <- append([]byte(nil), signer.PublicKeyBytes()...)
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errors)
+	for err := range errors {
+		t.Fatalf("concurrent first-use signer initialization failed: %v", err)
+	}
+	var winner []byte
+	for publicKey := range results {
+		if winner == nil {
+			winner = publicKey
+			continue
+		}
+		if !bytes.Equal(winner, publicKey) {
+			t.Fatalf("concurrent first-use signers disagreed: %x != %x", winner, publicKey)
+		}
+	}
+	if winner == nil {
+		t.Fatal("no concurrent signer was initialized")
+	}
+	if _, err := loadExistingEd25519Root(dataDir); err != nil {
+		t.Fatalf("concurrent first-use root is not reloadable: %v", err)
+	}
+}
+
+func TestConcurrentLiteModeInitializationSharesAuthorityDataDir(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "shared-kernel-state")
+	const workers = 8
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+			if err == nil {
+				err = db.Close()
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent shared data-dir initialization failed: %v", err)
+		}
+	}
+}
+
+func TestRuntimeEntrypointsRejectSymlinkedDataDir(t *testing.T) {
+	dir := chdirTempDir(t)
+	target := filepath.Join(dir, "target")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "data-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", link}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 2 {
+		t.Fatalf("hook accepted symlinked data dir: code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMCPServe([]string{"--transport", "stdio", "--data-dir", link}, &stdout, &stderr); code != 2 {
+		t.Fatalf("mcp serve accepted symlinked data dir: code=%d stderr=%s", code, stderr.String())
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, link); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("direct stdio accepted symlinked data dir: %v", err)
+	}
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("runtime wrote through data-dir symlink: %#v", entries)
+	}
+}
+
+type setupRecoveryInjectingReader struct {
+	chunks   [][]byte
+	index    int
+	injected bool
+	inject   func() error
+}
+
+func (r *setupRecoveryInjectingReader) Read(p []byte) (int, error) {
+	if r.index == 1 && !r.injected {
+		r.injected = true
+		if err := r.inject(); err != nil {
+			return 0, err
+		}
+	}
+	if r.index >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	chunk := r.chunks[r.index]
+	n := copy(p, chunk)
+	if n == len(chunk) {
+		r.index++
+	} else {
+		r.chunks[r.index] = chunk[n:]
+	}
+	return n, nil
+}
+
+func TestMCPRechecksRecoveryBeforeEveryToolCall(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	reader := &setupRecoveryInjectingReader{
+		chunks: [][]byte{
+			[]byte("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n"),
+			[]byte("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"file_write\",\"arguments\":{\"path\":\"ignored\",\"content\":\"x\"}}}\n"),
+		},
+		inject: func() error {
+			writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+			return nil
+		},
+	}
+	var stdout bytes.Buffer
+	err := serveLocalMCPStdioWithDataDir(reader, &stdout, dataDir)
+	if err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("mid-session recovery did not stop MCP: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"id":1`) || strings.Contains(stdout.String(), `"id":2`) {
+		t.Fatalf("MCP answered after recovery became pending: %s", stdout.String())
+	}
+}
+
+func TestRecoveryJournalTamperingFailsClosedWithoutCleanup(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*setupRecoveryJournal, string)
+	}{
+		{
+			name: "stage traversal",
+			mutate: func(journal *setupRecoveryJournal, _ string) {
+				journal.Files[0].StageFile = "../outside"
+			},
+		},
+		{
+			name: "receipt traversal",
+			mutate: func(journal *setupRecoveryJournal, _ string) {
+				journal.LifecycleReceiptID = "../outside"
+			},
+		},
+		{
+			name: "duplicate plan",
+			mutate: func(journal *setupRecoveryJournal, _ string) {
+				journal.Files[1].ID = journal.Files[0].ID
+			},
+		},
+		{
+			name:   "noncanonical bytes",
+			mutate: func(_ *setupRecoveryJournal, _ string) {},
+		},
+		{
+			name: "unclean binary path",
+			mutate: func(journal *setupRecoveryJournal, dir string) {
+				journal.BinaryPath = dir + "/bin/../" + filepath.Base(journal.BinaryPath)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := chdirTempDir(t)
+			dataDir := filepath.Join(dir, "helm")
+			journal := writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+			tampered := *journal
+			tampered.Files = append([]setupRecoveryFilePlan(nil), journal.Files...)
+			tc.mutate(&tampered, dir)
+			var raw []byte
+			var err error
+			if tc.name == "noncanonical bytes" {
+				raw, err = os.ReadFile(setupRecoveryJournalPath(dataDir))
+				if err == nil {
+					raw = append(raw, '\n')
+				}
+			} else {
+				raw, err = canonicalize.JCS(tampered)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writeSetupPrivateFile(setupRecoveryJournalPath(dataDir), raw); err != nil {
+				t.Fatal(err)
+			}
+			sentinel := filepath.Join(dir, "outside")
+			if err := os.WriteFile(sentinel, []byte("do-not-touch"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr); code != 2 {
+				t.Fatalf("tampered journal status exit=%d stderr=%s", code, stderr.String())
+			}
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+				t.Fatalf("tampered journal recover exit=%d stderr=%s", code, stderr.String())
+			}
+			if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil {
+				t.Fatal("tampered journal unexpectedly opened MCP")
+			}
+			stdout.Reset()
+			stderr.Reset()
+			if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), "recovery") {
+				t.Fatalf("tampered journal did not deny hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			persisted, err := os.ReadFile(setupRecoveryJournalPath(dataDir))
+			if err != nil || !bytes.Equal(persisted, raw) {
+				t.Fatalf("tampered journal changed during failure handling: equal=%v err=%v", bytes.Equal(persisted, raw), err)
+			}
+			if got, err := os.ReadFile(sentinel); err != nil || string(got) != "do-not-touch" {
+				t.Fatalf("tampered journal touched external sentinel: got=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestRecoveryJournalPinsExecutablePathAndAvailability(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, journal *setupRecoveryJournal, dir string)
+		want   string
+	}{
+		{
+			name: "same bytes different path",
+			mutate: func(t *testing.T, journal *setupRecoveryJournal, dir string) {
+				t.Helper()
+				raw, err := os.ReadFile(journal.BinaryPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				copyPath := filepath.Join(dir, "alternate", "helm-ai-kernel")
+				if err := os.MkdirAll(filepath.Dir(copyPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(copyPath, raw, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				journal.BinaryPath = copyPath
+			},
+			want: "path does not match",
+		},
+		{
+			name: "symlink alternate path",
+			mutate: func(t *testing.T, journal *setupRecoveryJournal, dir string) {
+				t.Helper()
+				linkPath := filepath.Join(dir, "alternate", "helm-ai-kernel")
+				if err := os.MkdirAll(filepath.Dir(linkPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(journal.BinaryPath, linkPath); err != nil {
+					t.Fatal(err)
+				}
+				journal.BinaryPath = linkPath
+			},
+			want: "path does not match",
+		},
+		{
+			name: "deleted binary",
+			mutate: func(_ *testing.T, journal *setupRecoveryJournal, dir string) {
+				journal.BinaryPath = filepath.Join(dir, "missing", "helm-ai-kernel")
+			},
+			want: "unavailable",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := chdirTempDir(t)
+			dataDir := filepath.Join(dir, "helm")
+			journal := writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+			tampered := *journal
+			tampered.Files = append([]setupRecoveryFilePlan(nil), journal.Files...)
+			tc.mutate(t, &tampered, dir)
+			raw, err := canonicalize.JCS(tampered)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writeSetupPrivateFile(setupRecoveryJournalPath(dataDir), raw); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+			if code != 1 || !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("binary-pinned recovery did not fail closed: code=%d stderr=%s", code, stderr.String())
+			}
+			if _, err := os.Stat(filepath.Join(dataDir, "root.key")); !os.IsNotExist(err) {
+				t.Fatalf("failed binary recovery initialized signer state: %v", err)
+			}
+		})
+	}
+}
+
+func TestSignedCommittedMarkerSurvivesPostMarkerCrashAndCleans(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	previousFinalize := finalizeCodexProjectRecoveryJournal
+	finalizeCodexProjectRecoveryJournal = func(dataDir string, journal *setupRecoveryJournal) error {
+		marker, err := newSignedSetupRecoveryCommittedMarker(dataDir, journal)
+		if err != nil {
+			return err
+		}
+		if err := writeSetupRecoveryMarker(dataDir, setupRecoveryCommittedFile, marker); err != nil {
+			return err
+		}
+		return errors.New("injected post-marker cleanup failure")
+	}
+	t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("signed post-marker setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil || !summary.RecoveryCleanupPending {
+		t.Fatalf("signed terminal marker was not surfaced: summary=%#v err=%v", summary, err)
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("verified signed marker remained runtime-blocking: pending=%v err=%v", pending, err)
+	}
+	if err := os.Remove(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := inspectSetupRecovery(dataDir)
+	if err != nil || inspection.State != setupRecoveryStateCommitted {
+		t.Fatalf("signed marker-only crash residue was not terminal: inspection=%#v err=%v", inspection, err)
+	}
+
+	finalizeCodexProjectRecoveryJournal = previousFinalize
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("signed terminal residue cleanup exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("signed terminal residue remained after cleanup: %v", err)
+	}
+}

--- a/core/cmd/helm-ai-kernel/setup_recovery_terminal.go
+++ b/core/cmd/helm-ai-kernel/setup_recovery_terminal.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+// setupRecoveryCommittedMarkerPayload is the signed terminal assertion. It
+// deliberately binds only identifiers and hashes; no user-owned config bytes
+// enter recovery state.
+type setupRecoveryCommittedMarkerPayload struct {
+	SchemaVersion      string `json:"schema_version"`
+	State              string `json:"state"`
+	TransactionID      string `json:"transaction_id"`
+	LifecycleReceiptID string `json:"lifecycle_receipt_id"`
+	JournalHash        string `json:"journal_hash"`
+	Operation          string `json:"operation"`
+	Target             string `json:"target"`
+	Scope              string `json:"scope"`
+	WorkspacePathHash  string `json:"workspace_path_hash"`
+	DataDirPathHash    string `json:"data_dir_path_hash"`
+	BinaryPath         string `json:"binary_path"`
+	BinaryContentHash  string `json:"binary_content_hash"`
+}
+
+func setupRecoveryJournalHash(journal *setupRecoveryJournal) (string, error) {
+	if err := validateSetupRecoveryJournal(journal); err != nil {
+		return "", err
+	}
+	data, err := canonicalize.JCS(journal)
+	if err != nil {
+		return "", err
+	}
+	return canonicalize.HashBytes(data), nil
+}
+
+func setupRecoveryCommittedMarkerPayloadBytes(marker *setupRecoveryMarker) ([]byte, error) {
+	if marker == nil || !setupRecoveryMarkerHasTerminalPayload(marker) {
+		return nil, fmt.Errorf("committed setup recovery marker has no complete terminal proof")
+	}
+	return canonicalize.JCS(setupRecoveryCommittedMarkerPayload{
+		SchemaVersion:      marker.SchemaVersion,
+		State:              marker.State,
+		TransactionID:      marker.TransactionID,
+		LifecycleReceiptID: marker.LifecycleReceiptID,
+		JournalHash:        marker.JournalHash,
+		Operation:          marker.Operation,
+		Target:             marker.Target,
+		Scope:              marker.Scope,
+		WorkspacePathHash:  marker.WorkspacePathHash,
+		DataDirPathHash:    marker.DataDirPathHash,
+		BinaryPath:         marker.BinaryPath,
+		BinaryContentHash:  marker.BinaryContentHash,
+	})
+}
+
+func newSignedSetupRecoveryCommittedMarker(dataDir string, journal *setupRecoveryJournal) (setupRecoveryMarker, error) {
+	journalHash, err := setupRecoveryJournalHash(journal)
+	if err != nil {
+		return setupRecoveryMarker{}, err
+	}
+	marker := setupRecoveryMarker{
+		SchemaVersion:      setupRecoveryMarkerSchema,
+		State:              setupRecoveryMarkerStateCommitted,
+		TransactionID:      journal.TransactionID,
+		LifecycleReceiptID: journal.LifecycleReceiptID,
+		JournalHash:        journalHash,
+		Operation:          journal.Operation,
+		Target:             journal.Target,
+		Scope:              journal.Scope,
+		WorkspacePathHash:  journal.WorkspacePathHash,
+		DataDirPathHash:    journal.DataDirPathHash,
+		BinaryPath:         journal.BinaryPath,
+		BinaryContentHash:  journal.BinaryContentHash,
+	}
+	payload, err := setupRecoveryCommittedMarkerPayloadBytes(&marker)
+	if err != nil {
+		return setupRecoveryMarker{}, err
+	}
+	receipt, err := readSetupLifecycleReceiptReadOnly(context.Background(), dataDir, journal.LifecycleReceiptID)
+	if err != nil {
+		return setupRecoveryMarker{}, fmt.Errorf("read lifecycle receipt for committed recovery marker: %w", err)
+	}
+	signer, err := loadExistingSetupLifecycleSignerForSignature(dataDir, receipt.Signature)
+	if err != nil {
+		return setupRecoveryMarker{}, fmt.Errorf("load existing lifecycle signer for committed recovery marker: %w", err)
+	}
+	marker.Signature, err = signer.Sign(payload)
+	if err != nil {
+		return setupRecoveryMarker{}, fmt.Errorf("sign committed recovery marker: %w", err)
+	}
+	if err := validateSetupRecoveryMarker(&marker); err != nil {
+		return setupRecoveryMarker{}, err
+	}
+	return marker, nil
+}
+
+func verifySetupRecoveryMarkerSignature(signer helmcrypto.Signer, marker *setupRecoveryMarker) (bool, error) {
+	payload, err := setupRecoveryCommittedMarkerPayloadBytes(marker)
+	if err != nil {
+		return false, err
+	}
+	switch typed := signer.(type) {
+	case *helmcrypto.HybridSigner:
+		return typed.Verify(payload, marker.Signature)
+	default:
+		signature, err := hex.DecodeString(marker.Signature)
+		if err != nil {
+			return false, err
+		}
+		verifier, err := helmcrypto.NewEd25519Verifier(signer.PublicKeyBytes())
+		if err != nil {
+			return false, err
+		}
+		return verifier.Verify(payload, signature), nil
+	}
+}
+
+// verifyCommittedSetupRecoveryTerminal prevents a filename-shaped COMMITTED
+// marker from opening the runtime gate. With a journal present, a failed
+// verification simply leaves the transaction pending and resumable. A
+// marker-only crash residue must independently prove the receipt, evidence,
+// config snapshots, and (for install) final binding before it is cleaned.
+func verifyCommittedSetupRecoveryTerminal(dataDir string, marker *setupRecoveryMarker, journal *setupRecoveryJournal) (bool, error) {
+	if marker == nil || marker.State != setupRecoveryMarkerStateCommitted || !setupRecoveryMarkerHasTerminalProof(marker) {
+		return false, nil
+	}
+	if journal != nil {
+		journalHash, err := setupRecoveryJournalHash(journal)
+		if err != nil {
+			return false, err
+		}
+		if marker.TransactionID != journal.TransactionID ||
+			marker.LifecycleReceiptID != journal.LifecycleReceiptID ||
+			marker.JournalHash != journalHash ||
+			marker.Operation != journal.Operation ||
+			marker.Target != journal.Target ||
+			marker.Scope != journal.Scope ||
+			marker.WorkspacePathHash != journal.WorkspacePathHash ||
+			marker.DataDirPathHash != journal.DataDirPathHash ||
+			marker.BinaryPath != journal.BinaryPath ||
+			marker.BinaryContentHash != journal.BinaryContentHash {
+			return false, nil
+		}
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		return false, err
+	}
+	if marker.WorkspacePathHash != workspacePathHash || marker.DataDirPathHash != canonicalize.HashBytes([]byte(dataDir)) {
+		return false, nil
+	}
+	identity, err := inspectSetupKernelBinary(marker.BinaryPath)
+	if err != nil || identity.Path != marker.BinaryPath || identity.ContentHash != marker.BinaryContentHash {
+		return false, nil
+	}
+	opts := setupOptions{Target: marker.Target, Scope: marker.Scope, DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil || summary.BinaryPath != marker.BinaryPath {
+		return false, nil
+	}
+	markerSigner, err := loadExistingSetupLifecycleSignerForSignature(dataDir, marker.Signature)
+	if err != nil {
+		return false, err
+	}
+	verifiedMarker, err := verifySetupRecoveryMarkerSignature(markerSigner, marker)
+	if err != nil || !verifiedMarker {
+		return false, nil
+	}
+	receipt, err := readSetupLifecycleReceiptReadOnly(context.Background(), dataDir, marker.LifecycleReceiptID)
+	if err != nil {
+		return false, err
+	}
+	receiptSigner, err := loadExistingSetupLifecycleSignerForSignature(dataDir, receipt.Signature)
+	if err != nil {
+		return false, err
+	}
+	evidence, err := verifySetupLifecycleEvidence(dataDir, receipt)
+	if err != nil {
+		return false, err
+	}
+	descriptorHash, err := canonicalize.CanonicalHash(evidence.Descriptor)
+	if err != nil {
+		return false, err
+	}
+	observationHash, err := canonicalize.CanonicalHash(evidence.Observation)
+	if err != nil {
+		return false, err
+	}
+	if err := validatePersistedSetupLifecycleReceipt(receiptSigner, receipt, marker.LifecycleReceiptID, descriptorHash, observationHash, workspacePathHash, marker.Operation); err != nil {
+		return false, nil
+	}
+	if evidence.Descriptor.Client != marker.Target || evidence.Descriptor.Scope != marker.Scope || evidence.Descriptor.Operation != marker.Operation ||
+		evidence.Descriptor.WorkspacePathHash != marker.WorkspacePathHash || evidence.Descriptor.DataDirPathHash != marker.DataDirPathHash ||
+		evidence.Descriptor.KernelBinaryPath != marker.BinaryPath || evidence.Descriptor.KernelBinaryContentHash != marker.BinaryContentHash ||
+		evidence.Observation.Operation != marker.Operation || evidence.Observation.WorkspacePathHash != marker.WorkspacePathHash || evidence.Observation.DataDirPathHash != marker.DataDirPathHash {
+		return false, nil
+	}
+	if ok, err := setupLifecycleSnapshotMatchesCurrent(evidence.Observation.ClientConfig, summary.ClientConfigPath); err != nil || !ok {
+		return false, err
+	}
+	if ok, err := setupLifecycleSnapshotMatchesCurrent(evidence.Observation.HookConfig, summary.HookConfigPath); err != nil || !ok {
+		return false, err
+	}
+
+	switch marker.Operation {
+	case "install":
+		if !evidence.Descriptor.ExpectedMCP || !evidence.Descriptor.ExpectedHook || !evidence.Observation.MCPConfigured || !evidence.Observation.HookConfigured {
+			return false, nil
+		}
+		clientState, err := readSetupFileState(summary.ClientConfigPath)
+		if err != nil {
+			return false, err
+		}
+		hookState, err := readSetupFileState(summary.HookConfigPath)
+		if err != nil {
+			return false, err
+		}
+		proof, err := validateCodexProjectInstallBindingForCurrentConfig(opts, clientState, hookState)
+		if err != nil || proof.Binding.InstallReceiptID != marker.LifecycleReceiptID {
+			return false, nil
+		}
+	case "remove":
+		if evidence.Descriptor.ExpectedMCP || evidence.Descriptor.ExpectedHook || evidence.Observation.MCPConfigured || evidence.Observation.HookConfigured {
+			return false, nil
+		}
+		binding, err := readSetupCodexProjectBinding(dataDir)
+		if err != nil {
+			return false, err
+		}
+		if binding != nil {
+			return false, nil
+		}
+		refreshSetupConfiguration(opts, &summary)
+		if summary.MCPConfigured || summary.HookConfigured {
+			return false, nil
+		}
+	default:
+		return false, nil
+	}
+	return true, nil
+}
+
+func setupLifecycleSnapshotMatchesCurrent(expected setupFileSnapshot, path string) (bool, error) {
+	actual, err := snapshotSetupFile(path)
+	if err != nil {
+		return false, err
+	}
+	return expected.PathHash == actual.PathHash && expected.Exists == actual.Exists && expected.ContentHash == actual.ContentHash, nil
+}

--- a/core/cmd/helm-ai-kernel/setup_runtime_admission.go
+++ b/core/cmd/helm-ai-kernel/setup_runtime_admission.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+// requireCodexProjectRuntimeAdmission prevents a configured native client from
+// silently booting under a newly generated local authority after its proven
+// lifecycle state has been deleted or altered. A standalone `mcp serve`
+// invocation with no Codex-project installation remains supported; once a
+// binding or exact HELM config is present, however, the complete signed
+// install proof is mandatory on every runtime admission boundary.
+func admitCodexProjectRuntime(dataDir string) (helmcrypto.Signer, bool, error) {
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	binding, err := readSetupCodexProjectBinding(dataDir)
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect Codex project install binding: %w", err)
+	}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect Codex project runtime configuration: %w", err)
+	}
+	refreshSetupConfiguration(opts, &summary)
+	if binding == nil && !summary.MCPConfigured && !summary.HookConfigured {
+		return nil, false, nil
+	}
+
+	clientState, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect Codex project config for runtime admission: %w", err)
+	}
+	hookState, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect Codex project hook for runtime admission: %w", err)
+	}
+	proof, err := validateCodexProjectInstallBindingForCurrentConfig(opts, clientState, hookState)
+	if err != nil {
+		return nil, false, fmt.Errorf("Codex project runtime provenance is invalid: %w", err)
+	}
+	if proof.Signer == nil {
+		return nil, false, fmt.Errorf("Codex project runtime provenance has no existing lifecycle signer")
+	}
+	return proof.Signer, true, nil
+}
+
+func requireCodexProjectRuntimeAdmission(dataDir string) error {
+	_, _, err := admitCodexProjectRuntime(dataDir)
+	return err
+}

--- a/core/pkg/store/receipt_store_sqlite.go
+++ b/core/pkg/store/receipt_store_sqlite.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -9,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 
 	_ "modernc.org/sqlite"
@@ -18,6 +20,23 @@ type SQLiteReceiptStore struct {
 	db      *sql.DB
 	writeMu sync.Mutex
 }
+
+// sqliteReceiptSynchronousPragma is deliberately FULL rather than NORMAL.
+// Setup lifecycle receipts become authority for an installed native-client
+// binding, so a successful COMMIT must survive a power-loss boundary before
+// config, binding, and recovery cleanup may advance.
+const sqliteReceiptSynchronousPragma = "PRAGMA synchronous=FULL;"
+
+const (
+	sqliteReceiptInitAttempts = 8
+	sqliteReceiptInitBackoff  = 25 * time.Millisecond
+)
+
+// sqliteReceiptColumns is the projection kept alongside the canonical receipt
+// envelope for indexing and backwards-compatible reads. The envelope is the
+// authoritative representation for newly written receipts because
+// ReceiptChainHash covers fields beyond this query projection.
+const sqliteReceiptColumns = `receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency, receipt_envelope`
 
 func NewSQLiteReceiptStore(db *sql.DB) (*SQLiteReceiptStore, error) {
 	s := &SQLiteReceiptStore{db: db}
@@ -32,14 +51,17 @@ func NewSQLiteReceiptStore(db *sql.DB) (*SQLiteReceiptStore, error) {
 		stmt string
 		name string
 	}{
-		{"PRAGMA journal_mode=WAL;", "enable WAL"},
-		{"PRAGMA synchronous=NORMAL;", "set synchronous mode"},
 		{"PRAGMA busy_timeout=5000;", "set busy timeout"},
+		{"PRAGMA journal_mode=WAL;", "enable WAL"},
+		{sqliteReceiptSynchronousPragma, "set synchronous mode"},
 		{"PRAGMA temp_store=MEMORY;", "set temp store"},
 		{"PRAGMA wal_autocheckpoint=1000;", "set WAL autocheckpoint"},
 	}
 	for _, pragma := range pragmas {
-		if _, err := db.Exec(pragma.stmt); err != nil {
+		if err := retrySQLiteReceiptInit(func() error {
+			_, err := db.Exec(pragma.stmt)
+			return err
+		}); err != nil {
 			return nil, fmt.Errorf("%s: %w", pragma.name, err)
 		}
 	}
@@ -50,6 +72,10 @@ func NewSQLiteReceiptStore(db *sql.DB) (*SQLiteReceiptStore, error) {
 }
 
 func (s *SQLiteReceiptStore) migrate() error {
+	return retrySQLiteReceiptInit(s.migrateOnce)
+}
+
+func (s *SQLiteReceiptStore) migrateOnce() error {
 	query := `
     CREATE TABLE IF NOT EXISTS receipts (
         receipt_id TEXT PRIMARY KEY,
@@ -69,7 +95,8 @@ func (s *SQLiteReceiptStore) migrate() error {
 		args_hash TEXT NOT NULL DEFAULT '',
 		log_id TEXT NOT NULL DEFAULT '',
 		leaf_index INTEGER NOT NULL DEFAULT 0,
-		transparency TEXT
+		transparency TEXT,
+		receipt_envelope TEXT NOT NULL DEFAULT ''
 	);`
 	if _, err := s.db.ExecContext(context.Background(), query); err != nil {
 		return err
@@ -86,6 +113,9 @@ func (s *SQLiteReceiptStore) migrate() error {
 	if err := s.ensureColumn("transparency", "TEXT"); err != nil {
 		return err
 	}
+	if err := s.ensureColumn("receipt_envelope", "TEXT NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
 	indexes := []string{
 		`CREATE INDEX IF NOT EXISTS idx_receipts_executor_id ON receipts(executor_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_receipts_decision_id ON receipts(decision_id)`,
@@ -100,6 +130,37 @@ func (s *SQLiteReceiptStore) migrate() error {
 		}
 	}
 	return nil
+}
+
+// retrySQLiteReceiptInit handles the short exclusive-lock window while a
+// second process enables WAL or creates indexes in the same authority store.
+// Receipt initialization is idempotent, so retrying the whole migration is
+// safe; non-contention errors fail immediately.
+func retrySQLiteReceiptInit(operation func() error) error {
+	var err error
+	for attempt := 0; attempt < sqliteReceiptInitAttempts; attempt++ {
+		if err = operation(); err == nil {
+			return nil
+		}
+		if !isSQLiteReceiptBusy(err) || attempt == sqliteReceiptInitAttempts-1 {
+			return err
+		}
+		time.Sleep(time.Duration(attempt+1) * sqliteReceiptInitBackoff)
+	}
+	return err
+}
+
+func isSQLiteReceiptBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "sqlite_busy") ||
+		strings.Contains(message, "sqlite_locked") ||
+		strings.Contains(message, "database is locked") ||
+		strings.Contains(message, "database schema is locked") ||
+		strings.Contains(message, "database table is locked") ||
+		strings.Contains(message, "database is busy")
 }
 
 func (s *SQLiteReceiptStore) ensureColumn(name, definition string) error {
@@ -134,30 +195,17 @@ func (s *SQLiteReceiptStore) ensureColumn(name, definition string) error {
 }
 
 func (s *SQLiteReceiptStore) Get(ctx context.Context, decisionID string) (*contracts.Receipt, error) {
-	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
-        FROM receipts
-        WHERE decision_id = ?
-    `
+	query := `SELECT ` + sqliteReceiptColumns + ` FROM receipts WHERE decision_id = ?`
 	return s.queryOne(ctx, query, decisionID)
 }
 
 func (s *SQLiteReceiptStore) GetByReceiptID(ctx context.Context, receiptID string) (*contracts.Receipt, error) {
-	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
-        FROM receipts
-        WHERE receipt_id = ?
-    `
+	query := `SELECT ` + sqliteReceiptColumns + ` FROM receipts WHERE receipt_id = ?`
 	return s.queryOne(ctx, query, receiptID)
 }
 
 func (s *SQLiteReceiptStore) List(ctx context.Context, limit int) ([]*contracts.Receipt, error) {
-	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
-        FROM receipts
-        ORDER BY timestamp DESC
-        LIMIT ?
-    `
+	query := `SELECT ` + sqliteReceiptColumns + ` FROM receipts ORDER BY timestamp DESC LIMIT ?`
 	rows, err := s.db.QueryContext(ctx, query, limit)
 	if err != nil {
 		return nil, err
@@ -179,13 +227,7 @@ func (s *SQLiteReceiptStore) List(ctx context.Context, limit int) ([]*contracts.
 }
 
 func (s *SQLiteReceiptStore) ListByAgent(ctx context.Context, agentID string, since uint64, limit int) ([]*contracts.Receipt, error) {
-	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
-        FROM receipts
-        WHERE executor_id = ? AND lamport_clock > ?
-        ORDER BY lamport_clock ASC, timestamp ASC
-        LIMIT ?
-    `
+	query := `SELECT ` + sqliteReceiptColumns + ` FROM receipts WHERE executor_id = ? AND lamport_clock > ? ORDER BY lamport_clock ASC, timestamp ASC LIMIT ?`
 	rows, err := s.db.QueryContext(ctx, query, agentID, since, limit)
 	if err != nil {
 		return nil, err
@@ -207,13 +249,7 @@ func (s *SQLiteReceiptStore) ListByAgent(ctx context.Context, agentID string, si
 }
 
 func (s *SQLiteReceiptStore) ListSince(ctx context.Context, since uint64, limit int) ([]*contracts.Receipt, error) {
-	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
-        FROM receipts
-        WHERE lamport_clock > ?
-        ORDER BY lamport_clock ASC, timestamp ASC
-        LIMIT ?
-    `
+	query := `SELECT ` + sqliteReceiptColumns + ` FROM receipts WHERE lamport_clock > ? ORDER BY lamport_clock ASC, timestamp ASC LIMIT ?`
 	rows, err := s.db.QueryContext(ctx, query, since, limit)
 	if err != nil {
 		return nil, err
@@ -242,8 +278,8 @@ func (s *SQLiteReceiptStore) Store(ctx context.Context, r *contracts.Receipt) er
 
 func insertSQLiteReceipt(ctx context.Context, execer sqlExecer, r *contracts.Receipt) error {
 	query := `INSERT INTO receipts (
-		receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
-	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency, receipt_envelope
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	metaJSON, err := json.Marshal(r.Metadata)
 	if err != nil {
@@ -253,10 +289,14 @@ func insertSQLiteReceipt(ctx context.Context, execer sqlExecer, r *contracts.Rec
 	if err != nil {
 		return err
 	}
+	envelope, err := canonicalize.JCS(r)
+	if err != nil {
+		return fmt.Errorf("canonicalize receipt envelope: %w", err)
+	}
 	timestamp := r.Timestamp.UTC().Format(time.RFC3339Nano)
 
 	_, err = execer.ExecContext(ctx, query,
-		r.ReceiptID, r.DecisionID, r.EffectID, r.ExternalReferenceID, r.Status, r.BlobHash, r.OutputHash, timestamp, r.ExecutorID, string(metaJSON), r.Signature, r.MerkleRoot, r.PrevHash, r.LamportClock, r.ArgsHash, r.LogID, r.LeafIndex, nullableJSON(transparencyJSON),
+		r.ReceiptID, r.DecisionID, r.EffectID, r.ExternalReferenceID, r.Status, r.BlobHash, r.OutputHash, timestamp, r.ExecutorID, string(metaJSON), r.Signature, r.MerkleRoot, r.PrevHash, r.LamportClock, r.ArgsHash, r.LogID, r.LeafIndex, nullableJSON(transparencyJSON), string(envelope),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to insert receipt: %w", err)
@@ -290,7 +330,7 @@ func (s *SQLiteReceiptStore) AppendCausal(ctx context.Context, sessionID string,
 		}
 	}()
 
-	last, err := queryLastSQLiteReceipt(ctx, conn, sessionID)
+	last, err := queryLastSQLiteCausalReceipt(ctx, conn, sessionID)
 	if err != nil {
 		return err
 	}
@@ -314,13 +354,7 @@ func (s *SQLiteReceiptStore) GetLastForSession(ctx context.Context, sessionID st
 }
 
 func queryLastSQLiteReceipt(ctx context.Context, queryer sqlQueryer, sessionID string) (*contracts.Receipt, error) {
-	query := `
-        SELECT receipt_id, decision_id, effect_id, external_reference_id, status, blob_hash, output_hash, timestamp, executor_id, metadata, signature, merkle_root, prev_hash, lamport_clock, args_hash, log_id, leaf_index, transparency
-        FROM receipts
-        WHERE executor_id = ?
-        ORDER BY lamport_clock DESC
-        LIMIT 1
-    `
+	query := `SELECT ` + sqliteReceiptColumns + ` FROM receipts WHERE executor_id = ? ORDER BY lamport_clock DESC LIMIT 1`
 	r, err := scanSQLiteReceipt(queryer.QueryRowContext(ctx, query, sessionID))
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -329,6 +363,25 @@ func queryLastSQLiteReceipt(ctx context.Context, queryer sqlQueryer, sessionID s
 		return nil, err
 	}
 	return r, nil
+}
+
+// queryLastSQLiteCausalReceipt refuses to extend a legacy row whose omitted
+// contract fields cannot be reconstructed. Reading legacy receipts remains
+// supported, but inventing a new PrevHash from a lossy projection would create
+// an unverifiable causal edge.
+func queryLastSQLiteCausalReceipt(ctx context.Context, queryer sqlQueryer, sessionID string) (*contracts.Receipt, error) {
+	last, err := queryLastSQLiteReceipt(ctx, queryer, sessionID)
+	if err != nil || last == nil {
+		return last, err
+	}
+	var envelope sql.NullString
+	if err := queryer.QueryRowContext(ctx, `SELECT receipt_envelope FROM receipts WHERE executor_id = ? ORDER BY lamport_clock DESC LIMIT 1`, sessionID).Scan(&envelope); err != nil {
+		return nil, err
+	}
+	if !envelope.Valid || envelope.String == "" {
+		return nil, fmt.Errorf("cannot append causal receipt after legacy receipt without a canonical envelope")
+	}
+	return last, nil
 }
 
 func (s *SQLiteReceiptStore) queryOne(ctx context.Context, query string, arg any) (*contracts.Receipt, error) {
@@ -352,15 +405,16 @@ func (s *SQLiteReceiptStore) queryOne(ctx context.Context, query string, arg any
 		logID        sql.NullString
 		leafIndex    uint64
 		transparency sql.NullString
+		envelope     sql.NullString
 	)
-	err := row.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash, &logID, &leafIndex, &transparency)
+	err := row.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash, &logID, &leafIndex, &transparency, &envelope)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("receipt not found")
 		}
 		return nil, err
 	}
-	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash, logID, leafIndex, transparency)
+	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash, logID, leafIndex, transparency, envelope)
 }
 
 type sqliteScanner interface {
@@ -387,14 +441,15 @@ func scanSQLiteReceipt(scanner sqliteScanner) (*contracts.Receipt, error) {
 		logID        sql.NullString
 		leafIndex    uint64
 		transparency sql.NullString
+		envelope     sql.NullString
 	)
-	if err := scanner.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash, &logID, &leafIndex, &transparency); err != nil {
+	if err := scanner.Scan(&receiptID, &decisionID, &effectID, &externalID, &status, &blobHash, &outputHash, &timestamp, &executorID, &metaJSON, &signature, &merkleRoot, &prevHash, &lamport, &argsHash, &logID, &leafIndex, &transparency, &envelope); err != nil {
 		return nil, err
 	}
-	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash, logID, leafIndex, transparency)
+	return receiptFromSQLiteFields(receiptID, decisionID, effectID, externalID, status, blobHash, outputHash, timestamp, executorID, metaJSON, signature, merkleRoot, prevHash, lamport, argsHash, logID, leafIndex, transparency, envelope)
 }
 
-func receiptFromSQLiteFields(receiptID, decisionID, effectID string, externalID sql.NullString, status, blobHash, outputHash, timestamp string, executorID, metaJSON, signature, merkleRoot, prevHash sql.NullString, lamport uint64, argsHash sql.NullString, logID sql.NullString, leafIndex uint64, transparency sql.NullString) (*contracts.Receipt, error) {
+func receiptFromSQLiteFields(receiptID, decisionID, effectID string, externalID sql.NullString, status, blobHash, outputHash, timestamp string, executorID, metaJSON, signature, merkleRoot, prevHash sql.NullString, lamport uint64, argsHash sql.NullString, logID sql.NullString, leafIndex uint64, transparency, envelope sql.NullString) (*contracts.Receipt, error) {
 	parsedTime := parseTime(timestamp)
 
 	var meta map[string]any
@@ -428,7 +483,98 @@ func receiptFromSQLiteFields(receiptID, decisionID, effectID string, externalID 
 			return nil, err
 		}
 	}
-	return receipt, nil
+	return receiptFromSQLiteEnvelope(envelope, receipt, metaJSON, transparency)
+}
+
+// receiptFromSQLiteEnvelope restores the canonical receipt representation
+// written by current stores. The indexed columns remain for lookup and legacy
+// databases, but cannot on their own reproduce ReceiptChainHash because that
+// hash covers the full Receipt contract.
+func receiptFromSQLiteEnvelope(envelope sql.NullString, projected *contracts.Receipt, metadata, transparency sql.NullString) (*contracts.Receipt, error) {
+	if !envelope.Valid || envelope.String == "" {
+		return projected, nil
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(envelope.String))
+	decoder.UseNumber()
+	var receipt contracts.Receipt
+	if err := decoder.Decode(&receipt); err != nil {
+		return nil, fmt.Errorf("decode receipt envelope: %w", err)
+	}
+	canonical, err := canonicalize.JCS(&receipt)
+	if err != nil {
+		return nil, fmt.Errorf("canonicalize receipt envelope: %w", err)
+	}
+	if !bytes.Equal(canonical, []byte(envelope.String)) {
+		return nil, fmt.Errorf("receipt envelope is not canonical")
+	}
+	if err := validateSQLiteReceiptEnvelopeProjection(&receipt, projected, metadata, transparency); err != nil {
+		return nil, err
+	}
+	return &receipt, nil
+}
+
+// validateSQLiteReceiptEnvelopeProjection makes an envelope/index mismatch a
+// read error instead of allowing a query to return one receipt while causal
+// chaining hashes another.
+func validateSQLiteReceiptEnvelopeProjection(envelope, projected *contracts.Receipt, metadata, transparency sql.NullString) error {
+	if envelope == nil || projected == nil {
+		return fmt.Errorf("receipt envelope and projection are required")
+	}
+	if envelope.ReceiptID != projected.ReceiptID ||
+		envelope.DecisionID != projected.DecisionID ||
+		envelope.EffectID != projected.EffectID ||
+		envelope.ExternalReferenceID != projected.ExternalReferenceID ||
+		envelope.Status != projected.Status ||
+		envelope.BlobHash != projected.BlobHash ||
+		envelope.OutputHash != projected.OutputHash ||
+		!envelope.Timestamp.Equal(projected.Timestamp) ||
+		envelope.ExecutorID != projected.ExecutorID ||
+		envelope.Signature != projected.Signature ||
+		envelope.MerkleRoot != projected.MerkleRoot ||
+		envelope.PrevHash != projected.PrevHash ||
+		envelope.LamportClock != projected.LamportClock ||
+		envelope.ArgsHash != projected.ArgsHash ||
+		envelope.LogID != projected.LogID ||
+		envelope.LeafIndex != projected.LeafIndex {
+		return fmt.Errorf("receipt envelope does not match indexed columns")
+	}
+	metadataMatches, err := sqliteReceiptJSONMatchesRaw(envelope.Metadata, metadata)
+	if err != nil {
+		return fmt.Errorf("canonicalize receipt metadata: %w", err)
+	}
+	if !metadataMatches {
+		return fmt.Errorf("receipt envelope metadata does not match indexed columns")
+	}
+	transparencyMatches, err := sqliteReceiptJSONMatchesRaw(envelope.Transparency, transparency)
+	if err != nil {
+		return fmt.Errorf("canonicalize receipt transparency: %w", err)
+	}
+	if !transparencyMatches {
+		return fmt.Errorf("receipt envelope transparency does not match indexed columns")
+	}
+	return nil
+}
+
+func sqliteReceiptJSONMatchesRaw(value any, raw sql.NullString) (bool, error) {
+	valueCanonical, err := canonicalize.JCS(value)
+	if err != nil {
+		return false, err
+	}
+	if !raw.Valid || raw.String == "" {
+		return bytes.Equal(valueCanonical, []byte("null")), nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(raw.String))
+	decoder.UseNumber()
+	var stored any
+	if err := decoder.Decode(&stored); err != nil {
+		return false, err
+	}
+	storedCanonical, err := canonicalize.JCS(stored)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(valueCanonical, storedCanonical), nil
 }
 
 func scanReceiptRow(rows *sql.Rows) (*contracts.Receipt, error) {

--- a/core/pkg/store/store_behavior_coverage_test.go
+++ b/core/pkg/store/store_behavior_coverage_test.go
@@ -8,11 +8,13 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
 
 	_ "github.com/lib/pq"
 	_ "modernc.org/sqlite"
@@ -230,6 +232,270 @@ func TestSQLiteReceiptRoundTripsChainFieldsAndAgentFilter(t *testing.T) {
 	}
 	if len(allSince) != 2 || allSince[0].ReceiptID != "r-agent-2" || allSince[1].ReceiptID != "r-other" {
 		t.Fatalf("unexpected cursor result: %+v", allSince)
+	}
+}
+
+func TestSQLiteReceiptEnvelopeMigrationKeepsLegacyRowsReadable(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "legacy-receipts.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(`
+		CREATE TABLE receipts (
+			receipt_id TEXT PRIMARY KEY,
+			decision_id TEXT,
+			effect_id TEXT,
+			external_reference_id TEXT,
+			status TEXT,
+			blob_hash TEXT,
+			output_hash TEXT,
+			timestamp DATETIME,
+			executor_id TEXT,
+			metadata JSON,
+			signature TEXT,
+			merkle_root TEXT,
+			prev_hash TEXT NOT NULL DEFAULT '',
+			lamport_clock INTEGER NOT NULL DEFAULT 0,
+			args_hash TEXT NOT NULL DEFAULT '',
+			log_id TEXT NOT NULL DEFAULT '',
+			leaf_index INTEGER NOT NULL DEFAULT 0,
+			transparency TEXT
+		);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO receipts (receipt_id, decision_id, effect_id, status, blob_hash, output_hash, timestamp, executor_id, lamport_clock)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"legacy-receipt", "legacy-decision", "legacy-effect", "ALLOW", "", "", time.Unix(1700000000, 0).UTC().Format(time.RFC3339Nano), "legacy-agent", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewSQLiteReceiptStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var columnCount int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(1) FROM pragma_table_info('receipts') WHERE name = 'receipt_envelope'`).Scan(&columnCount); err != nil {
+		t.Fatal(err)
+	}
+	if columnCount != 1 {
+		t.Fatalf("receipt_envelope migration count = %d, want 1", columnCount)
+	}
+	got, err := store.GetByReceiptID(ctx, "legacy-receipt")
+	if err != nil {
+		t.Fatalf("read legacy receipt after migration: %v", err)
+	}
+	if got.ReceiptID != "legacy-receipt" || got.DecisionID != "legacy-decision" {
+		t.Fatalf("legacy receipt changed during migration: %+v", got)
+	}
+	if err := store.AppendCausal(ctx, "legacy-agent", func(*contracts.Receipt, uint64, string) (*contracts.Receipt, error) {
+		return nil, nil
+	}); err == nil || !strings.Contains(err.Error(), "canonical envelope") {
+		t.Fatalf("legacy receipt should block causal append, err=%v", err)
+	}
+}
+
+func TestSQLiteReceiptEnvelopeRoundTripsLifecycleChainHash(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "receipts.db")
+	db, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewSQLiteReceiptStore(db)
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	signer, err := helmcrypto.NewEd25519Signer("native-lifecycle-key")
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	receipt := &contracts.Receipt{
+		ReceiptID:           "rcpt-native-install",
+		DecisionID:          "decision/native-client/install/rcpt-native-install",
+		EffectID:            "mcp.tools.call/file_write",
+		ExternalReferenceID: "codex-project:workspace-hash",
+		Status:              "DENY",
+		OutputHash:          "observation-hash",
+		Timestamp:           time.Unix(1700000000, 123456789).UTC(),
+		ExecutorID:          "codex-project:workspace-hash",
+		PrevHash:            "previous-hash",
+		LamportClock:        7,
+		ArgsHash:            "descriptor-hash",
+		Type:                "native_client_setup_lifecycle",
+		Action:              "install",
+		Verdict:             "DENY",
+		ToolName:            "file_write",
+		ReasonCode:          "ERR_SYNTHETIC_FILE_WRITE_DENIED",
+		Metadata: map[string]any{
+			"evidence_schema":     "helm.native-client.setup/v1",
+			"lifecycle_operation": "install",
+			"ordinal":             int64(9007199254740993),
+		},
+		Subject:  map[string]any{"ordinal": int64(9007199254740993)},
+		Evidence: map[string]string{"evidence": "sha256:fixture"},
+	}
+	if err := signer.SignReceipt(receipt); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	wantHash, err := contracts.ReceiptChainHash(receipt)
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := store.Store(ctx, receipt); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	var envelope string
+	if err := db.QueryRowContext(ctx, `SELECT receipt_envelope FROM receipts WHERE receipt_id = ?`, receipt.ReceiptID).Scan(&envelope); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if envelope == "" {
+		_ = db.Close()
+		t.Fatal("stored receipt envelope is empty")
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedStore, err := NewSQLiteReceiptStore(reopened)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := reopenedStore.GetByReceiptID(ctx, receipt.ReceiptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotHash, err := contracts.ReceiptChainHash(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotHash != wantHash {
+		t.Fatalf("persisted lifecycle receipt chain hash = %s, want issued %s", gotHash, wantHash)
+	}
+	if got.Type != receipt.Type || got.Action != receipt.Action || got.Verdict != receipt.Verdict || got.ToolName != receipt.ToolName || got.ReasonCode != receipt.ReasonCode {
+		t.Fatalf("lifecycle fields did not round-trip: %+v", got)
+	}
+	if got.SignatureProfile != receipt.SignatureProfile || got.SignatureAlgorithm != receipt.SignatureAlgorithm || got.KeyID != receipt.KeyID || got.PublicKeySet[helmcrypto.SigPrefixEd25519] != receipt.PublicKeySet[helmcrypto.SigPrefixEd25519] {
+		t.Fatalf("signer metadata did not round-trip: %+v", got)
+	}
+	if _, err := reopened.ExecContext(ctx, `UPDATE receipts SET status = 'ALLOW' WHERE receipt_id = ?`, receipt.ReceiptID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reopenedStore.GetByReceiptID(ctx, receipt.ReceiptID); err == nil || !strings.Contains(err.Error(), "does not match indexed columns") {
+		t.Fatalf("envelope/index mismatch should fail closed, err=%v", err)
+	}
+}
+
+func TestSQLiteReceiptEnvelopeKeepsCausalHashAfterReopen(t *testing.T) {
+	ctx := context.Background()
+	databasePath := filepath.Join(t.TempDir(), "causal-receipts.db")
+	signer, err := helmcrypto.NewEd25519Signer("native-lifecycle-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewSQLiteReceiptStore(db)
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	var issued *contracts.Receipt
+	if err := store.AppendCausal(ctx, "codex-project:workspace-hash", func(_ *contracts.Receipt, lamport uint64, prevHash string) (*contracts.Receipt, error) {
+		issued = &contracts.Receipt{
+			ReceiptID:           "rcpt-native-install",
+			DecisionID:          "decision/native-client/install/rcpt-native-install",
+			EffectID:            "mcp.tools.call/file_write",
+			ExternalReferenceID: "codex-project:workspace-hash",
+			Status:              "DENY",
+			OutputHash:          "install-observation",
+			Timestamp:           time.Unix(1700000000, 0).UTC(),
+			ExecutorID:          "codex-project:workspace-hash",
+			PrevHash:            prevHash,
+			LamportClock:        lamport,
+			ArgsHash:            "install-descriptor",
+			Type:                "native_client_setup_lifecycle",
+			Action:              "install",
+			Verdict:             "DENY",
+			ToolName:            "file_write",
+			ReasonCode:          "ERR_SYNTHETIC_FILE_WRITE_DENIED",
+			Metadata:            map[string]any{"lifecycle_operation": "install"},
+		}
+		return issued, signer.SignReceipt(issued)
+	}); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	issuedHash, err := contracts.ReceiptChainHash(issued)
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = reopened.Close() }()
+	reopenedStore, err := NewSQLiteReceiptStore(reopened)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reopenedStore.AppendCausal(ctx, "codex-project:workspace-hash", func(previous *contracts.Receipt, lamport uint64, prevHash string) (*contracts.Receipt, error) {
+		if previous == nil {
+			t.Fatal("reopened store lost the issued receipt")
+		}
+		if got, err := contracts.ReceiptChainHash(previous); err != nil || got != issuedHash {
+			t.Fatalf("reopened previous chain hash = %q err=%v, want %q", got, err, issuedHash)
+		}
+		next := &contracts.Receipt{
+			ReceiptID:           "rcpt-native-remove",
+			DecisionID:          "decision/native-client/remove/rcpt-native-remove",
+			EffectID:            "native_client.setup/codex-project/remove",
+			ExternalReferenceID: "codex-project:workspace-hash",
+			Status:              "REVOKED",
+			OutputHash:          "remove-observation",
+			Timestamp:           time.Unix(1700000001, 0).UTC(),
+			ExecutorID:          "codex-project:workspace-hash",
+			PrevHash:            prevHash,
+			LamportClock:        lamport,
+			ArgsHash:            "remove-descriptor",
+			Type:                "native_client_setup_lifecycle",
+			Action:              "remove",
+			Verdict:             "REVOKED",
+			ReasonCode:          "CONFIG_REMOVED",
+			Metadata:            map[string]any{"lifecycle_operation": "remove"},
+		}
+		return next, signer.SignReceipt(next)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	remove, err := reopenedStore.GetByReceiptID(ctx, "rcpt-native-remove")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remove.PrevHash != issuedHash || remove.LamportClock != 2 {
+		t.Fatalf("reopened causal receipt = prev %q lamport %d, want %q/2", remove.PrevHash, remove.LamportClock, issuedHash)
 	}
 }
 

--- a/core/pkg/store/store_sql_coverage_test.go
+++ b/core/pkg/store/store_sql_coverage_test.go
@@ -398,6 +398,7 @@ func TestCoverageSQLiteReceiptMigrationAndParsingBranches(t *testing.T) {
 		sql.NullString{String: "logid", Valid: true},
 		11,
 		sql.NullString{String: `{"backend":"translog","deferred":true}`, Valid: true},
+		sql.NullString{},
 	)
 	if err != nil {
 		t.Fatalf("receiptFromSQLiteFields: %v", err)
@@ -408,12 +409,13 @@ func TestCoverageSQLiteReceiptMigrationAndParsingBranches(t *testing.T) {
 	if receipt.LogID != "logid" || receipt.LeafIndex != 11 || receipt.Transparency == nil || !receipt.Transparency.Deferred {
 		t.Fatalf("transparency fields not decoded: %+v", receipt)
 	}
-	if _, err := receiptFromSQLiteFields("r", "d", "e", sql.NullString{}, "OK", "", "", "", sql.NullString{}, sql.NullString{String: `{`, Valid: true}, sql.NullString{}, sql.NullString{}, sql.NullString{}, 0, sql.NullString{}, sql.NullString{}, 0, sql.NullString{}); err == nil {
+	if _, err := receiptFromSQLiteFields("r", "d", "e", sql.NullString{}, "OK", "", "", "", sql.NullString{}, sql.NullString{String: `{`, Valid: true}, sql.NullString{}, sql.NullString{}, sql.NullString{}, 0, sql.NullString{}, sql.NullString{}, 0, sql.NullString{}, sql.NullString{}); err == nil {
 		t.Fatal("expected SQLite metadata decode error")
 	}
 
 	db, mock, cleanup := newStoreCoverageSQLMock(t)
 	defer cleanup()
+	mock.ExpectExec("PRAGMA busy_timeout").WillReturnResult(sqlmock.NewResult(0, 0))
 	mock.ExpectExec("PRAGMA journal_mode").WillReturnError(errors.New("wal failed"))
 	if _, err := NewSQLiteReceiptStore(db); err == nil {
 		t.Fatal("expected WAL setup error")
@@ -421,8 +423,6 @@ func TestCoverageSQLiteReceiptMigrationAndParsingBranches(t *testing.T) {
 
 	dbBusy, mockBusy, cleanupBusy := newStoreCoverageSQLMock(t)
 	defer cleanupBusy()
-	mockBusy.ExpectExec("PRAGMA journal_mode").WillReturnResult(sqlmock.NewResult(0, 0))
-	mockBusy.ExpectExec("PRAGMA synchronous").WillReturnResult(sqlmock.NewResult(0, 0))
 	mockBusy.ExpectExec("PRAGMA busy_timeout").WillReturnError(errors.New("busy failed"))
 	if _, err := NewSQLiteReceiptStore(dbBusy); err == nil {
 		t.Fatal("expected busy timeout setup error")
@@ -457,6 +457,31 @@ func TestCoverageSQLiteReceiptMigrationAndParsingBranches(t *testing.T) {
 	mockEnsure.ExpectExec("ALTER TABLE receipts ADD COLUMN missing TEXT").WillReturnError(errors.New("alter failed"))
 	if err := sqliteStore.ensureColumn("missing", "TEXT"); err == nil {
 		t.Fatal("expected ensure alter error")
+	}
+}
+
+func TestSQLiteReceiptInitRetriesOnlyBusyContention(t *testing.T) {
+	attempts := 0
+	if err := retrySQLiteReceiptInit(func() error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("database is locked (SQLITE_BUSY)")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("retry busy initialization: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("busy retry attempts = %d, want 3", attempts)
+	}
+
+	attempts = 0
+	nonBusy := errors.New("schema malformed")
+	if err := retrySQLiteReceiptInit(func() error {
+		attempts++
+		return nonBusy
+	}); !errors.Is(err, nonBusy) || attempts != 1 {
+		t.Fatalf("non-busy initialization should fail once, attempts=%d err=%v", attempts, err)
 	}
 }
 

--- a/docs/CLAIM_BOUNDARIES.md
+++ b/docs/CLAIM_BOUNDARIES.md
@@ -1,6 +1,6 @@
 ---
 title: Claim Boundaries
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # Claim Boundaries
@@ -19,6 +19,8 @@ or release artifacts.
 - Decisions, approvals, and revocations write local receipts.
 - EvidencePacks can be checked from local material without trusting a hosted
   service.
+- Codex project setup can record a signed local lifecycle transaction and a
+  Kernel-only synthetic denial without claiming a real client session.
 - The public conformance proof path supports `L1` and `L2` CLI shortcuts.
 
 ## Not Public Claims
@@ -29,6 +31,9 @@ or release artifacts.
 - No full operating-system, browser, IDE, eBPF, seccomp, TPM, hardware enclave,
   packet blocking, or proprietary hosted-agent control is claimed unless a
   tested path proves the specific effect crossed HELM.
+- No local config, lifecycle receipt, or synthetic denial is a claim that Codex
+  or Claude Code loaded the generated configuration. Native-client review must
+  identify the exact configured hook class and routed MCP call exercised.
 - No `L4` conformance claim is public. `L3` remains source/test coverage until
   a public proof path is wired and tested.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 ---
 title: Compatibility
-last_reviewed: 2026-05-05
+last_reviewed: 2026-07-14
 ---
 
 # Compatibility
@@ -68,6 +68,8 @@ This page is backed by:
 | Go kernel and CLI | Supported | `make build`, `make test` |
 | OpenAI-compatible proxy | Supported | `core/cmd/helm-ai-kernel/proxy_cmd.go`, proxy examples |
 | MCP server, OAuth scope enforcement, and bundle generation | Supported | `core/cmd/helm-ai-kernel/mcp_*`, MCP tests |
+| Codex project setup, recovery, and removal | Source-backed local lifecycle proof | `core/cmd/helm-ai-kernel/setup_cmd.go`, `setup_codex_*.go`, recovery tests; no real client-session claim |
+| Claude Code selected-hook/MCP setup | Direct CLI registration request plus local hook path | `core/cmd/helm-ai-kernel/setup_claude_code_binary.go`, `setup_cmd.go`; no CLI-owned MCP-config readback, Codex lifecycle equivalence, or real client-session claim |
 | Boundary records, MCP quarantine, receipts, evidence export/verify, conformance, and local onboarding proof APIs | Supported public proof path | `api/openapi/helm.openapi.yaml`, `core/cmd/helm-ai-kernel/route_registry.go`, `core/cmd/helm-ai-kernel/contract_routes.go` |
 | Evidence export and offline verification | Supported | `core/cmd/helm-ai-kernel/export_cmd.go`, `core/cmd/helm-ai-kernel/verify_cmd.go` |
 | Headless API contract for external clients | Supported | `api/openapi/helm.openapi.yaml`, `core/cmd/helm-ai-kernel/route_registry.go`, `make sdk-openapi-check` |

--- a/docs/EXECUTION_SECURITY_MODEL.md
+++ b/docs/EXECUTION_SECURITY_MODEL.md
@@ -1,6 +1,6 @@
 ---
 title: EXECUTION_SECURITY_MODEL
-last_reviewed: 2026-05-05
+last_reviewed: 2026-07-14
 ---
 
 # Execution Security Model
@@ -89,6 +89,8 @@ HELM AI Kernel does:
 - emit signed receipts for `ALLOW`, `DENY`, and `ESCALATE` decisions;
 - quarantine unknown MCP servers and tools until they are inspected and approved;
 - produce offline-verifiable EvidencePacks for source-backed receipt material.
+- maintain owner-checked, project-scoped Codex setup state and fail closed when its
+  local authority, lifecycle evidence, or recovery transaction is unsafe.
 
 HELM AI Kernel does not:
 
@@ -97,6 +99,10 @@ HELM AI Kernel does not:
 - replace secret scanning, network firewalls, endpoint controls, or OS sandboxing;
 - prevent prompt injection at generation time; enforcement happens at dispatch;
 - capture side effects from tools that bypass the HELM proxy or MCP boundary;
+- turn generated native-client configuration or a Kernel-only synthetic denial
+  into proof that a real Codex or Claude Code session loaded it;
+- govern native-client actions outside the exact configured hook classes and
+  routed MCP calls;
 - certify every MCP tool schema through static analysis;
 - certify compliance with a regulatory standard by itself.
 

--- a/docs/INTEGRATIONS/agent-clients.md
+++ b/docs/INTEGRATIONS/agent-clients.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Clients
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # Agent Clients
@@ -52,3 +52,16 @@ agent/tool requests action
 
 Setup writes local config and draft policy files only when `--yes` is present.
 It does not approve detected tools.
+
+## Native-Client Limits
+
+| Client path | Local evidence | Not established by setup |
+| --- | --- | --- |
+| Codex project scope | Exact owned config, signed lifecycle receipt, recovery journal, and Kernel-only synthetic denial | That a real Codex session loaded the config or governed any action outside the configured hook classes and routed MCP calls |
+| Claude Code | Direct CLI used to request MCP registration plus selected PreToolUse hook configuration | Readback of CLI-owned MCP serialization, Codex-style project lifecycle/recovery, or a real Claude Code session result |
+
+The Codex project lifecycle is intentionally isolated by workspace under the
+selected data directory. If it is interrupted, use `setup recover codex --scope
+project --yes`; migrate old unscoped state with `setup migrate codex --scope
+project --yes`. See the [Native Client Integration
+Boundary](native-client-boundary.md) for what that setup can and cannot prove.

--- a/docs/INTEGRATIONS/claude-code.md
+++ b/docs/INTEGRATIONS/claude-code.md
@@ -1,18 +1,29 @@
 ---
 title: Claude Code Integration
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-14
 ---
 
 # Claude Code Integration
 
 Use HELM with Claude Code when you want local PreToolUse decisions and signed
-receipts for selected high-risk tool effects.
+receipts for selected high-risk tool effects. This is a selected-hook and MCP
+configuration path, not a claim of full Claude Code control.
 
 ## Quick Setup
 
 ```bash
 helm-ai-kernel setup claude-code --yes
 ```
+
+Setup resolves a direct `claude` executable. If PATH resolves through a mise
+shim, it refuses the install rather than trusting the shim. Supply the direct
+executable path when needed:
+
+```bash
+CLAUDE_CODE_BIN=/absolute/path/to/claude helm-ai-kernel setup claude-code --yes
+```
+
+`CLAUDE_CODE_BIN` must be an executable path, not a bare command name.
 
 Check what was installed:
 
@@ -32,8 +43,14 @@ helm-ai-kernel setup remove claude-code --yes
 helm-ai-kernel setup claude-code --dry-run --json
 ```
 
-The JSON summary includes the binary path, client config path, hook config path,
-data dir, Kernel URL, draft policy path, and uninstall command.
+The JSON summary includes the Kernel binary path, client config path, hook
+config path, data dir, Kernel URL, draft policy path, and uninstall command.
+
+The summary identifies HELM's planned paths and local hook state. Claude Code
+owns MCP config serialization, so HELM does not read back that registration or
+claim a live Claude Code session loaded it. It also does not establish Codex-style
+project lifecycle or recovery semantics. See the [native client integration
+boundary](native-client-boundary.md) for the public boundary and review rules.
 
 ## Verify A Denial
 
@@ -72,3 +89,4 @@ helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb
 - `core/cmd/helm-ai-kernel/workstation_m3_cmd.go`
 - `docs/QUICKSTART.md`
 - `docs/reference/cli.md`
+- `docs/INTEGRATIONS/native-client-boundary.md`

--- a/docs/INTEGRATIONS/codex.md
+++ b/docs/INTEGRATIONS/codex.md
@@ -1,12 +1,13 @@
 ---
 title: Codex Integration
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-14
 ---
 
 # Codex Integration
 
 Use HELM with Codex when you want a local MCP and hook setup that records signed
-policy decision receipts for selected high-risk effects.
+policy decision receipts for selected high-risk effects. It governs only the
+configured hook classes and MCP calls routed through HELM.
 
 ## Quick Setup
 
@@ -20,17 +21,44 @@ Project scope:
 helm-ai-kernel setup codex --scope project --yes
 ```
 
-Check status:
+Project scope keeps its binding, recovery journal, and generated artifacts in a
+workspace-hash namespace below the selected data directory. The local signing
+authority and receipt store remain shared. See the [native client integration
+boundary](native-client-boundary.md) before moving or reusing local state.
+
+Check user scope:
 
 ```bash
 helm-ai-kernel setup status codex
 ```
 
-Remove the integration:
+Remove user scope:
 
 ```bash
 helm-ai-kernel setup remove codex --yes
 ```
+
+For a project-scope interruption, inspect and resume the recorded transaction
+instead of rerunning setup or removal:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --yes
+```
+
+Pre-v1 unscoped project state requires an explicit migration operation:
+
+```bash
+helm-ai-kernel setup migrate codex --scope project --yes
+```
+
+`--dry-run` validates the full current legacy source-and-project-destination
+snapshot without writing or reserving it; it is not a completed migration. With
+`--yes`, HELM locks and revalidates before moving validated state into the v1
+project namespace; a new binding destination is staged and validated before
+publication. If source retirement cannot finish or fully roll back after
+publication, the command reports sealed cleanup: v1 remains active authority
+and the retained source copy is not. Inspect the project status after the move.
 
 ## Inspect Before Writing
 
@@ -40,6 +68,14 @@ helm-ai-kernel setup codex --dry-run --json
 
 The dry run writes nothing and returns the target config paths, data dir, Kernel
 URL, draft policy path, and uninstall command.
+
+## Evidence Boundary
+
+Project setup records exact local config snapshots, a signed lifecycle receipt,
+and a Kernel-only synthetic denial. Its summary intentionally reports
+`client_load_observed=false`: those checks do not prove that a real Codex
+session loaded the config or blocked a client action. See the [native-client
+integration boundary](native-client-boundary.md) for that separate review.
 
 ## Manual MCP Setup
 
@@ -67,6 +103,7 @@ Tampered receipts return a non-zero exit and fail signature verification.
 - `core/cmd/helm-ai-kernel/setup_cmd_test.go`
 - `core/cmd/helm-ai-kernel/hook_cmd.go`
 - `core/cmd/helm-ai-kernel/mcp_cmd.go`
+- `docs/INTEGRATIONS/native-client-boundary.md`
 - `core/cmd/helm-ai-kernel/workstation_m3_cmd.go`
 - `docs/QUICKSTART.md`
 - `docs/reference/cli.md`

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: MCP
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # MCP
@@ -31,6 +31,12 @@ Print or install client config:
 helm-ai-kernel mcp print-config --client codex
 helm-ai-kernel mcp install --client claude-code
 ```
+
+Printing or installing client config is not proof that the client loaded it.
+HELM governs only calls that reach the configured server; direct upstream calls
+remain outside this boundary. For Codex project setup, recovery, and real-client
+review limits, see [Native Client Integration
+Boundary](native-client-boundary.md).
 
 ## Authorize Before Dispatch
 

--- a/docs/INTEGRATIONS/native-client-boundary.md
+++ b/docs/INTEGRATIONS/native-client-boundary.md
@@ -1,0 +1,56 @@
+---
+title: Native Client Integration Boundary
+last_reviewed: 2026-07-14
+---
+
+# Native Client Integration Boundary
+
+HELM can generate scoped local configuration for supported coding clients. That
+is useful local setup evidence, but it is not proof that a native client has
+loaded the configuration or that every client action crosses HELM.
+
+## What Local Setup Establishes
+
+For a scoped setup, HELM can record exact configuration ownership, a signed
+lifecycle receipt, and a Kernel-only synthetic denial. The setup result
+intentionally reports `client_load_observed=false`. It establishes that HELM
+generated and checked its local artifacts; it does not establish that Codex or
+Claude Code opened them, started a configured server, or blocked an action in a
+real session.
+
+## What HELM Can Govern
+
+HELM can govern only the configured hook classes that a client actually invokes
+and MCP calls routed through the configured HELM server. Direct upstream calls,
+unconfigured tool classes, terminal commands, browser actions, desktop actions,
+and other paths that do not reach HELM remain outside this integration boundary.
+
+## Evidence Levels
+
+Keep these distinct when reviewing an integration:
+
+1. **Local setup evidence** — source, tests, generated configuration, lifecycle
+   receipt, and synthetic denial.
+2. **Sterile client observation** — an authorized reviewer uses a disposable
+   client home and workspace, observes the scoped configuration load, and
+   exercises only the configured hook classes and routed MCP call.
+3. **Release and deployment evidence** — source-owned repository gates, release
+   authority, GitOps, and deployed smoke evidence remain separate from client
+   setup.
+
+Neither a local configuration receipt nor a screenshot substitutes for a
+sterile client observation. A client observation does not itself authorize a
+merge, deployment, or release.
+
+## Safe Next Steps
+
+Use a dry run to inspect the paths HELM would manage before writing them:
+
+```bash
+helm-ai-kernel setup codex --scope project --dry-run --json
+helm-ai-kernel setup claude-code --dry-run --json
+```
+
+Use the CLI reference for supported setup, status, removal, and recovery
+commands. Maintainer-only lifecycle and recovery procedures are deliberately
+kept outside the public documentation surface.

--- a/docs/INTEGRATIONS/native-client-lifecycle.md
+++ b/docs/INTEGRATIONS/native-client-lifecycle.md
@@ -1,0 +1,175 @@
+---
+title: Native Client Lifecycle Review Protocol
+last_reviewed: 2026-07-14
+visibility: maintainer
+---
+
+# Native Client Lifecycle Review Protocol
+
+This maintainer protocol separates local configuration proof from proof that a
+real native client loaded and obeyed that configuration. It is the source of
+truth for Codex project lifecycle state. It does not expand HELM's execution
+boundary beyond configured hook classes and MCP calls.
+
+## What Codex Project Setup Owns
+
+`helm-ai-kernel setup codex --scope project --yes` writes only the HELM-owned
+entries that its preflight can prove safe to manage. Project-specific state is
+separated by a SHA-256 workspace-path identity:
+
+```text
+<data-dir>/native-client/codex-projects/v1/<workspace-path-sha256>/
+  codex-project-binding.json
+  .helm-setup-recovery/
+  autoconfigure/
+```
+
+The local signing authority, receipt database, and lifecycle evidence remain
+shared beneath `<data-dir>`. A project binding, recovery journal, or generated
+artifact is never a fallback for another project that happens to use the same
+data directory.
+
+The authority root and every existing HELM-owned descendant must be real,
+owner-controlled directories; symlinks, group/world-writable modes, and special
+modes are rejected. On POSIX the existing directory owner must be the current
+user. The code rechecks that state before it treats a binding, recovery journal,
+or evidence file as authority.
+
+## Lifecycle Receipts And Recovery
+
+Codex project install and removal use a durable transaction. The transaction
+records exact config snapshots and stages HELM-owned changes before it mutates
+the live client configuration. A signed lifecycle receipt and canonical
+lifecycle evidence bind the operation, selected Kernel binary, workspace
+identity, data-directory identity, and observed local configuration.
+
+The durable receipt database stores the full canonical receipt envelope, not
+only an index projection. Recovery reads an existing receipt database
+read-only, re-canonicalizes the envelope, and checks that its receipt ID agrees
+with the database row. A missing, malformed, non-canonical, or legacy row that
+lacks the envelope fails closed for automatic provenance recovery.
+
+If setup is interrupted, do not rerun install or removal until you inspect the
+transaction:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --dry-run --json
+helm-ai-kernel setup recover codex --scope project --yes
+```
+
+`recover` either removes incomplete HELM residue, resumes the exact recorded
+transaction, or cleans a transaction already committed but not yet tidied. It
+does not overwrite a changed client configuration. Removal uses the same
+transaction and only deletes exact HELM-owned entries:
+
+```bash
+helm-ai-kernel setup remove codex --scope project --dry-run --json
+helm-ai-kernel setup remove codex --scope project --yes
+```
+
+Older unscoped Codex state needs the explicit migration command; normal runtime
+admission never silently adopts it:
+
+```bash
+helm-ai-kernel setup migrate codex --scope project --dry-run --json
+helm-ai-kernel setup migrate codex --scope project --yes
+```
+
+Migration validates the full current legacy source-and-destination snapshot:
+the selected binding and artifacts or structured recovery state, current
+workspace, and project namespace. Normal runtime admission never adopts
+unscoped state. `--dry-run` performs that validation without writing or
+reserving the snapshot. With `--yes`, HELM takes the project lifecycle lock and
+revalidates before moving validated state into the v1 project namespace. For a
+new binding destination, it stages and validates the complete namespaced
+binding/artifact set before publication; recovery migration rolls its validated
+recovery directory back if later sync or validation fails. A legacy binding
+pinned to a different currently-running Kernel binary is refused. If source
+retirement cannot finish or fully roll back after v1 publication, the command
+reports a sealed retired-source cleanup warning: v1 remains the active project
+authority and the retained source copy is not. Inspect `setup status` after
+migration, and use `setup recover` when a project recovery journal is present.
+
+## What Local Setup Proves — And Does Not
+
+The setup result intentionally reports `client_load_observed=false`. A matching
+local config and the Kernel-only synthetic denial prove that HELM generated and
+checked local artifacts; they do **not** prove that Codex opened them, launched
+the configured stdio server, or blocked an action in a real session.
+
+Likewise, a configured hook is limited to the exact hook classes in the client
+configuration, and a configured MCP server governs only calls routed through
+that server. Neither result proves every Codex action, every terminal command,
+browser use, desktop action, or a bypassing upstream server. Do not turn a
+configuration receipt or synthetic denial into a native-client session claim.
+
+Claude Code is intentionally not treated as equivalent to the Codex project
+lifecycle. Its setup resolves a direct `claude` executable, invokes its MCP CLI,
+and writes the selected PreToolUse hook configuration. HELM does not read back
+the CLI-owned MCP serialization, create a Codex-style project binding, or
+establish client-session proof. If `claude` resolves through a mise shim, setup
+refuses it. Set `CLAUDE_CODE_BIN` to the direct executable path instead:
+
+```bash
+CLAUDE_CODE_BIN=/absolute/path/to/claude helm-ai-kernel setup claude-code --yes
+```
+
+## Evidence Ladder
+
+Keep these evidence levels separate:
+
+1. **Source and focused-test proof** — the lifecycle, recovery, receipt, and
+   admission tests pass from the reviewed commit.
+2. **Local setup proof** — preflight, exact config ownership, signed lifecycle
+   receipt, and the Kernel-only synthetic denial pass. `client_load_observed`
+   remains false at this level.
+3. **Sterile native-client review** — a disposable client home and workspace
+   load the generated configuration in a real, user-authorized client session;
+   the reviewer observes the configured server, invokes only configured hook
+   classes and a routed MCP call, and verifies the resulting signed receipts.
+4. **Release proof** — the reviewed binary, source commit, hashes, signatures,
+   and test output are attached to a signed release artifact.
+5. **Approved environment proof** — an operator repeats the limited real-client
+   checks in an approved environment with the resulting evidence retained.
+
+Levels 1 and 2 do not substitute for levels 3 through 5.
+
+## Sterile Native-Client Review
+
+Use this protocol before claiming a real native-client integration:
+
+1. Record the Kernel binary path and content hash, source commit, client
+   version, policy inputs, and the disposable workspace path.
+2. Create a new client home such as `CODEX_HOME=<empty-directory>`; never copy
+   an existing browser session, client credential, or cached config into it.
+3. Run project setup with an explicit private data directory, retain the JSON
+   summary, and verify the lifecycle receipt/evidence before launching the
+   client.
+4. Have the authorized operator complete the client login in that sterile home.
+   Observe that the configured HELM stdio server is actually loaded.
+5. Run one harmless controlled case for each hook class present in the generated
+   configuration and one routed MCP call. Capture client-visible results and
+   verify the corresponding HELM receipts. A denied case must show no target
+   side effect.
+6. Tamper with an owned config or lifecycle proof only in the disposable
+   fixture, then confirm that admission fails closed. Remove the fixture with
+   the normal project-scope removal path.
+
+The review record must name the exact classes and MCP server/tool exercised.
+It must state `not exercised` for every other client action; absence of a test
+is not coverage.
+
+## Source Truth And Checks
+
+- `core/cmd/helm-ai-kernel/setup_cmd.go`
+- `core/cmd/helm-ai-kernel/setup_codex_project_paths.go`
+- `core/cmd/helm-ai-kernel/setup_codex_lifecycle.go`
+- `core/cmd/helm-ai-kernel/setup_lifecycle_readonly.go`
+- `core/cmd/helm-ai-kernel/setup_recovery_*.go`
+- `core/cmd/helm-ai-kernel/setup_claude_code_binary.go`
+- `core/cmd/helm-ai-kernel/setup_recovery_security_test.go`
+- `core/cmd/helm-ai-kernel/setup_cmd_test.go`
+
+Run the focused lifecycle suite for code changes, then `make docs-coverage
+docs-truth` for documentation changes.

--- a/docs/KERNEL_SCOPE.md
+++ b/docs/KERNEL_SCOPE.md
@@ -1,6 +1,6 @@
 ---
 title: KERNEL_SCOPE
-last_reviewed: 2026-05-12
+last_reviewed: 2026-07-14
 ---
 
 # HELM AI Kernel Scope
@@ -153,6 +153,15 @@ not an adapter. It provides:
 The governed proxy (`/v1/chat/completions`) intercepts OpenAI-compatible
 tool calls and routes them through the PEP boundary.
 
+### Native Client Setup
+
+The CLI can write selected local Codex and Claude Code configuration. Codex
+project scope additionally has an owner-checked workspace-hash namespace, signed
+lifecycle evidence, and crash recovery. This is configuration and local
+authority management, not an agent runtime: only configured hook classes and
+MCP calls routed through HELM can cross the Kernel boundary. A matching config
+or synthetic denial does not prove a live client session.
+
 ### Bounded-Surface Primitives
 
 The OSS kernel includes configurable surface containment primitives
@@ -176,6 +185,8 @@ OSS includes:
 - **MCP interceptor** — first-class governed MCP surface
 - **OpenAI proxy** — governed proxy for OpenAI-compatible SDKs
 - **Headless API contract** — HTTP routes, schemas, receipts, SDKs, and conformance fixtures for external clients
+- **Native setup lifecycle** — private local authority checks, project-scoped
+  Codex binding/recovery state, and selected client configuration
 - Adapters and integration surfaces
 
 OSS does not include:
@@ -187,6 +198,7 @@ OSS does not include:
 - Managed federation or hosted trust registries
 - Private entitlement, seat management, usage metering, or account-management systems
 - Non-OSS connector certification programs
+- General native-client, desktop, browser, or OS-wide enforcement
 
 The invariant is simple: OSS must stay fully useful on its own as a developer-first execution kernel: Go CLI, HTTP/API contracts, SDKs, evidence export, offline verification, replay, conformance, and release artifacts. Hosted, organization-specific, and browser UI operations live outside this repository and integrate through those public contracts.
 

--- a/docs/PROOF_LOOP.md
+++ b/docs/PROOF_LOOP.md
@@ -1,6 +1,6 @@
 ---
 title: HELM Proof Loop
-last_reviewed: 2026-07-02
+last_reviewed: 2026-07-14
 ---
 
 # HELM Proof Loop
@@ -47,6 +47,16 @@ helm-ai-kernel workstation verify-decision \
 | EvidencePack | Moves proof between machines | offline verifier result |
 | Category pages | Explain adjacent tools without superiority claims | cited public evidence |
 
+## Native Setup Is A Separate Layer
+
+Codex project setup adds a signed local lifecycle transaction around the
+generated config. Its exact-config checks and Kernel-only synthetic denial are
+useful local evidence, but `client_load_observed=false` means a real client has
+not yet been observed. The next layer is a sterile native-client review that
+exercises only configured hook classes and routed MCP calls; direct client or
+upstream paths remain outside the evidence. See the [Native Client Integration
+Boundary](INTEGRATIONS/native-client-boundary.md) for the public review limits.
+
 ## Boundaries
 
 - HELM only governs effects routed through an adapter, wrapper, hook, proxy, or
@@ -56,6 +66,8 @@ helm-ai-kernel workstation verify-decision \
 - Receipts prove the evaluated action and verdict. They do not prove every
   tool outside the boundary was governed.
 - EvidencePacks are portable proof bundles, not marketing screenshots.
+- Native setup receipts do not prove a client session merely because the config
+  and synthetic denial passed.
 
 ## Next
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-14
 ---
 
 # Quickstart
@@ -32,8 +32,8 @@ make build
 | Install | `brew install helm-ai-kernel` or `make build` |
 | CLI chooser | `helm-ai-kernel` or `helm-ai-kernel setup` |
 | Local proof | `helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs` |
-| Codex setup | `helm-ai-kernel setup codex --dry-run --json` |
-| Claude Code setup | `helm-ai-kernel setup claude-code --dry-run --json` |
+| Codex setup | Local config plan preview: `helm-ai-kernel setup codex --dry-run --json` |
+| Claude Code setup | Local setup preview; Claude-owned MCP serialization is not read back: `helm-ai-kernel setup claude-code --dry-run --json` |
 | Cursor / Windsurf / VS Code config | `helm-ai-kernel setup --client cursor --print-config` |
 | OpenClaw / Hermes adapters | [tool runtime adapters](INTEGRATIONS/tool-runtime-adapters.md) |
 | Framework adapters | [framework adapters](INTEGRATIONS/framework-adapters.md) |
@@ -154,6 +154,13 @@ helm-ai-kernel setup --client cursor --print-config
 
 Setup writes local config and draft policy artifacts. It does not approve
 detected tools.
+
+For Codex project scope, setup also records a signed lifecycle receipt and a
+Kernel-only synthetic denial. The summary intentionally keeps
+`client_load_observed=false`: that local proof is not a real client-session
+result. Read the [Native Client Integration
+Boundary](INTEGRATIONS/native-client-boundary.md) before describing the local
+result as a client-session outcome.
 
 ## Inspect
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ This tree is the canonical public documentation source for HELM AI Kernel. Publi
 
 - [OpenAI-compatible proxy](INTEGRATIONS/openai_baseurl.md)
 - [MCP integration](INTEGRATIONS/mcp.md)
+- [Native client integration boundary](INTEGRATIONS/native-client-boundary.md)
 - [Highflame ZeroID Integration](INTEGRATIONS/zeroid.md)
 - [Vaultak State Transaction Bridge](INTEGRATIONS/vaultak.md)
 - [BGT Labs Sentinel Authorization Gateway](INTEGRATIONS/sentinel.md)

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,6 +1,6 @@
 ---
 title: Receipts
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-14
 ---
 
 # Receipts
@@ -24,6 +24,12 @@ For MCP and boundary decisions, HELM records:
 Approvals and revocations also write receipts. A later evaluation must fail
 closed when an approval is expired, revoked, or outside its server, tool, or
 effect scope.
+
+Codex project setup and removal also record signed lifecycle receipts. Their
+durable rows retain the canonical receipt envelope; recovery reopens that store
+read-only and refuses a missing, malformed, non-canonical, or legacy
+index-only envelope. These receipts prove the local lifecycle transaction, not
+that a native client opened the generated configuration.
 
 ## Inspect Local Receipts
 
@@ -85,6 +91,16 @@ helm-ai-kernel verify evidence-pack.tar
 ```
 
 EvidencePacks are portable proof bundles for local review and offline replay.
+
+## Native Client Evidence
+
+Local Codex setup can prove exact HELM-owned configuration, a signed lifecycle
+record, and a Kernel-only synthetic denial. It intentionally reports
+`client_load_observed=false` until a separate real client session is observed.
+Do not use that local result as proof of every Codex action or direct upstream
+MCP call. See the [Native Client Integration
+Boundary](INTEGRATIONS/native-client-boundary.md) before describing a real
+client-session result.
 
 ## Release Evidence
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: HELM documentation
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # HELM documentation
@@ -35,6 +35,7 @@ Then choose one path.
 - [Scan agent risk](reference/agent-risk-scan.md)
 - [OpenAI proxy](INTEGRATIONS/openai_baseurl.md)
 - [Verify receipts](VERIFICATION.md)
+- [Native client integration boundary](INTEGRATIONS/native-client-boundary.md)
 
 ## More
 

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -118,6 +118,15 @@
       "sensitivity": "public"
     },
     {
+      "slug": "integrations/native-client-boundary",
+      "title": "Native Client Integration Boundary",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/native-client-boundary.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/native-client-boundary",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "integrations/framework-adapters",
       "title": "Framework Adapters",
       "section": "integrations",

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -1,8 +1,8 @@
 # Protect Local Coding Agents
 
 HELM can sit around Codex, Claude Code, and similar local agent workflows. The
-goal is narrow: selected effects cross a HELM boundary before dispatch, and
-each decision leaves a local receipt.
+goal is narrow: selected configured hook effects and routed MCP calls cross a
+HELM boundary before dispatch, and each decision leaves a local receipt.
 
 HELM is not a competing coding agent. It evaluates the actions your agent wants
 to take.
@@ -33,6 +33,20 @@ helm-ai-kernel setup claude-code --yes
 
 Setup writes draft policy and quarantine artifacts. It does not approve tools
 or grant broad operating permissions.
+
+For Codex project scope, setup also writes a project-isolated lifecycle record.
+It proves local configuration and a Kernel-only synthetic denial, not that a
+live client loaded the config. Inspect or recover an interrupted transaction
+with:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --yes
+```
+
+The [native client integration boundary](../INTEGRATIONS/native-client-boundary.md)
+defines the public proof limit: do not describe local setup output as a
+client-session result.
 
 ## Scan The Agent Surface
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # CLI
@@ -29,6 +29,25 @@ helm-ai-kernel setup --client cursor --print-config
 
 Setup writes local client configuration and draft policy artifacts. It does not
 approve tools.
+
+For Codex project scope, lifecycle management is explicit:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --dry-run --json
+helm-ai-kernel setup recover codex --scope project --yes
+helm-ai-kernel setup migrate codex --scope project --dry-run --json
+helm-ai-kernel setup migrate codex --scope project --yes
+helm-ai-kernel setup remove codex --scope project --yes
+```
+
+The lifecycle summary records local configuration and a Kernel-only synthetic
+denial; `client_load_observed=false` is not a client-session failure, it is an
+honest boundary. See the [Native Client Integration
+Boundary](../INTEGRATIONS/native-client-boundary.md) for public proof limits.
+
+Claude Code setup requires a direct executable. If PATH resolves through a mise
+shim, use `CLAUDE_CODE_BIN=/absolute/path/to/claude` with the setup command.
 
 ## MCP Approval Commands
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,33 +1,41 @@
 # HELM AI Kernel Threat Model
 
-Version: 2026-06-08-security-evidence-loop-v1
-Version Hash: sha256:77210a48f9f402bd0c28c1c93bc5d422a08f80003fa850e819cedff116697bc8
+Version: 2026-07-14-native-client-lifecycle-v1
+Version Hash: no signed release artifact has been created for this source revision
 Owner: HELM Kernel Security
-Review Date: 2026-06-08
+Review Date: 2026-07-14
 
 ## Assets
 
 - EvidencePack contracts, seals, signatures, receipt hashes, replay manifests, and trust profiles.
 - Boundary verdicts, policy evaluation inputs, sandbox specifications, and proof graph records.
 - Kernel package APIs consumed by Enterprise, services, SDKs, and public examples.
+- Local setup authority, project-scoped Codex bindings, recovery
+  journals, canonical lifecycle receipt envelopes, and lifecycle evidence.
 
 ## Entry Points
 
 - Go package APIs under `core/pkg/contracts`, `core/pkg/evidence`, `core/pkg/sandbox`, `core/pkg/proofgraph`, and boundary packages.
 - Test/conformance fixtures that are promoted into public proof or release evidence.
 - Serialized EvidencePack, receipt, replay, sandbox, and policy documents.
+- Local client configuration, legacy unscoped setup state, lifecycle databases,
+  and recovery directories supplied by the workstation filesystem.
 
 ## Trusted Inputs
 
 - Source-owned contracts and fixtures committed in this repo.
 - Signed EvidencePack material and configured external signer anchors.
 - Repo-local tests and conformance cases that run from a pinned commit.
+- Existing native lifecycle state only after private-directory, ownership,
+  canonical-envelope, and workspace-binding checks pass.
 
 ## Untrusted Inputs
 
 - Scanner output, vulnerability candidates, PoC transcripts, model-generated verifier text, and imported report attachments.
 - Sandbox command args, environment, mounts, network configuration, and repo checkout content.
 - Downstream Enterprise or service claims that are not backed by Kernel receipts.
+- A local config file, synthetic denial, client log, or claimed client load that
+  is not bound to the reviewed lifecycle receipt and sterile-session evidence.
 
 ## Tenant Boundaries
 
@@ -43,6 +51,8 @@ Review Date: 2026-06-08
 ## Effect Classes
 
 - ALLOW/DENY/ESCALATE boundary decisions, signature/seal creation, proof export, replay, sandbox execution, and connector-facing contract publication.
+- Codex project setup, recovery, migration, and removal of HELM-owned local
+  configuration entries.
 - High-risk effects require receipts, verifier evidence, and fail-closed behavior.
 
 ## Out-of-Scope Bug Classes
@@ -55,10 +65,16 @@ Review Date: 2026-06-08
 - Hash-only evidence accepted where signed or anchored proof was required.
 - Sandbox execution evidence without pinned images, credential checks, or network constraints.
 - Public or Enterprise claims drifting from Kernel source-owned receipt semantics.
+- One project accepting another project's binding, recovery journal, generated
+  artifact, or unscoped legacy state.
+- Lifecycle recovery accepting an index-only, malformed, or non-canonical
+  durable receipt instead of the signed envelope.
 
 ## Severity Calibration
 
 - Critical: forged or self-supplied EvidencePack/seal/verdict accepted as production proof.
 - High: verifier, sandbox, replay, or boundary receipt can be bypassed or confused across trust boundaries.
+- High: unsafe local authority state, cross-project native lifecycle state, or
+  a forged lifecycle receipt lets setup/recovery alter client configuration.
 - Medium: contract drift that weakens downstream evidence checks but remains blocked by another fail-closed gate.
 - Low: incomplete evidence metadata that does not alter enforcement, sealing, or release decisions.

--- a/examples/workstation/README.md
+++ b/examples/workstation/README.md
@@ -4,6 +4,11 @@ These examples package the manifest-first workstation adapter for local Codex or
 
 They do not use private vendor APIs. The wrapper records a local artifact directory, then HELM imports that directory into a signed Agent Run Receipt and deterministic ProofGraph.
 
+They do not install or exercise the native-client lifecycle. A wrapper receipt
+is not proof that Codex or Claude Code loaded HELM configuration; use
+[`docs/INTEGRATIONS/native-client-lifecycle.md`](../../docs/INTEGRATIONS/native-client-lifecycle.md)
+for the project-scoped setup and sterile-session review boundary.
+
 ## Codex-style run
 
 See `codex/README.md` for the local wrapper boundary.

--- a/examples/workstation/claude-code/README.md
+++ b/examples/workstation/claude-code/README.md
@@ -17,3 +17,7 @@ steps can call the selected-effect wrapper. They are examples only; use the
 documented hook surface for the local Claude Code installation.
 
 The wrapper and hooks do not read secrets, browser sessions, or raw chat history.
+They are not a live Claude Code integration result and do not establish Codex
+project lifecycle parity. Native Claude setup resolves a direct executable via
+`CLAUDE_CODE_BIN` when PATH would select a mise shim; see
+[`docs/INTEGRATIONS/native-client-lifecycle.md`](../../../docs/INTEGRATIONS/native-client-lifecycle.md).

--- a/examples/workstation/codex/README.md
+++ b/examples/workstation/codex/README.md
@@ -12,3 +12,7 @@ HELM_BIN=go\ run\ ./core/cmd/helm-ai-kernel \
 ```
 
 The wrapper does not read secrets, browser sessions, or raw chat history.
+It does not create or validate the project-scoped Codex setup lifecycle, launch
+Codex, or prove a native client session. Use
+[`docs/INTEGRATIONS/native-client-lifecycle.md`](../../../docs/INTEGRATIONS/native-client-lifecycle.md)
+for that separate boundary.


### PR DESCRIPTION
## Summary
- persist native lifecycle and recovery state inside a project-scoped namespace with secure locking and receipt handling
- harden migration, rollback, profile-drift, mode/signing, runtime-admission, and storage behavior
- add a public native-client boundary and maintainer lifecycle protocol; public claims now distinguish local setup, sterile client observation, and release/deployment evidence

## Validation
- go test -p 1 ./... -count=1
- go test -race ./pkg/store -count=1
- go vet ./...
- scripts/check_documentation_coverage.py
- scripts/check_documentation_truth.py

## Boundary
This change deliberately does not claim a real authenticated Codex or Claude Code session was observed. Local lifecycle evidence remains distinct from sterile-client observation and release authority.