### PR TITLE
test(setup): document lifecycle review evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 title: HELM AI Kernel Changelog
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-14
 ---
 
 # Changelog
@@ -84,10 +84,13 @@ All notable changes to the retained HELM AI Kernel surface are documented here. 
 
 ## [Unreleased]
 
-No public feature claim is active in this section. Keep research scaffolds and
-hardware-backed enforcement language out of the public changelog until a tagged
-release ships source-owned tests, verifier evidence, and release artifacts for
-that exact capability.
+- Documented the source-backed native-client lifecycle boundary: private Codex
+  project namespaces, durable receipt-envelope recovery, explicit legacy-state
+  migration, and selected-hook/MCP limits. The new maintainer review protocol
+  keeps local configuration and Kernel-only synthetic-denial proof separate
+  from a real native-client session.
+- No tagged release, real native-client session result, or broader desktop
+  enforcement claim is created by this documentation and lifecycle work.
 
 ## [0.7.2] - 2026-07-13
 

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -5,9 +5,10 @@
 - Public/private: Public OSS repo.
 - HELM normative status: Canonical HELM AI Kernel under UCS v1.3.
 - Current status: Active implementation with Go server, guardian evaluation, receipt storage/verification paths, API contracts, Dockerfile, Helm chart, tests, and docs.
-- Implemented capabilities: Guardian decision evaluation, API/server wiring, receipt persistence and verification primitives, external host evidence ingestion/verification/correlation, deployment assets, conformance/test scaffolding.
+- Implemented capabilities: Guardian decision evaluation, API/server wiring, receipt persistence and verification primitives, external host evidence ingestion/verification/correlation, deployment assets, conformance/test scaffolding, and Codex project-scoped setup/recovery with signed lifecycle evidence.
 - Not implemented: No Console source code in this repo; no hosted Enterprise automation production claim; no named buyer production rollout claim; no L4 conformance claim; no eBPF, seccomp, TPM, hardware enclave, or packet-blocking enforcement claim unless a tested code path proves it.
-- Public claims: HELM AI Kernel is the fail-closed execution firewall for AI agents; dangerous actions must be denied or escalated before dispatch; receipts can be verified and tampering must fail; HELM can consume and correlate external host/network evidence without claiming host-level enforcement.
+- Public claims: HELM AI Kernel is the fail-closed execution firewall for AI agents; dangerous actions that reach a configured boundary must be denied or escalated before dispatch; receipts can be verified and tampering must fail; HELM can consume and correlate external host/network evidence without claiming host-level enforcement.
+- Native-client boundary: Codex project setup stores an isolated project binding, recovery journal, and generated artifacts beneath a shared local authority. A matching config and Kernel-only synthetic denial are local setup evidence, not proof that a live Codex client loaded or obeyed the configuration. Claude Code setup resolves a direct CLI, requests MCP registration through that CLI, and writes selected hook configuration; it is not equivalent to the Codex project lifecycle or MCP-config readback.
 - Claim evidence: `core/cmd/helm-ai-kernel`, `core/pkg/guardian`, `core/pkg/receipt`, `core/pkg/evidence/externalhost`, `core/pkg/correlation/hostaction`, `core/pkg/verifier/externalreceipt`, `api/openapi`, `Dockerfile`, `charts/helm-ai-kernel`, `README.md`.
 - Tests that prove each claim: `go test ./...`, API contract checks, demo receipt smoke tests after API routes are enabled.
 - Docs that mention each claim: `README.md`, `docs/`, `examples/`, deployment/runbook docs.
@@ -15,5 +16,5 @@
 - Stale claims removed: Any unsupported hosted Enterprise automation, entitlement-enforcement, or production-conformance claim must remain absent until smoke-tested.
 - Remaining gaps: Keep release/version claims tied to published GitHub release assets and docs gates.
 - Verification commands: `make test` if available, `go test ./...`, API contract checks, Docker/Helm chart smoke commands from runbooks.
-- Last audited date: 2026-07-01.
+- Last audited date: 2026-07-14.
 - Owner: Mindburn Labs.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **A local firewall for AI-agent actions.**
 
-HELM sits between Claude Code, Codex, MCP tools, shell commands, and other agent
-actions. It decides `ALLOW`, `DENY`, or `ESCALATE`, then writes a signed receipt
-you can verify later.
+HELM evaluates actions that reach its configured MCP, proxy, wrapper, or hook
+boundary. It decides `ALLOW`, `DENY`, or `ESCALATE`, then writes a signed
+receipt you can verify later.
 
 ![HELM AI Kernel: one boundary, one decision, one receipt](docs/assets/readme-boundary-preview.png)
 
@@ -63,6 +63,7 @@ You get:  a signed receipt you can verify offline
 | CLI commands | [CLI reference](docs/reference/cli.md) |
 | Security model | [Execution security model](docs/EXECUTION_SECURITY_MODEL.md) |
 | MCP tool quarantine | [MCP integration](docs/INTEGRATIONS/mcp.md) |
+| Native client lifecycle and review limits | [Maintainer protocol](docs/INTEGRATIONS/native-client-lifecycle.md) |
 | Evidence verification | [Verification](docs/VERIFICATION.md) |
 | AI security category map | [AI Security Categories](docs/AI_SECURITY_CATEGORIES.md) |
 
@@ -73,6 +74,11 @@ You get:  a signed receipt you can verify offline
 - Not a vague AI-safety claim.
 
 It is the open-source execution boundary: policy in, action checked, receipt out.
+
+Codex project setup proves generated local configuration and a Kernel-only
+synthetic denial. It does not by itself prove that a live Codex session loaded
+the configuration; see the native-client lifecycle protocol before making that
+claim.
 
 ## Free Forever
 

--- a/core/cmd/helm-ai-kernel/setup_recovery_security_test.go
+++ b/core/cmd/helm-ai-kernel/setup_recovery_security_test.go
@@ -1,0 +1,2094 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+func writeSetupSecurityPendingJournal(t *testing.T, dataDir, operation string, plans []setupRecoveryFilePlan) *setupRecoveryJournal {
+	t.Helper()
+	if err := prepareSetupRecoveryDirectory(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if plans == nil {
+		specs, err := expectedSetupRecoveryPlans(operation)
+		if err != nil {
+			t.Fatal(err)
+		}
+		plans = make([]setupRecoveryFilePlan, 0, len(specs))
+		for _, spec := range specs {
+			plans = append(plans, setupRecoveryFilePlan{ID: spec.ID, StageFile: spec.StageFile})
+		}
+	}
+	binary, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := inspectSetupKernelBinary(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspacePathHash, err := setupRecoveryWorkspacePathHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	txnID, err := newSetupRecoveryTransactionID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptID, err := newSetupLifecycleReceiptID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	journal := &setupRecoveryJournal{
+		SchemaVersion:      setupRecoverySchema,
+		TransactionID:      txnID,
+		Operation:          operation,
+		Target:             "codex",
+		Scope:              "project",
+		WorkspacePathHash:  workspacePathHash,
+		DataDirPathHash:    canonicalize.HashBytes([]byte(dataDir)),
+		BinaryPath:         identity.Path,
+		BinaryContentHash:  identity.ContentHash,
+		LifecycleReceiptID: receiptID,
+		Phase:              setupRecoveryPhasePrepared,
+		Files:              plans,
+	}
+	if err := writeSetupRecoveryJournal(dataDir, *journal); err != nil {
+		t.Fatal(err)
+	}
+	if err := removeSetupRecoveryMarker(dataDir, setupRecoveryPreparingFile); err != nil {
+		t.Fatal(err)
+	}
+	return journal
+}
+
+func writeSetupRecoveryCrashTemp(t *testing.T, directory, suffix string) string {
+	t.Helper()
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(directory, setupRecoveryTemporaryPrefix+suffix)
+	if err := os.WriteFile(path, []byte("incomplete private write"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSetupRecoveryPreparedResidueFailsClosedThenRecovers(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	if err := os.MkdirAll(filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeSetupRecoveryCrashTemp(t, setupRecoveryRoot(dataDir), "101")
+	writeSetupRecoveryCrashTemp(t, filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir), "102")
+
+	pending, err := setupRecoveryRequired(dataDir)
+	if err != nil || !pending {
+		t.Fatalf("pre-journal residue pending=%v err=%v", pending, err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("status exit=%d stderr=%s", code, stderr.String())
+	}
+	var status setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &status); err != nil || !status.RecoveryRequired {
+		t.Fatalf("prepared residue status=%#v err=%v", status, err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("pending hook did not deny safely: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	for _, path := range []string{filepath.Join(dataDir, "root.key"), filepath.Join(dataDir, "receipts", "hooks")} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("pending hook created state %s: %v", path, err)
+		}
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("prepared residue did not block MCP: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("recover prepared residue exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("recover retained pre-journal residue: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("fresh setup stayed blocked after residue cleanup: code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestSetupRecoveryUnexpectedResidueIsPreservedAndFailsClosed(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	root := setupRecoveryRoot(dataDir)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	unknown := filepath.Join(root, "not-owned")
+	if err := os.WriteFile(unknown, []byte("user-data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "unexpected") {
+		t.Fatalf("status did not fail closed: code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "unexpected") {
+		t.Fatalf("recover accepted unknown residue: code=%d stderr=%s", code, stderr.String())
+	}
+	if raw, err := os.ReadFile(unknown); err != nil || string(raw) != "user-data" {
+		t.Fatalf("recover modified unknown residue: raw=%q err=%v", raw, err)
+	}
+}
+
+func TestSetupRecoveryPendingJournalToleratesOnlyWriterShapedCrashTemps(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	previousRecord := recordCodexProjectSetupLifecycleFn
+	recordCodexProjectSetupLifecycleFn = func(setupOptions, setupSummary, string) (setupLifecycleResult, error) {
+		return setupLifecycleResult{}, errors.New("injected lifecycle failure")
+	}
+	t.Cleanup(func() { recordCodexProjectSetupLifecycleFn = previousRecord })
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("setup with injected lifecycle failure exit=%d stderr=%s", code, stderr.String())
+	}
+	if inspection, err := inspectSetupRecovery(dataDir); err != nil || inspection.State != setupRecoveryStatePending {
+		t.Fatalf("initial pending recovery inspection=%#v err=%v", inspection, err)
+	}
+	writeSetupRecoveryCrashTemp(t, setupRecoveryRoot(dataDir), "201")
+	writeSetupRecoveryCrashTemp(t, filepath.Join(setupRecoveryRoot(dataDir), setupRecoveryStagingDir), "202")
+	if inspection, err := inspectSetupRecovery(dataDir); err != nil || inspection.State != setupRecoveryStatePending {
+		t.Fatalf("pending recovery rejected writer-shaped temps: inspection=%#v err=%v", inspection, err)
+	}
+
+	recordCodexProjectSetupLifecycleFn = previousRecord
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("pending recovery with crash temps exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("pending recovery left temporary residue: %v", err)
+	}
+
+	db, _, receiptStore, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var count int
+	if err := db.QueryRow("SELECT COUNT(1) FROM receipts WHERE status = 'DENY'").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("recovered install wrote %d lifecycle receipts, want one", count)
+	}
+	if _, err := receiptStore.GetByReceiptID(context.Background(), func() string {
+		var id string
+		if err := db.QueryRow("SELECT receipt_id FROM receipts WHERE status = 'DENY' LIMIT 1").Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}()); err != nil {
+		t.Fatalf("recovered lifecycle receipt unreadable: %v", err)
+	}
+}
+
+func TestSetupRecoveryRejectsMalformedTemporaryResidueWithoutDeletingIt(t *testing.T) {
+	cases := []struct {
+		name   string
+		stage  bool
+		create func(t *testing.T, path string, external string)
+	}{
+		{
+			name: "unknown root file",
+			create: func(t *testing.T, path string, _ string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("user-data"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "temporary-shaped staged symlink",
+			stage: true,
+			create: func(t *testing.T, path string, external string) {
+				t.Helper()
+				if err := os.Symlink(external, path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "temporary-shaped root directory",
+			create: func(t *testing.T, path string, _ string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name:  "temporary-shaped staged wrong mode",
+			stage: true,
+			create: func(t *testing.T, path string, _ string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte("must-remain"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Chmod(path, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := chdirTempDir(t)
+			dataDir := filepath.Join(dir, "helm")
+			root := setupRecoveryRoot(dataDir)
+			stageDir := filepath.Join(root, setupRecoveryStagingDir)
+			if err := os.MkdirAll(stageDir, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			directory := root
+			name := "not-owned"
+			if tc.stage {
+				directory = stageDir
+				name = setupRecoveryTemporaryPrefix + "303"
+			} else if strings.Contains(tc.name, "temporary-shaped") {
+				name = setupRecoveryTemporaryPrefix + "304"
+			}
+			path := filepath.Join(directory, name)
+			external := filepath.Join(dir, "external")
+			if err := os.WriteFile(external, []byte("outside"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			tc.create(t, path, external)
+
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr); code != 2 {
+				t.Fatalf("status accepted malformed temporary residue: code=%d stderr=%s", code, stderr.String())
+			}
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+				t.Fatalf("recover accepted malformed temporary residue: code=%d stderr=%s", code, stderr.String())
+			}
+			if _, err := os.Lstat(path); err != nil {
+				t.Fatalf("recover removed malformed temporary residue: %v", err)
+			}
+			if got, err := os.ReadFile(external); err != nil || string(got) != "outside" {
+				t.Fatalf("recover touched symlink target: got=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestForgedCodexRemovalJournalCannotAlterUnprovenConfig(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertCodexProjectMCP(summary.ClientConfigPath, summary.BinaryPath, dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := upsertOwnedSetupHookConfig(summary.HookConfigPath, setupHookMatcher(opts.Target), setupHookCommand(opts, summary.BinaryPath), opts.Target); err != nil {
+		t.Fatal(err)
+	}
+	clientBefore, err := readSetupFileState(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookBefore, err := readSetupFileState(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientAfter, err := buildRemoveCodexProjectMCPStateForBinary(clientBefore, dataDir, summary.BinaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookAfter, err := buildRemoveOwnedSetupHookState(hookBefore, opts.Target, setupHookCommand(opts, summary.BinaryPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeSetupSecurityPendingJournal(t, dataDir, "remove", []setupRecoveryFilePlan{
+		setupRecoveryPlanForStates(setupRecoveryFileMCP, clientBefore, clientAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileHook, hookBefore, hookAfter, ""),
+		setupRecoveryPlanForStates(setupRecoveryFileBinding, setupFileState{Path: setupCodexProjectBindingPath(dataDir)}, setupFileState{Path: setupCodexProjectBindingPath(dataDir)}, ""),
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "provenance") {
+		t.Fatalf("forged removal journal was not rejected: code=%d stderr=%s", code, stderr.String())
+	}
+	clientAfterAttempt, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil || !bytes.Equal(clientAfterAttempt, clientBefore.Data) {
+		t.Fatalf("forged removal journal changed MCP config: %q err=%v", clientAfterAttempt, err)
+	}
+	hookAfterAttempt, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil || !bytes.Equal(hookAfterAttempt, hookBefore.Data) {
+		t.Fatalf("forged removal journal changed hook config: %q err=%v", hookAfterAttempt, err)
+	}
+	for _, path := range []string{filepath.Join(dataDir, "root.key"), filepath.Join(dataDir, "helm.db")} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("forged removal journal created lifecycle state %s: %v", path, err)
+		}
+	}
+}
+
+func TestCodexRemovalRecoveryCompletesAfterBindingDeletedBeforeTerminalMarker(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+
+	previousFinalize := finalizeCodexProjectRecoveryJournal
+	finalizeCodexProjectRecoveryJournal = func(_ string, _ *setupRecoveryJournal) error {
+		return errors.New("injected pre-marker finalization failure")
+	}
+	t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("remove with injected finalization failure exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(setupCodexProjectBindingPath(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("binding survived the intended post-revocation crash boundary: %v", err)
+	}
+	if inspection, err := inspectSetupRecovery(dataDir); err != nil || inspection.State != setupRecoveryStatePending {
+		t.Fatalf("post-binding-delete recovery inspection=%#v err=%v", inspection, err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("pending post-binding-delete recovery did not block MCP: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("pending post-binding-delete recovery did not deny hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	var revokedBefore int
+	if err := db.QueryRow("SELECT COUNT(1) FROM receipts WHERE status = 'REVOKED'").Scan(&revokedBefore); err != nil {
+		t.Fatal(err)
+	}
+	if revokedBefore != 1 {
+		t.Fatalf("post-binding-delete state has %d revoked receipts, want one", revokedBefore)
+	}
+
+	finalizeCodexProjectRecoveryJournal = previousFinalize
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recover after binding delete exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("completed removal recovery left recovery root: %v", err)
+	}
+	var revokedAfter int
+	if err := db.QueryRow("SELECT COUNT(1) FROM receipts WHERE status = 'REVOKED'").Scan(&revokedAfter); err != nil {
+		t.Fatal(err)
+	}
+	if revokedAfter != 1 {
+		t.Fatalf("completed removal recovery duplicated revoked receipt: before=%d after=%d", revokedBefore, revokedAfter)
+	}
+	refreshSetupConfiguration(opts, &summary)
+	if summary.MCPConfigured || summary.HookConfigured {
+		t.Fatalf("completed removal recovery restored owned config: %#v", summary)
+	}
+}
+
+func TestCodexRemovalRecoveryAfterBindingDeleteRefusesChangedConfig(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	previousFinalize := finalizeCodexProjectRecoveryJournal
+	finalizeCodexProjectRecoveryJournal = func(_ string, _ *setupRecoveryJournal) error {
+		return errors.New("injected pre-marker finalization failure")
+	}
+	t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("remove with injected finalization failure exit=%d stderr=%s", code, stderr.String())
+	}
+	const userChange = "# user changed this after HELM removed its MCP\n"
+	if err := os.WriteFile(summary.ClientConfigPath, []byte(userChange), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	finalizeCodexProjectRecoveryJournal = previousFinalize
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "post-removal") {
+		t.Fatalf("recovery accepted a post-revocation config edit: code=%d stderr=%s", code, stderr.String())
+	}
+	if got, err := os.ReadFile(summary.ClientConfigPath); err != nil || string(got) != userChange {
+		t.Fatalf("recovery overwrote user config after binding deletion: got=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatalf("recovery discarded journal after a concurrent edit: %v", err)
+	}
+}
+
+func TestBindingAbsentRemovalJournalWithoutSignedRevocationCannotMutateConfig(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	stubSetupSideEffects(t)
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	clientBefore, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hookBefore, err := os.ReadFile(summary.HookConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparation, err := prepareCodexProjectRecoveryRemove(opts, summary)
+	if err != nil || preparation.journal == nil {
+		t.Fatalf("prepare removal journal err=%v preparation=%#v", err, preparation)
+	}
+	if err := os.Remove(setupCodexProjectBindingPath(dataDir)); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+		t.Fatalf("binding-absent journal without signed revocation recovered: code=%d stderr=%s", code, stderr.String())
+	}
+	if got, err := os.ReadFile(summary.ClientConfigPath); err != nil || !bytes.Equal(got, clientBefore) {
+		t.Fatalf("unsigned binding-absent journal changed MCP config: got=%q err=%v", got, err)
+	}
+	if got, err := os.ReadFile(summary.HookConfigPath); err != nil || !bytes.Equal(got, hookBefore) {
+		t.Fatalf("unsigned binding-absent journal changed hook config: got=%q err=%v", got, err)
+	}
+	if _, err := os.Stat(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatalf("unsigned binding-absent journal was discarded: %v", err)
+	}
+}
+
+func TestCodexProjectsShareAuthorityStateWithoutSharingBindingsRecoveryOrArtifacts(t *testing.T) {
+	root := t.TempDir()
+	projectA := filepath.Join(root, "project-a")
+	projectB := filepath.Join(root, "project-b")
+	for _, project := range []string{projectA, projectB} {
+		if err := os.MkdirAll(project, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+	enterProject := func(project string) {
+		t.Helper()
+		if err := os.Chdir(project); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stubSetupSideEffects(t)
+	dataDir := filepath.Join(root, "shared-kernel-state")
+	setup := func(project string) setupCodexProjectPaths {
+		t.Helper()
+		enterProject(project)
+		var stdout, stderr bytes.Buffer
+		if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+			t.Fatalf("setup %s exit=%d stderr=%s stdout=%s", project, code, stderr.String(), stdout.String())
+		}
+		paths, err := newSetupCodexProjectPaths(setupOptions{Target: "codex", Scope: "project", DataDir: dataDir})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return paths
+	}
+	pathsA := setup(projectA)
+	pathsB := setup(projectB)
+	if pathsA.StateRoot == pathsB.StateRoot || pathsA.BindingPath == pathsB.BindingPath || pathsA.RecoveryRoot == pathsB.RecoveryRoot || pathsA.ArtifactsDir == pathsB.ArtifactsDir {
+		t.Fatalf("project state namespaces collided: A=%#v B=%#v", pathsA, pathsB)
+	}
+	for _, path := range []string{pathsA.BindingPath, filepath.Join(pathsA.ArtifactsDir, "policy.draft.json"), pathsB.BindingPath, filepath.Join(pathsB.ArtifactsDir, "policy.draft.json")} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("missing project-scoped native state %s: %v", path, err)
+		}
+	}
+
+	enterProject(projectA)
+	if _, configured, err := admitCodexProjectRuntime(dataDir); err != nil || !configured {
+		t.Fatalf("project A lost runtime admission after project B setup: configured=%v err=%v", configured, err)
+	}
+	if err := prepareSetupRecoveryDirectory(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("project A prepared recovery was not project-local pending state: pending=%v err=%v", pending, err)
+	}
+
+	enterProject(projectB)
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("project A recovery incorrectly blocked project B: pending=%v err=%v", pending, err)
+	}
+	if _, configured, err := admitCodexProjectRuntime(dataDir); err != nil || !configured {
+		t.Fatalf("project B runtime admission failed while A recovery was pending: configured=%v err=%v", configured, err)
+	}
+
+	enterProject(projectA)
+	if err := cleanupIncompleteSetupRecoveryDirectory(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("remove project A exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(pathsA.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("removing project A retained its binding: %v", err)
+	}
+
+	enterProject(projectB)
+	if _, err := os.Stat(pathsB.BindingPath); err != nil {
+		t.Fatalf("removing project A altered project B binding: %v", err)
+	}
+	if _, configured, err := admitCodexProjectRuntime(dataDir); err != nil || !configured {
+		t.Fatalf("project B lost runtime admission after A removal: configured=%v err=%v", configured, err)
+	}
+}
+
+func TestLegacyUnscopedRecoveryStateBlocksNamespacedCodexEntrypoints(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.MkdirAll(filepath.Join(legacyRoot, setupRecoveryStagingDir), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyRoot, setupRecoveryJournalFile), []byte(`{"schema_version":"helm.codex-project-recovery/v1"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr); code != 2 || !strings.Contains(stderr.String(), "legacy unscoped") {
+		t.Fatalf("status ignored legacy recovery state: code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "legacy unscoped") {
+		t.Fatalf("setup ignored legacy recovery state: code=%d stderr=%s", code, stderr.String())
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "legacy unscoped") {
+		t.Fatalf("MCP ignored legacy recovery state: %v", err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("hook ignored legacy recovery state: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "root.key")); !os.IsNotExist(err) {
+		t.Fatalf("legacy-blocked entrypoint created new lifecycle authority: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(legacyRoot, setupRecoveryJournalFile)); err != nil {
+		t.Fatalf("legacy-blocked entrypoint altered recovery journal: %v", err)
+	}
+}
+
+func TestForgedCommittedMarkerKeepsLiveJournalPending(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	journal := writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+	if err := writeSetupRecoveryMarker(dataDir, setupRecoveryCommittedFile, setupRecoveryMarker{
+		SchemaVersion:      setupRecoveryMarkerSchema,
+		State:              setupRecoveryMarkerStateCommitted,
+		TransactionID:      journal.TransactionID,
+		LifecycleReceiptID: journal.LifecycleReceiptID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := setupRecoveryRequired(dataDir)
+	if err != nil || !pending {
+		t.Fatalf("forged committed marker unblocked recovery: pending=%v err=%v", pending, err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("forged committed marker unblocked MCP: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "recovery") {
+		t.Fatalf("forged committed marker unblocked hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatalf("forged marker discarded live journal: %v", err)
+	}
+}
+
+func TestStagedCodexBindingCannotBeReplayedBeforeConfigMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparation, err := prepareCodexProjectRecoveryInstall(opts, summary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindingPath, err := setupRecoverySafeStagePath(dataDir, setupCodexProjectBindingFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := readSetupFileState(bindingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var binding setupCodexProjectBinding
+	if err := decodeCanonicalSetupJSON(state.Data, &binding); err != nil {
+		t.Fatal(err)
+	}
+	binding.InstallReceiptID, err = newSetupLifecycleReceiptID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered, err := canonicalize.JCS(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(bindingPath, tampered); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := resumeCodexProjectRecovery(opts, preparation.summary, preparation.journal); err == nil || !strings.Contains(err.Error(), "staged") {
+		t.Fatalf("replayed staged binding was accepted: %v", err)
+	}
+	for _, path := range []string{summary.ClientConfigPath, summary.HookConfigPath, setupCodexProjectBindingPath(dataDir)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("invalid staged binding changed durable config %s: %v", path, err)
+		}
+	}
+}
+
+func TestLifecycleReceiptReadBackRejectsAfterInsertMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	previousPrepared := setupLifecycleStorePrepared
+	setupLifecycleStorePrepared = func(db *sql.DB) error {
+		_, err := db.Exec(`CREATE TRIGGER helm_setup_tamper AFTER INSERT ON receipts BEGIN UPDATE receipts SET signature = '00' WHERE receipt_id = NEW.receipt_id; END;`)
+		return err
+	}
+	t.Cleanup(func() { setupLifecycleStorePrepared = previousPrepared })
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || (!strings.Contains(stderr.String(), "failed verification") && !strings.Contains(stderr.String(), "receipt envelope does not match")) {
+		t.Fatalf("tampered appended receipt was accepted: code=%d stderr=%s", code, stderr.String())
+	}
+	pending, err := setupRecoveryRequired(dataDir)
+	if err != nil || !pending {
+		t.Fatalf("tampered receipt did not retain recovery: pending=%v err=%v", pending, err)
+	}
+	if _, err := os.Stat(setupCodexProjectBindingPath(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("tampered receipt published install binding: %v", err)
+	}
+}
+
+func TestRemovalProvenanceFailureDoesNotMutateReceiptStore(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientBefore, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientTampered := append(append([]byte(nil), clientBefore...), []byte("# user-owned change\n")...)
+	if err := writeSetupPrivateFile(summary.ClientConfigPath, clientTampered); err != nil {
+		t.Fatal(err)
+	}
+	dbBefore, err := os.ReadFile(filepath.Join(dataDir, "helm.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	walPath := filepath.Join(dataDir, "helm.db-wal")
+	walBefore, walBeforeErr := os.ReadFile(walPath)
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "differs from its proven install binding") {
+		t.Fatalf("tampered config removal did not fail provenance: code=%d stderr=%s", code, stderr.String())
+	}
+	dbAfter, err := os.ReadFile(filepath.Join(dataDir, "helm.db"))
+	if err != nil || !bytes.Equal(dbAfter, dbBefore) {
+		t.Fatalf("failed provenance check changed lifecycle DB: equal=%v err=%v", bytes.Equal(dbAfter, dbBefore), err)
+	}
+	walAfter, walAfterErr := os.ReadFile(walPath)
+	if (walBeforeErr == nil) != (walAfterErr == nil) || walBeforeErr == nil && !bytes.Equal(walAfter, walBefore) {
+		t.Fatalf("failed provenance check changed lifecycle WAL: beforeErr=%v afterErr=%v", walBeforeErr, walAfterErr)
+	}
+	clientAfter, err := os.ReadFile(summary.ClientConfigPath)
+	if err != nil || !bytes.Equal(clientAfter, clientTampered) {
+		t.Fatalf("failed provenance check changed user config: %q err=%v", clientAfter, err)
+	}
+}
+
+func TestLifecycleEvidenceRejectsSymlinkAndDuplicateJSON(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("initial setup exit=%d stderr=%s", code, stderr.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := readSetupLifecycleReceiptReadOnly(context.Background(), dataDir, summary.LifecycleReceiptID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Type != "native_client_setup_lifecycle" || receipt.Action != "install" || receipt.Verdict != "DENY" || receipt.ToolName != "file_write" || receipt.ReasonCode != "ERR_SYNTHETIC_FILE_WRITE_DENIED" || receipt.SignatureProfile == "" || receipt.SignatureAlgorithm == "" || receipt.KeyID == "" {
+		t.Fatalf("read-only lifecycle proof lost canonical receipt fields: %#v", receipt)
+	}
+	original, err := os.ReadFile(summary.LifecycleEvidencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(dir, "external-evidence.json")
+	if err := os.WriteFile(external, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(summary.LifecycleEvidencePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, summary.LifecycleEvidencePath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifySetupLifecycleEvidence(dataDir, receipt); err == nil {
+		t.Fatal("symlinked lifecycle evidence unexpectedly verified")
+	}
+	if err := os.Remove(summary.LifecycleEvidencePath); err != nil {
+		t.Fatal(err)
+	}
+	needle := `"receipt_id":"` + summary.LifecycleReceiptID + `"`
+	duplicate := strings.Replace(string(original), needle, `"receipt_id":"tampered","receipt_id":"`+summary.LifecycleReceiptID+`"`, 1)
+	if duplicate == string(original) {
+		t.Fatal("fixture did not locate receipt_id in canonical evidence")
+	}
+	if err := writeSetupPrivateFile(summary.LifecycleEvidencePath, []byte(duplicate)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifySetupLifecycleEvidence(dataDir, receipt); err == nil {
+		t.Fatal("duplicate-key lifecycle evidence unexpectedly verified")
+	}
+	db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`UPDATE receipts SET receipt_envelope = '' WHERE receipt_id = ?`, summary.LifecycleReceiptID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readSetupLifecycleReceiptReadOnly(context.Background(), dataDir, summary.LifecycleReceiptID); err == nil || !strings.Contains(err.Error(), "predates canonical durable receipt envelopes") {
+		t.Fatalf("legacy receipt projection was accepted as native lifecycle authority: %v", err)
+	}
+}
+
+func TestLifecycleSignerRejectsMalformedAndSymlinkedRootKey(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rootPath := filepath.Join(dataDir, "root.key")
+	if err := writeSetupPrivateFile(rootPath, []byte("00")); err != nil {
+		t.Fatal(err)
+	}
+	func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				t.Fatalf("malformed root.key panicked: %v", recovered)
+			}
+		}()
+		if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "seed size") {
+			t.Fatalf("malformed root.key error=%v", err)
+		}
+	}()
+	if err := os.Remove(rootPath); err != nil {
+		t.Fatal(err)
+	}
+	external := filepath.Join(dir, "external-root.key")
+	if err := os.WriteFile(external, []byte("00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, rootPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("symlinked root.key error=%v", err)
+	}
+}
+
+func TestLifecycleSignerRejectsInsecureExistingPrivateKeyModes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX 0600 boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	rootPath := filepath.Join(dataDir, "root.key")
+	if err := os.Chmod(rootPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadExistingEd25519Root(dataDir); err == nil || !strings.Contains(err.Error(), "exact mode 0600") {
+		t.Fatalf("insecure root.key mode accepted: %v", err)
+	}
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "exact mode 0600") {
+		t.Fatalf("load-or-generate accepted insecure root.key mode: %v", err)
+	}
+	if err := os.Chmod(rootPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HELM_RECEIPT_PROFILE", "hybrid")
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	mlDSAPath := filepath.Join(dataDir, "root.mldsa65.key")
+	if err := os.Chmod(mlDSAPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadExistingMLDSARoot(dataDir); err == nil || !strings.Contains(err.Error(), "exact mode 0600") {
+		t.Fatalf("insecure ML-DSA root mode accepted: %v", err)
+	}
+}
+
+func TestLifecycleSignerRejectsInvalidProfileBeforeAuthorityStateCreation(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "fresh-authority")
+	t.Setenv("HELM_RECEIPT_PROFILE", "invalid-profile")
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "unknown HELM_RECEIPT_PROFILE") {
+		t.Fatalf("invalid receipt profile was accepted: %v", err)
+	}
+	for _, path := range []string{
+		dataDir,
+		filepath.Join(dataDir, "root.key"),
+		filepath.Join(dataDir, "root.mldsa65.key"),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("invalid receipt profile created authority state %s: %v", path, err)
+		}
+	}
+}
+
+func TestCodexProjectSetupRejectsWorldWritableAuthorityDataDirBeforeConfigMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "shared-authority")
+	if err := os.MkdirAll(dataDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dataDir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dataDir, 0o700) })
+	stubSetupSideEffects(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "unsafe Codex project authority state") || !strings.Contains(stderr.String(), "group/world-writable") {
+		t.Fatalf("unsafe authority setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, path := range []string{
+		filepath.Join(dir, ".codex", "config.toml"),
+		filepath.Join(dir, ".codex", "hooks.json"),
+		filepath.Join(dataDir, "root.key"),
+		setupRecoveryRoot(dataDir),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("unsafe authority setup mutated %s: %v", path, err)
+		}
+	}
+	if _, err := loadOrGenerateSignerWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("signer accepted world-writable authority data dir: %v", err)
+	}
+}
+
+func TestAuthoritySubdirectoryRejectsExistingWorldWritableStateComponent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dataDir := filepath.Join(t.TempDir(), "authority")
+	if _, err := ensureSetupAuthorityDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	unsafe := filepath.Join(dataDir, "native-client")
+	if err := os.MkdirAll(unsafe, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unsafe, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+	if err := ensureSetupAuthoritySubdirectory(dataDir, filepath.Join("native-client", "codex-projects")); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("unsafe authority subdirectory accepted: %v", err)
+	}
+}
+
+func TestCodexProjectSetupRejectsUnsafeProjectStateAncestorBeforeConfigMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "shared-authority")
+	if _, err := ensureSetupAuthorityDataDir(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	unsafe := filepath.Join(dataDir, "native-client")
+	if err := os.MkdirAll(unsafe, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unsafe, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+	stubSetupSideEffects(t)
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "inspect Codex project recovery state") || !strings.Contains(stderr.String(), "group/world-writable") {
+		t.Fatalf("unsafe project state ancestor setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	for _, path := range []string{
+		filepath.Join(dir, ".codex", "config.toml"),
+		filepath.Join(dir, ".codex", "hooks.json"),
+		filepath.Join(dataDir, "root.key"),
+		setupRecoveryRoot(dataDir),
+	} {
+		if _, err := os.Lstat(path); !os.IsNotExist(err) {
+			t.Fatalf("unsafe project state ancestor setup mutated %s: %v", path, err)
+		}
+	}
+}
+
+func TestConfiguredCodexRuntimeRejectsUnsafeProjectStateAuthority(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dataDir, _ := setupProvenNativeCodexProjectForRuntime(t)
+	unsafe := filepath.Join(dataDir, "native-client")
+	if err := os.Chmod(unsafe, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+
+	if _, _, err := newLocalMCPRuntimeWithDataDir(dataDir); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("configured runtime admitted unsafe project authority: %v", err)
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil || !strings.Contains(err.Error(), "group/world-writable") {
+		t.Fatalf("stdio runtime admitted unsafe project authority: %v", err)
+	}
+}
+
+func moveCurrentCodexProjectBindingToLegacyForTest(t *testing.T, dataDir string) setupCodexProjectPaths {
+	t.Helper()
+	paths := currentCodexProjectPaths(dataDir)
+	bindingData, err := os.ReadFile(paths.BindingPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(legacyCodexProjectBindingPath(dataDir), bindingData); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(paths.BindingPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSetupAuthoritySubdirectory(dataDir, "autoconfigure"); err != nil {
+		t.Fatal(err)
+	}
+	for _, filename := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json"} {
+		source := filepath.Join(paths.ArtifactsDir, filename)
+		data, err := os.ReadFile(source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := writeSetupPrivateFile(filepath.Join(legacyCodexProjectArtifactsDir(dataDir), filename), data); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(source); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Remove(paths.ArtifactsDir); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.Remove(paths.StateRoot); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return paths
+}
+
+func TestSetupMigrateCodexProjectBindingMovesOnlyValidatedLegacyState(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	if _, err := os.Stat(legacyBinding); err != nil {
+		t.Fatalf("legacy fixture binding is missing: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("current binding survived fixture migration: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--json", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("migration dry-run exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyBinding); err != nil {
+		t.Fatalf("migration dry-run changed legacy binding: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("migration dry-run created current binding: %v", err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyBinding); !os.IsNotExist(err) {
+		t.Fatalf("migration retained legacy binding: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); err != nil {
+		t.Fatalf("migration did not publish current binding: %v", err)
+	}
+	for _, filename := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json"} {
+		if _, err := os.Stat(filepath.Join(paths.ArtifactsDir, filename)); err != nil {
+			t.Fatalf("migration did not publish %s: %v", filename, err)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("removal after binding migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRefusesWrongWorkspaceWithoutMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	binding, err := readSetupCodexProjectBindingAtPath(legacyBinding)
+	if err != nil || binding == nil {
+		t.Fatalf("read legacy fixture binding: binding=%#v err=%v", binding, err)
+	}
+	binding.WorkspacePathHash = strings.Repeat("0", 64)
+	data, err := marshalSetupCodexProjectBinding(*binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(legacyBinding, data); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "different workspace") {
+		t.Fatalf("wrong-workspace migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyBinding); err != nil {
+		t.Fatalf("wrong-workspace migration removed legacy binding: %v", err)
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("wrong-workspace migration wrote current binding: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryMovesValidatedJournalThenRecovers(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparation, err := prepareCodexProjectRecoveryInstall(opts, summary)
+	if err != nil || preparation == nil || preparation.journal == nil {
+		t.Fatalf("prepare current recovery fixture: preparation=%#v err=%v", preparation, err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncSetupParentDirectory(legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recovery migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); !os.IsNotExist(err) {
+		t.Fatalf("recovery migration retained legacy root: %v", err)
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || !pending {
+		t.Fatalf("migrated recovery was not pending: pending=%v err=%v", pending, err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("recovery after migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("migrated recovery remained pending: pending=%v err=%v", pending, err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRejectsUnsafeLegacyArtifactsBeforeDryRunOrApply(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyArtifacts := legacyCodexProjectArtifactsDir(dataDir)
+	beforeBinding, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeArtifact, err := os.ReadFile(filepath.Join(legacyArtifacts, "inventory.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(legacyArtifacts, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(legacyArtifacts, 0o700) })
+
+	for _, args := range [][]string{
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "autoconfigure authority") {
+			t.Fatalf("unsafe artifact migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if got, err := os.ReadFile(legacyBinding); err != nil || !bytes.Equal(got, beforeBinding) {
+			t.Fatalf("unsafe artifact migration changed legacy binding: equal=%v err=%v", bytes.Equal(got, beforeBinding), err)
+		}
+		if got, err := os.ReadFile(filepath.Join(legacyArtifacts, "inventory.json")); err != nil || !bytes.Equal(got, beforeArtifact) {
+			t.Fatalf("unsafe artifact migration changed legacy artifact: equal=%v err=%v", bytes.Equal(got, beforeArtifact), err)
+		}
+		if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+			t.Fatalf("unsafe artifact migration created current binding: %v", err)
+		}
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRollsBackSecondArtifactStageFailure(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyArtifacts := legacyCodexProjectArtifactsDir(dataDir)
+	beforeBinding, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beforeArtifacts := make(map[string][]byte)
+	for _, filename := range []string{"inventory.json", "policy.draft.json", "mcp_quarantine_plan.json"} {
+		data, err := os.ReadFile(filepath.Join(legacyArtifacts, filename))
+		if err != nil {
+			t.Fatal(err)
+		}
+		beforeArtifacts[filename] = data
+	}
+	previousWrite := writeLegacyCodexProjectMigrationFile
+	writeLegacyCodexProjectMigrationFile = func(path string, data []byte) error {
+		if filepath.Base(path) == "policy.draft.json" && strings.Contains(path, setupLegacyMigrationTemporaryPrefix) {
+			return errors.New("injected second artifact stage failure")
+		}
+		return previousWrite(path, data)
+	}
+	t.Cleanup(func() { writeLegacyCodexProjectMigrationFile = previousWrite })
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "injected second artifact") {
+		t.Fatalf("injected migration failure exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if got, err := os.ReadFile(legacyBinding); err != nil || !bytes.Equal(got, beforeBinding) {
+		t.Fatalf("second artifact failure changed legacy binding: equal=%v err=%v", bytes.Equal(got, beforeBinding), err)
+	}
+	for filename, before := range beforeArtifacts {
+		if got, err := os.ReadFile(filepath.Join(legacyArtifacts, filename)); err != nil || !bytes.Equal(got, before) {
+			t.Fatalf("second artifact failure changed %s: equal=%v err=%v", filename, bytes.Equal(got, before), err)
+		}
+	}
+	if _, err := os.Stat(paths.StateRoot); !os.IsNotExist(err) {
+		t.Fatalf("second artifact failure retained current project state: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRejectsDestinationArtifactConflictWithoutMutation(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyArtifact := filepath.Join(legacyCodexProjectArtifactsDir(dataDir), "inventory.json")
+	legacyBindingData, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyArtifactData, err := os.ReadFile(legacyArtifact)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureCodexProjectStateAuthority(dataDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(paths.BindingPath, legacyBindingData); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(paths.ArtifactsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeSetupPrivateFile(filepath.Join(paths.ArtifactsDir, "inventory.json"), []byte("different-current-artifact")); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+		{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+	} {
+		stdout.Reset()
+		stderr.Reset()
+		if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "differs from the validated legacy artifact") {
+			t.Fatalf("artifact-conflict migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+		}
+		if got, err := os.ReadFile(legacyBinding); err != nil || !bytes.Equal(got, legacyBindingData) {
+			t.Fatalf("artifact-conflict migration changed legacy binding: equal=%v err=%v", bytes.Equal(got, legacyBindingData), err)
+		}
+		if got, err := os.ReadFile(legacyArtifact); err != nil || !bytes.Equal(got, legacyArtifactData) {
+			t.Fatalf("artifact-conflict migration changed legacy artifact: equal=%v err=%v", bytes.Equal(got, legacyArtifactData), err)
+		}
+		if got, err := os.ReadFile(filepath.Join(paths.ArtifactsDir, "inventory.json")); err != nil || string(got) != "different-current-artifact" {
+			t.Fatalf("artifact-conflict migration changed current artifact: got=%q err=%v", got, err)
+		}
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryRejectsUnsafeDestinationAndMalformedSourceDuringDryRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	t.Run("unsafe destination ancestor", func(t *testing.T) {
+		dir := chdirTempDir(t)
+		dataDir := filepath.Join(dir, "kernel-state")
+		opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+		summary, err := buildSetupSummary(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+			t.Fatal(err)
+		}
+		paths := currentCodexProjectPaths(dataDir)
+		legacyRoot := legacySetupRecoveryRoot(dataDir)
+		if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+			t.Fatal(err)
+		}
+		unsafe := filepath.Join(dataDir, "native-client", "codex-projects")
+		if err := os.Chmod(unsafe, 0o777); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(unsafe, 0o700) })
+		for _, args := range [][]string{
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+		} {
+			var stdout, stderr bytes.Buffer
+			if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "group/world-writable") {
+				t.Fatalf("unsafe destination migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if _, err := os.Stat(legacyRoot); err != nil {
+				t.Fatalf("unsafe destination migration moved legacy recovery: %v", err)
+			}
+			if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+				t.Fatalf("unsafe destination migration created current recovery: %v", err)
+			}
+		}
+	})
+	t.Run("malformed source staging", func(t *testing.T) {
+		dir := chdirTempDir(t)
+		dataDir := filepath.Join(dir, "kernel-state")
+		opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+		summary, err := buildSetupSummary(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+			t.Fatal(err)
+		}
+		paths := currentCodexProjectPaths(dataDir)
+		legacyRoot := legacySetupRecoveryRoot(dataDir)
+		if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(legacyRoot, setupRecoveryStagingDir, "unexpected"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		for _, args := range [][]string{
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--dry-run", "--data-dir", dataDir},
+			{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir},
+		} {
+			var stdout, stderr bytes.Buffer
+			if code := Run(args, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "unexpected setup recovery staged entry") {
+				t.Fatalf("malformed source migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+			}
+			if _, err := os.Stat(legacyRoot); err != nil {
+				t.Fatalf("malformed source migration moved legacy recovery: %v", err)
+			}
+			if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+				t.Fatalf("malformed source migration created current recovery: %v", err)
+			}
+		}
+	})
+}
+
+func TestSetupMigrateCodexProjectRecoverySyncFailureRestoresLegacySource(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+		t.Fatal(err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	previousSync := syncLegacyCodexProjectMigrationParent
+	syncLegacyCodexProjectMigrationParent = func(path string) error {
+		if path == paths.RecoveryRoot {
+			return errors.New("injected migrated recovery sync failure")
+		}
+		return previousSync(path)
+	}
+	t.Cleanup(func() { syncLegacyCodexProjectMigrationParent = previousSync })
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "injected migrated recovery sync failure") {
+		t.Fatalf("sync-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); err != nil {
+		t.Fatalf("sync-failure migration did not restore legacy recovery: %v", err)
+	}
+	if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+		t.Fatalf("sync-failure migration retained current recovery: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryReportsRollbackFailure(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+		t.Fatal(err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	previousSync := syncLegacyCodexProjectMigrationParent
+	previousRename := renameLegacyCodexProjectMigration
+	syncLegacyCodexProjectMigrationParent = func(path string) error {
+		if path == paths.RecoveryRoot {
+			return errors.New("injected migrated recovery sync failure")
+		}
+		return previousSync(path)
+	}
+	renameLegacyCodexProjectMigration = func(oldPath, newPath string) error {
+		if oldPath == paths.RecoveryRoot && newPath == legacyRoot {
+			return errors.New("injected recovery rollback rename failure")
+		}
+		return previousRename(oldPath, newPath)
+	}
+	t.Cleanup(func() {
+		syncLegacyCodexProjectMigrationParent = previousSync
+		renameLegacyCodexProjectMigration = previousRename
+	})
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "rollback migrated recovery state") || !strings.Contains(stderr.String(), "injected recovery rollback rename failure") {
+		t.Fatalf("rollback-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); !os.IsNotExist(err) {
+		t.Fatalf("rollback-failure migration unexpectedly restored legacy recovery: %v", err)
+	}
+	if _, err := os.Stat(paths.RecoveryRoot); err != nil {
+		t.Fatalf("rollback-failure migration hid current recovery state: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectRecoveryRejectsJournalPresenceChangeUnderLock(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	opts := setupOptions{Target: "codex", Scope: "project", DataDir: dataDir}
+	summary, err := buildSetupSummary(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareCodexProjectRecoveryInstall(opts, summary); err != nil {
+		t.Fatal(err)
+	}
+	paths := currentCodexProjectPaths(dataDir)
+	legacyRoot := legacySetupRecoveryRoot(dataDir)
+	if err := os.Rename(paths.RecoveryRoot, legacyRoot); err != nil {
+		t.Fatal(err)
+	}
+	previousAfterPreflight := afterLegacyRecoveryMigrationPreflight
+	afterLegacyRecoveryMigrationPreflight = func() {
+		if err := os.Remove(filepath.Join(legacyRoot, setupRecoveryJournalFile)); err != nil {
+			t.Fatalf("remove legacy journal during interleaving test: %v", err)
+		}
+	}
+	t.Cleanup(func() { afterLegacyRecoveryMigrationPreflight = previousAfterPreflight })
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "journal presence changed") {
+		t.Fatalf("journal-presence migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(legacyRoot); err != nil {
+		t.Fatalf("journal-presence migration moved legacy recovery: %v", err)
+	}
+	if _, err := os.Stat(paths.RecoveryRoot); !os.IsNotExist(err) {
+		t.Fatalf("journal-presence migration created current recovery: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingRevalidatesLegacyAuthorityBeforePublish(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows file mode semantics do not provide the POSIX directory boundary")
+	}
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyArtifacts := legacyCodexProjectArtifactsDir(dataDir)
+	previousAfterPreflight := afterLegacyBindingMigrationPreflight
+	afterLegacyBindingMigrationPreflight = func() {
+		if err := os.Chmod(legacyArtifacts, 0o777); err != nil {
+			t.Fatalf("make legacy authority unsafe during interleaving test: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		afterLegacyBindingMigrationPreflight = previousAfterPreflight
+		_ = os.Chmod(legacyArtifacts, 0o700)
+	})
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 || !strings.Contains(stderr.String(), "revalidate legacy autoconfigure authority") {
+		t.Fatalf("legacy-authority interleaving migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(paths.BindingPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy-authority interleaving migration published target binding: %v", err)
+	}
+	if _, err := os.Stat(legacyCodexProjectBindingPath(dataDir)); err != nil {
+		t.Fatalf("legacy-authority interleaving migration moved source binding: %v", err)
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingKeepsPublishedStateWhenRetiredSourceCleanupFails(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	previousRemoveTree := removeLegacyCodexProjectMigrationTree
+	removeLegacyCodexProjectMigrationTree = func(path string) error {
+		if strings.HasPrefix(filepath.Base(path), setupLegacyMigrationTemporaryPrefix) && filepath.Dir(path) == dataDir {
+			return errors.New("injected retired-source cleanup failure")
+		}
+		return previousRemoveTree(path)
+	}
+	t.Cleanup(func() { removeLegacyCodexProjectMigrationTree = previousRemoveTree })
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 || !strings.Contains(stderr.String(), "migration completed") || !strings.Contains(stderr.String(), "retired-source cleanup remains") {
+		t.Fatalf("cleanup-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if _, err := os.Stat(paths.BindingPath); err != nil {
+		t.Fatalf("cleanup-failure migration rolled back published target binding: %v", err)
+	}
+	if _, err := os.Stat(legacyCodexProjectBindingPath(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("cleanup-failure migration retained active legacy binding: %v", err)
+	}
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundRetiredSource := false
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), setupLegacyMigrationTemporaryPrefix) {
+			foundRetiredSource = true
+			break
+		}
+	}
+	if !foundRetiredSource {
+		t.Fatal("cleanup-failure migration lost retired source instead of retaining it safely")
+	}
+}
+
+func TestSetupMigrateCodexProjectBindingKeepsPublishedStateWhenSourceRollbackFails(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "kernel-state")
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 {
+		t.Fatalf("setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	paths := moveCurrentCodexProjectBindingToLegacyForTest(t, dataDir)
+	legacyBinding := legacyCodexProjectBindingPath(dataDir)
+	legacyInventory := filepath.Join(legacyCodexProjectArtifactsDir(dataDir), "inventory.json")
+	beforeBinding, err := os.ReadFile(legacyBinding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousRename := renameLegacyCodexProjectMigration
+	renameLegacyCodexProjectMigration = func(oldPath, newPath string) error {
+		if oldPath == legacyInventory && strings.HasPrefix(filepath.Base(filepath.Dir(newPath)), setupLegacyMigrationTemporaryPrefix) {
+			return errors.New("injected second source move failure")
+		}
+		if newPath == legacyBinding && strings.HasPrefix(filepath.Base(filepath.Dir(oldPath)), setupLegacyMigrationTemporaryPrefix) {
+			return errors.New("injected source rollback rename failure")
+		}
+		return previousRename(oldPath, newPath)
+	}
+	t.Cleanup(func() { renameLegacyCodexProjectMigration = previousRename })
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Run([]string{"helm-ai-kernel", "setup", "migrate", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 0 || !strings.Contains(stderr.String(), "could not be completed or fully rolled back") || !strings.Contains(stderr.String(), "injected source rollback rename failure") {
+		t.Fatalf("rollback-failure migration exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	if got, err := os.ReadFile(paths.BindingPath); err != nil || !bytes.Equal(got, beforeBinding) {
+		t.Fatalf("rollback-failure migration lost published target binding: equal=%v err=%v", bytes.Equal(got, beforeBinding), err)
+	}
+	if _, err := os.Stat(legacyBinding); !os.IsNotExist(err) {
+		t.Fatalf("rollback-failure migration restored an ambiguous active legacy binding: %v", err)
+	}
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundSealedBackup := false
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), setupLegacyMigrationTemporaryPrefix) {
+			continue
+		}
+		backup := filepath.Join(dataDir, entry.Name(), "00-"+setupCodexProjectBindingFile)
+		if got, err := os.ReadFile(backup); err == nil && bytes.Equal(got, beforeBinding) {
+			foundSealedBackup = true
+			break
+		}
+	}
+	if !foundSealedBackup {
+		t.Fatal("rollback-failure migration did not retain the sealed source backup")
+	}
+}
+
+func TestSetupCodexProjectLifecycleLockRejectsConcurrentMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("safe cross-process lifecycle lock intentionally fails closed on Windows")
+	}
+	dataDir := filepath.Join(t.TempDir(), "kernel-state")
+	first, err := acquireSetupCodexProjectLifecycleLock(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second, err := acquireSetupCodexProjectLifecycleLock(dataDir)
+	if second != nil {
+		_ = second.Close()
+		t.Fatal("second lifecycle lock unexpectedly succeeded")
+	}
+	if err == nil || !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("second lifecycle lock error=%v", err)
+	}
+}
+
+func TestConcurrentFirstUseChoosesOneDurableLifecycleRoot(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "shared-kernel-state")
+	const workers = 16
+	start := make(chan struct{})
+	results := make(chan []byte, workers)
+	errors := make(chan error, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+			if err != nil {
+				errors <- err
+				return
+			}
+			results <- append([]byte(nil), signer.PublicKeyBytes()...)
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	close(errors)
+	for err := range errors {
+		t.Fatalf("concurrent first-use signer initialization failed: %v", err)
+	}
+	var winner []byte
+	for publicKey := range results {
+		if winner == nil {
+			winner = publicKey
+			continue
+		}
+		if !bytes.Equal(winner, publicKey) {
+			t.Fatalf("concurrent first-use signers disagreed: %x != %x", winner, publicKey)
+		}
+	}
+	if winner == nil {
+		t.Fatal("no concurrent signer was initialized")
+	}
+	if _, err := loadExistingEd25519Root(dataDir); err != nil {
+		t.Fatalf("concurrent first-use root is not reloadable: %v", err)
+	}
+}
+
+func TestConcurrentLiteModeInitializationSharesAuthorityDataDir(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "shared-kernel-state")
+	const workers = 8
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			db, _, _, err := setupLiteModeWithDataDir(context.Background(), dataDir)
+			if err == nil {
+				err = db.Close()
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent shared data-dir initialization failed: %v", err)
+		}
+	}
+}
+
+func TestRuntimeEntrypointsRejectSymlinkedDataDir(t *testing.T) {
+	dir := chdirTempDir(t)
+	target := filepath.Join(dir, "target")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "data-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", link}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 2 {
+		t.Fatalf("hook accepted symlinked data dir: code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := runMCPServe([]string{"--transport", "stdio", "--data-dir", link}, &stdout, &stderr); code != 2 {
+		t.Fatalf("mcp serve accepted symlinked data dir: code=%d stderr=%s", code, stderr.String())
+	}
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, link); err == nil || !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("direct stdio accepted symlinked data dir: %v", err)
+	}
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("runtime wrote through data-dir symlink: %#v", entries)
+	}
+}
+
+type setupRecoveryInjectingReader struct {
+	chunks   [][]byte
+	index    int
+	injected bool
+	inject   func() error
+}
+
+func (r *setupRecoveryInjectingReader) Read(p []byte) (int, error) {
+	if r.index == 1 && !r.injected {
+		r.injected = true
+		if err := r.inject(); err != nil {
+			return 0, err
+		}
+	}
+	if r.index >= len(r.chunks) {
+		return 0, io.EOF
+	}
+	chunk := r.chunks[r.index]
+	n := copy(p, chunk)
+	if n == len(chunk) {
+		r.index++
+	} else {
+		r.chunks[r.index] = chunk[n:]
+	}
+	return n, nil
+}
+
+func TestMCPRechecksRecoveryBeforeEveryToolCall(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	reader := &setupRecoveryInjectingReader{
+		chunks: [][]byte{
+			[]byte("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}\n"),
+			[]byte("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"file_write\",\"arguments\":{\"path\":\"ignored\",\"content\":\"x\"}}}\n"),
+		},
+		inject: func() error {
+			writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+			return nil
+		},
+	}
+	var stdout bytes.Buffer
+	err := serveLocalMCPStdioWithDataDir(reader, &stdout, dataDir)
+	if err == nil || !strings.Contains(err.Error(), "recovery") {
+		t.Fatalf("mid-session recovery did not stop MCP: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"id":1`) || strings.Contains(stdout.String(), `"id":2`) {
+		t.Fatalf("MCP answered after recovery became pending: %s", stdout.String())
+	}
+}
+
+func TestRecoveryJournalTamperingFailsClosedWithoutCleanup(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*setupRecoveryJournal, string)
+	}{
+		{
+			name: "stage traversal",
+			mutate: func(journal *setupRecoveryJournal, _ string) {
+				journal.Files[0].StageFile = "../outside"
+			},
+		},
+		{
+			name: "receipt traversal",
+			mutate: func(journal *setupRecoveryJournal, _ string) {
+				journal.LifecycleReceiptID = "../outside"
+			},
+		},
+		{
+			name: "duplicate plan",
+			mutate: func(journal *setupRecoveryJournal, _ string) {
+				journal.Files[1].ID = journal.Files[0].ID
+			},
+		},
+		{
+			name:   "noncanonical bytes",
+			mutate: func(_ *setupRecoveryJournal, _ string) {},
+		},
+		{
+			name: "unclean binary path",
+			mutate: func(journal *setupRecoveryJournal, dir string) {
+				journal.BinaryPath = dir + "/bin/../" + filepath.Base(journal.BinaryPath)
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := chdirTempDir(t)
+			dataDir := filepath.Join(dir, "helm")
+			journal := writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+			tampered := *journal
+			tampered.Files = append([]setupRecoveryFilePlan(nil), journal.Files...)
+			tc.mutate(&tampered, dir)
+			var raw []byte
+			var err error
+			if tc.name == "noncanonical bytes" {
+				raw, err = os.ReadFile(setupRecoveryJournalPath(dataDir))
+				if err == nil {
+					raw = append(raw, '\n')
+				}
+			} else {
+				raw, err = canonicalize.JCS(tampered)
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writeSetupPrivateFile(setupRecoveryJournalPath(dataDir), raw); err != nil {
+				t.Fatal(err)
+			}
+			sentinel := filepath.Join(dir, "outside")
+			if err := os.WriteFile(sentinel, []byte("do-not-touch"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			var stdout, stderr bytes.Buffer
+			if code := Run([]string{"helm-ai-kernel", "setup", "status", "codex", "--scope", "project", "--data-dir", dataDir}, &stdout, &stderr); code != 2 {
+				t.Fatalf("tampered journal status exit=%d stderr=%s", code, stderr.String())
+			}
+			stdout.Reset()
+			stderr.Reset()
+			if code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr); code != 1 {
+				t.Fatalf("tampered journal recover exit=%d stderr=%s", code, stderr.String())
+			}
+			if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err == nil {
+				t.Fatal("tampered journal unexpectedly opened MCP")
+			}
+			stdout.Reset()
+			stderr.Reset()
+			if code := runHookPreToolCmd([]string{"--client", "codex", "--data-dir", dataDir}, strings.NewReader(`{"tool_name":"Write","tool_input":{"file_path":".env"}}`), &stdout, &stderr); code != 0 || !strings.Contains(stdout.String(), "recovery") {
+				t.Fatalf("tampered journal did not deny hook: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+			}
+			persisted, err := os.ReadFile(setupRecoveryJournalPath(dataDir))
+			if err != nil || !bytes.Equal(persisted, raw) {
+				t.Fatalf("tampered journal changed during failure handling: equal=%v err=%v", bytes.Equal(persisted, raw), err)
+			}
+			if got, err := os.ReadFile(sentinel); err != nil || string(got) != "do-not-touch" {
+				t.Fatalf("tampered journal touched external sentinel: got=%q err=%v", got, err)
+			}
+		})
+	}
+}
+
+func TestRecoveryJournalPinsExecutablePathAndAvailability(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(t *testing.T, journal *setupRecoveryJournal, dir string)
+		want   string
+	}{
+		{
+			name: "same bytes different path",
+			mutate: func(t *testing.T, journal *setupRecoveryJournal, dir string) {
+				t.Helper()
+				raw, err := os.ReadFile(journal.BinaryPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+				copyPath := filepath.Join(dir, "alternate", "helm-ai-kernel")
+				if err := os.MkdirAll(filepath.Dir(copyPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(copyPath, raw, 0o700); err != nil {
+					t.Fatal(err)
+				}
+				journal.BinaryPath = copyPath
+			},
+			want: "path does not match",
+		},
+		{
+			name: "symlink alternate path",
+			mutate: func(t *testing.T, journal *setupRecoveryJournal, dir string) {
+				t.Helper()
+				linkPath := filepath.Join(dir, "alternate", "helm-ai-kernel")
+				if err := os.MkdirAll(filepath.Dir(linkPath), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(journal.BinaryPath, linkPath); err != nil {
+					t.Fatal(err)
+				}
+				journal.BinaryPath = linkPath
+			},
+			want: "path does not match",
+		},
+		{
+			name: "deleted binary",
+			mutate: func(_ *testing.T, journal *setupRecoveryJournal, dir string) {
+				journal.BinaryPath = filepath.Join(dir, "missing", "helm-ai-kernel")
+			},
+			want: "unavailable",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := chdirTempDir(t)
+			dataDir := filepath.Join(dir, "helm")
+			journal := writeSetupSecurityPendingJournal(t, dataDir, "install", nil)
+			tampered := *journal
+			tampered.Files = append([]setupRecoveryFilePlan(nil), journal.Files...)
+			tc.mutate(t, &tampered, dir)
+			raw, err := canonicalize.JCS(tampered)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := writeSetupPrivateFile(setupRecoveryJournalPath(dataDir), raw); err != nil {
+				t.Fatal(err)
+			}
+			var stdout, stderr bytes.Buffer
+			code := Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+			if code != 1 || !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("binary-pinned recovery did not fail closed: code=%d stderr=%s", code, stderr.String())
+			}
+			if _, err := os.Stat(filepath.Join(dataDir, "root.key")); !os.IsNotExist(err) {
+				t.Fatalf("failed binary recovery initialized signer state: %v", err)
+			}
+		})
+	}
+}
+
+func TestSignedCommittedMarkerSurvivesPostMarkerCrashAndCleans(t *testing.T) {
+	dir := chdirTempDir(t)
+	dataDir := filepath.Join(dir, "helm")
+	previousFinalize := finalizeCodexProjectRecoveryJournal
+	finalizeCodexProjectRecoveryJournal = func(dataDir string, journal *setupRecoveryJournal) error {
+		marker, err := newSignedSetupRecoveryCommittedMarker(dataDir, journal)
+		if err != nil {
+			return err
+		}
+		if err := writeSetupRecoveryMarker(dataDir, setupRecoveryCommittedFile, marker); err != nil {
+			return err
+		}
+		return errors.New("injected post-marker cleanup failure")
+	}
+	t.Cleanup(func() { finalizeCodexProjectRecoveryJournal = previousFinalize })
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("signed post-marker setup exit=%d stderr=%s stdout=%s", code, stderr.String(), stdout.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil || !summary.RecoveryCleanupPending {
+		t.Fatalf("signed terminal marker was not surfaced: summary=%#v err=%v", summary, err)
+	}
+	if pending, err := setupRecoveryRequired(dataDir); err != nil || pending {
+		t.Fatalf("verified signed marker remained runtime-blocking: pending=%v err=%v", pending, err)
+	}
+	if err := os.Remove(setupRecoveryJournalPath(dataDir)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := inspectSetupRecovery(dataDir)
+	if err != nil || inspection.State != setupRecoveryStateCommitted {
+		t.Fatalf("signed marker-only crash residue was not terminal: inspection=%#v err=%v", inspection, err)
+	}
+
+	finalizeCodexProjectRecoveryJournal = previousFinalize
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "recover", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("signed terminal residue cleanup exit=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(setupRecoveryRoot(dataDir)); !os.IsNotExist(err) {
+		t.Fatalf("signed terminal residue remained after cleanup: %v", err)
+	}
+}

--- a/docs/CLAIM_BOUNDARIES.md
+++ b/docs/CLAIM_BOUNDARIES.md
@@ -1,6 +1,6 @@
 ---
 title: Claim Boundaries
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # Claim Boundaries
@@ -19,6 +19,8 @@ or release artifacts.
 - Decisions, approvals, and revocations write local receipts.
 - EvidencePacks can be checked from local material without trusting a hosted
   service.
+- Codex project setup can record a signed local lifecycle transaction and a
+  Kernel-only synthetic denial without claiming a real client session.
 - The public conformance proof path supports `L1` and `L2` CLI shortcuts.
 
 ## Not Public Claims
@@ -29,6 +31,9 @@ or release artifacts.
 - No full operating-system, browser, IDE, eBPF, seccomp, TPM, hardware enclave,
   packet blocking, or proprietary hosted-agent control is claimed unless a
   tested path proves the specific effect crossed HELM.
+- No local config, lifecycle receipt, or synthetic denial is a claim that Codex
+  or Claude Code loaded the generated configuration. Native-client review must
+  identify the exact configured hook class and routed MCP call exercised.
 - No `L4` conformance claim is public. `L3` remains source/test coverage until
   a public proof path is wired and tested.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -68,6 +68,8 @@ This page is backed by:
 | Go kernel and CLI | Supported | `make build`, `make test` |
 | OpenAI-compatible proxy | Supported | `core/cmd/helm-ai-kernel/proxy_cmd.go`, proxy examples |
 | MCP server, OAuth scope enforcement, and bundle generation | Supported | `core/cmd/helm-ai-kernel/mcp_*`, MCP tests |
+| Codex project setup, recovery, and removal | Source-backed local lifecycle proof | `core/cmd/helm-ai-kernel/setup_cmd.go`, `setup_codex_*.go`, recovery tests; no real client-session claim |
+| Claude Code selected-hook/MCP setup | Direct CLI registration request plus local hook path | `core/cmd/helm-ai-kernel/setup_claude_code_binary.go`, `setup_cmd.go`; no CLI-owned MCP-config readback, Codex lifecycle equivalence, or real client-session claim |
 | Boundary records, MCP quarantine, receipts, evidence export/verify, conformance, and local onboarding proof APIs | Supported public proof path | `api/openapi/helm.openapi.yaml`, `core/cmd/helm-ai-kernel/route_registry.go`, `core/cmd/helm-ai-kernel/contract_routes.go` |
 | Evidence export and offline verification | Supported | `core/cmd/helm-ai-kernel/export_cmd.go`, `core/cmd/helm-ai-kernel/verify_cmd.go` |
 | Headless API contract for external clients | Supported | `api/openapi/helm.openapi.yaml`, `core/cmd/helm-ai-kernel/route_registry.go`, `make sdk-openapi-check` |

--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -13,6 +13,7 @@ how your agent runs.
 | If you want to... | Read |
 | --- | --- |
 | Configure Codex hooks and routed MCP paths | [Codex integration](INTEGRATIONS/codex.md) |
+| Review Codex project setup or recovery | [Native client integration boundary](INTEGRATIONS/native-client-boundary.md) |
 | Configure Claude Code hooks and routed MCP paths | [Claude Code integration](INTEGRATIONS/claude-code.md) |
 | Scan an agent before enforcement | [Agent Risk Scan](reference/agent-risk-scan.md) |
 | Govern MCP tools | [Govern MCP tools](guides/govern-mcp-tools.md) |
@@ -94,20 +95,31 @@ The local policy boundary defaults to `127.0.0.1:7714`.
 
 ## Local Client Setup Is Not Client Proof
 
-Inspect a Codex project setup before writing it:
+For a Codex project, inspect the local changes before applying them:
 
 ```bash
 helm-ai-kernel setup codex --scope project --dry-run --json
 helm-ai-kernel mcp print-config --client codex
 ```
 
-Those commands create or describe local configuration only. They intentionally
-leave `client_load_observed=false`; they do not show that Codex or Claude Code
+After an explicit `--yes` setup, the exact configuration checks, signed
+lifecycle receipt, and Kernel-only synthetic denial deliberately keep
+`client_load_observed=false`; they do not prove that Codex or Claude Code
 loaded the configuration, started the server, or blocked a real client action.
-A client claim requires a sterile client home and disposable workspace that
-loads the configured server and exercises only the configured hook classes and
-routed MCP calls. Direct upstream calls and unconfigured client actions remain
-outside that proof.
+If setup is interrupted, inspect the recorded transaction before trying another
+install or removal:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --yes
+```
+
+A native-client claim needs a sterile client home and disposable workspace that
+actually load the generated configuration, then exercise only the configured
+hook classes and a routed MCP call. Direct upstream calls and unconfigured
+client actions remain outside that observation. See the [native client
+integration boundary](INTEGRATIONS/native-client-boundary.md) for the exact
+review limit.
 
 ## Verify A Decision
 

--- a/docs/DEVELOPER_SURFACE_MAP.md
+++ b/docs/DEVELOPER_SURFACE_MAP.md
@@ -70,6 +70,7 @@ flowchart TD
 | Configure coding-agent hooks and routed MCP paths | `/developer-journey`, `/integrations/mcp` | `docs/DEVELOPER_JOURNEY.md`, `core/cmd/helm-ai-kernel/setup_cmd.go`, `core/cmd/helm-ai-kernel/hook_cmd.go`, `core/cmd/helm-ai-kernel/mcp_cmd.go` |
 | Point OpenAI-compatible clients at HELM | `/integrations/openai-compatible-proxy` | `docs/INTEGRATIONS/openai_baseurl.md`, `examples/python_openai_baseurl/`, `examples/ts_openai_baseurl/` |
 | Use MCP | `/integrations/mcp` | `docs/INTEGRATIONS/mcp.md`, `examples/mcp_client/`, `mcp-bundle.json` |
+| Review Codex project setup, recovery, and its proof limit | `/integrations/native-client-boundary` | `docs/INTEGRATIONS/native-client-boundary.md`, `docs/INTEGRATIONS/native-client-lifecycle.md`, `core/cmd/helm-ai-kernel/setup_codex_lifecycle.go`, `core/cmd/helm-ai-kernel/setup_recovery_*.go` |
 | Use Python, TypeScript, JavaScript, Go, Rust, or Java | `/sdks` | `sdk/`, `examples/*_client/`, `examples/*openai_baseurl/` |
 | Understand policy languages and bundles | `/reference/protocols-and-schemas`, `/compatibility` | `docs/architecture/policy-languages.md`, `protocols/bundles/`, `examples/policies/` |
 | Validate conformance | `/conformance` | `docs/CONFORMANCE.md`, `protocols/conformance/v1/`, `tests/conformance/` |
@@ -84,11 +85,13 @@ loads public pages from `docs/public-docs.manifest.json`, then validates that
 coverage-backed claims appear in public docs, search, Markdown exports,
 `llms.txt`, `llms-full.txt`, and MCP responses.
 
-A setup result or printed client configuration proves only local configuration.
-It intentionally leaves `client_load_observed=false` until a sterile native
-client session loads the configured server. Client claims are limited to the
-configured hook classes and routed MCP calls; direct upstream calls and other
-client actions remain outside that evidence.
+Codex project setup is a local lifecycle surface, not a native-client runtime
+claim. Its exact configuration checks, signed lifecycle receipt, and
+Kernel-only synthetic denial leave `client_load_observed=false`. A claim that
+Codex loaded the configuration requires a separate sterile-client observation
+of the configured hook classes and routed MCP call. Printed configuration alone
+proves only local setup; direct upstream calls and other unconfigured client
+actions remain outside that evidence.
 
 ## Troubleshooting
 

--- a/docs/EXECUTION_SECURITY_MODEL.md
+++ b/docs/EXECUTION_SECURITY_MODEL.md
@@ -95,6 +95,8 @@ HELM AI Kernel does:
 - emit signed receipts for `ALLOW`, `DENY`, and `ESCALATE` decisions;
 - quarantine unknown MCP servers and tools until they are inspected and approved;
 - produce offline-verifiable EvidencePacks for source-backed receipt material.
+- maintain owner-checked, project-scoped Codex setup state and fail closed when its
+  local authority, lifecycle evidence, or recovery transaction is unsafe.
 
 HELM AI Kernel does not:
 
@@ -103,6 +105,10 @@ HELM AI Kernel does not:
 - replace secret scanning, network firewalls, endpoint controls, or OS sandboxing;
 - prevent prompt injection at generation time; enforcement happens at dispatch;
 - capture side effects from tools that bypass the HELM proxy or MCP boundary;
+- turn generated native-client configuration or a Kernel-only synthetic denial
+  into proof that a real Codex or Claude Code session loaded it;
+- govern native-client actions outside the exact configured hook classes and
+  routed MCP calls;
 - certify every MCP tool schema through static analysis;
 - certify compliance with a regulatory standard by itself.
 

--- a/docs/INTEGRATIONS/agent-clients.md
+++ b/docs/INTEGRATIONS/agent-clients.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Clients
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # Agent Clients
@@ -52,3 +52,16 @@ agent/tool requests action
 
 Setup writes local config and draft policy files only when `--yes` is present.
 It does not approve detected tools.
+
+## Native-Client Limits
+
+| Client path | Local evidence | Not established by setup |
+| --- | --- | --- |
+| Codex project scope | Exact owned config, signed lifecycle receipt, recovery journal, and Kernel-only synthetic denial | That a real Codex session loaded the config or governed any action outside the configured hook classes and routed MCP calls |
+| Claude Code | Direct CLI used to request MCP registration plus selected PreToolUse hook configuration | Readback of CLI-owned MCP serialization, Codex-style project lifecycle/recovery, or a real Claude Code session result |
+
+The Codex project lifecycle is intentionally isolated by workspace under the
+selected data directory. If it is interrupted, use `setup recover codex --scope
+project --yes`; migrate old unscoped state with `setup migrate codex --scope
+project --yes`. See the [Native Client Integration
+Boundary](native-client-boundary.md) for what that setup can and cannot prove.

--- a/docs/INTEGRATIONS/claude-code.md
+++ b/docs/INTEGRATIONS/claude-code.md
@@ -1,18 +1,29 @@
 ---
 title: Claude Code Integration
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-14
 ---
 
 # Claude Code Integration
 
 Use HELM with Claude Code when you want local PreToolUse decisions and signed
-receipts for selected high-risk tool effects.
+receipts for selected high-risk tool effects. This is a selected-hook and MCP
+configuration path, not a claim of full Claude Code control.
 
 ## Quick Setup
 
 ```bash
 helm-ai-kernel setup claude-code --yes
 ```
+
+Setup resolves a direct `claude` executable. If PATH resolves through a mise
+shim, it refuses the install rather than trusting the shim. Supply the direct
+executable path when needed:
+
+```bash
+CLAUDE_CODE_BIN=/absolute/path/to/claude helm-ai-kernel setup claude-code --yes
+```
+
+`CLAUDE_CODE_BIN` must be an executable path, not a bare command name.
 
 Check what was installed:
 
@@ -32,8 +43,14 @@ helm-ai-kernel setup remove claude-code --yes
 helm-ai-kernel setup claude-code --dry-run --json
 ```
 
-The JSON summary includes the binary path, client config path, hook config path,
-data dir, Kernel URL, draft policy path, and uninstall command.
+The JSON summary includes the Kernel binary path, client config path, hook
+config path, data dir, Kernel URL, draft policy path, and uninstall command.
+
+The summary identifies HELM's planned paths and local hook state. Claude Code
+owns MCP config serialization, so HELM does not read back that registration or
+claim a live Claude Code session loaded it. It also does not establish Codex-style
+project lifecycle or recovery semantics. See the [native client integration
+boundary](native-client-boundary.md) for the public boundary and review rules.
 
 ## Verify A Denial
 
@@ -72,3 +89,4 @@ helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb
 - `core/cmd/helm-ai-kernel/workstation_m3_cmd.go`
 - `docs/QUICKSTART.md`
 - `docs/reference/cli.md`
+- `docs/INTEGRATIONS/native-client-boundary.md`

--- a/docs/INTEGRATIONS/codex.md
+++ b/docs/INTEGRATIONS/codex.md
@@ -1,12 +1,13 @@
 ---
 title: Codex Integration
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-14
 ---
 
 # Codex Integration
 
 Use HELM with Codex when you want a local MCP and hook setup that records signed
-policy decision receipts for selected high-risk effects.
+policy decision receipts for selected high-risk effects. It governs only the
+configured hook classes and MCP calls routed through HELM.
 
 ## Quick Setup
 
@@ -20,17 +21,44 @@ Project scope:
 helm-ai-kernel setup codex --scope project --yes
 ```
 
-Check status:
+Project scope keeps its binding, recovery journal, and generated artifacts in a
+workspace-hash namespace below the selected data directory. The local signing
+authority and receipt store remain shared. See the [native client integration
+boundary](native-client-boundary.md) before moving or reusing local state.
+
+Check user scope:
 
 ```bash
 helm-ai-kernel setup status codex
 ```
 
-Remove the integration:
+Remove user scope:
 
 ```bash
 helm-ai-kernel setup remove codex --yes
 ```
+
+For a project-scope interruption, inspect and resume the recorded transaction
+instead of rerunning setup or removal:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --yes
+```
+
+Pre-v1 unscoped project state requires an explicit migration operation:
+
+```bash
+helm-ai-kernel setup migrate codex --scope project --yes
+```
+
+`--dry-run` validates the full current legacy source-and-project-destination
+snapshot without writing or reserving it; it is not a completed migration. With
+`--yes`, HELM locks and revalidates before moving validated state into the v1
+project namespace; a new binding destination is staged and validated before
+publication. If source retirement cannot finish or fully roll back after
+publication, the command reports sealed cleanup: v1 remains active authority
+and the retained source copy is not. Inspect the project status after the move.
 
 ## Inspect Before Writing
 
@@ -40,6 +68,14 @@ helm-ai-kernel setup codex --dry-run --json
 
 The dry run writes nothing and returns the target config paths, data dir, Kernel
 URL, draft policy path, and uninstall command.
+
+## Evidence Boundary
+
+Project setup records exact local config snapshots, a signed lifecycle receipt,
+and a Kernel-only synthetic denial. Its summary intentionally reports
+`client_load_observed=false`: those checks do not prove that a real Codex
+session loaded the config or blocked a client action. See the [native-client
+integration boundary](native-client-boundary.md) for that separate review.
 
 ## Manual MCP Setup
 
@@ -67,6 +103,7 @@ Tampered receipts return a non-zero exit and fail signature verification.
 - `core/cmd/helm-ai-kernel/setup_cmd_test.go`
 - `core/cmd/helm-ai-kernel/hook_cmd.go`
 - `core/cmd/helm-ai-kernel/mcp_cmd.go`
+- `docs/INTEGRATIONS/native-client-boundary.md`
 - `core/cmd/helm-ai-kernel/workstation_m3_cmd.go`
 - `docs/QUICKSTART.md`
 - `docs/reference/cli.md`

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -1,6 +1,6 @@
 ---
 title: MCP
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # MCP
@@ -31,6 +31,12 @@ Print or install client config:
 helm-ai-kernel mcp print-config --client codex
 helm-ai-kernel mcp install --client claude-code
 ```
+
+Printing or installing client config is not proof that the client loaded it.
+HELM governs only calls that reach the configured server; direct upstream calls
+remain outside this boundary. For Codex project setup, recovery, and real-client
+review limits, see [Native Client Integration
+Boundary](native-client-boundary.md).
 
 ## Authorize Before Dispatch
 

--- a/docs/INTEGRATIONS/native-client-boundary.md
+++ b/docs/INTEGRATIONS/native-client-boundary.md
@@ -1,0 +1,56 @@
+---
+title: Native Client Integration Boundary
+last_reviewed: 2026-07-14
+---
+
+# Native Client Integration Boundary
+
+HELM can generate scoped local configuration for supported coding clients. That
+is useful local setup evidence, but it is not proof that a native client has
+loaded the configuration or that every client action crosses HELM.
+
+## What Local Setup Establishes
+
+For a scoped setup, HELM can record exact configuration ownership, a signed
+lifecycle receipt, and a Kernel-only synthetic denial. The setup result
+intentionally reports `client_load_observed=false`. It establishes that HELM
+generated and checked its local artifacts; it does not establish that Codex or
+Claude Code opened them, started a configured server, or blocked an action in a
+real session.
+
+## What HELM Can Govern
+
+HELM can govern only the configured hook classes that a client actually invokes
+and MCP calls routed through the configured HELM server. Direct upstream calls,
+unconfigured tool classes, terminal commands, browser actions, desktop actions,
+and other paths that do not reach HELM remain outside this integration boundary.
+
+## Evidence Levels
+
+Keep these distinct when reviewing an integration:
+
+1. **Local setup evidence** — source, tests, generated configuration, lifecycle
+   receipt, and synthetic denial.
+2. **Sterile client observation** — an authorized reviewer uses a disposable
+   client home and workspace, observes the scoped configuration load, and
+   exercises only the configured hook classes and routed MCP call.
+3. **Release and deployment evidence** — source-owned repository gates, release
+   authority, GitOps, and deployed smoke evidence remain separate from client
+   setup.
+
+Neither a local configuration receipt nor a screenshot substitutes for a
+sterile client observation. A client observation does not itself authorize a
+merge, deployment, or release.
+
+## Safe Next Steps
+
+Use a dry run to inspect the paths HELM would manage before writing them:
+
+```bash
+helm-ai-kernel setup codex --scope project --dry-run --json
+helm-ai-kernel setup claude-code --dry-run --json
+```
+
+Use the CLI reference for supported setup, status, removal, and recovery
+commands. Maintainer-only lifecycle and recovery procedures are deliberately
+kept outside the public documentation surface.

--- a/docs/INTEGRATIONS/native-client-lifecycle.md
+++ b/docs/INTEGRATIONS/native-client-lifecycle.md
@@ -1,0 +1,175 @@
+---
+title: Native Client Lifecycle Review Protocol
+last_reviewed: 2026-07-14
+visibility: maintainer
+---
+
+# Native Client Lifecycle Review Protocol
+
+This maintainer protocol separates local configuration proof from proof that a
+real native client loaded and obeyed that configuration. It is the source of
+truth for Codex project lifecycle state. It does not expand HELM's execution
+boundary beyond configured hook classes and MCP calls.
+
+## What Codex Project Setup Owns
+
+`helm-ai-kernel setup codex --scope project --yes` writes only the HELM-owned
+entries that its preflight can prove safe to manage. Project-specific state is
+separated by a SHA-256 workspace-path identity:
+
+```text
+<data-dir>/native-client/codex-projects/v1/<workspace-path-sha256>/
+  codex-project-binding.json
+  .helm-setup-recovery/
+  autoconfigure/
+```
+
+The local signing authority, receipt database, and lifecycle evidence remain
+shared beneath `<data-dir>`. A project binding, recovery journal, or generated
+artifact is never a fallback for another project that happens to use the same
+data directory.
+
+The authority root and every existing HELM-owned descendant must be real,
+owner-controlled directories; symlinks, group/world-writable modes, and special
+modes are rejected. On POSIX the existing directory owner must be the current
+user. The code rechecks that state before it treats a binding, recovery journal,
+or evidence file as authority.
+
+## Lifecycle Receipts And Recovery
+
+Codex project install and removal use a durable transaction. The transaction
+records exact config snapshots and stages HELM-owned changes before it mutates
+the live client configuration. A signed lifecycle receipt and canonical
+lifecycle evidence bind the operation, selected Kernel binary, workspace
+identity, data-directory identity, and observed local configuration.
+
+The durable receipt database stores the full canonical receipt envelope, not
+only an index projection. Recovery reads an existing receipt database
+read-only, re-canonicalizes the envelope, and checks that its receipt ID agrees
+with the database row. A missing, malformed, non-canonical, or legacy row that
+lacks the envelope fails closed for automatic provenance recovery.
+
+If setup is interrupted, do not rerun install or removal until you inspect the
+transaction:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --dry-run --json
+helm-ai-kernel setup recover codex --scope project --yes
+```
+
+`recover` either removes incomplete HELM residue, resumes the exact recorded
+transaction, or cleans a transaction already committed but not yet tidied. It
+does not overwrite a changed client configuration. Removal uses the same
+transaction and only deletes exact HELM-owned entries:
+
+```bash
+helm-ai-kernel setup remove codex --scope project --dry-run --json
+helm-ai-kernel setup remove codex --scope project --yes
+```
+
+Older unscoped Codex state needs the explicit migration command; normal runtime
+admission never silently adopts it:
+
+```bash
+helm-ai-kernel setup migrate codex --scope project --dry-run --json
+helm-ai-kernel setup migrate codex --scope project --yes
+```
+
+Migration validates the full current legacy source-and-destination snapshot:
+the selected binding and artifacts or structured recovery state, current
+workspace, and project namespace. Normal runtime admission never adopts
+unscoped state. `--dry-run` performs that validation without writing or
+reserving the snapshot. With `--yes`, HELM takes the project lifecycle lock and
+revalidates before moving validated state into the v1 project namespace. For a
+new binding destination, it stages and validates the complete namespaced
+binding/artifact set before publication; recovery migration rolls its validated
+recovery directory back if later sync or validation fails. A legacy binding
+pinned to a different currently-running Kernel binary is refused. If source
+retirement cannot finish or fully roll back after v1 publication, the command
+reports a sealed retired-source cleanup warning: v1 remains the active project
+authority and the retained source copy is not. Inspect `setup status` after
+migration, and use `setup recover` when a project recovery journal is present.
+
+## What Local Setup Proves — And Does Not
+
+The setup result intentionally reports `client_load_observed=false`. A matching
+local config and the Kernel-only synthetic denial prove that HELM generated and
+checked local artifacts; they do **not** prove that Codex opened them, launched
+the configured stdio server, or blocked an action in a real session.
+
+Likewise, a configured hook is limited to the exact hook classes in the client
+configuration, and a configured MCP server governs only calls routed through
+that server. Neither result proves every Codex action, every terminal command,
+browser use, desktop action, or a bypassing upstream server. Do not turn a
+configuration receipt or synthetic denial into a native-client session claim.
+
+Claude Code is intentionally not treated as equivalent to the Codex project
+lifecycle. Its setup resolves a direct `claude` executable, invokes its MCP CLI,
+and writes the selected PreToolUse hook configuration. HELM does not read back
+the CLI-owned MCP serialization, create a Codex-style project binding, or
+establish client-session proof. If `claude` resolves through a mise shim, setup
+refuses it. Set `CLAUDE_CODE_BIN` to the direct executable path instead:
+
+```bash
+CLAUDE_CODE_BIN=/absolute/path/to/claude helm-ai-kernel setup claude-code --yes
+```
+
+## Evidence Ladder
+
+Keep these evidence levels separate:
+
+1. **Source and focused-test proof** — the lifecycle, recovery, receipt, and
+   admission tests pass from the reviewed commit.
+2. **Local setup proof** — preflight, exact config ownership, signed lifecycle
+   receipt, and the Kernel-only synthetic denial pass. `client_load_observed`
+   remains false at this level.
+3. **Sterile native-client review** — a disposable client home and workspace
+   load the generated configuration in a real, user-authorized client session;
+   the reviewer observes the configured server, invokes only configured hook
+   classes and a routed MCP call, and verifies the resulting signed receipts.
+4. **Release proof** — the reviewed binary, source commit, hashes, signatures,
+   and test output are attached to a signed release artifact.
+5. **Approved environment proof** — an operator repeats the limited real-client
+   checks in an approved environment with the resulting evidence retained.
+
+Levels 1 and 2 do not substitute for levels 3 through 5.
+
+## Sterile Native-Client Review
+
+Use this protocol before claiming a real native-client integration:
+
+1. Record the Kernel binary path and content hash, source commit, client
+   version, policy inputs, and the disposable workspace path.
+2. Create a new client home such as `CODEX_HOME=<empty-directory>`; never copy
+   an existing browser session, client credential, or cached config into it.
+3. Run project setup with an explicit private data directory, retain the JSON
+   summary, and verify the lifecycle receipt/evidence before launching the
+   client.
+4. Have the authorized operator complete the client login in that sterile home.
+   Observe that the configured HELM stdio server is actually loaded.
+5. Run one harmless controlled case for each hook class present in the generated
+   configuration and one routed MCP call. Capture client-visible results and
+   verify the corresponding HELM receipts. A denied case must show no target
+   side effect.
+6. Tamper with an owned config or lifecycle proof only in the disposable
+   fixture, then confirm that admission fails closed. Remove the fixture with
+   the normal project-scope removal path.
+
+The review record must name the exact classes and MCP server/tool exercised.
+It must state `not exercised` for every other client action; absence of a test
+is not coverage.
+
+## Source Truth And Checks
+
+- `core/cmd/helm-ai-kernel/setup_cmd.go`
+- `core/cmd/helm-ai-kernel/setup_codex_project_paths.go`
+- `core/cmd/helm-ai-kernel/setup_codex_lifecycle.go`
+- `core/cmd/helm-ai-kernel/setup_lifecycle_readonly.go`
+- `core/cmd/helm-ai-kernel/setup_recovery_*.go`
+- `core/cmd/helm-ai-kernel/setup_claude_code_binary.go`
+- `core/cmd/helm-ai-kernel/setup_recovery_security_test.go`
+- `core/cmd/helm-ai-kernel/setup_cmd_test.go`
+
+Run the focused lifecycle suite for code changes, then `make docs-coverage
+docs-truth` for documentation changes.

--- a/docs/KERNEL_SCOPE.md
+++ b/docs/KERNEL_SCOPE.md
@@ -1,6 +1,6 @@
 ---
 title: KERNEL_SCOPE
-last_reviewed: 2026-05-12
+last_reviewed: 2026-07-14
 ---
 
 # HELM AI Kernel Scope
@@ -153,6 +153,15 @@ not an adapter. It provides:
 The governed proxy (`/v1/chat/completions`) intercepts OpenAI-compatible
 tool calls and routes them through the PEP boundary.
 
+### Native Client Setup
+
+The CLI can write selected local Codex and Claude Code configuration. Codex
+project scope additionally has an owner-checked workspace-hash namespace, signed
+lifecycle evidence, and crash recovery. This is configuration and local
+authority management, not an agent runtime: only configured hook classes and
+MCP calls routed through HELM can cross the Kernel boundary. A matching config
+or synthetic denial does not prove a live client session.
+
 ### Bounded-Surface Primitives
 
 The OSS kernel includes configurable surface containment primitives
@@ -176,6 +185,8 @@ OSS includes:
 - **MCP interceptor** — first-class governed MCP surface
 - **OpenAI proxy** — governed proxy for OpenAI-compatible SDKs
 - **Headless API contract** — HTTP routes, schemas, receipts, SDKs, and conformance fixtures for external clients
+- **Native setup lifecycle** — private local authority checks, project-scoped
+  Codex binding/recovery state, and selected client configuration
 - Adapters and integration surfaces
 
 OSS does not include:
@@ -187,6 +198,7 @@ OSS does not include:
 - Managed federation or hosted trust registries
 - Private entitlement, seat management, usage metering, or account-management systems
 - Non-OSS connector certification programs
+- General native-client, desktop, browser, or OS-wide enforcement
 
 The invariant is simple: OSS must stay fully useful on its own as a developer-first execution kernel: Go CLI, HTTP/API contracts, SDKs, evidence export, offline verification, replay, conformance, and release artifacts. Hosted, organization-specific, and browser UI operations live outside this repository and integrate through those public contracts.
 

--- a/docs/PROOF_LOOP.md
+++ b/docs/PROOF_LOOP.md
@@ -1,6 +1,6 @@
 ---
 title: HELM Proof Loop
-last_reviewed: 2026-07-02
+last_reviewed: 2026-07-14
 ---
 
 # HELM Proof Loop
@@ -47,6 +47,16 @@ helm-ai-kernel workstation verify-decision \
 | EvidencePack | Moves proof between machines | offline verifier result |
 | Category pages | Explain adjacent tools without superiority claims | cited public evidence |
 
+## Native Setup Is A Separate Layer
+
+Codex project setup adds a signed local lifecycle transaction around the
+generated config. Its exact-config checks and Kernel-only synthetic denial are
+useful local evidence, but `client_load_observed=false` means a real client has
+not yet been observed. The next layer is a sterile native-client review that
+exercises only configured hook classes and routed MCP calls; direct client or
+upstream paths remain outside the evidence. See the [Native Client Integration
+Boundary](INTEGRATIONS/native-client-boundary.md) for the public review limits.
+
 ## Boundaries
 
 - HELM only governs effects routed through an adapter, wrapper, hook, proxy, or
@@ -56,6 +66,8 @@ helm-ai-kernel workstation verify-decision \
 - Receipts prove the evaluated action and verdict. They do not prove every
   tool outside the boundary was governed.
 - EvidencePacks are portable proof bundles, not marketing screenshots.
+- Native setup receipts do not prove a client session merely because the config
+  and synthetic denial passed.
 
 ## Next
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-14
 ---
 
 # Quickstart
@@ -32,8 +32,8 @@ make build
 | Install | `brew install helm-ai-kernel` or `make build` |
 | CLI chooser | `helm-ai-kernel` or `helm-ai-kernel setup` |
 | Local proof | `helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs` |
-| Codex setup | `helm-ai-kernel setup codex --dry-run --json` |
-| Claude Code setup | `helm-ai-kernel setup claude-code --dry-run --json` |
+| Codex setup | Local config plan preview: `helm-ai-kernel setup codex --dry-run --json` |
+| Claude Code setup | Local setup preview; Claude-owned MCP serialization is not read back: `helm-ai-kernel setup claude-code --dry-run --json` |
 | Cursor / Windsurf / VS Code config | `helm-ai-kernel setup --client cursor --print-config` |
 | OpenClaw / Hermes adapters | [tool runtime adapters](INTEGRATIONS/tool-runtime-adapters.md) |
 | Framework adapters | [framework adapters](INTEGRATIONS/framework-adapters.md) |
@@ -154,6 +154,13 @@ helm-ai-kernel setup --client cursor --print-config
 
 Setup writes local config and draft policy artifacts. It does not approve
 detected tools.
+
+For Codex project scope, setup also records a signed lifecycle receipt and a
+Kernel-only synthetic denial. The summary intentionally keeps
+`client_load_observed=false`: that local proof is not a real client-session
+result. Read the [Native Client Integration
+Boundary](INTEGRATIONS/native-client-boundary.md) before describing the local
+result as a client-session outcome.
 
 ## Inspect
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ This tree is the canonical public documentation source for HELM AI Kernel. Publi
 
 - [OpenAI-compatible proxy](INTEGRATIONS/openai_baseurl.md)
 - [MCP integration](INTEGRATIONS/mcp.md)
+- [Native client integration boundary](INTEGRATIONS/native-client-boundary.md)
 - [Highflame ZeroID Integration](INTEGRATIONS/zeroid.md)
 - [Vaultak State Transaction Bridge](INTEGRATIONS/vaultak.md)
 - [BGT Labs Sentinel Authorization Gateway](INTEGRATIONS/sentinel.md)

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -1,6 +1,6 @@
 ---
 title: Receipts
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-14
 ---
 
 # Receipts
@@ -24,6 +24,12 @@ For MCP and boundary decisions, HELM records:
 Approvals and revocations also write receipts. A later evaluation must fail
 closed when an approval is expired, revoked, or outside its server, tool, or
 effect scope.
+
+Codex project setup and removal also record signed lifecycle receipts. Their
+durable rows retain the canonical receipt envelope; recovery reopens that store
+read-only and refuses a missing, malformed, non-canonical, or legacy
+index-only envelope. These receipts prove the local lifecycle transaction, not
+that a native client opened the generated configuration.
 
 ## Inspect Local Receipts
 
@@ -85,6 +91,16 @@ helm-ai-kernel verify evidence-pack.tar
 ```
 
 EvidencePacks are portable proof bundles for local review and offline replay.
+
+## Native Client Evidence
+
+Local Codex setup can prove exact HELM-owned configuration, a signed lifecycle
+record, and a Kernel-only synthetic denial. It intentionally reports
+`client_load_observed=false` until a separate real client session is observed.
+Do not use that local result as proof of every Codex action or direct upstream
+MCP call. See the [Native Client Integration
+Boundary](INTEGRATIONS/native-client-boundary.md) before describing a real
+client-session result.
 
 ## Release Evidence
 

--- a/docs/guides/govern-mcp-tools.md
+++ b/docs/guides/govern-mcp-tools.md
@@ -42,7 +42,12 @@ Codex command or asking a client CLI to install a server does not prove that a
 native client loaded the configuration, and it does not cover direct upstream
 calls or unconfigured client actions. Local setup evidence remains
 `client_load_observed=false` until a sterile client session visibly loads the
-configured server.
+configured server. For Codex project setup, inspect local lifecycle changes
+before writing them:
+
+```bash
+helm-ai-kernel setup codex --scope project --dry-run --json
+```
 
 ## 4. Verify The Local MCP Boundary
 
@@ -50,11 +55,12 @@ configured server.
 ./scripts/launch/demo-mcp.sh
 ```
 
-This demo starts a local HELM boundary and fixture server. It verifies local MCP
-authorization paths only; it does not start Codex or Claude Code or demonstrate
-that either client loaded its configuration. A native-client claim requires a
-sterile session that exercises the configured routed MCP call (and any
-configured hook class).
+This demo starts a local HELM boundary and fixture server; it verifies that
+local MCP authorization paths fail closed. It does not start a native client or
+show that Codex or Claude Code loaded client configuration. That claim requires
+a sterile client session which observes the configured server and exercises the
+specific routed MCP call (and any configured hook class) under review. See the
+[native client integration boundary](../INTEGRATIONS/native-client-boundary.md).
 
 ## 5. Inspect Receipts
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,13 +39,14 @@ Then choose one path.
 
 ## Local Client Setup Boundary
 
-Codex setup and printed MCP configuration can record exact local configuration,
-but intentionally leave `client_load_observed=false`. They do not prove that
-Codex or Claude Code loaded the configuration in a real session. A native
-client claim needs a sterile client home and disposable workspace that loads the
-configured server, exercises only configured hook classes and routed MCP calls,
-and verifies resulting receipts. Direct upstream and unconfigured client paths
-remain outside that review.
+Codex project setup can record exact local configuration, a signed lifecycle
+receipt, and a Kernel-only synthetic denial. It intentionally reports
+`client_load_observed=false`: those local checks do not show that Codex or
+Claude Code loaded the configuration in a real session. A native-client claim
+requires a sterile client home and disposable workspace that visibly load the
+configured server, exercise only configured hook classes and routed MCP calls,
+and verify the resulting receipts. Other client actions and bypassing upstream
+paths remain outside that review.
 
 ## More
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ Then choose one path.
 - [Scan agent risk](reference/agent-risk-scan.md)
 - [OpenAI proxy](INTEGRATIONS/openai_baseurl.md)
 - [Verify receipts](VERIFICATION.md)
+- [Native client integration boundary](INTEGRATIONS/native-client-boundary.md)
 
 ## Local Client Setup Boundary
 

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -118,6 +118,15 @@
       "sensitivity": "public"
     },
     {
+      "slug": "integrations/native-client-boundary",
+      "title": "Native Client Integration Boundary",
+      "section": "integrations",
+      "source_path": "docs/INTEGRATIONS/native-client-boundary.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/integrations/native-client-boundary",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "integrations/framework-adapters",
       "title": "Framework Adapters",
       "section": "integrations",

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -1,8 +1,8 @@
 # Protect Local Coding Agents
 
 HELM can sit around Codex, Claude Code, and similar local agent workflows. The
-goal is narrow: selected effects cross a HELM boundary before dispatch, and
-each decision leaves a local receipt.
+goal is narrow: selected configured hook effects and routed MCP calls cross a
+HELM boundary before dispatch, and each decision leaves a local receipt.
 
 HELM is not a competing coding agent. It evaluates the actions your agent wants
 to take.
@@ -33,6 +33,20 @@ helm-ai-kernel setup claude-code --yes
 
 Setup writes draft policy and quarantine artifacts. It does not approve tools
 or grant broad operating permissions.
+
+For Codex project scope, setup also writes a project-isolated lifecycle record.
+It proves local configuration and a Kernel-only synthetic denial, not that a
+live client loaded the config. Inspect or recover an interrupted transaction
+with:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --yes
+```
+
+The [native client integration boundary](../INTEGRATIONS/native-client-boundary.md)
+defines the public proof limit: do not describe local setup output as a
+client-session result.
 
 ## Scan The Agent Surface
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-14
 ---
 
 # CLI
@@ -29,6 +29,25 @@ helm-ai-kernel setup --client cursor --print-config
 
 Setup writes local client configuration and draft policy artifacts. It does not
 approve tools.
+
+For Codex project scope, lifecycle management is explicit:
+
+```bash
+helm-ai-kernel setup status codex --scope project --json
+helm-ai-kernel setup recover codex --scope project --dry-run --json
+helm-ai-kernel setup recover codex --scope project --yes
+helm-ai-kernel setup migrate codex --scope project --dry-run --json
+helm-ai-kernel setup migrate codex --scope project --yes
+helm-ai-kernel setup remove codex --scope project --yes
+```
+
+The lifecycle summary records local configuration and a Kernel-only synthetic
+denial; `client_load_observed=false` is not a client-session failure, it is an
+honest boundary. See the [Native Client Integration
+Boundary](../INTEGRATIONS/native-client-boundary.md) for public proof limits.
+
+Claude Code setup requires a direct executable. If PATH resolves through a mise
+shim, use `CLAUDE_CODE_BIN=/absolute/path/to/claude` with the setup command.
 
 ## MCP Approval Commands
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,33 +1,41 @@
 # HELM AI Kernel Threat Model
 
-Version: 2026-06-08-security-evidence-loop-v1
-Version Hash: sha256:77210a48f9f402bd0c28c1c93bc5d422a08f80003fa850e819cedff116697bc8
+Version: 2026-07-14-native-client-lifecycle-v1
+Version Hash: no signed release artifact has been created for this source revision
 Owner: HELM Kernel Security
-Review Date: 2026-06-08
+Review Date: 2026-07-14
 
 ## Assets
 
 - EvidencePack contracts, seals, signatures, receipt hashes, replay manifests, and trust profiles.
 - Boundary verdicts, policy evaluation inputs, sandbox specifications, and proof graph records.
 - Kernel package APIs consumed by Enterprise, services, SDKs, and public examples.
+- Local setup authority, project-scoped Codex bindings, recovery
+  journals, canonical lifecycle receipt envelopes, and lifecycle evidence.
 
 ## Entry Points
 
 - Go package APIs under `core/pkg/contracts`, `core/pkg/evidence`, `core/pkg/sandbox`, `core/pkg/proofgraph`, and boundary packages.
 - Test/conformance fixtures that are promoted into public proof or release evidence.
 - Serialized EvidencePack, receipt, replay, sandbox, and policy documents.
+- Local client configuration, legacy unscoped setup state, lifecycle databases,
+  and recovery directories supplied by the workstation filesystem.
 
 ## Trusted Inputs
 
 - Source-owned contracts and fixtures committed in this repo.
 - Signed EvidencePack material and configured external signer anchors.
 - Repo-local tests and conformance cases that run from a pinned commit.
+- Existing native lifecycle state only after private-directory, ownership,
+  canonical-envelope, and workspace-binding checks pass.
 
 ## Untrusted Inputs
 
 - Scanner output, vulnerability candidates, PoC transcripts, model-generated verifier text, and imported report attachments.
 - Sandbox command args, environment, mounts, network configuration, and repo checkout content.
 - Downstream Enterprise or service claims that are not backed by Kernel receipts.
+- A local config file, synthetic denial, client log, or claimed client load that
+  is not bound to the reviewed lifecycle receipt and sterile-session evidence.
 
 ## Tenant Boundaries
 
@@ -43,6 +51,8 @@ Review Date: 2026-06-08
 ## Effect Classes
 
 - ALLOW/DENY/ESCALATE boundary decisions, signature/seal creation, proof export, replay, sandbox execution, and connector-facing contract publication.
+- Codex project setup, recovery, migration, and removal of HELM-owned local
+  configuration entries.
 - High-risk effects require receipts, verifier evidence, and fail-closed behavior.
 
 ## Out-of-Scope Bug Classes
@@ -55,10 +65,16 @@ Review Date: 2026-06-08
 - Hash-only evidence accepted where signed or anchored proof was required.
 - Sandbox execution evidence without pinned images, credential checks, or network constraints.
 - Public or Enterprise claims drifting from Kernel source-owned receipt semantics.
+- One project accepting another project's binding, recovery journal, generated
+  artifact, or unscoped legacy state.
+- Lifecycle recovery accepting an index-only, malformed, or non-canonical
+  durable receipt instead of the signed envelope.
 
 ## Severity Calibration
 
 - Critical: forged or self-supplied EvidencePack/seal/verdict accepted as production proof.
 - High: verifier, sandbox, replay, or boundary receipt can be bypassed or confused across trust boundaries.
+- High: unsafe local authority state, cross-project native lifecycle state, or
+  a forged lifecycle receipt lets setup/recovery alter client configuration.
 - Medium: contract drift that weakens downstream evidence checks but remains blocked by another fail-closed gate.
 - Low: incomplete evidence metadata that does not alter enforcement, sealing, or release decisions.

--- a/examples/starters/codex/README.md
+++ b/examples/starters/codex/README.md
@@ -18,12 +18,20 @@ helm-ai-kernel mcp serve --transport http
 ## Native Client Boundary
 
 `helm-ai-kernel init codex` creates a starter layout; the governed-call script
-is a local HTTP fixture, not a Codex client run. `helm-ai-kernel setup codex`
-or printed MCP configuration can prove local setup only and deliberately leave
+is a local HTTP fixture, not a Codex client run. To inspect Codex project-local
+configuration separately, use:
+
+```bash
+helm-ai-kernel setup codex --scope project --dry-run --json
+```
+
+After an explicit `--yes` setup, its exact configuration checks, signed
+lifecycle receipt, and Kernel-only synthetic denial still report
 `client_load_observed=false`. A real native-client claim requires a sterile
-client home and disposable workspace that loads the configured server and
-exercises the configured hook classes or routed MCP call. Direct upstream calls
-and unconfigured client actions remain outside that proof.
+client home and disposable workspace that load the configured server and
+exercise the configured hook classes or routed MCP call; direct upstream calls
+and unconfigured client actions remain outside that proof. See the [native
+client integration boundary](../../../docs/INTEGRATIONS/native-client-boundary.md).
 
 ## What's Included
 

--- a/examples/workstation/README.md
+++ b/examples/workstation/README.md
@@ -4,6 +4,11 @@ These examples package the manifest-first workstation adapter for local Codex or
 
 They do not use private vendor APIs. The wrapper records a local artifact directory, then HELM imports that directory into a signed Agent Run Receipt and deterministic ProofGraph.
 
+They do not install or exercise the native-client lifecycle. A wrapper receipt
+is not proof that Codex or Claude Code loaded HELM configuration; use
+[`docs/INTEGRATIONS/native-client-lifecycle.md`](../../docs/INTEGRATIONS/native-client-lifecycle.md)
+for the project-scoped setup and sterile-session review boundary.
+
 ## Codex-style run
 
 See `codex/README.md` for the local wrapper boundary.

--- a/examples/workstation/claude-code/README.md
+++ b/examples/workstation/claude-code/README.md
@@ -17,3 +17,7 @@ steps can call the selected-effect wrapper. They are examples only; use the
 documented hook surface for the local Claude Code installation.
 
 The wrapper and hooks do not read secrets, browser sessions, or raw chat history.
+They are not a live Claude Code integration result and do not establish Codex
+project lifecycle parity. Native Claude setup resolves a direct executable via
+`CLAUDE_CODE_BIN` when PATH would select a mise shim; see
+[`docs/INTEGRATIONS/native-client-lifecycle.md`](../../../docs/INTEGRATIONS/native-client-lifecycle.md).

--- a/examples/workstation/codex/README.md
+++ b/examples/workstation/codex/README.md
@@ -12,3 +12,7 @@ HELM_BIN=go\ run\ ./core/cmd/helm-ai-kernel \
 ```
 
 The wrapper does not read secrets, browser sessions, or raw chat history.
+It does not create or validate the project-scoped Codex setup lifecycle, launch
+Codex, or prove a native client session. Use
+[`docs/INTEGRATIONS/native-client-lifecycle.md`](../../../docs/INTEGRATIONS/native-client-lifecycle.md)
+for that separate boundary.


### PR DESCRIPTION
## Scope

Stacked HELM-178 evidence slice for the project lifecycle foundation. It adds recovery-security coverage and the native-client review boundary across kernel and workstation documentation.

## Exact-head validation

- focused lifecycle and recovery Go test passed
- documentation coverage and documentation truth checks passed
- git diff --check passed
- immutable review patch is 145,823 bytes, below the 524,288-byte deterministic cap

## Evidence boundary

Lifecycle receipts and configuration prove only setup. They do not prove that Codex or Claude Code loaded that configuration, nor that paths outside routed MCP/hooks crossed HELM. Those claims require a sterile client observation.

## Dependency and release authority

This draft depends on #562. It has no merge, deployment, or production-runtime authority. The current #562 exact head is blocked by its own oversized immutable review input and by the still-unproven live authority control plane. No manual merge, deployment, branch deletion, or worktree cleanup is authorized.