### PR TITLE
fix(deploy): initialize authority state safely

### DIFF
--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -48,6 +48,9 @@
 {{- if and .Values.helm.emergencyStop.enabled (not (or .Values.helm.emergencyStop.commandPublicKeys .Values.helm.emergencyStop.existingSecret)) -}}
 {{- fail "helm.emergencyStop.enabled=true requires helm.emergencyStop.commandPublicKeys or helm.emergencyStop.existingSecret" -}}
 {{- end -}}
+{{- if not (regexMatch "^.+@sha256:[0-9a-f]{64}$" .Values.runtimeInit.image) -}}
+{{- fail "runtimeInit.image must be pinned by immutable sha256 digest" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -78,6 +81,85 @@ spec:
       serviceAccountName: {{ include "helm-ai-kernel.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: prepare-authority-state
+          image: {{ .Values.runtimeInit.image | quote }}
+          imagePullPolicy: {{ .Values.runtimeInit.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+              # The initializer must change the mounted volume's owner before
+              # the non-root kernel starts. Keep this to the one capability
+              # required for chown; it is not a privileged container.
+              add:
+                - CHOWN
+            readOnlyRootFilesystem: true
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              set -eu
+              umask 077
+              data_dir="$HELM_AUTHORITY_DATA_DIR"
+              root_key="$data_dir/root.key"
+              source_key="/var/run/helm-signing-key/root.key"
+              runtime_uid="$HELM_AUTHORITY_RUNTIME_UID"
+              runtime_gid="$HELM_AUTHORITY_RUNTIME_GID"
+
+              if [ ! -r "$source_key" ]; then
+                echo "authority signing Secret is not readable" >&2
+                exit 1
+              fi
+
+              mkdir -p "$data_dir"
+              chown 0:0 "$data_dir"
+              chmod 0700 "$data_dir"
+
+              if [ -L "$root_key" ]; then
+                echo "refusing symlinked durable authority root key" >&2
+                exit 1
+              fi
+              if [ -e "$root_key" ] && [ ! -f "$root_key" ]; then
+                echo "durable authority root key is not a regular file" >&2
+                exit 1
+              fi
+
+              if [ -f "$root_key" ]; then
+                chown 0:0 "$root_key"
+                chmod 0600 "$root_key"
+                if ! cmp -s "$source_key" "$root_key"; then
+                  echo "durable authority root key differs from signing Secret; refusing silent rotation" >&2
+                  exit 1
+                fi
+              else
+                tmp_key="$data_dir/.root.key.init.$$"
+                rm -f "$tmp_key"
+                cp "$source_key" "$tmp_key"
+                chmod 0600 "$tmp_key"
+                mv -f "$tmp_key" "$root_key"
+              fi
+              chmod 0600 "$root_key"
+              chown "$runtime_uid:$runtime_gid" "$root_key"
+              chown "$runtime_uid:$runtime_gid" "$data_dir"
+          env:
+            - name: HELM_AUTHORITY_DATA_DIR
+              value: {{ .Values.helm.dataDir | quote }}
+            - name: HELM_AUTHORITY_RUNTIME_UID
+              value: {{ required "podSecurityContext.runAsUser is required for authority-state initialization" .Values.podSecurityContext.runAsUser | quote }}
+            - name: HELM_AUTHORITY_RUNTIME_GID
+              value: {{ required "podSecurityContext.runAsGroup is required for authority-state initialization" .Values.podSecurityContext.runAsGroup | quote }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.helm.dataDir | quote }}
+            - name: signing-key
+              mountPath: /var/run/helm-signing-key
+              readOnly: true
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -292,10 +374,6 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ .Values.helm.dataDir }}
-            - name: signing-key
-              mountPath: {{ printf "%s/root.key" (.Values.helm.dataDir | trimSuffix "/") }}
-              subPath: root.key
-              readOnly: true
             - name: policy
               mountPath: {{ include "helm-ai-kernel.policyMountPath" . }}
               readOnly: true
@@ -326,6 +404,7 @@ spec:
         - name: signing-key
           secret:
             secretName: {{ include "helm-ai-kernel.signingSecretName" . }}
+            defaultMode: 256
             items:
               - key: signing-key
                 path: root.key

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -93,12 +93,31 @@
     "podSecurityContext": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Pod-level securityContext. Defaults run the kernel as non-root (UID/GID 65534, nobody) with fsGroup so the data volume is writable."
+      "description": "Pod-level securityContext. Defaults run the kernel as non-root (UID/GID 65534, nobody). fsGroup remains a volume-compatibility setting; the root-only runtimeInit container explicitly creates the authority directory with exact 0700 permissions and the configured runtime owner."
     },
     "securityContext": {
       "type": "object",
       "additionalProperties": true,
       "description": "Container-level securityContext. Defaults drop ALL Linux capabilities, disable privilege escalation, and mount the root filesystem read-only; helm.dataDir is the only writable path."
+    },
+    "runtimeInit": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Root-only one-shot init container that copies the signing Secret into helm.dataDir as an exact-mode, runtime-owned private root key. The image must be immutable because it establishes local signing authority before the non-root kernel starts.",
+      "properties": {
+        "image": {
+          "type": "string",
+          "pattern": "^.+@sha256:[0-9a-f]{64}$",
+          "default": "docker.io/alpine/helm@sha256:105741fa6621ed9a3ea944066de78bb27d4b9bb93a56ce8e7cb4d621e1e4bbf2",
+          "description": "Digest-pinned image used only by the authority-state init container. A mirror is allowed only when referenced by immutable sha256 digest."
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "default": "IfNotPresent",
+          "description": "Image pull policy for the authority-state init container."
+        }
+      }
     },
     "service": {
       "type": "object",

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -30,6 +30,9 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65534
   runAsGroup: 65534
+  # This remains a volume-compatibility setting. It is not used to establish
+  # local signing authority: runtimeInit resets helm.dataDir to 0700 and the
+  # configured runtime UID/GID before the kernel starts.
   fsGroup: 65534
 
 securityContext:
@@ -38,6 +41,14 @@ securityContext:
   capabilities:
     drop:
       - ALL
+
+# Root-only, one-shot authority materializer. The immutable image copies the
+# signing Secret into the data volume with the exact owner/mode that the
+# non-root kernel validates at startup. A changed durable root key fails closed
+# rather than being silently overwritten by a Secret update.
+runtimeInit:
+  image: "docker.io/alpine/helm@sha256:105741fa6621ed9a3ea944066de78bb27d4b9bb93a56ce8e7cb4d621e1e4bbf2"
+  pullPolicy: IfNotPresent
 
 service:
   type: ClusterIP

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,20 @@
 # See docs/QUICKSTART.md for configuration guidance.
 
 services:
+  authority-state:
+    image: docker.io/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
+    user: "0:0"
+    command:
+      - sh
+      - -ec
+      - |
+        mkdir -p /var/lib/helm-ai-kernel
+        chown 65532:65532 /var/lib/helm-ai-kernel
+        chmod 0700 /var/lib/helm-ai-kernel
+    volumes:
+      - ${HELM_SMOKE_DATA_DIR:-helmdata}:/var/lib/helm-ai-kernel
+    restart: "no"
+
   helm:
     build:
       context: .
@@ -30,6 +44,9 @@ services:
       HELM_RUNTIME_PRINCIPAL_ID: "${HELM_RUNTIME_PRINCIPAL_ID:-system-admin}"
       HELM_HEALTH_PORT: "8081"
       EVIDENCE_SIGNING_KEY: "${EVIDENCE_SIGNING_KEY:-helm-evidence-dev}"
+    depends_on:
+      authority-state:
+        condition: service_completed_successfully
     ports:
       - "127.0.0.1:${HELM_SMOKE_API_PORT:-8080}:8080"
       - "127.0.0.1:${HELM_SMOKE_HEALTH_PORT:-8081}:8081"

--- a/scripts/ci/check_docker_smoke_hardening.py
+++ b/scripts/ci/check_docker_smoke_hardening.py
@@ -39,6 +39,12 @@ def check_docker_smoke(path: Path) -> None:
         'HELM_ADMIN_API_KEY="$ADMIN_KEY"',
         'HELM_SERVICE_API_KEY="$SERVICE_KEY"',
         'EVIDENCE_SIGNING_KEY="$EVIDENCE_SIGNING_KEY"',
+        'AUTHORITY_INIT_IMAGE="docker.io/library/busybox@sha256:',
+        "require_pinned_authority_init_image()",
+        'chown 65532:65532 /runtime-data && chmod 0700 /runtime-data',
+        "ARTIFACT_DIR=",
+        "diagnose_runtime_failure()",
+        'docker logs --tail 200 "$CONTAINER_NAME"',
     ]:
         require(text, token, path)
 
@@ -50,6 +56,8 @@ def check_docker_smoke(path: Path) -> None:
         '-p "${HEALTH_PORT}:8081"',
         '-p "0.0.0.0:${API_PORT}:8080"',
         '-p "0.0.0.0:${HEALTH_PORT}:8081"',
+        'chmod 0777 "$DATA_DIR"',
+        'busybox:1.36.1',
     ]:
         forbid(text, token, path)
 
@@ -62,6 +70,16 @@ def check_compose(path: Path) -> None:
     forbid(text, '"${HELM_SMOKE_HEALTH_PORT:-8081}:8081"', path)
     forbid(text, '"0.0.0.0:${HELM_SMOKE_API_PORT:-8080}:8080"', path)
     forbid(text, '"0.0.0.0:${HELM_SMOKE_HEALTH_PORT:-8081}:8081"', path)
+    for token in [
+        "authority-state:",
+        "image: docker.io/library/busybox@sha256:",
+        'user: "0:0"',
+        "chown 65532:65532 /var/lib/helm-ai-kernel",
+        "chmod 0700 /var/lib/helm-ai-kernel",
+        "condition: service_completed_successfully",
+    ]:
+        require(text, token, path)
+    forbid(text, "image: busybox:1.36.1", path)
 
 
 def main() -> None:

--- a/scripts/ci/check_helm_smoke_hardening.py
+++ b/scripts/ci/check_helm_smoke_hardening.py
@@ -17,6 +17,11 @@ def fail(message: str) -> None:
     raise SystemExit(1)
 
 
+def require(text: str, token: str, path: Path) -> None:
+    if token not in text:
+        fail(f"{path}: missing required authority-state hardening token: {token}")
+
+
 def require_digest_default(path: Path, text: str) -> None:
     match = re.search(r'KUBE_HELM_IMAGE="\$\{KUBE_HELM_IMAGE:-([^}]+)\}"', text)
     if not match:
@@ -56,9 +61,39 @@ def check_chart_smoke(path: Path) -> None:
     require_digest_default(path, text)
 
 
+def check_authority_state_chart(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    required = [
+        'name: prepare-authority-state',
+        'runtimeInit.image must be pinned by immutable sha256 digest',
+        'runAsUser: 0',
+        'runAsGroup: 0',
+        'runAsNonRoot: false',
+        'readOnlyRootFilesystem: true',
+        'add:\n                - CHOWN',
+        'chown 0:0 "$data_dir"\n              chmod 0700 "$data_dir"',
+        'chown 0:0 "$root_key"\n                chmod 0600 "$root_key"',
+        'chmod 0600 "$root_key"\n              chown "$runtime_uid:$runtime_gid" "$root_key"\n              chown "$runtime_uid:$runtime_gid" "$data_dir"',
+        'HELM_AUTHORITY_RUNTIME_UID',
+        'HELM_AUTHORITY_RUNTIME_GID',
+        'chmod 0700 "$data_dir"',
+        'chmod 0600 "$root_key"',
+        'cmp -s "$source_key" "$root_key"',
+        'refusing silent rotation',
+        'mountPath: /var/run/helm-signing-key',
+        'defaultMode: 256',
+    ]
+    for token in required:
+        require(text, token, path)
+    for token in ['subPath: root.key', 'mountPath: {{ printf "%s/root.key"']:
+        if token in text:
+            fail(f"{path}: kernel must not receive the signing Secret as a root.key subPath")
+
+
 def main() -> None:
     check_kind_smoke(ROOT / "scripts/ci/kind_smoke.sh")
     check_chart_smoke(ROOT / "scripts/ci/helm_chart_smoke.sh")
+    check_authority_state_chart(ROOT / "deploy/helm-chart/templates/deployment.yaml")
     print("Helm smoke hardening checks passed.")
 
 

--- a/scripts/ci/docker_smoke.sh
+++ b/scripts/ci/docker_smoke.sh
@@ -20,10 +20,13 @@ HEALTH_PORT="${HELM_SMOKE_HEALTH_PORT:-18081}"
 TENANT_ID="${HELM_SMOKE_TENANT_ID:-tenant-smoke}"
 AGENT_ID="${HELM_SMOKE_AGENT_ID:-agent.smoke}"
 CONTAINER_NAME="${HELM_SMOKE_CONTAINER_NAME:-helm-ai-kernel-smoke}"
-DATA_DIR="${HELM_SMOKE_DATA_DIR:-}"
+RUNTIME_DATA_DIR="${HELM_SMOKE_DATA_DIR:-}"
+ARTIFACT_DIR="${HELM_SMOKE_ARTIFACT_DIR:-}"
 COMPOSE_PROJECT="${HELM_SMOKE_COMPOSE_PROJECT:-helmoss_smoke}"
 COMPOSE_FILE="${HELM_SMOKE_COMPOSE_FILE:-docker-compose.yml}"
-cleanup_data=0
+AUTHORITY_INIT_IMAGE="docker.io/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662"
+cleanup_runtime_data=0
+cleanup_artifacts=0
 
 BUILD_VERSION="${HELM_BUILD_VERSION:-$(cat "$ROOT/VERSION" 2>/dev/null || echo dev)}"
 BUILD_COMMIT="${HELM_BUILD_COMMIT:-$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
@@ -36,9 +39,17 @@ require() {
     }
 }
 
+require_pinned_authority_init_image() {
+    if [[ ! "$AUTHORITY_INIT_IMAGE" =~ @sha256:[0-9a-f]{64}$ ]]; then
+        echo "::error::AUTHORITY_INIT_IMAGE must be pinned by immutable sha256 digest"
+        exit 1
+    fi
+}
+
 require docker
 require curl
 require python3
+require_pinned_authority_init_image
 
 random_key() {
     python3 - <<'PY'
@@ -51,15 +62,32 @@ ADMIN_KEY="${HELM_SMOKE_ADMIN_KEY:-$(random_key)}"
 SERVICE_KEY="${HELM_SMOKE_SERVICE_KEY:-$(random_key)}"
 EVIDENCE_SIGNING_KEY="${HELM_SMOKE_EVIDENCE_SIGNING_KEY:-$(random_key)}"
 
-if [ -z "$DATA_DIR" ]; then
+if [ -z "$RUNTIME_DATA_DIR" ]; then
     mkdir -p "$ROOT/tmp"
-    DATA_DIR="$(mktemp -d "$ROOT/tmp/helm-ai-kernel-docker-smoke.XXXXXX")"
-    cleanup_data=1
+    RUNTIME_DATA_DIR="$(mktemp -d "$ROOT/tmp/helm-ai-kernel-docker-runtime.XXXXXX")"
+    cleanup_runtime_data=1
 fi
-mkdir -p "$DATA_DIR"
-# The runtime image runs as distroless nonroot (65532). Bind-mounted smoke
-# directories must be writable by that UID across Linux and Docker Desktop.
-chmod 0777 "$DATA_DIR"
+mkdir -p "$RUNTIME_DATA_DIR"
+RUNTIME_DATA_DIR="$(cd "$RUNTIME_DATA_DIR" && pwd -P)"
+
+if [ -z "$ARTIFACT_DIR" ]; then
+    mkdir -p "$ROOT/tmp"
+    ARTIFACT_DIR="$(mktemp -d "$ROOT/tmp/helm-ai-kernel-docker-artifacts.XXXXXX")"
+    cleanup_artifacts=1
+fi
+mkdir -p "$ARTIFACT_DIR"
+ARTIFACT_DIR="$(cd "$ARTIFACT_DIR" && pwd -P)"
+
+prepare_direct_runtime_data_dir() {
+    # The runtime rejects group/world-writable or foreign-owned authority
+    # state. Prepare only the mounted state directory; smoke artifacts stay
+    # outside that authority boundary.
+    docker run --rm --user 0:0 \
+        --mount "type=bind,source=$RUNTIME_DATA_DIR,target=/runtime-data" \
+        "$AUTHORITY_INIT_IMAGE" \
+        sh -ec 'chown 65532:65532 /runtime-data && chmod 0700 /runtime-data' \
+        >/dev/null
+}
 
 cleanup() {
     if [ "$MODE" = "compose" ]; then
@@ -67,25 +95,67 @@ cleanup() {
     else
         docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
     fi
-    if [ "$cleanup_data" = "1" ]; then
+    if [ "$cleanup_runtime_data" = "1" ]; then
         # The container ran as distroless nonroot (UID 65532) and may have
-        # written files under $DATA_DIR/keys/ with mode 0700 (KMS keystore).
-        # The host user can't traverse that directory, so delegate the
-        # recursive delete to a short-lived root container with the same
-        # mount. Falling through to the host rm afterwards picks up the
-        # now-empty $DATA_DIR plus anything the cleanup container missed.
-        if [ -d "$DATA_DIR" ]; then
-            docker run --rm \
-                --mount "type=bind,source=$DATA_DIR,target=/cleanup" \
-                busybox:1.36.1 \
+        # written files under $RUNTIME_DATA_DIR/keys/ with mode 0700 (KMS
+        # keystore). The host user can't traverse that directory, so delegate
+        # the recursive delete to a short-lived root container with the same
+        # mount. Falling through to the host rm afterwards picks up the now-
+        # empty directory plus anything the cleanup container missed.
+        if [ -d "$RUNTIME_DATA_DIR" ]; then
+            docker run --rm --user 0:0 \
+                --mount "type=bind,source=$RUNTIME_DATA_DIR,target=/cleanup" \
+                "$AUTHORITY_INIT_IMAGE" \
                 sh -c 'rm -rf /cleanup/..?* /cleanup/.[!.]* /cleanup/* 2>/dev/null || true' \
                 >/dev/null 2>&1 || true
         fi
-        rm -rf "$DATA_DIR" 2>/dev/null || true
+        rm -rf "$RUNTIME_DATA_DIR" 2>/dev/null || true
+    fi
+    if [ "$cleanup_artifacts" = "1" ]; then
+        rm -rf "$ARTIFACT_DIR" 2>/dev/null || true
+    fi
+    if [ "$cleanup_runtime_data" = "1" ] || [ "$cleanup_artifacts" = "1" ]; then
         rmdir "$ROOT/tmp" >/dev/null 2>&1 || true
     fi
 }
-trap cleanup EXIT
+
+diagnose_runtime_failure() {
+    echo "::group::docker smoke diagnostics"
+    echo "runtime diagnostics omit inspect and environment output so credentials are not exposed"
+    if [ "$MODE" = "compose" ]; then
+        (cd "$ROOT" && docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" ps) || true
+        (cd "$ROOT" && docker compose -p "$COMPOSE_PROJECT" -f "$COMPOSE_FILE" logs --no-color --tail 200 helm authority-state) || true
+    else
+        docker ps -a --filter "name=^/$CONTAINER_NAME$" --format '{{.Names}} {{.Status}}' || true
+        docker logs --tail 200 "$CONTAINER_NAME" || true
+    fi
+    echo "::endgroup::"
+}
+
+on_exit() {
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        diagnose_runtime_failure
+    fi
+    cleanup
+    return "$status"
+}
+
+runtime_file_exists() {
+    docker run --rm --user 0:0 \
+        --mount "type=bind,source=$RUNTIME_DATA_DIR,target=/runtime-data,readonly" \
+        "$AUTHORITY_INIT_IMAGE" \
+        test -f "/runtime-data/$1"
+}
+
+root_key_hash() {
+    docker run --rm --user 0:0 \
+        --mount "type=bind,source=$RUNTIME_DATA_DIR,target=/runtime-data,readonly" \
+        "$AUTHORITY_INIT_IMAGE" \
+        sha256sum /runtime-data/root.key | awk '{print $1}'
+}
+
+trap on_exit EXIT
 
 wait_http() {
     url="$1"
@@ -115,6 +185,7 @@ auth_headers=(
 
 start_docker() {
     docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    prepare_direct_runtime_data_dir
     docker run -d --name "$CONTAINER_NAME" \
         -p "127.0.0.1:${API_PORT}:8080" \
         -p "127.0.0.1:${HEALTH_PORT}:8081" \
@@ -124,7 +195,7 @@ start_docker() {
         -e HELM_RUNTIME_PRINCIPAL_ID="$AGENT_ID" \
         -e EVIDENCE_SIGNING_KEY="$EVIDENCE_SIGNING_KEY" \
         -e HELM_HEALTH_PORT=8081 \
-        -v "${DATA_DIR}:/var/lib/helm-ai-kernel" \
+        -v "${RUNTIME_DATA_DIR}:/var/lib/helm-ai-kernel" \
         "$IMAGE" >/dev/null
 }
 
@@ -135,7 +206,7 @@ start_compose() {
     HELM_RUNTIME_TENANT_ID="$TENANT_ID" \
     HELM_RUNTIME_PRINCIPAL_ID="$AGENT_ID" \
     EVIDENCE_SIGNING_KEY="$EVIDENCE_SIGNING_KEY" \
-    HELM_SMOKE_DATA_DIR="$DATA_DIR" \
+    HELM_SMOKE_DATA_DIR="$RUNTIME_DATA_DIR" \
     HELM_SMOKE_API_PORT="$API_PORT" \
     HELM_SMOKE_HEALTH_PORT="$HEALTH_PORT" \
     HELM_BUILD_VERSION="$BUILD_VERSION" \
@@ -158,8 +229,8 @@ assert_compose_build_metadata() {
     if [ "$MODE" != "compose" ]; then
         return
     fi
-    curl -fsS "$(base_url)/version" >"$DATA_DIR/version.json"
-    python3 - "$DATA_DIR/version.json" "$BUILD_COMMIT" <<'PY'
+    curl -fsS "$(base_url)/version" >"$ARTIFACT_DIR/version.json"
+    python3 - "$ARTIFACT_DIR/version.json" "$BUILD_COMMIT" <<'PY'
 import json, sys
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
 expected_commit = sys.argv[2]
@@ -185,22 +256,14 @@ stop_runtime() {
     fi
 }
 
-root_key_hash() {
-    if shasum -a 256 "$DATA_DIR/root.key" >/dev/null 2>&1; then
-        shasum -a 256 "$DATA_DIR/root.key" | awk '{print $1}'
-        return
-    fi
-    docker run --rm -v "${DATA_DIR}:/data:ro" busybox:1.36.1 sha256sum /data/root.key | awk '{print $1}'
-}
-
 evaluate_unknown_tool() {
     curl -fsS -X POST "$(base_url)/api/v1/evaluate" \
         -H 'Content-Type: application/json' \
         "${auth_headers[@]}" \
-        --data-binary @- >"$DATA_DIR/decision.json" <<JSON
+        --data-binary @- >"$ARTIFACT_DIR/decision.json" <<JSON
 {"principal":"${AGENT_ID}","action":"EXECUTE_TOOL","resource":"unknown.tool.smoke","context":{"session_id":"${AGENT_ID}","destination":"blocked.smoke.local","payload_size":1}}
 JSON
-    python3 - "$DATA_DIR/decision.json" <<'PY'
+    python3 - "$ARTIFACT_DIR/decision.json" <<'PY'
 import json, sys
 decision = json.load(open(sys.argv[1]))
 verdict = str(decision.get("verdict", "")).upper()
@@ -212,8 +275,8 @@ PY
 }
 
 list_receipts() {
-    curl -fsS "$(base_url)/api/v1/receipts?limit=10" "${auth_headers[@]}" >"$DATA_DIR/receipts.json"
-    python3 - "$DATA_DIR/receipts.json" <<'PY'
+    curl -fsS "$(base_url)/api/v1/receipts?limit=10" "${auth_headers[@]}" >"$ARTIFACT_DIR/receipts.json"
+    python3 - "$ARTIFACT_DIR/receipts.json" <<'PY'
 import json, sys
 payload = json.load(open(sys.argv[1]))
 receipts = payload.get("receipts") or []
@@ -228,20 +291,20 @@ PY
 
 fetch_receipt() {
     receipt_id="$1"
-    curl -fsS "$(base_url)/api/v1/receipts/${receipt_id}" "${auth_headers[@]}" >"$DATA_DIR/receipt.json"
+    curl -fsS "$(base_url)/api/v1/receipts/${receipt_id}" "${auth_headers[@]}" >"$ARTIFACT_DIR/receipt.json"
 }
 
 assert_authz_negative() {
-    status="$(curl -sS -o "$DATA_DIR/no-auth.json" -w '%{http_code}' "$(base_url)/api/v1/receipts?limit=1")"
+    status="$(curl -sS -o "$ARTIFACT_DIR/no-auth.json" -w '%{http_code}' "$(base_url)/api/v1/receipts?limit=1")"
     if [ "$status" != "401" ]; then
         echo "::error::expected missing auth to return 401, got $status"
-        cat "$DATA_DIR/no-auth.json"
+        cat "$ARTIFACT_DIR/no-auth.json"
         exit 1
     fi
-    status="$(curl -sS -o "$DATA_DIR/no-tenant.json" -w '%{http_code}' "$(base_url)/api/v1/receipts?limit=1" -H "Authorization: Bearer ${ADMIN_KEY}")"
+    status="$(curl -sS -o "$ARTIFACT_DIR/no-tenant.json" -w '%{http_code}' "$(base_url)/api/v1/receipts?limit=1" -H "Authorization: Bearer ${ADMIN_KEY}")"
     if [ "$status" != "403" ]; then
         echo "::error::expected missing tenant to return 403, got $status"
-        cat "$DATA_DIR/no-tenant.json"
+        cat "$ARTIFACT_DIR/no-tenant.json"
         exit 1
     fi
 }
@@ -251,16 +314,16 @@ export_and_verify_evidence() {
         "${auth_headers[@]}" \
         -H 'Content-Type: application/json' \
         --data-binary "{\"session_id\":\"${AGENT_ID}\",\"format\":\"tar.gz\"}" \
-        -o "$DATA_DIR/evidence.tar.gz"
-    test -s "$DATA_DIR/evidence.tar.gz"
+        -o "$ARTIFACT_DIR/evidence.tar.gz"
+    test -s "$ARTIFACT_DIR/evidence.tar.gz"
 
     curl -fsS -X POST "$(base_url)/api/v1/evidence/verify" \
         -H 'Content-Type: application/octet-stream' \
-        --data-binary "@$DATA_DIR/evidence.tar.gz" >"$DATA_DIR/evidence-verify.json"
+        --data-binary "@$ARTIFACT_DIR/evidence.tar.gz" >"$ARTIFACT_DIR/evidence-verify.json"
     curl -fsS -X POST "$(base_url)/api/v1/replay/verify" \
         -H 'Content-Type: application/octet-stream' \
-        --data-binary "@$DATA_DIR/evidence.tar.gz" >"$DATA_DIR/replay-verify.json"
-    python3 - "$DATA_DIR/evidence-verify.json" "$DATA_DIR/replay-verify.json" <<'PY'
+        --data-binary "@$ARTIFACT_DIR/evidence.tar.gz" >"$ARTIFACT_DIR/replay-verify.json"
+    python3 - "$ARTIFACT_DIR/evidence-verify.json" "$ARTIFACT_DIR/replay-verify.json" <<'PY'
 import json, sys
 for path in sys.argv[1:]:
     payload = json.load(open(path))
@@ -274,21 +337,21 @@ PY
 }
 
 assert_persistence_files() {
-    test -f "$DATA_DIR/root.key" || { echo "::error::root.key missing from durable data dir"; exit 1; }
-    test -f "$DATA_DIR/helm.db" || { echo "::error::helm.db missing from durable data dir"; exit 1; }
-    root_key_hash >"$DATA_DIR/root-key.before"
+    runtime_file_exists root.key || { echo "::error::root.key missing from durable data dir"; exit 1; }
+    runtime_file_exists helm.db || { echo "::error::helm.db missing from durable data dir"; exit 1; }
+    root_key_hash >"$ARTIFACT_DIR/root-key.before"
 }
 
 assert_persistence_after_restart() {
-    root_key_hash >"$DATA_DIR/root-key.after"
-    diff "$DATA_DIR/root-key.before" "$DATA_DIR/root-key.after" >/dev/null || {
+    root_key_hash >"$ARTIFACT_DIR/root-key.after"
+    diff "$ARTIFACT_DIR/root-key.before" "$ARTIFACT_DIR/root-key.after" >/dev/null || {
         echo "::error::root key changed across restart"
         exit 1
     }
     list_receipts >/dev/null
 }
 
-echo "docker smoke mode=$MODE image=$IMAGE api_port=$API_PORT health_port=$HEALTH_PORT data_dir=$DATA_DIR"
+echo "docker smoke mode=$MODE image=$IMAGE api_port=$API_PORT health_port=$HEALTH_PORT runtime_data_dir=$RUNTIME_DATA_DIR artifact_dir=$ARTIFACT_DIR"
 start_runtime
 assert_compose_build_metadata
 evaluate_unknown_tool

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -99,6 +99,42 @@ assert_not_contains "$default_rendered" "configmap-reload"
 assert_not_contains "$default_rendered" "kind: CustomResourceDefinition"
 assert_not_contains "$default_rendered" "HelmPolicyBundle"
 assert_not_contains "$default_rendered" "policy-reader"
+assert_contains "$default_rendered" "name: prepare-authority-state"
+assert_contains "$default_rendered" "HELM_AUTHORITY_DATA_DIR"
+assert_contains "$default_rendered" "HELM_AUTHORITY_RUNTIME_UID"
+assert_contains "$default_rendered" "HELM_AUTHORITY_RUNTIME_GID"
+assert_contains "$default_rendered" "/var/run/helm-signing-key"
+assert_contains "$default_rendered" "defaultMode: 256"
+assert_contains "$default_rendered" "runAsNonRoot: false"
+assert_contains "$default_rendered" "runAsUser: 0"
+assert_contains "$default_rendered" "runAsGroup: 0"
+authority_init_security="$RENDER_DIR/rendered-authority-init-security.yaml"
+awk '/name: prepare-authority-state/{capture=1} capture{print} capture && /^[[:space:]]+command:/{exit}' "$default_rendered" >"$authority_init_security"
+assert_contains "$authority_init_security" "add:"
+assert_contains "$authority_init_security" "CHOWN"
+assert_not_contains "$authority_init_security" "SYS_ADMIN"
+assert_contains "$default_rendered" "refusing silent rotation"
+assert_not_contains "$default_rendered" "subPath: root.key"
+assert_not_contains "$default_rendered" "mountPath: /data/root.key"
+
+runtime_init_fail_log="$RENDER_DIR/runtime-init-unpinned-image.log"
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set runtimeInit.image=alpine:3.20 >"$RENDER_DIR/runtime-init-unpinned-image.yaml" 2>"$runtime_init_fail_log"; then
+    echo "::error::chart render with an unpinned authority init image unexpectedly succeeded"
+    exit 1
+fi
+assert_contains "$runtime_init_fail_log" "runtimeInit.image"
+
+authority_identity_rendered="$RENDER_DIR/rendered-authority-identity.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set podSecurityContext.runAsUser=12345 \
+    --set podSecurityContext.runAsGroup=12346 >"$authority_identity_rendered"
+assert_contains "$authority_identity_rendered" "HELM_AUTHORITY_RUNTIME_UID"
+assert_contains "$authority_identity_rendered" "value: \"12345\""
+assert_contains "$authority_identity_rendered" "HELM_AUTHORITY_RUNTIME_GID"
+assert_contains "$authority_identity_rendered" "value: \"12346\""
 
 emergency_stop_rendered="$RENDER_DIR/rendered-emergency-stop.yaml"
 helm_runner template "$RELEASE" "$CHART" \

--- a/scripts/ci/kind_smoke.sh
+++ b/scripts/ci/kind_smoke.sh
@@ -66,7 +66,27 @@ PY
     chmod 0600 "$HELM_KUBECONFIG"
 }
 
+kind_failure_diagnostics() {
+    # Keep diagnostics useful without reading Secrets or printing process
+    # environments. Pod descriptions expose secret references, not values.
+    echo "::group::kind smoke diagnostics"
+    kubectl -n "$NAMESPACE" get pods -o wide || true
+    kubectl -n "$NAMESPACE" describe pods || true
+    while IFS= read -r pod; do
+        [ -n "$pod" ] || continue
+        echo "::group::logs $pod"
+        kubectl -n "$NAMESPACE" logs "$pod" --all-containers=true --prefix=true || true
+        kubectl -n "$NAMESPACE" logs "$pod" --all-containers=true --prefix=true --previous || true
+        echo "::endgroup::"
+    done < <(kubectl -n "$NAMESPACE" get pods -o name 2>/dev/null || true)
+    echo "::endgroup::"
+}
+
 cleanup() {
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        kind_failure_diagnostics
+    fi
     if [ -n "$PF_PID" ]; then
         kill "$PF_PID" >/dev/null 2>&1 || true
     fi
@@ -75,6 +95,7 @@ cleanup() {
         kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
     fi
     rm -rf "$TMP_DIR"
+    return "$status"
 }
 trap cleanup EXIT
 

--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -493,6 +493,9 @@
       "command": "python3 scripts/ci/check_helm_smoke_hardening.py",
       "timeout_seconds": 120,
       "paths": [
+        "deploy/helm-chart/templates/deployment.yaml",
+        "deploy/helm-chart/values.yaml",
+        "deploy/helm-chart/values.schema.json",
         "scripts/ci/kind_smoke.sh",
         "scripts/ci/helm_chart_smoke.sh",
         "scripts/ci/check_helm_smoke_hardening.py",


### PR DESCRIPTION
## Scope
Part 1 of the HELM-178 capacity-safe stack. This contains deployment/runtime wiring only: root-only authority-state initialization with the minimum `CHOWN` capability, durable-key mismatch fail-closed behavior, and non-root runtime ownership. It intentionally excludes all core lifecycle code and public documentation; those require later dependent slices to remain truthful.

## Invariants
- Secret mount exists only in the init container; the runtime receives the data volume, not a root-key subPath.
- The initializer creates a 0700 authority directory and 0600 durable key, refuses a mismatched durable key, then transfers ownership to the configured non-root runtime UID/GID.
- Compose waits for authority-state before runtime startup.

## Validation
- `git diff --check`
- `/usr/bin/python3 scripts/ci/check_docker_smoke_hardening.py`
- `/usr/bin/python3 scripts/ci/check_helm_smoke_hardening.py`
- `bash -n scripts/ci/docker_smoke.sh scripts/ci/helm_chart_smoke.sh scripts/ci/kind_smoke.sh`
- `KUBE_HELM_CMD=/Users/ivan/.local/bin/kube-helm bash scripts/ci/helm_chart_smoke.sh`
- Current permit-mode patch measurement: 82,170 bytes (limit 524,288; recompute against virtual merge SHA before any update)

## Blocked validation
Docker daemon and Podman connection are unavailable locally, so Docker/Compose/Kind smoke was not run. This PR is draft and has no merge, release, or deployment authority.