### PR TITLE
docs(kernel): clarify MCP and client setup evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **A local firewall for AI-agent actions.**
 
-HELM sits between Claude Code, Codex, MCP tools, shell commands, and other agent
-actions. It decides `ALLOW`, `DENY`, or `ESCALATE`, then writes a signed receipt
-you can verify later.
+HELM evaluates actions that a client, hook, wrapper, MCP adapter, or proxy
+deliberately sends to its boundary. It returns `ALLOW`, `DENY`, or `ESCALATE`,
+then writes a signed receipt you can verify later.
 
 ![HELM AI Kernel: one boundary, one decision, one receipt](docs/assets/readme-boundary-preview.png)
 
@@ -18,8 +18,11 @@ helm-ai-kernel setup claude-code --yes
 # Codex: helm-ai-kernel setup codex --yes
 ```
 
-Ask your agent to do something risky. HELM blocks or escalates the action before
-it runs, then records the decision.
+The setup commands create local client configuration and hook artifacts.
+**Evidence boundary:** setup artifact proof is not client-runtime proof. It
+does not prove that a particular installed client loaded the configuration or
+routed a live action through HELM. Use a disposable, versioned client run plus
+its boundary receipt for that evidence.
 
 ```bash
 helm-ai-kernel workstation verify-decision \

--- a/docs/INTEGRATIONS/agent-clients.md
+++ b/docs/INTEGRATIONS/agent-clients.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Clients
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-15
 ---
 
 # Agent Clients
@@ -40,15 +40,14 @@ Claude Desktop uses a bundle:
 helm-ai-kernel mcp pack --client claude-desktop --out helm-ai-kernel.mcpb
 ```
 
-## What HELM Does
+## Setup Evidence Boundary
 
-```text
-agent/tool requests action
--> HELM evaluates before dispatch
--> ALLOW: action runs
--> DENY: action is blocked
--> ESCALATE: action is blocked and a receipt is written
-```
-
-Setup writes local config and draft policy files only when `--yes` is present.
+Setup writes or registers local MCP configuration, writes local hook
+configuration, and creates draft policy artifacts only when `--yes` is present.
 It does not approve detected tools.
+
+**Evidence boundary:** setup artifact proof is not client-runtime proof. It does
+not prove a particular installed client loaded the configuration, emitted a hook
+event, or routed a live action through HELM. When a separately verified adapter
+submits a request to HELM, that adapter—not `setup`—is responsible for acting on
+the `ALLOW`, `DENY`, or `ESCALATE` decision.

--- a/docs/INTEGRATIONS/claude-code.md
+++ b/docs/INTEGRATIONS/claude-code.md
@@ -1,12 +1,12 @@
 ---
 title: Claude Code Integration
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-15
 ---
 
 # Claude Code Integration
 
-Use HELM with Claude Code when you want local PreToolUse decisions and signed
-receipts for selected high-risk tool effects.
+Use HELM to register local Claude Code MCP configuration, write a local
+PreToolUse hook configuration, and create draft policy artifacts.
 
 ## Quick Setup
 
@@ -35,6 +35,11 @@ helm-ai-kernel setup claude-code --dry-run --json
 The JSON summary includes the binary path, client config path, hook config path,
 data dir, Kernel URL, draft policy path, and uninstall command.
 
+**Evidence boundary:** setup artifact proof is not client-runtime proof. The
+source tests cover target CLI/config and hook artifacts; they do not prove a
+particular installed Claude Code version loaded them, emitted a hook event, or
+routed a live tool call through HELM.
+
 ## Verify A Denial
 
 Denied hook decisions write signed receipts under:
@@ -49,6 +54,9 @@ Verify one:
 helm-ai-kernel workstation verify-decision \
   --receipt ~/.helm-ai-kernel/receipts/hooks/<decision>.json
 ```
+
+This verifies an existing receipt; it is not evidence that Claude Code emitted
+it.
 
 ## MCP Configuration
 

--- a/docs/INTEGRATIONS/codex.md
+++ b/docs/INTEGRATIONS/codex.md
@@ -1,12 +1,12 @@
 ---
 title: Codex Integration
-last_reviewed: 2026-06-29
+last_reviewed: 2026-07-15
 ---
 
 # Codex Integration
 
-Use HELM with Codex when you want a local MCP and hook setup that records signed
-policy decision receipts for selected high-risk effects.
+Use HELM to register local Codex MCP configuration, write a local pre-tool hook
+configuration, and create draft policy artifacts.
 
 ## Quick Setup
 
@@ -41,6 +41,11 @@ helm-ai-kernel setup codex --dry-run --json
 The dry run writes nothing and returns the target config paths, data dir, Kernel
 URL, draft policy path, and uninstall command.
 
+**Evidence boundary:** setup artifact proof is not client-runtime proof. The
+source tests cover target CLI/config and hook artifacts; they do not prove a
+particular installed Codex version loaded them, emitted a hook event, or routed
+a live tool call through HELM.
+
 ## Manual MCP Setup
 
 Print Codex MCP configuration:
@@ -60,6 +65,7 @@ helm-ai-kernel workstation verify-decision \
 ```
 
 Tampered receipts return a non-zero exit and fail signature verification.
+This verifies an existing receipt; it is not evidence that Codex emitted it.
 
 ## Source Truth
 

--- a/docs/INTEGRATIONS/mcp.md
+++ b/docs/INTEGRATIONS/mcp.md
@@ -1,19 +1,25 @@
 ---
 title: MCP
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-15
 ---
 
 # MCP
 
-Use HELM as a pre-dispatch firewall for MCP tool calls.
+Use HELM to produce local MCP profile, configuration, approval, and
+authorization artifacts. A runtime adapter must deliberately route a tool call
+through that boundary before it can govern an upstream call.
 
 ```text
-tools/list -> visible tools are filtered
-tools/call -> HELM evaluates before dispatch
-ALLOW -> call upstream
-DENY -> block
-ESCALATE -> block, write receipt, show scoped approval command
+mcp wrap -> emits an execution-firewall profile for an upstream command or URL
+mcp print-config / mcp install -> emits or creates client configuration artifacts
+mcp authorize-call -> evaluates one local request and records its verdict
+ALLOW -> authorization result; a separately verified adapter may decide whether to dispatch
+DENY / ESCALATE -> this CLI does not dispatch
 ```
+
+**Evidence boundary:** `mcp wrap` and `mcp authorize-call` do not launch,
+proxy, or invoke an upstream MCP server. An `ALLOW` is an authorization result,
+not an upstream-dispatch receipt.
 
 ## Wrap A Server
 
@@ -40,8 +46,10 @@ helm-ai-kernel mcp authorize-call \
   --tool-name pwd
 ```
 
-An unknown or unapproved server returns `ESCALATE`. The action is not
-dispatched. Use the approval loop in [Quickstart](/quickstart#see-an-escalation).
+An unknown or unapproved server returns `ESCALATE`, writes the local decision
+receipt, and does not dispatch the action. `ALLOW` still does not invoke the
+upstream server; the caller must use a separately verified adapter to do that.
+Use the approval loop in [Quickstart](/quickstart#see-an-escalation).
 
 ## Scan Before Approval
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-last_reviewed: 2026-07-10
+last_reviewed: 2026-07-15
 ---
 
 # Quickstart
@@ -125,7 +125,7 @@ helm-ai-kernel mcp revoke \
   --reason "inspection finished"
 ```
 
-## Connect A Local Agent
+## Prepare Local Agent Configuration
 
 See the supported matrix:
 
@@ -152,8 +152,11 @@ helm-ai-kernel setup codex --dry-run --json
 helm-ai-kernel setup --client cursor --print-config
 ```
 
-Setup writes local config and draft policy artifacts. It does not approve
-detected tools.
+Setup writes or registers local config and draft policy artifacts. It does not
+approve detected tools. **Evidence boundary:** setup artifact proof is not
+client-runtime proof. It does not prove a particular installed Codex or Claude
+Code client loaded the configuration, emitted a hook event, or routed a live
+action through HELM.
 
 ## Inspect
 

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -1,16 +1,17 @@
 # Protect Local Coding Agents
 
-HELM can sit around Codex, Claude Code, and similar local agent workflows. The
-goal is narrow: selected effects cross a HELM boundary before dispatch, and
-each decision leaves a local receipt.
+HELM can prepare local configuration for Codex, Claude Code, and similar local
+agent workflows. The goal is narrow: a separately verified adapter can submit
+selected effects to a HELM boundary and preserve its decision receipt.
 
 HELM is not a competing coding agent. It evaluates the actions your agent wants
 to take.
 
 ## Agent Adapters
 
-Codex and Claude Code use local setup hooks. OpenClaw and Hermes use adapter
-helpers from `helm-agent-integrations`:
+The Codex and Claude Code setup commands register MCP configuration and write
+local hook configuration. OpenClaw and Hermes use adapter helpers from
+`helm-agent-integrations`:
 
 - [OpenClaw](/integrations/openclaw) normalizes skill calls before dispatch.
 - [Hermes](/integrations/hermes) normalizes tool proposals before dispatch.
@@ -32,7 +33,10 @@ helm-ai-kernel setup claude-code --yes
 ```
 
 Setup writes draft policy and quarantine artifacts. It does not approve tools
-or grant broad operating permissions.
+or grant broad operating permissions. **Evidence boundary:** setup artifact
+proof is not client-runtime proof. It does not prove a particular installed
+client loaded the configuration, emitted a hook event, or routed a live action
+through HELM.
 
 ## Scan The Agent Surface
 
@@ -52,8 +56,10 @@ runtime dispatch, approve tools, or upload anything.
 
 ## Prove A Denial
 
-Ask the local agent to attempt an action the starter policy denies, such as a
-risky shell cleanup. HELM should block before dispatch and write a receipt.
+The setup artifact test does not prove that a local client executed its hook.
+For a client-specific denial claim, run a disposable, versioned client test and
+retain both the observed hook event and boundary receipt. The command below
+verifies a receipt only after an adapter or hook has produced one.
 
 Verify the receipt:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-last_reviewed: 2026-07-01
+last_reviewed: 2026-07-15
 ---
 
 # CLI
@@ -12,8 +12,12 @@ inspect receipts.
 
 ```bash
 helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
-helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/<run-id> --profile dev-local --json
+helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> --profile dev-local --json
 ```
+
+`mcp proof` writes its run material under `--out/<run-id>` and the sealed
+EvidencePack under `--out/<run-id>/evidencepacks/<run-id>`. The proof is
+deliberately no-dispatch.
 
 ## Local Agent Setup
 
@@ -27,8 +31,11 @@ helm-ai-kernel setup codex --dry-run --json
 helm-ai-kernel setup --client cursor --print-config
 ```
 
-Setup writes local client configuration and draft policy artifacts. It does not
-approve tools.
+Setup writes or registers local client configuration, writes local hook
+configuration, and creates draft policy artifacts. It does not approve tools.
+**Evidence boundary:** setup artifact proof is not client-runtime proof. It does
+not prove a particular installed client loaded the configuration, emitted a hook
+event, or routed a live action through HELM.
 
 ## MCP Approval Commands
 
@@ -37,7 +44,7 @@ you need the reference form:
 
 | Command | Purpose |
 | --- | --- |
-| `helm-ai-kernel mcp authorize-call --server-id <id> --tool-name <tool>` | Evaluate one MCP tool call before dispatch. |
+| `helm-ai-kernel mcp authorize-call --server-id <id> --tool-name <tool>` | Evaluate and record one local MCP authorization decision; it does not invoke an upstream server. |
 | `helm-ai-kernel mcp approve --server-id <id> --tools <csv> --ttl 15m --reason <text>` | Approve an exact local server/tool scope. |
 | `helm-ai-kernel mcp approve --server-id <id> --tools <csv> --effects side_effect --ttl 15m --reason <text>` | Approve a side-effect tool scope. |
 | `helm-ai-kernel mcp revoke --server-id <id> --reason <text>` | Revoke a local approval. |

--- a/scripts/check_documentation_truth.py
+++ b/scripts/check_documentation_truth.py
@@ -275,6 +275,37 @@ def validate_sdk_freshness_docs(failures: list[str]) -> None:
         failures.append(f'docs/EXAMPLES.md is missing current Java coordinate {java_coordinate}')
 
 
+def validate_mcp_and_client_setup_docs(failures: list[str]) -> None:
+    mcp_doc = ROOT / 'docs' / 'INTEGRATIONS' / 'mcp.md'
+    if mcp_doc.exists():
+        text = read_text(mcp_doc)
+        if 'ALLOW -> call upstream' in text:
+            failures.append('docs/INTEGRATIONS/mcp.md claims an ALLOW calls upstream')
+        if 'do not launch,\nproxy, or invoke an upstream MCP server' not in text:
+            failures.append('docs/INTEGRATIONS/mcp.md must state that its CLI does not invoke upstream MCP servers')
+
+    cli_doc = ROOT / 'docs' / 'reference' / 'cli.md'
+    if cli_doc.exists():
+        text = read_text(cli_doc)
+        expected_bundle_path = '~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id>'
+        if expected_bundle_path not in text:
+            failures.append(f'docs/reference/cli.md is missing MCP proof bundle path {expected_bundle_path}')
+        if '~/.helm-ai-kernel/proofs/<run-id>/<run-id>' in text:
+            failures.append('docs/reference/cli.md contains the obsolete MCP proof bundle path')
+
+    setup_docs = (
+        ROOT / 'README.md',
+        ROOT / 'docs' / 'QUICKSTART.md',
+        ROOT / 'docs' / 'INTEGRATIONS' / 'codex.md',
+        ROOT / 'docs' / 'INTEGRATIONS' / 'claude-code.md',
+        ROOT / 'docs' / 'INTEGRATIONS' / 'agent-clients.md',
+        ROOT / 'docs' / 'quickstart' / 'workstation-governance.md',
+    )
+    for path in setup_docs:
+        if path.exists() and 'client-runtime proof' not in read_text(path):
+            failures.append(f'{path.relative_to(ROOT)} must distinguish setup artifacts from client-runtime proof')
+
+
 def main() -> int:
     coverage = subprocess.run([sys.executable, str(ROOT / 'scripts' / 'check_documentation_coverage.py')], cwd=ROOT)
     if coverage.returncode != 0:
@@ -312,6 +343,7 @@ def main() -> int:
                 failures.append(f'sdk/go/go.mod is missing standalone generated SDK dependency {module}')
 
     validate_sdk_freshness_docs(failures)
+    validate_mcp_and_client_setup_docs(failures)
 
     for row in rows:
         source = ROOT if row['source_path'] == '.' else ROOT / row['source_path']


### PR DESCRIPTION
## What changed

- Corrects the MCP page: `mcp wrap` and `mcp authorize-call` create local profile/decision artifacts and do not invoke an upstream MCP server.
- Corrects the `mcp proof` verification path to `--out/<run-id>/evidencepacks/<run-id>`.
- Separates Codex and Claude Code setup-artifact proof from observed client loading, hook events, or live interception.
- Adds a focused docs-truth guard for these boundaries.

## Why

The previous wording treated an `ALLOW` decision as an upstream dispatch and treated generated client setup artifacts as proof of client runtime behavior. Current kernel source and tests do not support either claim.

## Validation

- `python3 scripts/check_documentation_truth.py`
- `cd core && go test ./cmd/helm-ai-kernel -run 'TestRunMCPProofProducesNoDispatchEvidencePack|TestRunMCPAuthorizeCallApprovedPinnedLocalToolAllowJSON|TestSetupInstallClaudeWritesHookAndRunsQuickstart|TestSetupCodexProjectRemoveUndoLocalConfig' -count=1`
- `git diff --check`

## Boundaries

Documentation and documentation-check changes only. This PR makes no claim of a live Codex/Claude Code client runtime, upstream MCP dispatch, release, merge, or deployment.