### PR TITLE
feat(approval): bind source-owned grants

### DIFF
--- a/core/pkg/contracts/approval_grant.go
+++ b/core/pkg/contracts/approval_grant.go
@@ -1,0 +1,221 @@
+package contracts
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	ApprovalGrantSchemaV1   = "approval-grant.v1"
+	ApprovalGrantContractV1 = "2026-07-15"
+
+	ApprovalGrantDecisionAllow = "ALLOW"
+
+	ApprovalGrantActionInstall   = "install"
+	ApprovalGrantActionUpgrade   = "upgrade"
+	ApprovalGrantActionUninstall = "uninstall"
+	ApprovalGrantActionRollback  = "rollback"
+)
+
+var (
+	ErrApprovalGrantInvalid   = errors.New("approval grant invalid")
+	ErrApprovalGrantInactive  = errors.New("approval grant inactive")
+	ErrApprovalGrantIntegrity = errors.New("approval grant integrity failure")
+)
+
+// ApprovalGrant is the source-owned binding for a future, server-signed,
+// single-use approval authority. It is deliberately not an authorization on
+// its own: callers MUST verify the server signature and atomically consume the
+// grant in a durable store before performing a mutation.
+//
+// GrantHash seals every authority-bearing field below. Signature material and
+// durable consumption state are introduced by later boundary slices; legacy
+// approval metadata MUST NOT be promoted into this contract.
+type ApprovalGrant struct {
+	SchemaVersion   string `json:"schema_version"`
+	ContractVersion string `json:"contract_version"`
+
+	GrantID     string `json:"grant_id"`
+	TenantID    string `json:"tenant_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Audience    string `json:"audience"`
+
+	PackID           string `json:"pack_id"`
+	PackVersion      string `json:"pack_version"`
+	PackManifestHash string `json:"pack_manifest_hash"`
+	Action           string `json:"action"`
+
+	IntentHash string `json:"intent_hash"`
+	EffectHash string `json:"effect_hash"`
+	PlanHash   string `json:"plan_hash"`
+	Decision   string `json:"decision"`
+
+	PolicyVersion string `json:"policy_version"`
+	PolicyEpoch   string `json:"policy_epoch"`
+	PolicyHash    string `json:"policy_hash"`
+
+	ApprovalID    string `json:"approval_id"`
+	CeremonyHash  string `json:"ceremony_hash"`
+	SignerSetHash string `json:"signer_set_hash"`
+
+	ServerIdentity    string `json:"server_identity"`
+	KernelTrustRootID string `json:"kernel_trust_root_id"`
+	SigningKeyRef     string `json:"signing_key_ref"`
+
+	IssuedAt  time.Time `json:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+	Nonce     string    `json:"nonce"`
+
+	GrantHash string `json:"grant_hash,omitempty"`
+}
+
+// Validate checks the immutable grant shape. It does not establish signature
+// trust, liveness, or replay safety.
+func (g ApprovalGrant) Validate() error {
+	if g.SchemaVersion != ApprovalGrantSchemaV1 {
+		return approvalGrantInvalid("unsupported schema_version")
+	}
+	if g.ContractVersion != ApprovalGrantContractV1 {
+		return approvalGrantInvalid("unsupported contract_version")
+	}
+
+	required := []struct {
+		field string
+		value string
+	}{
+		{field: "grant_id", value: g.GrantID},
+		{field: "tenant_id", value: g.TenantID},
+		{field: "workspace_id", value: g.WorkspaceID},
+		{field: "audience", value: g.Audience},
+		{field: "pack_id", value: g.PackID},
+		{field: "pack_version", value: g.PackVersion},
+		{field: "policy_version", value: g.PolicyVersion},
+		{field: "policy_epoch", value: g.PolicyEpoch},
+		{field: "approval_id", value: g.ApprovalID},
+		{field: "server_identity", value: g.ServerIdentity},
+		{field: "kernel_trust_root_id", value: g.KernelTrustRootID},
+		{field: "signing_key_ref", value: g.SigningKeyRef},
+	}
+	for _, item := range required {
+		if !isApprovalGrantToken(item.value) {
+			return approvalGrantInvalid(item.field + " is required and must not contain whitespace")
+		}
+	}
+
+	hashes := []struct {
+		field string
+		value string
+	}{
+		{field: "pack_manifest_hash", value: g.PackManifestHash},
+		{field: "intent_hash", value: g.IntentHash},
+		{field: "effect_hash", value: g.EffectHash},
+		{field: "plan_hash", value: g.PlanHash},
+		{field: "policy_hash", value: g.PolicyHash},
+		{field: "ceremony_hash", value: g.CeremonyHash},
+		{field: "signer_set_hash", value: g.SignerSetHash},
+	}
+	for _, item := range hashes {
+		if !isApprovalGrantSHA256(item.value) {
+			return approvalGrantInvalid(item.field + " must be a lowercase sha256 reference")
+		}
+	}
+
+	switch g.Action {
+	case ApprovalGrantActionInstall,
+		ApprovalGrantActionUpgrade,
+		ApprovalGrantActionUninstall,
+		ApprovalGrantActionRollback:
+	default:
+		return approvalGrantInvalid("unsupported action")
+	}
+	if g.Decision != ApprovalGrantDecisionAllow {
+		return approvalGrantInvalid("decision must be ALLOW")
+	}
+	if g.IssuedAt.IsZero() || g.ExpiresAt.IsZero() {
+		return approvalGrantInvalid("issued_at and expires_at are required")
+	}
+	if !g.ExpiresAt.After(g.IssuedAt) {
+		return approvalGrantInvalid("expires_at must be after issued_at")
+	}
+	if !isApprovalGrantNonce(g.Nonce) {
+		return approvalGrantInvalid("nonce must be 32 lowercase hexadecimal bytes")
+	}
+	if g.GrantHash != "" && !isApprovalGrantSHA256(g.GrantHash) {
+		return approvalGrantInvalid("grant_hash must be a lowercase sha256 reference")
+	}
+	return nil
+}
+
+// Seal deterministically hashes the JCS representation of every bound field.
+// Seal does not sign or authorize the grant.
+func (g ApprovalGrant) Seal() (ApprovalGrant, error) {
+	if err := g.Validate(); err != nil {
+		return ApprovalGrant{}, err
+	}
+	g.GrantHash = ""
+	hash, err := hashJCS(g)
+	if err != nil {
+		return ApprovalGrant{}, fmt.Errorf("%w: seal: %v", ErrApprovalGrantInvalid, err)
+	}
+	g.GrantHash = hash
+	return g, nil
+}
+
+// ValidateAt checks deterministic integrity and whether the sealed grant is
+// active at now. It still does not verify a server signature or consume replay
+// state, so success MUST NOT be treated as mutation authority.
+func (g ApprovalGrant) ValidateAt(now time.Time) error {
+	if err := g.Validate(); err != nil {
+		return err
+	}
+	if g.GrantHash == "" {
+		return fmt.Errorf("%w: grant_hash is required", ErrApprovalGrantIntegrity)
+	}
+	sealed, err := g.Seal()
+	if err != nil {
+		return err
+	}
+	if sealed.GrantHash != g.GrantHash {
+		return fmt.Errorf("%w: grant_hash mismatch", ErrApprovalGrantIntegrity)
+	}
+	if now.Before(g.IssuedAt) {
+		return fmt.Errorf("%w: grant is not yet active", ErrApprovalGrantInactive)
+	}
+	if !now.Before(g.ExpiresAt) {
+		return fmt.Errorf("%w: grant is expired", ErrApprovalGrantInactive)
+	}
+	return nil
+}
+
+func approvalGrantInvalid(message string) error {
+	return fmt.Errorf("%w: %s", ErrApprovalGrantInvalid, message)
+}
+
+func isApprovalGrantToken(value string) bool {
+	return value != "" && strings.IndexFunc(value, unicode.IsSpace) == -1
+}
+
+func isApprovalGrantSHA256(value string) bool {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	digest := strings.TrimPrefix(value, prefix)
+	if len(digest) != 64 || strings.ToLower(digest) != digest {
+		return false
+	}
+	decoded, err := hex.DecodeString(digest)
+	return err == nil && len(decoded) == 32
+}
+
+func isApprovalGrantNonce(value string) bool {
+	if len(value) != 64 || strings.ToLower(value) != value {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == 32
+}

--- a/core/pkg/contracts/approval_grant_test.go
+++ b/core/pkg/contracts/approval_grant_test.go
@@ -1,0 +1,217 @@
+package contracts
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestApprovalGrantSealDeterministicAndBindsAuthorityFields(t *testing.T) {
+	base := validApprovalGrant()
+	sealed, err := base.Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	sealedAgain, err := sealed.Seal()
+	if err != nil {
+		t.Fatalf("Seal() repeat error = %v", err)
+	}
+	if sealed.GrantHash != sealedAgain.GrantHash {
+		t.Fatalf("Seal() is not deterministic: %s != %s", sealed.GrantHash, sealedAgain.GrantHash)
+	}
+
+	mutations := map[string]func(*ApprovalGrant){
+		"grant id":        func(g *ApprovalGrant) { g.GrantID = "grant-b" },
+		"tenant":          func(g *ApprovalGrant) { g.TenantID = "tenant-b" },
+		"workspace":       func(g *ApprovalGrant) { g.WorkspaceID = "workspace-b" },
+		"audience":        func(g *ApprovalGrant) { g.Audience = "packs.lifecycle.other" },
+		"pack":            func(g *ApprovalGrant) { g.PackID = "pack-b" },
+		"pack version":    func(g *ApprovalGrant) { g.PackVersion = "2.0.0" },
+		"manifest":        func(g *ApprovalGrant) { g.PackManifestHash = sha256Ref("b") },
+		"action":          func(g *ApprovalGrant) { g.Action = ApprovalGrantActionUninstall },
+		"intent":          func(g *ApprovalGrant) { g.IntentHash = sha256Ref("c") },
+		"effect":          func(g *ApprovalGrant) { g.EffectHash = sha256Ref("d") },
+		"plan":            func(g *ApprovalGrant) { g.PlanHash = sha256Ref("e") },
+		"policy version":  func(g *ApprovalGrant) { g.PolicyVersion = "policy-v2" },
+		"policy epoch":    func(g *ApprovalGrant) { g.PolicyEpoch = "epoch-2" },
+		"policy hash":     func(g *ApprovalGrant) { g.PolicyHash = sha256Ref("f") },
+		"approval":        func(g *ApprovalGrant) { g.ApprovalID = "approval-b" },
+		"ceremony":        func(g *ApprovalGrant) { g.CeremonyHash = sha256Ref("1") },
+		"signer set":      func(g *ApprovalGrant) { g.SignerSetHash = sha256Ref("2") },
+		"server identity": func(g *ApprovalGrant) { g.ServerIdentity = "spiffe://helm/server-b" },
+		"trust root":      func(g *ApprovalGrant) { g.KernelTrustRootID = "trust-root-b" },
+		"signing key":     func(g *ApprovalGrant) { g.SigningKeyRef = "key-b" },
+		"issued at":       func(g *ApprovalGrant) { g.IssuedAt = g.IssuedAt.Add(time.Second) },
+		"expires at":      func(g *ApprovalGrant) { g.ExpiresAt = g.ExpiresAt.Add(time.Second) },
+		"nonce":           func(g *ApprovalGrant) { g.Nonce = repeatHex("3") },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			candidate := base
+			mutate(&candidate)
+			changed, err := candidate.Seal()
+			if err != nil {
+				t.Fatalf("Seal() mutated error = %v", err)
+			}
+			if changed.GrantHash == sealed.GrantHash {
+				t.Fatalf("authority mutation did not change grant hash %s", sealed.GrantHash)
+			}
+		})
+	}
+}
+
+func TestApprovalGrantValidateRejectsMissingAuthorityFields(t *testing.T) {
+	tests := map[string]func(*ApprovalGrant){
+		"schema":          func(g *ApprovalGrant) { g.SchemaVersion = "" },
+		"contract":        func(g *ApprovalGrant) { g.ContractVersion = "" },
+		"grant id":        func(g *ApprovalGrant) { g.GrantID = "" },
+		"tenant":          func(g *ApprovalGrant) { g.TenantID = "" },
+		"workspace":       func(g *ApprovalGrant) { g.WorkspaceID = "" },
+		"audience":        func(g *ApprovalGrant) { g.Audience = "" },
+		"pack":            func(g *ApprovalGrant) { g.PackID = "" },
+		"pack version":    func(g *ApprovalGrant) { g.PackVersion = "" },
+		"pack manifest":   func(g *ApprovalGrant) { g.PackManifestHash = "" },
+		"action":          func(g *ApprovalGrant) { g.Action = "" },
+		"intent":          func(g *ApprovalGrant) { g.IntentHash = "" },
+		"effect":          func(g *ApprovalGrant) { g.EffectHash = "" },
+		"plan":            func(g *ApprovalGrant) { g.PlanHash = "" },
+		"decision":        func(g *ApprovalGrant) { g.Decision = "" },
+		"policy version":  func(g *ApprovalGrant) { g.PolicyVersion = "" },
+		"policy epoch":    func(g *ApprovalGrant) { g.PolicyEpoch = "" },
+		"policy hash":     func(g *ApprovalGrant) { g.PolicyHash = "" },
+		"approval":        func(g *ApprovalGrant) { g.ApprovalID = "" },
+		"ceremony":        func(g *ApprovalGrant) { g.CeremonyHash = "" },
+		"signer set":      func(g *ApprovalGrant) { g.SignerSetHash = "" },
+		"server identity": func(g *ApprovalGrant) { g.ServerIdentity = "" },
+		"trust root":      func(g *ApprovalGrant) { g.KernelTrustRootID = "" },
+		"signing key":     func(g *ApprovalGrant) { g.SigningKeyRef = "" },
+		"issued at":       func(g *ApprovalGrant) { g.IssuedAt = time.Time{} },
+		"expires at":      func(g *ApprovalGrant) { g.ExpiresAt = time.Time{} },
+		"nonce":           func(g *ApprovalGrant) { g.Nonce = "" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			grant := validApprovalGrant()
+			mutate(&grant)
+			if err := grant.Validate(); !errors.Is(err, ErrApprovalGrantInvalid) {
+				t.Fatalf("Validate() error = %v, want ErrApprovalGrantInvalid", err)
+			}
+		})
+	}
+}
+
+func TestApprovalGrantValidateRejectsMalformedOrUnsafeValues(t *testing.T) {
+	tests := map[string]func(*ApprovalGrant){
+		"unknown schema":        func(g *ApprovalGrant) { g.SchemaVersion = "approval-grant.v2" },
+		"unknown contract":      func(g *ApprovalGrant) { g.ContractVersion = "2099-01-01" },
+		"untrimmed tenant":      func(g *ApprovalGrant) { g.TenantID = " tenant-a" },
+		"malformed hash":        func(g *ApprovalGrant) { g.IntentHash = "sha256:abc" },
+		"uppercase hash":        func(g *ApprovalGrant) { g.EffectHash = "sha256:" + repeatHex("A") },
+		"unsupported action":    func(g *ApprovalGrant) { g.Action = "delete" },
+		"non-allow decision":    func(g *ApprovalGrant) { g.Decision = "DENY" },
+		"expiry equals issue":   func(g *ApprovalGrant) { g.ExpiresAt = g.IssuedAt },
+		"expiry before issue":   func(g *ApprovalGrant) { g.ExpiresAt = g.IssuedAt.Add(-time.Second) },
+		"short nonce":           func(g *ApprovalGrant) { g.Nonce = "ab" },
+		"uppercase nonce":       func(g *ApprovalGrant) { g.Nonce = repeatHex("A") },
+		"malformed sealed hash": func(g *ApprovalGrant) { g.GrantHash = "sha256:abc" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			grant := validApprovalGrant()
+			mutate(&grant)
+			if err := grant.Validate(); !errors.Is(err, ErrApprovalGrantInvalid) {
+				t.Fatalf("Validate() error = %v, want ErrApprovalGrantInvalid", err)
+			}
+		})
+	}
+
+	for _, action := range []string{
+		ApprovalGrantActionInstall,
+		ApprovalGrantActionUpgrade,
+		ApprovalGrantActionUninstall,
+		ApprovalGrantActionRollback,
+	} {
+		t.Run("allowed action "+action, func(t *testing.T) {
+			grant := validApprovalGrant()
+			grant.Action = action
+			if err := grant.Validate(); err != nil {
+				t.Fatalf("Validate() action %q error = %v", action, err)
+			}
+		})
+	}
+}
+
+func TestApprovalGrantValidateAtChecksIntegrityAndWindow(t *testing.T) {
+	grant := validApprovalGrant()
+	now := grant.IssuedAt.Add(time.Minute)
+
+	if err := grant.ValidateAt(now); !errors.Is(err, ErrApprovalGrantIntegrity) {
+		t.Fatalf("ValidateAt() unsealed error = %v, want ErrApprovalGrantIntegrity", err)
+	}
+
+	sealed, err := grant.Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.IssuedAt); err != nil {
+		t.Fatalf("ValidateAt() issued_at error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.ExpiresAt.Add(-time.Nanosecond)); err != nil {
+		t.Fatalf("ValidateAt() before expiry error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.IssuedAt.Add(-time.Nanosecond)); !errors.Is(err, ErrApprovalGrantInactive) {
+		t.Fatalf("ValidateAt() before issue error = %v, want ErrApprovalGrantInactive", err)
+	}
+	if err := sealed.ValidateAt(sealed.ExpiresAt); !errors.Is(err, ErrApprovalGrantInactive) {
+		t.Fatalf("ValidateAt() at expiry error = %v, want ErrApprovalGrantInactive", err)
+	}
+
+	sealed.TenantID = "tenant-substitution"
+	if err := sealed.ValidateAt(now); !errors.Is(err, ErrApprovalGrantIntegrity) {
+		t.Fatalf("ValidateAt() substituted error = %v, want ErrApprovalGrantIntegrity", err)
+	}
+}
+
+func validApprovalGrant() ApprovalGrant {
+	issuedAt := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	return ApprovalGrant{
+		SchemaVersion:     ApprovalGrantSchemaV1,
+		ContractVersion:   ApprovalGrantContractV1,
+		GrantID:           "grant-a",
+		TenantID:          "tenant-a",
+		WorkspaceID:       "workspace-a",
+		Audience:          "packs.lifecycle",
+		PackID:            "pack-a",
+		PackVersion:       "1.0.0",
+		PackManifestHash:  sha256Ref("a"),
+		Action:            ApprovalGrantActionInstall,
+		IntentHash:        sha256Ref("0"),
+		EffectHash:        sha256Ref("1"),
+		PlanHash:          sha256Ref("2"),
+		Decision:          ApprovalGrantDecisionAllow,
+		PolicyVersion:     "policy-v1",
+		PolicyEpoch:       "epoch-1",
+		PolicyHash:        sha256Ref("3"),
+		ApprovalID:        "approval-a",
+		CeremonyHash:      sha256Ref("4"),
+		SignerSetHash:     sha256Ref("5"),
+		ServerIdentity:    "spiffe://helm/server-a",
+		KernelTrustRootID: "trust-root-a",
+		SigningKeyRef:     "key-a",
+		IssuedAt:          issuedAt,
+		ExpiresAt:         issuedAt.Add(5 * time.Minute),
+		Nonce:             repeatHex("6"),
+	}
+}
+
+func sha256Ref(character string) string {
+	return "sha256:" + repeatHex(character)
+}
+
+func repeatHex(character string) string {
+	result := ""
+	for len(result) < 64 {
+		result += character
+	}
+	return result
+}


### PR DESCRIPTION
Supersedes draft #569 with an identical tree and a DCO-compliant commit, without rewriting the published branch history.

## Summary

- define the first source-owned `ApprovalGrant` binding for HELM-142
- bind tenant, workspace, audience, pack/version/manifest, lifecycle action, canonical intent/effect/plan hashes, decision, policy version/epoch/hash, approval ceremony, signer set, server identity/trust key, issue/expiry window, and nonce
- add deterministic JCS sealing plus integrity and active-window validation
- cover field substitution, malformed hashes/nonces, unsupported decisions/actions, expiry boundaries, and deterministic resealing

## Security boundary

This PR defines a deterministic contract only. It does **not** authorize a mutation, verify a server or approver signature, consume replay state, persist a ceremony, activate a legacy approval route, or gate pack mutations. `ValidateAt` explicitly remains non-authorizing.

PR #549 remains the separate fail-closed containment record. This branch is based directly on `main` so the source-owned contract can be reviewed below the immutable reviewer patch cap.

HELM-142 remains Active after this PR. Follow-up slices must add trusted challenge/assertion verification, durable signer/quorum state, server-signed grant issuance carried into the existing ext-authz permit path, atomic single-use consumption, pack lifecycle enforcement, outcome/reconciliation, EvidencePack closure, and joined negative E2E evidence.

## Validation

- `GOWORK=off go test ./pkg/contracts -run 'TestApprovalGrant' -count=1`
- `GOWORK=off go test -race ./pkg/contracts -run 'TestApprovalGrant' -count=1`
- `GOWORK=off go test ./pkg/contracts -count=1`
- `GOWORK=off go vet ./pkg/contracts`
- `make verify-fixtures`
- `make verify-boundary`
- `make quality-pr`
- `git diff --check`

Linear: HELM-142
