### PR TITLE
docs(security): define proposed desktop transport boundary

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,18 @@ The retained release process is PR-first and tag-driven. `main` is protected;
 prepare releases on a branch, merge only after gates pass, and tag the merged
 commit.
 
+## Execution Authority Boundary
+
+For a code merge, follow the current `GOVERNANCE.md` contract: green required
+deterministic checks on the pull request's current merge commit, with all
+review threads resolved. The live `main protection` ruleset (`16024605`) is
+the enforcement source; consult it rather than this release process for its
+current configuration.
+
+The distinct-provider exact-head machine interlock remains an R&D track and is
+not current merge authority. Release tags and package publishes require an
+explicit maintainer action.
+
 ## Source target
 
 `VERSION` identifies the source release target. It is not evidence that a tag,

--- a/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
+++ b/docs/launchpad/OSS_1_0_RELEASE_TRAIN.md
@@ -42,6 +42,13 @@ published drift evidence for that exact version.
 
 ## Cross-Release Rules
 
+- Code-merge authority follows `GOVERNANCE.md`: green required deterministic
+  checks on the pull request's current merge commit, with all review threads
+  resolved. The live `main protection` ruleset (`16024605`) is the enforcement
+  source; this train does not duplicate its mutable configuration. The
+  distinct-provider exact-head machine interlock remains an R&D track, not a
+  current merge requirement. Release tags and package publishes require an
+  explicit maintainer action.
 - One release has one theme. Do not mix EvidencePack, RiskEnvelope, release
   infrastructure, and product-scope work in the same tag unless the prior tag
   failed and the fix is required to publish correctly.
@@ -66,7 +73,9 @@ published drift evidence for that exact version.
    dependencies.
 2. Run scoped `/helm-audit`; use codebase-memory or CodeGraph for structural
    code discovery.
-3. Merge only approved and green prerequisite PRs, preserving attribution.
+3. Collect the current Governance merge evidence for prerequisite PRs,
+   preserving attribution; do not treat advisory review or the R&D interlock as
+   merge authority.
 4. Apply one release theme and keep unrelated changes out.
 5. Run `make prepare-version VERSION=<target>`.
 6. Regenerate OpenAPI, proto, schema, and SDK outputs only when source contracts
@@ -86,8 +95,8 @@ make release-assets
 10. Open one release PR. Require CI, CodeQL, Scorecard, docs truth, SDKs,
     contract drift, deployment smoke, kind smoke, release smoke, and launchpad
     smoke to pass.
-11. Merge only after required review.
-12. Tag merged `main` as `v<target>`; create `sdk/go/v<target>` at the same
+11. Merge the release PR only when the current Governance merge evidence is satisfied.
+12. Tag the merged `main` as `v<target>`; create `sdk/go/v<target>` at the same
     commit if the workflow does not already do it.
 13. Monitor the tag workflow: version contract, validate, deployment smoke, kind
     smoke, release smoke, binaries, cosign, reproducibility, container, chart,

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,6 +1,6 @@
 # HELM AI Kernel Threat Model
 
-Version: 2026-07-15-security-evidence-loop-v2
+Version: 2026-07-15-security-evidence-loop-v3
 Owner: HELM Kernel Security
 Review Date: 2026-07-15
 
@@ -44,41 +44,46 @@ Review Date: 2026-07-15
 The current local Desktop composition starts the Kernel at fixed
 `127.0.0.1:8420` and supplies the Console sidecar with `HELM_KERNEL_ORIGIN`
 plus a Kernel bearer capability in `HELM_KERNEL_TOKEN`. Its availability
-preflight binds and releases a fixed port before the child starts. A local
-process that wins that bind, or replaces the listener after startup, can receive a
+preflight binds and releases a fixed port before the child starts. A distinct
+local process that has already claimed that known port can receive a
 credential-bearing Console request. Loopback addressing and the Console
-readiness HMAC do not bind the receiving endpoint to the spawned Kernel
-process.
+readiness HMAC do not bind that fixed endpoint to the spawned Kernel process.
 
-`transport-v1` must defend against an untrusted local process that can
-bind/rebind loopback endpoints but cannot read inherited private handles or
-tamper with the Desktop, Kernel, or Console processes. It does not claim to
-defend a compromised user account or a compromised sidecar process. A port,
-URL, readiness response, or bearer alone is not a process-identity boundary.
+`transport-v1` is the proposed, not-implemented defense against that distinct
+local port-squatter threat. It does not claim hostile same-UID or
+replaced-process protection. A port, URL, readiness response, or bearer alone
+is not a process-identity boundary.
 
 Before any Desktop use of this path can claim a governed local boundary,
 `transport-v1` must fail closed:
 
-- Desktop creates and retains the private listener, then transfers its owned
-  handle to the Kernel; there is no bind-then-close preflight or fixed-TCP
-  fallback.
-- Kernel serves only on that inherited listener or a platform-private
-  socket/pipe and rejects peers without a per-launch, endpoint-bound
-  capability.
-- Console uses that private channel only. It must not receive a reusable
-  Kernel bearer plus an arbitrary local origin, and it must not expose the
-  channel or capability to browser code.
-- A sidecar exit, restart, revocation, or failed peer check invalidates the
-  launch capability and blocks the Console rather than reconnecting to a
-  replacement endpoint.
-- Tests cover malicious pre-bind, post-ready listener replacement, stale or
-  replayed launch capabilities, wrong peer, and cleanup after crash/restart.
+- Kernel atomically binds `127.0.0.1:0`; there is no Desktop availability
+  preflight and no `:8420` fallback.
+- Kernel emits one bounded, HMAC-authenticated transport record on its direct
+  child stdout. The record binds the per-launch nonce to the dynamic loopback
+  origin and port.
+- Desktop validates the record's size, encoding, nonce, MAC, loopback origin,
+  and port, then verifies `/healthz` before starting Console with the attested
+  dynamic origin.
+- Console rejects malformed or non-loopback origins before it forwards a
+  bearer credential. It does not expose the origin or capability to browser
+  code.
+- Exit, restart, revocation, a bad transport record, or failed health check
+  invalidates the launch and blocks Console; relaunch requires a fresh record.
+- Tests cover a pre-bound fixed port, malformed or replayed records, nonce or
+  MAC mismatch, non-loopback origins, failed health checks, and absence of a
+  `:8420` fallback.
 
-Cross-repository ownership is explicit: `helm-desktop` owns endpoint creation,
-handle transfer, and sidecar lifecycle; `helm-ai-kernel` owns private-listener
-serving and peer/capability verification; `app-helm-console` owns the BFF
-client boundary and browser non-exposure. No runtime code or public API in
-this repository implements `transport-v1` yet.
+Inherited listeners, Unix-domain sockets, mTLS, or socket activation are the
+stronger follow-on requirement for a hostile same-UID or replaced-process
+threat. `transport-v1` does not claim that stronger protection.
+
+Cross-repository ownership is explicit: `helm-desktop` owns the per-launch
+nonce/HMAC, direct-child record validation, health check, and sidecar
+lifecycle; `helm-ai-kernel` owns the atomic dynamic bind and bounded transport
+record; `app-helm-console` owns origin rejection before bearer forwarding and
+browser non-exposure. No runtime code or public API in this repository
+implements `transport-v1` yet.
 
 ## Effect Classes
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,9 +1,8 @@
 # HELM AI Kernel Threat Model
 
-Version: 2026-06-08-security-evidence-loop-v1
-Version Hash: sha256:77210a48f9f402bd0c28c1c93bc5d422a08f80003fa850e819cedff116697bc8
+Version: 2026-07-15-security-evidence-loop-v2
 Owner: HELM Kernel Security
-Review Date: 2026-06-08
+Review Date: 2026-07-15
 
 ## Assets
 
@@ -39,6 +38,47 @@ Review Date: 2026-06-08
 
 - Signing keys, KMS references, local development signing keys, secret refs, sandbox mounts, environment variables, and external anchor credentials.
 - Credential material must never be stored in receipts, EvidencePacks, fixtures, transcripts, or test golden files.
+
+### Desktop local sidecar transport (`transport-v1`, proposed — not implemented)
+
+The current local Desktop composition starts the Kernel at fixed
+`127.0.0.1:8420` and supplies the Console sidecar with `HELM_KERNEL_ORIGIN`
+plus a Kernel bearer capability in `HELM_KERNEL_TOKEN`. Its availability
+preflight binds and releases a fixed port before the child starts. A local
+process that wins that bind, or replaces the listener after startup, can receive a
+credential-bearing Console request. Loopback addressing and the Console
+readiness HMAC do not bind the receiving endpoint to the spawned Kernel
+process.
+
+`transport-v1` must defend against an untrusted local process that can
+bind/rebind loopback endpoints but cannot read inherited private handles or
+tamper with the Desktop, Kernel, or Console processes. It does not claim to
+defend a compromised user account or a compromised sidecar process. A port,
+URL, readiness response, or bearer alone is not a process-identity boundary.
+
+Before any Desktop use of this path can claim a governed local boundary,
+`transport-v1` must fail closed:
+
+- Desktop creates and retains the private listener, then transfers its owned
+  handle to the Kernel; there is no bind-then-close preflight or fixed-TCP
+  fallback.
+- Kernel serves only on that inherited listener or a platform-private
+  socket/pipe and rejects peers without a per-launch, endpoint-bound
+  capability.
+- Console uses that private channel only. It must not receive a reusable
+  Kernel bearer plus an arbitrary local origin, and it must not expose the
+  channel or capability to browser code.
+- A sidecar exit, restart, revocation, or failed peer check invalidates the
+  launch capability and blocks the Console rather than reconnecting to a
+  replacement endpoint.
+- Tests cover malicious pre-bind, post-ready listener replacement, stale or
+  replayed launch capabilities, wrong peer, and cleanup after crash/restart.
+
+Cross-repository ownership is explicit: `helm-desktop` owns endpoint creation,
+handle transfer, and sidecar lifecycle; `helm-ai-kernel` owns private-listener
+serving and peer/capability verification; `app-helm-console` owns the BFF
+client boundary and browser non-exposure. No runtime code or public API in
+this repository implements `transport-v1` yet.
 
 ## Effect Classes
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,8 +1,9 @@
 # HELM AI Kernel Threat Model
 
-Version: 2026-07-15-security-evidence-loop-v3
+Version: 2026-08-03-security-evidence-loop-v4
+Version Hash: no signed release artifact has been created for this source revision
 Owner: HELM Kernel Security
-Review Date: 2026-07-15
+Review Date: 2026-08-03
 
 ## Assets
 

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -39,26 +39,37 @@ Review Date: 2026-07-15
 - Signing keys, KMS references, local development signing keys, secret refs, sandbox mounts, environment variables, and external anchor credentials.
 - Credential material must never be stored in receipts, EvidencePacks, fixtures, transcripts, or test golden files.
 
-### Desktop local sidecar transport (`transport-v1`, proposed — not implemented)
+### Desktop local sidecar transport (`transport-v1`, Desktop source implemented — Kernel support absent on current `main`)
 
-The current local Desktop composition starts the Kernel at fixed
-`127.0.0.1:8420` and supplies the Console sidecar with `HELM_KERNEL_ORIGIN`
-plus a Kernel bearer capability in `HELM_KERNEL_TOKEN`. Its availability
-preflight binds and releases a fixed port before the child starts. A distinct
-local process that has already claimed that known port can receive a
-credential-bearing Console request. Loopback addressing and the Console
-readiness HMAC do not bind that fixed endpoint to the spawned Kernel process.
+`transport-v1` defends the local Desktop composition against a distinct local
+process squatting a known port and receiving a credential-bearing Console
+request. A port, URL, readiness response, or bearer alone is not a
+process-identity boundary. It does not claim hostile same-UID or
+replaced-process protection.
 
-`transport-v1` is the proposed, not-implemented defense against that distinct
-local port-squatter threat. It does not claim hostile same-UID or
-replaced-process protection. A port, URL, readiness response, or bearer alone
-is not a process-identity boundary.
+Status, read back from source on 2026-08-03:
+
+- **`helm-desktop` — implemented.** It sets `HELM_DESKTOP_TRANSPORT_V1` on the
+  child, reads a bounded handoff record off the direct child, binds it with an
+  HMAC over the per-launch nonce, origin, and challenge, and proves it at
+  `/api/v1/desktop/transport/proof` before starting Console. On a handoff
+  timeout it fails closed (`transport_timeout`); there is no fixed Kernel-port
+  fallback in that handoff path.
+- **`helm-ai-kernel` current `main` — not implemented.** `serve` retains its
+  normal `127.0.0.1:7714` default (`core/cmd/helm-ai-kernel/server_cmd.go`),
+  and this repository has no `HELM_DESKTOP_TRANSPORT_V1` configuration,
+  transport record, or proof route.
+
+Until the Kernel half lands on `main`, the Desktop source reaches its handoff
+timeout and refuses rather than degrading to a fixed Kernel endpoint. That is
+the fail-closed source behavior, not package, runtime, or release proof of a
+working governed boundary.
 
 Before any Desktop use of this path can claim a governed local boundary,
 `transport-v1` must fail closed:
 
 - Kernel atomically binds `127.0.0.1:0`; there is no Desktop availability
-  preflight and no `:8420` fallback.
+  preflight and no fixed-port fallback.
 - Kernel emits one bounded, HMAC-authenticated transport record on its direct
   child stdout. The record binds the per-launch nonce to the dynamic loopback
   origin and port.
@@ -72,18 +83,18 @@ Before any Desktop use of this path can claim a governed local boundary,
   invalidates the launch and blocks Console; relaunch requires a fresh record.
 - Tests cover a pre-bound fixed port, malformed or replayed records, nonce or
   MAC mismatch, non-loopback origins, failed health checks, and absence of a
-  `:8420` fallback.
+  fixed-port fallback.
 
 Inherited listeners, Unix-domain sockets, mTLS, or socket activation are the
 stronger follow-on requirement for a hostile same-UID or replaced-process
 threat. `transport-v1` does not claim that stronger protection.
 
-Cross-repository ownership is explicit: `helm-desktop` owns the per-launch
+For a complete transport-v1 design, `helm-desktop` owns the per-launch
 nonce/HMAC, direct-child record validation, health check, and sidecar
 lifecycle; `helm-ai-kernel` owns the atomic dynamic bind and bounded transport
 record; `app-helm-console` owns origin rejection before bearer forwarding and
 browser non-exposure. No runtime code or public API in this repository
-implements `transport-v1` yet.
+implements the Kernel transport-v1 half yet.
 
 ## Effect Classes
 


### PR DESCRIPTION
## Summary

- document the P0 fixed-port/bearer race and the narrow proposed Transport-v1 contract;
- distinguish a separate-local-port-squatter boundary from the stronger hostile same-UID/replaced-process threat;
- correct contribution, governance, release, and release-train wording so CI/review/signoff are evidence, not execution authority.

## Proposed Transport-v1

Kernel atomically binds an ephemeral loopback listener, emits one bounded HMAC-authenticated direct-child transport record, Desktop validates the record and exact health endpoint before starting Console, and Console rejects malformed/non-loopback origins before bearer forwarding. There is no legacy `:8420` fallback.

This is **not implemented** in this PR. Inherited listeners, UDS/mTLS/socket activation are follow-on requirements for the stronger same-UID/replaced-process threat.

## Validation

- documentation truth check
- documentation coverage check
- `git diff --check`

## Boundary

Documentation only: no runtime/API behavior, permit, release, signing, deployment, or security certification changed. Draft PR; no merge or deploy authority.