### PR TITLE
feat(approval): define signed assertion contract

### DIFF
--- a/core/pkg/contracts/approval_assertion.go
+++ b/core/pkg/contracts/approval_assertion.go
@@ -55,8 +55,13 @@ type ApprovalChallenge struct {
 	PolicyVersion string `json:"policy_version"`
 	PolicyEpoch   string `json:"policy_epoch"`
 	PolicyHash    string `json:"policy_hash"`
-	RequiredRole  string `json:"required_role"`
-	Quorum        int    `json:"quorum"`
+
+	AuthoritySource       string `json:"authority_source"`
+	AuthorityVersion      string `json:"authority_version"`
+	AuthoritySnapshotHash string `json:"authority_snapshot_hash"`
+
+	RequiredRole string `json:"required_role"`
+	Quorum       int    `json:"quorum"`
 
 	ServerIdentity string    `json:"server_identity"`
 	HoldStartedAt  time.Time `json:"hold_started_at"`
@@ -92,6 +97,8 @@ func (c ApprovalChallenge) Validate() error {
 		{field: "pack_version", value: c.PackVersion},
 		{field: "policy_version", value: c.PolicyVersion},
 		{field: "policy_epoch", value: c.PolicyEpoch},
+		{field: "authority_source", value: c.AuthoritySource},
+		{field: "authority_version", value: c.AuthorityVersion},
 		{field: "required_role", value: c.RequiredRole},
 		{field: "server_identity", value: c.ServerIdentity},
 	}
@@ -110,6 +117,7 @@ func (c ApprovalChallenge) Validate() error {
 		{field: "effect_hash", value: c.EffectHash},
 		{field: "plan_hash", value: c.PlanHash},
 		{field: "policy_hash", value: c.PolicyHash},
+		{field: "authority_snapshot_hash", value: c.AuthoritySnapshotHash},
 	}
 	for _, item := range hashes {
 		if !isApprovalGrantSHA256(item.value) {
@@ -133,6 +141,9 @@ func (c ApprovalChallenge) Validate() error {
 	}
 	if c.HoldStartedAt.IsZero() || c.EligibleAt.IsZero() || c.IssuedAt.IsZero() || c.ExpiresAt.IsZero() {
 		return approvalChallengeInvalid("hold_started_at, eligible_at, issued_at, and expires_at are required")
+	}
+	if !isApprovalGrantUTC(c.HoldStartedAt) || !isApprovalGrantUTC(c.EligibleAt) || !isApprovalGrantUTC(c.IssuedAt) || !isApprovalGrantUTC(c.ExpiresAt) {
+		return approvalChallengeInvalid("hold_started_at, eligible_at, issued_at, and expires_at must use UTC")
 	}
 	if !c.EligibleAt.After(c.HoldStartedAt) {
 		return approvalChallengeInvalid("eligible_at must be after hold_started_at")

--- a/core/pkg/contracts/approval_assertion.go
+++ b/core/pkg/contracts/approval_assertion.go
@@ -1,0 +1,304 @@
+package contracts
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	ApprovalChallengeDomainV1   = "HELM/ApprovalChallenge/v1"
+	ApprovalChallengeSchemaV1   = "approval-challenge.v1"
+	ApprovalChallengeContractV1 = "2026-07-15"
+
+	ApprovalAssertionDomainV1   = "HELM/ApprovalAssertion/v1"
+	ApprovalAssertionSchemaV1   = "approval-assertion.v1"
+	ApprovalAssertionContractV1 = "2026-07-15"
+	ApprovalAssertionEd25519    = "ed25519"
+)
+
+var (
+	ErrApprovalChallengeInvalid   = errors.New("approval challenge invalid")
+	ErrApprovalChallengeInactive  = errors.New("approval challenge inactive")
+	ErrApprovalChallengeIntegrity = errors.New("approval challenge integrity failure")
+	ErrApprovalAssertionInvalid   = errors.New("approval assertion invalid")
+)
+
+// ApprovalChallenge is the canonical server-issued payload an approver signs.
+// Server timestamps and ChallengeHash are authoritative only when this record
+// is loaded from the owning durable ceremony store; a client-submitted copy is
+// not proof of elapsed hold time or policy authority.
+type ApprovalChallenge struct {
+	Domain          string `json:"domain"`
+	SchemaVersion   string `json:"schema_version"`
+	ContractVersion string `json:"contract_version"`
+
+	ChallengeID string `json:"challenge_id"`
+	ApprovalID  string `json:"approval_id"`
+	TenantID    string `json:"tenant_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Audience    string `json:"audience"`
+
+	PackID           string `json:"pack_id"`
+	PackVersion      string `json:"pack_version"`
+	PackManifestHash string `json:"pack_manifest_hash"`
+	Action           string `json:"action"`
+
+	IntentHash string `json:"intent_hash"`
+	EffectHash string `json:"effect_hash"`
+	PlanHash   string `json:"plan_hash"`
+	Decision   string `json:"decision"`
+
+	PolicyVersion string `json:"policy_version"`
+	PolicyEpoch   string `json:"policy_epoch"`
+	PolicyHash    string `json:"policy_hash"`
+	RequiredRole  string `json:"required_role"`
+	Quorum        int    `json:"quorum"`
+
+	ServerIdentity string    `json:"server_identity"`
+	HoldStartedAt  time.Time `json:"hold_started_at"`
+	EligibleAt     time.Time `json:"eligible_at"`
+	IssuedAt       time.Time `json:"issued_at"`
+	ExpiresAt      time.Time `json:"expires_at"`
+	Nonce          string    `json:"nonce"`
+
+	ChallengeHash string `json:"challenge_hash,omitempty"`
+}
+
+func (c ApprovalChallenge) Validate() error {
+	if c.Domain != ApprovalChallengeDomainV1 {
+		return approvalChallengeInvalid("unsupported domain")
+	}
+	if c.SchemaVersion != ApprovalChallengeSchemaV1 {
+		return approvalChallengeInvalid("unsupported schema_version")
+	}
+	if c.ContractVersion != ApprovalChallengeContractV1 {
+		return approvalChallengeInvalid("unsupported contract_version")
+	}
+
+	required := []struct {
+		field string
+		value string
+	}{
+		{field: "challenge_id", value: c.ChallengeID},
+		{field: "approval_id", value: c.ApprovalID},
+		{field: "tenant_id", value: c.TenantID},
+		{field: "workspace_id", value: c.WorkspaceID},
+		{field: "audience", value: c.Audience},
+		{field: "pack_id", value: c.PackID},
+		{field: "pack_version", value: c.PackVersion},
+		{field: "policy_version", value: c.PolicyVersion},
+		{field: "policy_epoch", value: c.PolicyEpoch},
+		{field: "required_role", value: c.RequiredRole},
+		{field: "server_identity", value: c.ServerIdentity},
+	}
+	for _, item := range required {
+		if !isApprovalGrantToken(item.value) {
+			return approvalChallengeInvalid(item.field + " is required and must not contain whitespace")
+		}
+	}
+
+	hashes := []struct {
+		field string
+		value string
+	}{
+		{field: "pack_manifest_hash", value: c.PackManifestHash},
+		{field: "intent_hash", value: c.IntentHash},
+		{field: "effect_hash", value: c.EffectHash},
+		{field: "plan_hash", value: c.PlanHash},
+		{field: "policy_hash", value: c.PolicyHash},
+	}
+	for _, item := range hashes {
+		if !isApprovalGrantSHA256(item.value) {
+			return approvalChallengeInvalid(item.field + " must be a lowercase sha256 reference")
+		}
+	}
+
+	switch c.Action {
+	case ApprovalGrantActionInstall,
+		ApprovalGrantActionUpgrade,
+		ApprovalGrantActionUninstall,
+		ApprovalGrantActionRollback:
+	default:
+		return approvalChallengeInvalid("unsupported action")
+	}
+	if c.Decision != ApprovalGrantDecisionAllow {
+		return approvalChallengeInvalid("decision must be ALLOW")
+	}
+	if c.Quorum <= 0 {
+		return approvalChallengeInvalid("quorum must be positive")
+	}
+	if c.HoldStartedAt.IsZero() || c.EligibleAt.IsZero() || c.IssuedAt.IsZero() || c.ExpiresAt.IsZero() {
+		return approvalChallengeInvalid("hold_started_at, eligible_at, issued_at, and expires_at are required")
+	}
+	if !c.EligibleAt.After(c.HoldStartedAt) {
+		return approvalChallengeInvalid("eligible_at must be after hold_started_at")
+	}
+	if c.IssuedAt.Before(c.EligibleAt) {
+		return approvalChallengeInvalid("issued_at must not be before eligible_at")
+	}
+	if !c.ExpiresAt.After(c.IssuedAt) {
+		return approvalChallengeInvalid("expires_at must be after issued_at")
+	}
+	if !isApprovalGrantNonce(c.Nonce) {
+		return approvalChallengeInvalid("nonce must be 32 lowercase hexadecimal bytes")
+	}
+	if c.ChallengeHash != "" && !isApprovalGrantSHA256(c.ChallengeHash) {
+		return approvalChallengeInvalid("challenge_hash must be a lowercase sha256 reference")
+	}
+	return nil
+}
+
+// Seal creates the domain-separated JCS hash referenced by approval assertions.
+// The signable challenge, including its fresh nonce, MUST be minted and released
+// from the owning durable ceremony no earlier than IssuedAt, and IssuedAt cannot
+// precede EligibleAt. The timestamp alone does not prove release time; callers
+// MUST load issuance provenance from that durable store rather than accept a
+// client-submitted challenge.
+func (c ApprovalChallenge) Seal() (ApprovalChallenge, error) {
+	if err := c.Validate(); err != nil {
+		return ApprovalChallenge{}, err
+	}
+	c.ChallengeHash = ""
+	hash, err := hashJCS(c)
+	if err != nil {
+		return ApprovalChallenge{}, fmt.Errorf("%w: seal: %v", ErrApprovalChallengeInvalid, err)
+	}
+	c.ChallengeHash = hash
+	return c, nil
+}
+
+// ValidateAt verifies the sealed challenge and its server-measured active
+// window. It does not prove the record came from durable server state.
+func (c ApprovalChallenge) ValidateAt(now time.Time) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	if c.ChallengeHash == "" {
+		return fmt.Errorf("%w: challenge_hash is required", ErrApprovalChallengeIntegrity)
+	}
+	sealed, err := c.Seal()
+	if err != nil {
+		return err
+	}
+	if sealed.ChallengeHash != c.ChallengeHash {
+		return fmt.Errorf("%w: challenge_hash mismatch", ErrApprovalChallengeIntegrity)
+	}
+	if now.Before(c.EligibleAt) {
+		return fmt.Errorf("%w: hold has not elapsed", ErrApprovalChallengeInactive)
+	}
+	if now.Before(c.IssuedAt) {
+		return fmt.Errorf("%w: challenge is not yet issued", ErrApprovalChallengeInactive)
+	}
+	if !now.Before(c.ExpiresAt) {
+		return fmt.Errorf("%w: challenge is expired", ErrApprovalChallengeInactive)
+	}
+	return nil
+}
+
+// ApprovalAssertion carries only the credential key reference and signature.
+// Principal, tenant, device, role, and action authority MUST come from a
+// trusted registry; client-submitted actor or public-key claims are excluded.
+type ApprovalAssertion struct {
+	Domain          string `json:"domain"`
+	SchemaVersion   string `json:"schema_version"`
+	ContractVersion string `json:"contract_version"`
+	ChallengeID     string `json:"challenge_id"`
+	ChallengeHash   string `json:"challenge_hash"`
+	KeyID           string `json:"key_id"`
+	Algorithm       string `json:"algorithm"`
+	Signature       string `json:"signature"`
+}
+
+func (a ApprovalAssertion) Validate() error {
+	if err := a.validateSigningEnvelope(); err != nil {
+		return err
+	}
+	if _, err := a.SignatureBytes(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (a ApprovalAssertion) validateSigningEnvelope() error {
+	if a.Domain != ApprovalAssertionDomainV1 {
+		return approvalAssertionInvalid("unsupported domain")
+	}
+	if a.SchemaVersion != ApprovalAssertionSchemaV1 {
+		return approvalAssertionInvalid("unsupported schema_version")
+	}
+	if a.ContractVersion != ApprovalAssertionContractV1 {
+		return approvalAssertionInvalid("unsupported contract_version")
+	}
+	if !isApprovalGrantToken(a.ChallengeID) {
+		return approvalAssertionInvalid("challenge_id is required and must not contain whitespace")
+	}
+	if !isApprovalGrantSHA256(a.ChallengeHash) {
+		return approvalAssertionInvalid("challenge_hash must be a lowercase sha256 reference")
+	}
+	if !isApprovalGrantToken(a.KeyID) {
+		return approvalAssertionInvalid("key_id is required and must not contain whitespace")
+	}
+	if a.Algorithm != ApprovalAssertionEd25519 {
+		return approvalAssertionInvalid("algorithm must be ed25519")
+	}
+	return nil
+}
+
+// SigningDigest returns the domain-separated JCS digest signed by the
+// assertion key. It binds the assertion contract, challenge, key selection,
+// and algorithm; Signature itself is deliberately excluded.
+func (a ApprovalAssertion) SigningDigest() ([]byte, error) {
+	if err := a.validateSigningEnvelope(); err != nil {
+		return nil, err
+	}
+	payload := struct {
+		Domain          string `json:"domain"`
+		SchemaVersion   string `json:"schema_version"`
+		ContractVersion string `json:"contract_version"`
+		ChallengeID     string `json:"challenge_id"`
+		ChallengeHash   string `json:"challenge_hash"`
+		KeyID           string `json:"key_id"`
+		Algorithm       string `json:"algorithm"`
+	}{
+		Domain:          a.Domain,
+		SchemaVersion:   a.SchemaVersion,
+		ContractVersion: a.ContractVersion,
+		ChallengeID:     a.ChallengeID,
+		ChallengeHash:   a.ChallengeHash,
+		KeyID:           a.KeyID,
+		Algorithm:       a.Algorithm,
+	}
+	hash, err := hashJCS(payload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: signing digest: %v", ErrApprovalAssertionInvalid, err)
+	}
+	return hex.DecodeString(strings.TrimPrefix(hash, "sha256:"))
+}
+
+func (a ApprovalAssertion) SignatureBytes() ([]byte, error) {
+	const prefix = "ed25519:"
+	if !strings.HasPrefix(a.Signature, prefix) {
+		return nil, approvalAssertionInvalid("signature must use the ed25519 prefix")
+	}
+	raw := strings.TrimPrefix(a.Signature, prefix)
+	if len(raw) != ed25519.SignatureSize*2 || strings.ToLower(raw) != raw {
+		return nil, approvalAssertionInvalid("signature must be 64 lowercase hexadecimal bytes")
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil || len(decoded) != ed25519.SignatureSize {
+		return nil, approvalAssertionInvalid("signature must be 64 lowercase hexadecimal bytes")
+	}
+	return decoded, nil
+}
+
+func approvalChallengeInvalid(message string) error {
+	return fmt.Errorf("%w: %s", ErrApprovalChallengeInvalid, message)
+}
+
+func approvalAssertionInvalid(message string) error {
+	return fmt.Errorf("%w: %s", ErrApprovalAssertionInvalid, message)
+}

--- a/core/pkg/contracts/approval_assertion.go
+++ b/core/pkg/contracts/approval_assertion.go
@@ -1,3 +1,5 @@
+// quantum_posture: approval assertions use classical Ed25519 signatures;
+// this contract does not claim hybrid or post-quantum approval authority.
 package contracts
 
 import (

--- a/core/pkg/contracts/approval_assertion_test.go
+++ b/core/pkg/contracts/approval_assertion_test.go
@@ -1,0 +1,243 @@
+package contracts
+
+import (
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApprovalGrantAndAssertionGoldenVectors(t *testing.T) {
+	grant, err := validApprovalGrant().Seal()
+	if err != nil {
+		t.Fatalf("ApprovalGrant.Seal() error = %v", err)
+	}
+	if want := "sha256:cbe72fb406de363da696477c4e69dffd930bdeb9603d101a5b389dac98319cd7"; grant.GrantHash != want {
+		t.Fatalf("ApprovalGrant.GrantHash = %q, want %q", grant.GrantHash, want)
+	}
+
+	challenge, err := validApprovalChallenge().Seal()
+	if err != nil {
+		t.Fatalf("ApprovalChallenge.Seal() error = %v", err)
+	}
+	if want := "sha256:aba636bf5caa97e81b2fe77f2fef4a54e6426ee6b1307f958de9f281561b36c4"; challenge.ChallengeHash != want {
+		t.Fatalf("ApprovalChallenge.ChallengeHash = %q, want %q", challenge.ChallengeHash, want)
+	}
+
+	assertion := validApprovalAssertion(challenge)
+	digest, err := assertion.SigningDigest()
+	if err != nil {
+		t.Fatalf("ApprovalAssertion.SigningDigest() error = %v", err)
+	}
+	if got, want := hex.EncodeToString(digest), "2ce9f9c03ec4628fd9095f031aa1793a16b35d1bbbba2c50d8bdd29bb147cbbd"; got != want {
+		t.Fatalf("ApprovalAssertion signing digest = %q, want %q", got, want)
+	}
+}
+
+func TestApprovalChallengeSealIsDeterministicAndBindsFields(t *testing.T) {
+	base := validApprovalChallenge()
+	sealed, err := base.Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	sealedAgain, err := sealed.Seal()
+	if err != nil {
+		t.Fatalf("Seal() repeat error = %v", err)
+	}
+	if sealed.ChallengeHash != sealedAgain.ChallengeHash {
+		t.Fatalf("Seal() is not deterministic: %s != %s", sealed.ChallengeHash, sealedAgain.ChallengeHash)
+	}
+
+	mutations := map[string]func(*ApprovalChallenge){
+		"tenant":       func(c *ApprovalChallenge) { c.TenantID = "tenant-b" },
+		"pack":         func(c *ApprovalChallenge) { c.PackID = "pack-b" },
+		"effect":       func(c *ApprovalChallenge) { c.EffectHash = sha256Ref("9") },
+		"policy":       func(c *ApprovalChallenge) { c.PolicyHash = sha256Ref("8") },
+		"role":         func(c *ApprovalChallenge) { c.RequiredRole = "security-admin" },
+		"quorum":       func(c *ApprovalChallenge) { c.Quorum = 3 },
+		"issued at":    func(c *ApprovalChallenge) { c.IssuedAt = c.IssuedAt.Add(time.Second) },
+		"expires at":   func(c *ApprovalChallenge) { c.ExpiresAt = c.ExpiresAt.Add(time.Second) },
+		"server":       func(c *ApprovalChallenge) { c.ServerIdentity = "spiffe://helm/server-b" },
+		"fresh nonce":  func(c *ApprovalChallenge) { c.Nonce = repeatHex("7") },
+		"challenge id": func(c *ApprovalChallenge) { c.ChallengeID = "challenge-b" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			candidate := base
+			mutate(&candidate)
+			changed, err := candidate.Seal()
+			if err != nil {
+				t.Fatalf("Seal() mutated error = %v", err)
+			}
+			if changed.ChallengeHash == sealed.ChallengeHash {
+				t.Fatalf("mutation did not change challenge hash %s", sealed.ChallengeHash)
+			}
+		})
+	}
+}
+
+func TestApprovalChallengeValidateAtChecksIssuanceIntegrityAndWindow(t *testing.T) {
+	challenge := validApprovalChallenge()
+	if err := challenge.ValidateAt(challenge.IssuedAt); !errors.Is(err, ErrApprovalChallengeIntegrity) {
+		t.Fatalf("ValidateAt() unsealed error = %v, want ErrApprovalChallengeIntegrity", err)
+	}
+
+	sealed, err := challenge.Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.IssuedAt); err != nil {
+		t.Fatalf("ValidateAt() issued_at error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.ExpiresAt.Add(-time.Nanosecond)); err != nil {
+		t.Fatalf("ValidateAt() before expiry error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.EligibleAt.Add(-time.Nanosecond)); !errors.Is(err, ErrApprovalChallengeInactive) {
+		t.Fatalf("ValidateAt() before eligibility error = %v, want ErrApprovalChallengeInactive", err)
+	}
+	if err := sealed.ValidateAt(sealed.IssuedAt.Add(-time.Nanosecond)); !errors.Is(err, ErrApprovalChallengeInactive) {
+		t.Fatalf("ValidateAt() before issuance error = %v, want ErrApprovalChallengeInactive", err)
+	}
+	if err := sealed.ValidateAt(sealed.ExpiresAt); !errors.Is(err, ErrApprovalChallengeInactive) {
+		t.Fatalf("ValidateAt() at expiry error = %v, want ErrApprovalChallengeInactive", err)
+	}
+
+	sealed.EffectHash = sha256Ref("9")
+	if err := sealed.ValidateAt(sealed.IssuedAt); !errors.Is(err, ErrApprovalChallengeIntegrity) {
+		t.Fatalf("ValidateAt() tampered error = %v, want ErrApprovalChallengeIntegrity", err)
+	}
+}
+
+func TestApprovalChallengeRejectsUnsafeTemporalShape(t *testing.T) {
+	tests := map[string]func(*ApprovalChallenge){
+		"zero hold":              func(c *ApprovalChallenge) { c.EligibleAt = c.HoldStartedAt },
+		"issued during hold":     func(c *ApprovalChallenge) { c.IssuedAt = c.EligibleAt.Add(-time.Nanosecond) },
+		"expiry equals issuance": func(c *ApprovalChallenge) { c.ExpiresAt = c.IssuedAt },
+		"missing nonce":          func(c *ApprovalChallenge) { c.Nonce = "" },
+		"non allow decision":     func(c *ApprovalChallenge) { c.Decision = "DENY" },
+		"zero quorum":            func(c *ApprovalChallenge) { c.Quorum = 0 },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			challenge := validApprovalChallenge()
+			mutate(&challenge)
+			if err := challenge.Validate(); !errors.Is(err, ErrApprovalChallengeInvalid) {
+				t.Fatalf("Validate() error = %v, want ErrApprovalChallengeInvalid", err)
+			}
+		})
+	}
+}
+
+func TestApprovalAssertionSigningDigestBindsEnvelope(t *testing.T) {
+	challenge, err := validApprovalChallenge().Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	base := validApprovalAssertion(challenge)
+	digest, err := base.SigningDigest()
+	if err != nil {
+		t.Fatalf("SigningDigest() error = %v", err)
+	}
+
+	mutations := map[string]func(*ApprovalAssertion){
+		"challenge id":   func(a *ApprovalAssertion) { a.ChallengeID = "challenge-b" },
+		"challenge hash": func(a *ApprovalAssertion) { a.ChallengeHash = sha256Ref("9") },
+		"key id":         func(a *ApprovalAssertion) { a.KeyID = "approver-key-b" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			candidate := base
+			mutate(&candidate)
+			changed, err := candidate.SigningDigest()
+			if err != nil {
+				t.Fatalf("SigningDigest() mutated error = %v", err)
+			}
+			if string(changed) == string(digest) {
+				t.Fatal("signing-envelope mutation did not change digest")
+			}
+		})
+	}
+
+	changedSignature := base
+	changedSignature.Signature = "ed25519:" + strings.Repeat("1", 128)
+	unchanged, err := changedSignature.SigningDigest()
+	if err != nil {
+		t.Fatalf("SigningDigest() signature change error = %v", err)
+	}
+	if string(unchanged) != string(digest) {
+		t.Fatal("signature must be excluded from its own digest")
+	}
+}
+
+func TestApprovalAssertionRejectsMalformedEnvelopeOrSignature(t *testing.T) {
+	challenge, err := validApprovalChallenge().Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	tests := map[string]func(*ApprovalAssertion){
+		"wrong domain":      func(a *ApprovalAssertion) { a.Domain = "HELM/ApprovalAssertion/v2" },
+		"unknown algorithm": func(a *ApprovalAssertion) { a.Algorithm = "rsa" },
+		"missing key":       func(a *ApprovalAssertion) { a.KeyID = "" },
+		"short signature":   func(a *ApprovalAssertion) { a.Signature = "ed25519:ab" },
+		"uppercase signature": func(a *ApprovalAssertion) {
+			a.Signature = "ed25519:" + strings.Repeat("A", 128)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			assertion := validApprovalAssertion(challenge)
+			mutate(&assertion)
+			if err := assertion.Validate(); !errors.Is(err, ErrApprovalAssertionInvalid) {
+				t.Fatalf("Validate() error = %v, want ErrApprovalAssertionInvalid", err)
+			}
+		})
+	}
+}
+
+func validApprovalChallenge() ApprovalChallenge {
+	holdStarted := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	eligible := holdStarted.Add(5 * time.Minute)
+	return ApprovalChallenge{
+		Domain:           ApprovalChallengeDomainV1,
+		SchemaVersion:    ApprovalChallengeSchemaV1,
+		ContractVersion:  ApprovalChallengeContractV1,
+		ChallengeID:      "challenge-a",
+		ApprovalID:       "approval-a",
+		TenantID:         "tenant-a",
+		WorkspaceID:      "workspace-a",
+		Audience:         "packs.lifecycle",
+		PackID:           "pack-a",
+		PackVersion:      "1.0.0",
+		PackManifestHash: sha256Ref("a"),
+		Action:           ApprovalGrantActionInstall,
+		IntentHash:       sha256Ref("0"),
+		EffectHash:       sha256Ref("1"),
+		PlanHash:         sha256Ref("2"),
+		Decision:         ApprovalGrantDecisionAllow,
+		PolicyVersion:    "policy-v1",
+		PolicyEpoch:      "epoch-1",
+		PolicyHash:       sha256Ref("3"),
+		RequiredRole:     "pack-admin",
+		Quorum:           2,
+		ServerIdentity:   "spiffe://helm/server-a",
+		HoldStartedAt:    holdStarted,
+		EligibleAt:       eligible,
+		IssuedAt:         eligible.Add(time.Minute),
+		ExpiresAt:        eligible.Add(10 * time.Minute),
+		Nonce:            repeatHex("6"),
+	}
+}
+
+func validApprovalAssertion(challenge ApprovalChallenge) ApprovalAssertion {
+	return ApprovalAssertion{
+		Domain:          ApprovalAssertionDomainV1,
+		SchemaVersion:   ApprovalAssertionSchemaV1,
+		ContractVersion: ApprovalAssertionContractV1,
+		ChallengeID:     challenge.ChallengeID,
+		ChallengeHash:   challenge.ChallengeHash,
+		KeyID:           "approver-key-a",
+		Algorithm:       ApprovalAssertionEd25519,
+		Signature:       "ed25519:" + strings.Repeat("0", 128),
+	}
+}

--- a/core/pkg/contracts/approval_assertion_test.go
+++ b/core/pkg/contracts/approval_assertion_test.go
@@ -21,7 +21,7 @@ func TestApprovalGrantAndAssertionGoldenVectors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApprovalChallenge.Seal() error = %v", err)
 	}
-	if want := "sha256:aba636bf5caa97e81b2fe77f2fef4a54e6426ee6b1307f958de9f281561b36c4"; challenge.ChallengeHash != want {
+	if want := "sha256:8771698d9efa5b3d76dd168ec2f0aab84944e619bdee44fa6dd5ffe45e7b1bce"; challenge.ChallengeHash != want {
 		t.Fatalf("ApprovalChallenge.ChallengeHash = %q, want %q", challenge.ChallengeHash, want)
 	}
 
@@ -30,7 +30,7 @@ func TestApprovalGrantAndAssertionGoldenVectors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ApprovalAssertion.SigningDigest() error = %v", err)
 	}
-	if got, want := hex.EncodeToString(digest), "2ce9f9c03ec4628fd9095f031aa1793a16b35d1bbbba2c50d8bdd29bb147cbbd"; got != want {
+	if got, want := hex.EncodeToString(digest), "7499e8cf1eba48e127f70c7e74987f350d79426f3766a4716816953fe9e2b25e"; got != want {
 		t.Fatalf("ApprovalAssertion signing digest = %q, want %q", got, want)
 	}
 }
@@ -54,6 +54,7 @@ func TestApprovalChallengeSealIsDeterministicAndBindsFields(t *testing.T) {
 		"pack":         func(c *ApprovalChallenge) { c.PackID = "pack-b" },
 		"effect":       func(c *ApprovalChallenge) { c.EffectHash = sha256Ref("9") },
 		"policy":       func(c *ApprovalChallenge) { c.PolicyHash = sha256Ref("8") },
+		"authority":    func(c *ApprovalChallenge) { c.AuthoritySnapshotHash = sha256Ref("7") },
 		"role":         func(c *ApprovalChallenge) { c.RequiredRole = "security-admin" },
 		"quorum":       func(c *ApprovalChallenge) { c.Quorum = 3 },
 		"issued at":    func(c *ApprovalChallenge) { c.IssuedAt = c.IssuedAt.Add(time.Second) },
@@ -111,12 +112,15 @@ func TestApprovalChallengeValidateAtChecksIssuanceIntegrityAndWindow(t *testing.
 
 func TestApprovalChallengeRejectsUnsafeTemporalShape(t *testing.T) {
 	tests := map[string]func(*ApprovalChallenge){
-		"zero hold":              func(c *ApprovalChallenge) { c.EligibleAt = c.HoldStartedAt },
-		"issued during hold":     func(c *ApprovalChallenge) { c.IssuedAt = c.EligibleAt.Add(-time.Nanosecond) },
-		"expiry equals issuance": func(c *ApprovalChallenge) { c.ExpiresAt = c.IssuedAt },
-		"missing nonce":          func(c *ApprovalChallenge) { c.Nonce = "" },
-		"non allow decision":     func(c *ApprovalChallenge) { c.Decision = "DENY" },
-		"zero quorum":            func(c *ApprovalChallenge) { c.Quorum = 0 },
+		"zero hold":                 func(c *ApprovalChallenge) { c.EligibleAt = c.HoldStartedAt },
+		"issued during hold":        func(c *ApprovalChallenge) { c.IssuedAt = c.EligibleAt.Add(-time.Nanosecond) },
+		"expiry equals issuance":    func(c *ApprovalChallenge) { c.ExpiresAt = c.IssuedAt },
+		"missing nonce":             func(c *ApprovalChallenge) { c.Nonce = "" },
+		"missing authority source":  func(c *ApprovalChallenge) { c.AuthoritySource = "" },
+		"missing authority version": func(c *ApprovalChallenge) { c.AuthorityVersion = "" },
+		"malformed authority hash":  func(c *ApprovalChallenge) { c.AuthoritySnapshotHash = "sha256:abc" },
+		"non allow decision":        func(c *ApprovalChallenge) { c.Decision = "DENY" },
+		"zero quorum":               func(c *ApprovalChallenge) { c.Quorum = 0 },
 	}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -126,6 +130,22 @@ func TestApprovalChallengeRejectsUnsafeTemporalShape(t *testing.T) {
 				t.Fatalf("Validate() error = %v, want ErrApprovalChallengeInvalid", err)
 			}
 		})
+	}
+}
+
+func TestApprovalContractsRejectNonUTCTimestamps(t *testing.T) {
+	nonUTC := time.FixedZone("UTC+2", 2*60*60)
+
+	challenge := validApprovalChallenge()
+	challenge.IssuedAt = challenge.IssuedAt.In(nonUTC)
+	if err := challenge.Validate(); !errors.Is(err, ErrApprovalChallengeInvalid) {
+		t.Fatalf("ApprovalChallenge.Validate() error = %v, want ErrApprovalChallengeInvalid", err)
+	}
+
+	grant := validApprovalGrant()
+	grant.IssuedAt = grant.IssuedAt.In(nonUTC)
+	if err := grant.Validate(); !errors.Is(err, ErrApprovalGrantInvalid) {
+		t.Fatalf("ApprovalGrant.Validate() error = %v, want ErrApprovalGrantInvalid", err)
 	}
 }
 
@@ -199,33 +219,36 @@ func validApprovalChallenge() ApprovalChallenge {
 	holdStarted := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
 	eligible := holdStarted.Add(5 * time.Minute)
 	return ApprovalChallenge{
-		Domain:           ApprovalChallengeDomainV1,
-		SchemaVersion:    ApprovalChallengeSchemaV1,
-		ContractVersion:  ApprovalChallengeContractV1,
-		ChallengeID:      "challenge-a",
-		ApprovalID:       "approval-a",
-		TenantID:         "tenant-a",
-		WorkspaceID:      "workspace-a",
-		Audience:         "packs.lifecycle",
-		PackID:           "pack-a",
-		PackVersion:      "1.0.0",
-		PackManifestHash: sha256Ref("a"),
-		Action:           ApprovalGrantActionInstall,
-		IntentHash:       sha256Ref("0"),
-		EffectHash:       sha256Ref("1"),
-		PlanHash:         sha256Ref("2"),
-		Decision:         ApprovalGrantDecisionAllow,
-		PolicyVersion:    "policy-v1",
-		PolicyEpoch:      "epoch-1",
-		PolicyHash:       sha256Ref("3"),
-		RequiredRole:     "pack-admin",
-		Quorum:           2,
-		ServerIdentity:   "spiffe://helm/server-a",
-		HoldStartedAt:    holdStarted,
-		EligibleAt:       eligible,
-		IssuedAt:         eligible.Add(time.Minute),
-		ExpiresAt:        eligible.Add(10 * time.Minute),
-		Nonce:            repeatHex("6"),
+		Domain:                ApprovalChallengeDomainV1,
+		SchemaVersion:         ApprovalChallengeSchemaV1,
+		ContractVersion:       ApprovalChallengeContractV1,
+		ChallengeID:           "challenge-a",
+		ApprovalID:            "approval-a",
+		TenantID:              "tenant-a",
+		WorkspaceID:           "workspace-a",
+		Audience:              "packs.lifecycle",
+		PackID:                "pack-a",
+		PackVersion:           "1.0.0",
+		PackManifestHash:      sha256Ref("a"),
+		Action:                ApprovalGrantActionInstall,
+		IntentHash:            sha256Ref("0"),
+		EffectHash:            sha256Ref("1"),
+		PlanHash:              sha256Ref("2"),
+		Decision:              ApprovalGrantDecisionAllow,
+		PolicyVersion:         "policy-v1",
+		PolicyEpoch:           "epoch-1",
+		PolicyHash:            sha256Ref("3"),
+		AuthoritySource:       "spiffe://helm/authority/approvers",
+		AuthorityVersion:      "authority-v1",
+		AuthoritySnapshotHash: sha256Ref("4"),
+		RequiredRole:          "pack-admin",
+		Quorum:                2,
+		ServerIdentity:        "spiffe://helm/server-a",
+		HoldStartedAt:         holdStarted,
+		EligibleAt:            eligible,
+		IssuedAt:              eligible.Add(time.Minute),
+		ExpiresAt:             eligible.Add(10 * time.Minute),
+		Nonce:                 repeatHex("6"),
 	}
 }
 

--- a/core/pkg/contracts/approval_assertion_test.go
+++ b/core/pkg/contracts/approval_assertion_test.go
@@ -1,3 +1,5 @@
+// quantum_posture: these vectors cover classical Ed25519 approval assertions;
+// they do not establish hybrid or post-quantum approval support.
 package contracts
 
 import (

--- a/core/pkg/contracts/approval_grant.go
+++ b/core/pkg/contracts/approval_grant.go
@@ -138,6 +138,9 @@ func (g ApprovalGrant) Validate() error {
 	if g.IssuedAt.IsZero() || g.ExpiresAt.IsZero() {
 		return approvalGrantInvalid("issued_at and expires_at are required")
 	}
+	if !isApprovalGrantUTC(g.IssuedAt) || !isApprovalGrantUTC(g.ExpiresAt) {
+		return approvalGrantInvalid("issued_at and expires_at must use UTC")
+	}
 	if !g.ExpiresAt.After(g.IssuedAt) {
 		return approvalGrantInvalid("expires_at must be after issued_at")
 	}
@@ -218,4 +221,9 @@ func isApprovalGrantNonce(value string) bool {
 	}
 	decoded, err := hex.DecodeString(value)
 	return err == nil && len(decoded) == 32
+}
+
+func isApprovalGrantUTC(value time.Time) bool {
+	_, offset := value.Zone()
+	return offset == 0
 }


### PR DESCRIPTION
Linear: HELM-142

## Summary
- define the canonical tenant/workspace/pack/effect-bound approval challenge
- bind pinned authority source, version, and snapshot hash into the signed challenge
- require UTC timestamps, a positive hold, post-eligibility issuance, bounded expiry, and fresh nonce
- define an Ed25519 assertion envelope whose signing digest binds domain, schema, contract, challenge, key selection, and algorithm
- pin grant, challenge, and assertion digest golden vectors
- declare the classical Ed25519 quantum posture without making hybrid/PQ claims

## Truth boundary
This is a contract-only stacked slice. The owning durable ceremony must mint and release the signable challenge no earlier than IssuedAt, withhold its fresh nonce until eligibility, validate the authority snapshot in the server-side registry, and load issuance provenance server-side. This PR does not verify authority, persist a ceremony, prevent replay, issue an effect permit, authorize a pack mutation, or complete HELM-142.

## Stack
- base: #570 (ApprovalGrant contract)
- this PR adds challenge/assertion contracts, UTC/provenance hardening, and tests
- next: #573 (pure trusted signer quorum verifier)

## Validation
- GOWORK=off go test ./pkg/contracts -count=1
- GOWORK=off go test -race ./pkg/contracts -count=1
- GOWORK=off go vet ./pkg/contracts
- make quantum-crypto-inventory

Merge/release remain NO-GO until the cross-language reference pack, durable ceremony, exact-head authorization gates, single-use permit lifecycle, and mutation enforcement are source-owned and proven.