### PR TITLE
feat(approval): verify trusted signer quorum

### DIFF
--- a/core/pkg/boundary/approvalverify/verifier.go
+++ b/core/pkg/boundary/approvalverify/verifier.go
@@ -1,0 +1,481 @@
+// quantum_posture: approval quorum verification uses classical Ed25519
+// assertions; this package does not claim hybrid or post-quantum support.
+// Package approvalverify verifies cryptographic human assertions over a
+// server-issued approval challenge. It is a pure verification layer: it does
+// not persist challenges, consume replay state, issue effect permits, or
+// authorize mutations.
+package approvalverify
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+var (
+	ErrVerificationFailed = errors.New("approval assertion verification failed")
+	ErrAuthorityRejected  = errors.New("approval assertion authority rejected")
+	ErrSignatureRejected  = errors.New("approval assertion signature rejected")
+	ErrDuplicateSigner    = errors.New("approval assertion duplicate signer")
+	ErrQuorumNotMet       = errors.New("approval assertion quorum not met")
+)
+
+// TrustedApproverKey is an authority-registry snapshot. Tenant, principal,
+// credential, device, workspace, role, and action authority come from this
+// record, never from the submitted assertion.
+type TrustedApproverKey struct {
+	KeyID        string
+	TenantID     string
+	PrincipalID  string
+	CredentialID string
+	DeviceID     string
+	PublicKey    ed25519.PublicKey
+	WorkspaceIDs []string
+	Roles        []string
+	Actions      []string
+	Audiences    []string
+	Enabled      bool
+	NotBefore    time.Time
+	NotAfter     time.Time
+}
+
+// TrustStore carries a pinned authority-registry snapshot. Its metadata and
+// keys MUST be loaded and snapshot-validated by the owning server-side
+// registry. VerifyQuorum exact-binds that metadata but does not rederive a
+// registry-specific snapshot hash from this generic projection.
+type TrustStore struct {
+	AuthoritySource       string
+	AuthorityVersion      string
+	AuthoritySnapshotHash string
+	Keys                  map[string]TrustedApproverKey
+}
+
+// ExpectedBinding is the caller's exact, policy-owned effect context. A route
+// must build it independently of the submitted assertion and challenge body.
+type ExpectedBinding struct {
+	ChallengeID           string
+	ChallengeHash         string
+	ApprovalID            string
+	TenantID              string
+	WorkspaceID           string
+	Audience              string
+	PackID                string
+	PackVersion           string
+	PackManifestHash      string
+	Action                string
+	IntentHash            string
+	EffectHash            string
+	PlanHash              string
+	Decision              string
+	PolicyVersion         string
+	PolicyEpoch           string
+	PolicyHash            string
+	AuthoritySource       string
+	AuthorityVersion      string
+	AuthoritySnapshotHash string
+	RequiredRole          string
+	Quorum                int
+	ServerIdentity        string
+}
+
+type VerifyOptions struct {
+	Expected        ExpectedBinding
+	MinHoldDuration time.Duration
+	MaxChallengeTTL time.Duration
+	MaxAssertions   int
+}
+
+// VerifiedSigner is verifier-derived evidence. It intentionally excludes the
+// public key and cannot be used to authorize a later effect by itself.
+type VerifiedSigner struct {
+	PrincipalID   string `json:"principal_id"`
+	CredentialID  string `json:"credential_id"`
+	DeviceID      string `json:"device_id"`
+	KeyID         string `json:"key_id"`
+	Role          string `json:"role"`
+	AssertionHash string `json:"assertion_hash"`
+}
+
+// VerifiedApprovalRef is a deterministic quorum projection suitable as input
+// to a later durable ceremony commitment. It provides ApprovalID and
+// SignerSetHash, but it is not an ApprovalGrant and it does not provide the
+// ApprovalGrant.CeremonyHash. The owning ceremony MUST durably commit and hash
+// the complete record before the Kernel issues a signed, single-use effect
+// permit.
+type VerifiedApprovalRef struct {
+	ApprovalID            string           `json:"approval_id"`
+	ChallengeID           string           `json:"challenge_id"`
+	ChallengeHash         string           `json:"challenge_hash"`
+	TenantID              string           `json:"tenant_id"`
+	WorkspaceID           string           `json:"workspace_id"`
+	Audience              string           `json:"audience"`
+	PackID                string           `json:"pack_id"`
+	PackVersion           string           `json:"pack_version"`
+	PackManifestHash      string           `json:"pack_manifest_hash"`
+	Action                string           `json:"action"`
+	IntentHash            string           `json:"intent_hash"`
+	EffectHash            string           `json:"effect_hash"`
+	PlanHash              string           `json:"plan_hash"`
+	Decision              string           `json:"decision"`
+	PolicyVersion         string           `json:"policy_version"`
+	PolicyEpoch           string           `json:"policy_epoch"`
+	PolicyHash            string           `json:"policy_hash"`
+	AuthoritySource       string           `json:"authority_source"`
+	AuthorityVersion      string           `json:"authority_version"`
+	AuthoritySnapshotHash string           `json:"authority_snapshot_hash"`
+	ServerIdentity        string           `json:"server_identity"`
+	RequiredRole          string           `json:"required_role"`
+	Quorum                int              `json:"quorum"`
+	Signers               []VerifiedSigner `json:"signers"`
+	SignerSetHash         string           `json:"signer_set_hash"`
+	VerifiedAt            time.Time        `json:"verified_at"`
+}
+
+// VerifyQuorum verifies every supplied assertion and requires distinct
+// principal, credential, device, key, and public-key identities. It accepts at
+// least Quorum and at most MaxAssertions; every valid supplied signer is
+// committed into SignerSetHash. The challenge and authority snapshot MUST be
+// loaded from their owning durable stores. This function does not provide
+// replay prevention or mutation authority.
+func VerifyQuorum(
+	challenge contracts.ApprovalChallenge,
+	assertions []contracts.ApprovalAssertion,
+	store TrustStore,
+	opts VerifyOptions,
+	now time.Time,
+) (VerifiedApprovalRef, error) {
+	if err := validateOptions(opts); err != nil {
+		return VerifiedApprovalRef{}, err
+	}
+	if err := challenge.ValidateAt(now); err != nil {
+		return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+	}
+	if challenge.EligibleAt.Sub(challenge.HoldStartedAt) < opts.MinHoldDuration {
+		return VerifiedApprovalRef{}, verificationFailed("challenge hold duration is below policy minimum")
+	}
+	if challenge.ExpiresAt.Sub(challenge.HoldStartedAt) > opts.MaxChallengeTTL {
+		return VerifiedApprovalRef{}, verificationFailed("challenge ttl exceeds maximum")
+	}
+	if err := verifyExpectedBinding(challenge, opts.Expected); err != nil {
+		return VerifiedApprovalRef{}, err
+	}
+	if err := validateTrustStore(store, challenge); err != nil {
+		return VerifiedApprovalRef{}, err
+	}
+
+	if len(assertions) < challenge.Quorum {
+		return VerifiedApprovalRef{}, fmt.Errorf("%w: got %d assertions, need %d", ErrQuorumNotMet, len(assertions), challenge.Quorum)
+	}
+	if len(assertions) > opts.MaxAssertions {
+		return VerifiedApprovalRef{}, verificationFailed("assertion count exceeds policy maximum")
+	}
+
+	seenKeys := make(map[string]struct{}, len(assertions))
+	seenPrincipals := make(map[string]struct{}, len(assertions))
+	seenCredentials := make(map[string]struct{}, len(assertions))
+	seenDevices := make(map[string]struct{}, len(assertions))
+	seenPublicKeys := make(map[string]struct{}, len(assertions))
+	verified := make([]VerifiedSigner, 0, len(assertions))
+
+	for _, assertion := range assertions {
+		if err := assertion.Validate(); err != nil {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+		}
+		if assertion.ChallengeID != challenge.ChallengeID || assertion.ChallengeHash != challenge.ChallengeHash {
+			return VerifiedApprovalRef{}, verificationFailed("assertion challenge binding mismatch")
+		}
+		digest, err := assertion.SigningDigest()
+		if err != nil {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+		}
+		if _, duplicate := seenKeys[assertion.KeyID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("key_id", assertion.KeyID)
+		}
+
+		key, ok := store.Keys[assertion.KeyID]
+		if !ok {
+			return VerifiedApprovalRef{}, authorityRejected("unknown key")
+		}
+		if err := validateTrustedKey(key, assertion.KeyID, challenge, now); err != nil {
+			return VerifiedApprovalRef{}, err
+		}
+
+		signature, err := assertion.SignatureBytes()
+		if err != nil {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrSignatureRejected, err)
+		}
+		if !ed25519.Verify(key.PublicKey, digest, signature) {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: bad ed25519 signature for key %s", ErrSignatureRejected, assertion.KeyID)
+		}
+		if _, duplicate := seenPrincipals[key.PrincipalID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("principal_id", key.PrincipalID)
+		}
+		if _, duplicate := seenCredentials[key.CredentialID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("credential_id", key.CredentialID)
+		}
+		if _, duplicate := seenDevices[key.DeviceID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("device_id", key.DeviceID)
+		}
+		publicKeyIdentity := string(key.PublicKey)
+		if _, duplicate := seenPublicKeys[publicKeyIdentity]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("public_key", assertion.KeyID)
+		}
+		assertionHash, err := canonicalize.CanonicalHash(assertion)
+		if err != nil {
+			return VerifiedApprovalRef{}, verificationFailed("assertion canonicalization failed")
+		}
+
+		seenKeys[assertion.KeyID] = struct{}{}
+		seenPrincipals[key.PrincipalID] = struct{}{}
+		seenCredentials[key.CredentialID] = struct{}{}
+		seenDevices[key.DeviceID] = struct{}{}
+		seenPublicKeys[publicKeyIdentity] = struct{}{}
+		verified = append(verified, VerifiedSigner{
+			PrincipalID:   key.PrincipalID,
+			CredentialID:  key.CredentialID,
+			DeviceID:      key.DeviceID,
+			KeyID:         key.KeyID,
+			Role:          challenge.RequiredRole,
+			AssertionHash: "sha256:" + assertionHash,
+		})
+	}
+
+	if len(verified) < challenge.Quorum {
+		return VerifiedApprovalRef{}, fmt.Errorf("%w: got %d unique signers, need %d", ErrQuorumNotMet, len(verified), challenge.Quorum)
+	}
+	sort.Slice(verified, func(i, j int) bool {
+		if verified[i].PrincipalID != verified[j].PrincipalID {
+			return verified[i].PrincipalID < verified[j].PrincipalID
+		}
+		if verified[i].CredentialID != verified[j].CredentialID {
+			return verified[i].CredentialID < verified[j].CredentialID
+		}
+		if verified[i].DeviceID != verified[j].DeviceID {
+			return verified[i].DeviceID < verified[j].DeviceID
+		}
+		return verified[i].KeyID < verified[j].KeyID
+	})
+
+	signerSetHash, err := canonicalize.CanonicalHash(struct {
+		Domain                string           `json:"domain"`
+		ChallengeHash         string           `json:"challenge_hash"`
+		AuthoritySnapshotHash string           `json:"authority_snapshot_hash"`
+		Signers               []VerifiedSigner `json:"signers"`
+	}{
+		Domain:                "HELM/ApprovalSignerSet/v1",
+		ChallengeHash:         challenge.ChallengeHash,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash,
+		Signers:               verified,
+	})
+	if err != nil {
+		return VerifiedApprovalRef{}, verificationFailed("signer set canonicalization failed")
+	}
+
+	return VerifiedApprovalRef{
+		ApprovalID:            challenge.ApprovalID,
+		ChallengeID:           challenge.ChallengeID,
+		ChallengeHash:         challenge.ChallengeHash,
+		TenantID:              challenge.TenantID,
+		WorkspaceID:           challenge.WorkspaceID,
+		Audience:              challenge.Audience,
+		PackID:                challenge.PackID,
+		PackVersion:           challenge.PackVersion,
+		PackManifestHash:      challenge.PackManifestHash,
+		Action:                challenge.Action,
+		IntentHash:            challenge.IntentHash,
+		EffectHash:            challenge.EffectHash,
+		PlanHash:              challenge.PlanHash,
+		Decision:              challenge.Decision,
+		PolicyVersion:         challenge.PolicyVersion,
+		PolicyEpoch:           challenge.PolicyEpoch,
+		PolicyHash:            challenge.PolicyHash,
+		AuthoritySource:       challenge.AuthoritySource,
+		AuthorityVersion:      challenge.AuthorityVersion,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash,
+		ServerIdentity:        challenge.ServerIdentity,
+		RequiredRole:          challenge.RequiredRole,
+		Quorum:                challenge.Quorum,
+		Signers:               verified,
+		SignerSetHash:         "sha256:" + signerSetHash,
+		VerifiedAt:            now.UTC(),
+	}, nil
+}
+
+func validateOptions(opts VerifyOptions) error {
+	if opts.MinHoldDuration <= 0 {
+		return verificationFailed("minimum hold duration is required")
+	}
+	if opts.MaxChallengeTTL <= 0 {
+		return verificationFailed("max challenge ttl is required")
+	}
+	if opts.MaxChallengeTTL <= opts.MinHoldDuration {
+		return verificationFailed("max challenge ttl must exceed minimum hold duration")
+	}
+	if opts.MaxAssertions <= 0 {
+		return verificationFailed("maximum assertion count is required")
+	}
+	if opts.MaxAssertions < opts.Expected.Quorum {
+		return verificationFailed("maximum assertion count must cover expected quorum")
+	}
+	required := []struct {
+		field string
+		value string
+	}{
+		{field: "challenge_id", value: opts.Expected.ChallengeID},
+		{field: "challenge_hash", value: opts.Expected.ChallengeHash},
+		{field: "approval_id", value: opts.Expected.ApprovalID},
+		{field: "tenant_id", value: opts.Expected.TenantID},
+		{field: "workspace_id", value: opts.Expected.WorkspaceID},
+		{field: "audience", value: opts.Expected.Audience},
+		{field: "pack_id", value: opts.Expected.PackID},
+		{field: "pack_version", value: opts.Expected.PackVersion},
+		{field: "pack_manifest_hash", value: opts.Expected.PackManifestHash},
+		{field: "action", value: opts.Expected.Action},
+		{field: "intent_hash", value: opts.Expected.IntentHash},
+		{field: "effect_hash", value: opts.Expected.EffectHash},
+		{field: "plan_hash", value: opts.Expected.PlanHash},
+		{field: "decision", value: opts.Expected.Decision},
+		{field: "policy_version", value: opts.Expected.PolicyVersion},
+		{field: "policy_epoch", value: opts.Expected.PolicyEpoch},
+		{field: "policy_hash", value: opts.Expected.PolicyHash},
+		{field: "authority_source", value: opts.Expected.AuthoritySource},
+		{field: "authority_version", value: opts.Expected.AuthorityVersion},
+		{field: "authority_snapshot_hash", value: opts.Expected.AuthoritySnapshotHash},
+		{field: "required_role", value: opts.Expected.RequiredRole},
+		{field: "server_identity", value: opts.Expected.ServerIdentity},
+	}
+	for _, item := range required {
+		if strings.TrimSpace(item.value) == "" {
+			return verificationFailed("expected " + item.field + " is required")
+		}
+	}
+	if opts.Expected.Quorum <= 0 {
+		return verificationFailed("expected quorum must be positive")
+	}
+	return nil
+}
+
+func verifyExpectedBinding(challenge contracts.ApprovalChallenge, expected ExpectedBinding) error {
+	matches := []struct {
+		field    string
+		actual   string
+		expected string
+	}{
+		{field: "challenge_id", actual: challenge.ChallengeID, expected: expected.ChallengeID},
+		{field: "challenge_hash", actual: challenge.ChallengeHash, expected: expected.ChallengeHash},
+		{field: "approval_id", actual: challenge.ApprovalID, expected: expected.ApprovalID},
+		{field: "tenant_id", actual: challenge.TenantID, expected: expected.TenantID},
+		{field: "workspace_id", actual: challenge.WorkspaceID, expected: expected.WorkspaceID},
+		{field: "audience", actual: challenge.Audience, expected: expected.Audience},
+		{field: "pack_id", actual: challenge.PackID, expected: expected.PackID},
+		{field: "pack_version", actual: challenge.PackVersion, expected: expected.PackVersion},
+		{field: "pack_manifest_hash", actual: challenge.PackManifestHash, expected: expected.PackManifestHash},
+		{field: "action", actual: challenge.Action, expected: expected.Action},
+		{field: "intent_hash", actual: challenge.IntentHash, expected: expected.IntentHash},
+		{field: "effect_hash", actual: challenge.EffectHash, expected: expected.EffectHash},
+		{field: "plan_hash", actual: challenge.PlanHash, expected: expected.PlanHash},
+		{field: "decision", actual: challenge.Decision, expected: expected.Decision},
+		{field: "policy_version", actual: challenge.PolicyVersion, expected: expected.PolicyVersion},
+		{field: "policy_epoch", actual: challenge.PolicyEpoch, expected: expected.PolicyEpoch},
+		{field: "policy_hash", actual: challenge.PolicyHash, expected: expected.PolicyHash},
+		{field: "authority_source", actual: challenge.AuthoritySource, expected: expected.AuthoritySource},
+		{field: "authority_version", actual: challenge.AuthorityVersion, expected: expected.AuthorityVersion},
+		{field: "authority_snapshot_hash", actual: challenge.AuthoritySnapshotHash, expected: expected.AuthoritySnapshotHash},
+		{field: "required_role", actual: challenge.RequiredRole, expected: expected.RequiredRole},
+		{field: "server_identity", actual: challenge.ServerIdentity, expected: expected.ServerIdentity},
+	}
+	for _, item := range matches {
+		if item.actual != item.expected {
+			return verificationFailed(item.field + " binding mismatch")
+		}
+	}
+	if challenge.Quorum != expected.Quorum {
+		return verificationFailed("quorum binding mismatch")
+	}
+	return nil
+}
+
+func validateTrustStore(store TrustStore, challenge contracts.ApprovalChallenge) error {
+	if store.AuthoritySource != challenge.AuthoritySource {
+		return authorityRejected("authority source mismatch")
+	}
+	if store.AuthorityVersion != challenge.AuthorityVersion {
+		return authorityRejected("authority version mismatch")
+	}
+	if store.AuthoritySnapshotHash != challenge.AuthoritySnapshotHash {
+		return authorityRejected("authority snapshot mismatch")
+	}
+	if len(store.Keys) == 0 {
+		return authorityRejected("authority snapshot has no keys")
+	}
+	return nil
+}
+
+func validateTrustedKey(key TrustedApproverKey, assertionKeyID string, challenge contracts.ApprovalChallenge, now time.Time) error {
+	if !key.Enabled {
+		return authorityRejected("key is disabled")
+	}
+	if key.KeyID == "" || key.KeyID != assertionKeyID {
+		return authorityRejected("key identity mismatch")
+	}
+	if key.TenantID == "" || key.TenantID != challenge.TenantID {
+		return authorityRejected("key tenant mismatch")
+	}
+	if !containsExactAuthority(key.WorkspaceIDs, challenge.WorkspaceID) {
+		return authorityRejected("workspace is not authorized")
+	}
+	if !isAuthorityToken(key.PrincipalID) || !isAuthorityToken(key.CredentialID) || !isAuthorityToken(key.DeviceID) {
+		return authorityRejected("key authority identity is incomplete")
+	}
+	if len(key.PublicKey) != ed25519.PublicKeySize {
+		return authorityRejected("invalid ed25519 public key length")
+	}
+	if key.NotBefore.IsZero() || key.NotAfter.IsZero() || !key.NotAfter.After(key.NotBefore) {
+		return authorityRejected("key validity window is invalid")
+	}
+	if now.Before(key.NotBefore) || !now.Before(key.NotAfter) {
+		return authorityRejected("key is outside its validity window")
+	}
+	if !containsExactAuthority(key.Roles, challenge.RequiredRole) {
+		return authorityRejected("required role is not authorized")
+	}
+	if !containsExactAuthority(key.Actions, challenge.Action) {
+		return authorityRejected("pack action is not authorized")
+	}
+	if !containsExactAuthority(key.Audiences, challenge.Audience) {
+		return authorityRejected("audience is not authorized")
+	}
+	return nil
+}
+
+func containsExactAuthority(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func isAuthorityToken(value string) bool {
+	return value != "" && strings.IndexFunc(value, unicode.IsSpace) == -1
+}
+
+func verificationFailed(message string) error {
+	return fmt.Errorf("%w: %s", ErrVerificationFailed, message)
+}
+
+func authorityRejected(message string) error {
+	return fmt.Errorf("%w: %s", ErrAuthorityRejected, message)
+}
+
+func duplicateSigner(field, value string) error {
+	return fmt.Errorf("%w: duplicate %s %s", ErrDuplicateSigner, field, value)
+}

--- a/core/pkg/boundary/approvalverify/verifier_test.go
+++ b/core/pkg/boundary/approvalverify/verifier_test.go
@@ -1,0 +1,601 @@
+// quantum_posture: these tests cover classical Ed25519 approval assertions;
+// they do not establish hybrid or post-quantum approval support.
+package approvalverify
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func TestVerifyQuorumAcceptsDistinctTrustedSignersDeterministically(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	assertions := []contracts.ApprovalAssertion{
+		signedAssertion(t, challenge, "key-b", privateKeys["key-b"]),
+		signedAssertion(t, challenge, "key-a", privateKeys["key-a"]),
+	}
+	now := challenge.IssuedAt.Add(time.Minute)
+
+	got, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), now)
+	if err != nil {
+		t.Fatalf("VerifyQuorum() error = %v", err)
+	}
+	if gotBinding := bindingFromProjection(got); gotBinding != optionsFor(challenge).Expected {
+		t.Fatalf("VerifyQuorum() projection binding = %+v, want %+v", gotBinding, optionsFor(challenge).Expected)
+	}
+	if got.VerifiedAt != now.UTC() {
+		t.Fatalf("VerifiedAt = %s, want %s", got.VerifiedAt, now.UTC())
+	}
+	if len(got.Signers) != 2 || got.Signers[0].PrincipalID != "principal-a" || got.Signers[1].PrincipalID != "principal-b" {
+		t.Fatalf("Signers are not canonically sorted: %+v", got.Signers)
+	}
+	if want := "sha256:1d55fba5c74963688c529912e88f8a52f078744a92cc3f2b0b27f10c703bab8c"; got.SignerSetHash != want {
+		t.Fatalf("SignerSetHash = %q, want %q", got.SignerSetHash, want)
+	}
+
+	reversed, err := VerifyQuorum(challenge, []contracts.ApprovalAssertion{assertions[1], assertions[0]}, store, optionsFor(challenge), now)
+	if err != nil {
+		t.Fatalf("VerifyQuorum() reversed error = %v", err)
+	}
+	if reversed.SignerSetHash != got.SignerSetHash {
+		t.Fatalf("SignerSetHash depends on assertion order: %s != %s", reversed.SignerSetHash, got.SignerSetHash)
+	}
+}
+
+func TestVerifyQuorumRejectsExpectedBindingSubstitution(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	assertions := signedQuorum(t, challenge, privateKeys)
+	mutations := map[string]func(*ExpectedBinding){
+		"challenge id":       func(e *ExpectedBinding) { e.ChallengeID = "challenge-b" },
+		"challenge hash":     func(e *ExpectedBinding) { e.ChallengeHash = shaRef("9") },
+		"approval":           func(e *ExpectedBinding) { e.ApprovalID = "approval-b" },
+		"tenant":             func(e *ExpectedBinding) { e.TenantID = "tenant-b" },
+		"workspace":          func(e *ExpectedBinding) { e.WorkspaceID = "workspace-b" },
+		"audience":           func(e *ExpectedBinding) { e.Audience = "packs.other" },
+		"pack":               func(e *ExpectedBinding) { e.PackID = "pack-b" },
+		"pack version":       func(e *ExpectedBinding) { e.PackVersion = "2.0.0" },
+		"manifest":           func(e *ExpectedBinding) { e.PackManifestHash = shaRef("8") },
+		"action":             func(e *ExpectedBinding) { e.Action = contracts.ApprovalGrantActionRollback },
+		"intent":             func(e *ExpectedBinding) { e.IntentHash = shaRef("7") },
+		"effect":             func(e *ExpectedBinding) { e.EffectHash = shaRef("6") },
+		"plan":               func(e *ExpectedBinding) { e.PlanHash = shaRef("5") },
+		"policy":             func(e *ExpectedBinding) { e.PolicyHash = shaRef("4") },
+		"decision":           func(e *ExpectedBinding) { e.Decision = "DENY" },
+		"policy version":     func(e *ExpectedBinding) { e.PolicyVersion = "policy-v2" },
+		"policy epoch":       func(e *ExpectedBinding) { e.PolicyEpoch = "epoch-2" },
+		"authority source":   func(e *ExpectedBinding) { e.AuthoritySource = "spiffe://helm/authority/other" },
+		"authority version":  func(e *ExpectedBinding) { e.AuthorityVersion = "authority-v2" },
+		"authority snapshot": func(e *ExpectedBinding) { e.AuthoritySnapshotHash = shaRef("b") },
+		"role":               func(e *ExpectedBinding) { e.RequiredRole = "security-admin" },
+		"quorum":             func(e *ExpectedBinding) { e.Quorum = 3 },
+		"server":             func(e *ExpectedBinding) { e.ServerIdentity = "spiffe://helm/server-b" },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			opts := optionsFor(challenge)
+			mutate(&opts.Expected)
+			if _, err := VerifyQuorum(challenge, assertions, store, opts, challenge.IssuedAt); !errors.Is(err, ErrVerificationFailed) {
+				t.Fatalf("VerifyQuorum() error = %v, want ErrVerificationFailed", err)
+			}
+		})
+	}
+}
+
+func TestVerifyQuorumRejectsAssertionChallengeSubstitution(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	base := signedQuorum(t, challenge, privateKeys)
+	tests := map[string]func(*contracts.ApprovalAssertion){
+		"challenge id":   func(a *contracts.ApprovalAssertion) { a.ChallengeID = "challenge-b" },
+		"challenge hash": func(a *contracts.ApprovalAssertion) { a.ChallengeHash = shaRef("9") },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			assertions := append([]contracts.ApprovalAssertion(nil), base...)
+			mutate(&assertions[0])
+			if _, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), challenge.IssuedAt); !errors.Is(err, ErrVerificationFailed) {
+				t.Fatalf("VerifyQuorum() error = %v, want ErrVerificationFailed", err)
+			}
+		})
+	}
+}
+
+func TestVerifyQuorumRejectsInactiveOrPolicyUnsafeChallenge(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	assertions := signedQuorum(t, challenge, privateKeys)
+
+	tests := map[string]struct {
+		now    time.Time
+		mutate func(*VerifyOptions)
+	}{
+		"before eligible": {now: challenge.EligibleAt.Add(-time.Nanosecond)},
+		"before issuance": {now: challenge.IssuedAt.Add(-time.Nanosecond)},
+		"at expiry":       {now: challenge.ExpiresAt},
+		"hold too short": {
+			now: challenge.IssuedAt,
+			mutate: func(o *VerifyOptions) {
+				o.MinHoldDuration = challenge.EligibleAt.Sub(challenge.HoldStartedAt) + time.Second
+			},
+		},
+		"ttl too long": {
+			now: challenge.IssuedAt,
+			mutate: func(o *VerifyOptions) {
+				o.MaxChallengeTTL = challenge.ExpiresAt.Sub(challenge.HoldStartedAt) - time.Second
+			},
+		},
+		"missing hold policy": {
+			now: challenge.IssuedAt,
+			mutate: func(o *VerifyOptions) {
+				o.MinHoldDuration = 0
+			},
+		},
+		"ttl does not exceed hold": {
+			now: challenge.IssuedAt,
+			mutate: func(o *VerifyOptions) {
+				o.MaxChallengeTTL = o.MinHoldDuration
+			},
+		},
+		"missing assertion cap": {
+			now: challenge.IssuedAt,
+			mutate: func(o *VerifyOptions) {
+				o.MaxAssertions = 0
+			},
+		},
+		"cap below quorum": {
+			now: challenge.IssuedAt,
+			mutate: func(o *VerifyOptions) {
+				o.MaxAssertions = challenge.Quorum - 1
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := optionsFor(challenge)
+			if test.mutate != nil {
+				test.mutate(&opts)
+			}
+			if _, err := VerifyQuorum(challenge, assertions, store, opts, test.now); !errors.Is(err, ErrVerificationFailed) {
+				t.Fatalf("VerifyQuorum() error = %v, want ErrVerificationFailed", err)
+			}
+		})
+	}
+}
+
+func TestVerifyQuorumRejectsUntrustedAuthority(t *testing.T) {
+	challenge := sealedChallenge(t)
+	baseStore, privateKeys := trustedStore(challenge)
+	baseAssertions := signedQuorum(t, challenge, privateKeys)
+	now := challenge.IssuedAt
+
+	tests := map[string]func(*TrustStore, *[]contracts.ApprovalAssertion){
+		"unknown key": func(_ *TrustStore, assertions *[]contracts.ApprovalAssertion) {
+			(*assertions)[0].KeyID = "unknown-key"
+		},
+		"disabled": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.Enabled = false
+			store.Keys["key-a"] = key
+		},
+		"cross tenant": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.TenantID = "tenant-b"
+			store.Keys["key-a"] = key
+		},
+		"cross workspace": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.WorkspaceIDs = []string{"workspace-b"}
+			store.Keys["key-a"] = key
+		},
+		"wildcard role": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.Roles = []string{"*"}
+			store.Keys["key-a"] = key
+		},
+		"wildcard audience": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.Audiences = []string{"*"}
+			store.Keys["key-a"] = key
+		},
+		"wrong audience": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.Audiences = []string{"packs.other"}
+			store.Keys["key-a"] = key
+		},
+		"wrong action": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.Actions = []string{contracts.ApprovalGrantActionUninstall}
+			store.Keys["key-a"] = key
+		},
+		"expired key": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.NotAfter = now
+			store.Keys["key-a"] = key
+		},
+		"future key": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.NotBefore = now.Add(time.Second)
+			store.Keys["key-a"] = key
+		},
+		"registry key mismatch": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.KeyID = "key-other"
+			store.Keys["key-a"] = key
+		},
+		"malformed public key": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.PublicKey = ed25519.PublicKey{1}
+			store.Keys["key-a"] = key
+		},
+		"invalid key window": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.NotAfter = key.NotBefore
+			store.Keys["key-a"] = key
+		},
+		"incomplete identity": func(store *TrustStore, _ *[]contracts.ApprovalAssertion) {
+			key := store.Keys["key-a"]
+			key.DeviceID = "device a"
+			store.Keys["key-a"] = key
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := cloneStore(baseStore)
+			assertions := append([]contracts.ApprovalAssertion(nil), baseAssertions...)
+			mutate(&store, &assertions)
+			if _, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), now); !errors.Is(err, ErrAuthorityRejected) {
+				t.Fatalf("VerifyQuorum() error = %v, want ErrAuthorityRejected", err)
+			}
+		})
+	}
+}
+
+func TestVerifyQuorumRejectsAuthoritySnapshotSubstitution(t *testing.T) {
+	challenge := sealedChallenge(t)
+	baseStore, privateKeys := trustedStore(challenge)
+	assertions := signedQuorum(t, challenge, privateKeys)
+	tests := map[string]func(*TrustStore){
+		"source":   func(s *TrustStore) { s.AuthoritySource = "spiffe://helm/authority/other" },
+		"version":  func(s *TrustStore) { s.AuthorityVersion = "authority-v2" },
+		"snapshot": func(s *TrustStore) { s.AuthoritySnapshotHash = shaRef("b") },
+		"empty":    func(s *TrustStore) { s.Keys = nil },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := cloneStore(baseStore)
+			mutate(&store)
+			if _, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), challenge.IssuedAt); !errors.Is(err, ErrAuthorityRejected) {
+				t.Fatalf("VerifyQuorum() error = %v, want ErrAuthorityRejected", err)
+			}
+		})
+	}
+}
+
+func TestVerifyQuorumRejectsBadOrMalleableSignature(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	assertions := signedQuorum(t, challenge, privateKeys)
+	corruptSignature(&assertions[0])
+	if _, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), challenge.IssuedAt); !errors.Is(err, ErrSignatureRejected) {
+		t.Fatalf("VerifyQuorum() bad signature error = %v, want ErrSignatureRejected", err)
+	}
+
+	store.Keys["key-alias"] = store.Keys["key-a"]
+	alias := store.Keys["key-alias"]
+	alias.KeyID = "key-alias"
+	alias.PrincipalID = "principal-alias"
+	alias.CredentialID = "credential-alias"
+	alias.DeviceID = "device-alias"
+	store.Keys["key-alias"] = alias
+	assertions = signedQuorum(t, challenge, privateKeys)
+	assertions[0].KeyID = "key-alias"
+	if _, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), challenge.IssuedAt); !errors.Is(err, ErrSignatureRejected) {
+		t.Fatalf("VerifyQuorum() key-id substitution error = %v, want ErrSignatureRejected", err)
+	}
+}
+
+func TestVerifyQuorumRejectsDuplicateSignerDimensions(t *testing.T) {
+	challenge := sealedChallenge(t)
+	baseStore, privateKeys := trustedStore(challenge)
+	baseAssertions := signedQuorum(t, challenge, privateKeys)
+	tests := map[string]func(*TrustedApproverKey, *contracts.ApprovalAssertion){
+		"key": func(_ *TrustedApproverKey, assertion *contracts.ApprovalAssertion) {
+			*assertion = baseAssertions[0]
+		},
+		"principal":  func(k *TrustedApproverKey, _ *contracts.ApprovalAssertion) { k.PrincipalID = "principal-a" },
+		"credential": func(k *TrustedApproverKey, _ *contracts.ApprovalAssertion) { k.CredentialID = "credential-a" },
+		"device":     func(k *TrustedApproverKey, _ *contracts.ApprovalAssertion) { k.DeviceID = "device-a" },
+		"public key": func(k *TrustedApproverKey, assertion *contracts.ApprovalAssertion) {
+			k.PublicKey = baseStore.Keys["key-a"].PublicKey
+			*assertion = signedAssertion(t, challenge, "key-b", privateKeys["key-a"])
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			store := cloneStore(baseStore)
+			assertions := append([]contracts.ApprovalAssertion(nil), baseAssertions...)
+			key := store.Keys["key-b"]
+			mutate(&key, &assertions[1])
+			store.Keys["key-b"] = key
+			if _, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), challenge.IssuedAt); !errors.Is(err, ErrDuplicateSigner) {
+				t.Fatalf("VerifyQuorum() error = %v, want ErrDuplicateSigner", err)
+			}
+		})
+	}
+}
+
+func TestVerifyQuorumPinsBoundedOverQuorumSemantics(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	privateC := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{3}, ed25519.SeedSize))
+	privateKeys["key-c"] = privateC
+	store.Keys["key-c"] = TrustedApproverKey{
+		KeyID:        "key-c",
+		TenantID:     challenge.TenantID,
+		PrincipalID:  "principal-c",
+		CredentialID: "credential-c",
+		DeviceID:     "device-c",
+		PublicKey:    privateC.Public().(ed25519.PublicKey),
+		WorkspaceIDs: []string{challenge.WorkspaceID},
+		Roles:        []string{challenge.RequiredRole},
+		Actions:      []string{challenge.Action},
+		Audiences:    []string{challenge.Audience},
+		Enabled:      true,
+		NotBefore:    challenge.HoldStartedAt.Add(-time.Hour),
+		NotAfter:     challenge.ExpiresAt.Add(time.Hour),
+	}
+	all := []contracts.ApprovalAssertion{
+		signedAssertion(t, challenge, "key-a", privateKeys["key-a"]),
+		signedAssertion(t, challenge, "key-b", privateKeys["key-b"]),
+		signedAssertion(t, challenge, "key-c", privateKeys["key-c"]),
+	}
+	permutations := [][]int{{0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0}}
+	opts := optionsFor(challenge)
+	opts.MaxAssertions = 3
+	var signerSetHash string
+	for _, permutation := range permutations {
+		assertions := []contracts.ApprovalAssertion{all[permutation[0]], all[permutation[1]], all[permutation[2]]}
+		got, err := VerifyQuorum(challenge, assertions, store, opts, challenge.IssuedAt)
+		if err != nil {
+			t.Fatalf("VerifyQuorum() permutation %v error = %v", permutation, err)
+		}
+		if len(got.Signers) != 3 {
+			t.Fatalf("VerifyQuorum() permutation %v signers = %d, want 3", permutation, len(got.Signers))
+		}
+		if signerSetHash == "" {
+			signerSetHash = got.SignerSetHash
+		} else if got.SignerSetHash != signerSetHash {
+			t.Fatalf("SignerSetHash depends on over-quorum order: %s != %s", got.SignerSetHash, signerSetHash)
+		}
+	}
+
+	invalidSurplus := append([]contracts.ApprovalAssertion(nil), all...)
+	corruptSignature(&invalidSurplus[2])
+	if _, err := VerifyQuorum(challenge, invalidSurplus, store, opts, challenge.IssuedAt); !errors.Is(err, ErrSignatureRejected) {
+		t.Fatalf("VerifyQuorum() invalid surplus error = %v, want ErrSignatureRejected", err)
+	}
+
+	opts.MaxAssertions = 2
+	if _, err := VerifyQuorum(challenge, all, store, opts, challenge.IssuedAt); !errors.Is(err, ErrVerificationFailed) {
+		t.Fatalf("VerifyQuorum() over cap error = %v, want ErrVerificationFailed", err)
+	}
+}
+
+func TestVerifyQuorumRejectsInsufficientQuorum(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	one := []contracts.ApprovalAssertion{signedAssertion(t, challenge, "key-a", privateKeys["key-a"])}
+	if _, err := VerifyQuorum(challenge, one, store, optionsFor(challenge), challenge.IssuedAt); !errors.Is(err, ErrQuorumNotMet) {
+		t.Fatalf("VerifyQuorum() error = %v, want ErrQuorumNotMet", err)
+	}
+}
+
+func TestVerifyQuorumPreservesContractErrorIdentity(t *testing.T) {
+	challenge := sealedChallenge(t)
+	store, privateKeys := trustedStore(challenge)
+	assertions := signedQuorum(t, challenge, privateKeys)
+
+	_, err := VerifyQuorum(challenge, assertions, store, optionsFor(challenge), challenge.EligibleAt.Add(-time.Nanosecond))
+	if !errors.Is(err, ErrVerificationFailed) || !errors.Is(err, contracts.ErrApprovalChallengeInactive) {
+		t.Fatalf("VerifyQuorum() challenge error = %v, want verifier and contract identities", err)
+	}
+
+	assertions[0].Signature = "ed25519:ab"
+	_, err = VerifyQuorum(challenge, assertions, store, optionsFor(challenge), challenge.IssuedAt)
+	if !errors.Is(err, ErrVerificationFailed) || !errors.Is(err, contracts.ErrApprovalAssertionInvalid) {
+		t.Fatalf("VerifyQuorum() assertion error = %v, want verifier and contract identities", err)
+	}
+}
+
+func sealedChallenge(t *testing.T) contracts.ApprovalChallenge {
+	t.Helper()
+	holdStarted := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
+	challenge, err := (contracts.ApprovalChallenge{
+		Domain:                contracts.ApprovalChallengeDomainV1,
+		SchemaVersion:         contracts.ApprovalChallengeSchemaV1,
+		ContractVersion:       contracts.ApprovalChallengeContractV1,
+		ChallengeID:           "challenge-a",
+		ApprovalID:            "approval-a",
+		TenantID:              "tenant-a",
+		WorkspaceID:           "workspace-a",
+		Audience:              "packs.lifecycle",
+		PackID:                "pack-a",
+		PackVersion:           "1.0.0",
+		PackManifestHash:      shaRef("a"),
+		Action:                contracts.ApprovalGrantActionInstall,
+		IntentHash:            shaRef("0"),
+		EffectHash:            shaRef("1"),
+		PlanHash:              shaRef("2"),
+		Decision:              contracts.ApprovalGrantDecisionAllow,
+		PolicyVersion:         "policy-v1",
+		PolicyEpoch:           "epoch-1",
+		PolicyHash:            shaRef("3"),
+		AuthoritySource:       "spiffe://helm/authority/approvers",
+		AuthorityVersion:      "authority-v1",
+		AuthoritySnapshotHash: shaRef("4"),
+		RequiredRole:          "pack-admin",
+		Quorum:                2,
+		ServerIdentity:        "spiffe://helm/server-a",
+		HoldStartedAt:         holdStarted,
+		EligibleAt:            holdStarted.Add(5 * time.Minute),
+		IssuedAt:              holdStarted.Add(6 * time.Minute),
+		ExpiresAt:             holdStarted.Add(15 * time.Minute),
+		Nonce:                 strings.Repeat("6", 64),
+	}).Seal()
+	if err != nil {
+		t.Fatalf("ApprovalChallenge.Seal() error = %v", err)
+	}
+	return challenge
+}
+
+func trustedStore(challenge contracts.ApprovalChallenge) (TrustStore, map[string]ed25519.PrivateKey) {
+	privateA := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{1}, ed25519.SeedSize))
+	privateB := ed25519.NewKeyFromSeed(bytes.Repeat([]byte{2}, ed25519.SeedSize))
+	privateKeys := map[string]ed25519.PrivateKey{"key-a": privateA, "key-b": privateB}
+	keys := make(map[string]TrustedApproverKey, 2)
+	for i, keyID := range []string{"key-a", "key-b"} {
+		suffix := string(rune('a' + i))
+		keys[keyID] = TrustedApproverKey{
+			KeyID:        keyID,
+			TenantID:     challenge.TenantID,
+			PrincipalID:  "principal-" + suffix,
+			CredentialID: "credential-" + suffix,
+			DeviceID:     "device-" + suffix,
+			PublicKey:    privateKeys[keyID].Public().(ed25519.PublicKey),
+			WorkspaceIDs: []string{challenge.WorkspaceID},
+			Roles:        []string{challenge.RequiredRole},
+			Actions:      []string{challenge.Action},
+			Audiences:    []string{challenge.Audience},
+			Enabled:      true,
+			NotBefore:    challenge.HoldStartedAt.Add(-time.Hour),
+			NotAfter:     challenge.ExpiresAt.Add(time.Hour),
+		}
+	}
+	return TrustStore{
+		AuthoritySource:       challenge.AuthoritySource,
+		AuthorityVersion:      challenge.AuthorityVersion,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash,
+		Keys:                  keys,
+	}, privateKeys
+}
+
+func signedQuorum(t *testing.T, challenge contracts.ApprovalChallenge, privateKeys map[string]ed25519.PrivateKey) []contracts.ApprovalAssertion {
+	t.Helper()
+	return []contracts.ApprovalAssertion{
+		signedAssertion(t, challenge, "key-a", privateKeys["key-a"]),
+		signedAssertion(t, challenge, "key-b", privateKeys["key-b"]),
+	}
+}
+
+func signedAssertion(t *testing.T, challenge contracts.ApprovalChallenge, keyID string, privateKey ed25519.PrivateKey) contracts.ApprovalAssertion {
+	t.Helper()
+	assertion := contracts.ApprovalAssertion{
+		Domain:          contracts.ApprovalAssertionDomainV1,
+		SchemaVersion:   contracts.ApprovalAssertionSchemaV1,
+		ContractVersion: contracts.ApprovalAssertionContractV1,
+		ChallengeID:     challenge.ChallengeID,
+		ChallengeHash:   challenge.ChallengeHash,
+		KeyID:           keyID,
+		Algorithm:       contracts.ApprovalAssertionEd25519,
+	}
+	digest, err := assertion.SigningDigest()
+	if err != nil {
+		t.Fatalf("ApprovalAssertion.SigningDigest() error = %v", err)
+	}
+	assertion.Signature = "ed25519:" + hex.EncodeToString(ed25519.Sign(privateKey, digest))
+	return assertion
+}
+
+func corruptSignature(assertion *contracts.ApprovalAssertion) {
+	last := byte('0')
+	if assertion.Signature[len(assertion.Signature)-1] == last {
+		last = '1'
+	}
+	assertion.Signature = assertion.Signature[:len(assertion.Signature)-1] + string(last)
+}
+
+func optionsFor(challenge contracts.ApprovalChallenge) VerifyOptions {
+	return VerifyOptions{
+		Expected: ExpectedBinding{
+			ChallengeID:           challenge.ChallengeID,
+			ChallengeHash:         challenge.ChallengeHash,
+			ApprovalID:            challenge.ApprovalID,
+			TenantID:              challenge.TenantID,
+			WorkspaceID:           challenge.WorkspaceID,
+			Audience:              challenge.Audience,
+			PackID:                challenge.PackID,
+			PackVersion:           challenge.PackVersion,
+			PackManifestHash:      challenge.PackManifestHash,
+			Action:                challenge.Action,
+			IntentHash:            challenge.IntentHash,
+			EffectHash:            challenge.EffectHash,
+			PlanHash:              challenge.PlanHash,
+			Decision:              challenge.Decision,
+			PolicyVersion:         challenge.PolicyVersion,
+			PolicyEpoch:           challenge.PolicyEpoch,
+			PolicyHash:            challenge.PolicyHash,
+			AuthoritySource:       challenge.AuthoritySource,
+			AuthorityVersion:      challenge.AuthorityVersion,
+			AuthoritySnapshotHash: challenge.AuthoritySnapshotHash,
+			RequiredRole:          challenge.RequiredRole,
+			Quorum:                challenge.Quorum,
+			ServerIdentity:        challenge.ServerIdentity,
+		},
+		MinHoldDuration: 5 * time.Minute,
+		MaxChallengeTTL: 20 * time.Minute,
+		MaxAssertions:   4,
+	}
+}
+
+func cloneStore(store TrustStore) TrustStore {
+	cloned := TrustStore{
+		AuthoritySource:       store.AuthoritySource,
+		AuthorityVersion:      store.AuthorityVersion,
+		AuthoritySnapshotHash: store.AuthoritySnapshotHash,
+		Keys:                  make(map[string]TrustedApproverKey, len(store.Keys)),
+	}
+	for keyID, key := range store.Keys {
+		cloned.Keys[keyID] = key
+	}
+	return cloned
+}
+
+func bindingFromProjection(got VerifiedApprovalRef) ExpectedBinding {
+	return ExpectedBinding{
+		ChallengeID:           got.ChallengeID,
+		ChallengeHash:         got.ChallengeHash,
+		ApprovalID:            got.ApprovalID,
+		TenantID:              got.TenantID,
+		WorkspaceID:           got.WorkspaceID,
+		Audience:              got.Audience,
+		PackID:                got.PackID,
+		PackVersion:           got.PackVersion,
+		PackManifestHash:      got.PackManifestHash,
+		Action:                got.Action,
+		IntentHash:            got.IntentHash,
+		EffectHash:            got.EffectHash,
+		PlanHash:              got.PlanHash,
+		Decision:              got.Decision,
+		PolicyVersion:         got.PolicyVersion,
+		PolicyEpoch:           got.PolicyEpoch,
+		PolicyHash:            got.PolicyHash,
+		AuthoritySource:       got.AuthoritySource,
+		AuthorityVersion:      got.AuthorityVersion,
+		AuthoritySnapshotHash: got.AuthoritySnapshotHash,
+		RequiredRole:          got.RequiredRole,
+		Quorum:                got.Quorum,
+		ServerIdentity:        got.ServerIdentity,
+	}
+}
+
+func shaRef(character string) string {
+	return "sha256:" + strings.Repeat(character, 64)
+}


### PR DESCRIPTION
Linear: HELM-142

## Summary

- verify domain-separated Ed25519 assertions with the signed key selection intact
- exact-bind challenge, tenant, workspace, pack, intent/effect/plan, decision, policy, server, role, quorum, and pinned authority source/version/snapshot metadata
- require exact workspace/role/action/audience membership with no wildcard privilege expansion
- reject duplicate key, public key, principal, credential, or device identities
- accept every valid signer from quorum through a policy-owned `MaxAssertions` cap and commit all supplied signers into a deterministic `SignerSetHash`
- preserve underlying contract error identities and pin deterministic/negative vectors

## Follow-up conformance

Draft child PR [#579](https://github.com/Mindburn-Labs/helm-ai-kernel/pull/579) now supplies the machine-readable cross-language reference pack and independent verifier at exact head `69aa965257ea86a08069e9705c5c97886e4212d7`. That child is review evidence only; it is not merged and does not expand this PR's authority.

## Truth boundary

This remains a pure verifier slice. Trust metadata and keys must already be loaded and snapshot-validated by the owning server-side registry; this generic verifier exact-binds the pinned metadata but does not rederive a registry-specific snapshot hash. It does not persist challenges, prove nonce release time, prevent replay, commit a ceremony, issue an effect permit, authorize a pack mutation, or complete HELM-142.

The stack still needs durable post-hold challenge issuance that withholds the nonce until eligibility, tenant-bound authority loading, atomic ceremony/replay state, signed single-use permit issuance, mutation-path enforcement, and joined EvidencePack/reconciliation proof.

## Stack

- base: #572 (challenge/assertion contract)
- #572 base: #570 (ApprovalGrant contract)
- child conformance pack: #579
- this PR adds only the trusted authority/quorum verifier and its tests

## Validation at exact head `815e9df15b2b4d10c8673a757a6deb10cbb548ce`

- `make quality-pr`: all blocking gates passed
- `go test -race ./pkg/contracts ./pkg/boundary/approvalverify -count=1`
- `go test ./pkg/boundary/approvalverify -count=100`
- `go vet ./pkg/contracts ./pkg/boundary/approvalverify`
- `make verify-fixtures`
- `make verify-boundary`: 987 current, 0 stale, 0 errors
- approval verifier coverage: 90.6% statements
- GitHub Documentation Gates: passed

Independent security and conformance reviews: GO for stacked draft review only. Merge and release remain NO-GO.
