### PR TITLE
ci: contract breaking-change gate on PRs (HELM-151 GATE 1)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,11 @@ surface for the `helm-ai-kernel` project.
 - `make quality-pr` mirrors the CI summary gate for pull requests.
 - `make quality-nightly` mirrors the scheduled advisory assurance workflow.
 - `make quality-release` mirrors release validation before tag publication.
+- `make openapi-breaking` / `make proto-breaking` run the contract
+  breaking-change gate (HELM-151 GATE 1) against the PR base branch —
+  `oasdiff` for the OpenAPI surfaces, `buf breaking` for the policy-schema
+  protos. Both now run in the `pr` profile; a major-version bump or the
+  `contract:breaking-approved` PR label is the explicit override.
 
 ## Active Quality Workflows
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,27 @@ jobs:
       - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
         with:
           repo-token: ${{ github.token }}
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
+        with:
+          github_token: ${{ github.token }}
+      - name: Install oasdiff (contract breaking-change gate — HELM-151)
+        run: |
+          set -euo pipefail
+          # Prebuilt binary — oasdiff's module needs Go >= 1.26 and CI pins
+          # GOTOOLCHAIN=local on Go 1.25, so `go install` cannot build it.
+          ver=1.23.0
+          tmp="$(mktemp -d)"
+          curl -fsSL "https://github.com/oasdiff/oasdiff/releases/download/v${ver}/oasdiff_${ver}_linux_amd64.tar.gz" \
+            | tar -xz -C "$tmp"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmp/oasdiff" "$HOME/.local/bin/oasdiff"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/oasdiff" --version
       - name: Run Make-first PR quality profile
+        env:
+          # `contract:breaking-approved` label downgrades a contract break to a
+          # visible warning (HELM-151 GATE 1 override).
+          CONTRACT_BREAKING_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'contract:breaking-approved') && '1' || '0' }}
         run: make quality-pr
 
   hygiene:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-cli test-race test-sdk-go-standalone test-sdk-ts test-platform test-sdk-py test-sdk-rust test-sdk-java sdk-openapi-check sdk-examples-smoke verify-fixtures verify-presentation tee-collateral-verify test-all bench bench-report lint proto-lint proto-breaking docker-verify release-readiness crucible proxy docker docker-up docker-smoke compose-smoke helm-chart-smoke kind-smoke deployment-smoke release-smoke version-drift version-drift-report version-drift-published version-status prepare-version sbom vex provenance onboard demo-cli mcp-pack mcp-install release-binaries release-binaries-reproducible release-assets build-release release-all verify-boundary verify-cosign bench-pin codegen codegen-go codegen-python codegen-ts codegen-java codegen-rust codegen-check quality-pr quality-merge quality-release quality-nightly quality-list quality-explain quality-self-test quality-typecheck quality-contracts quality-security quality-runbooks quality-mutation quality-flake quality-impact clean docs-coverage docs-truth launch-record-assets real-use-assets launch-release-dry-run launch-ready conformance-release-report conformance-release-gate
+.PHONY: build test test-cli test-race test-sdk-go-standalone test-sdk-ts test-platform test-sdk-py test-sdk-rust test-sdk-java sdk-openapi-check sdk-examples-smoke verify-fixtures verify-presentation tee-collateral-verify test-all bench bench-report lint proto-lint proto-breaking openapi-breaking docker-verify release-readiness crucible proxy docker docker-up docker-smoke compose-smoke helm-chart-smoke kind-smoke deployment-smoke release-smoke version-drift version-drift-report version-drift-published version-status prepare-version sbom vex provenance onboard demo-cli mcp-pack mcp-install release-binaries release-binaries-reproducible release-assets build-release release-all verify-boundary verify-cosign bench-pin codegen codegen-go codegen-python codegen-ts codegen-java codegen-rust codegen-check quality-pr quality-merge quality-release quality-nightly quality-list quality-explain quality-self-test quality-typecheck quality-contracts quality-security quality-runbooks quality-mutation quality-flake quality-impact clean docs-coverage docs-truth launch-record-assets real-use-assets launch-release-dry-run launch-ready conformance-release-report conformance-release-gate
 
 # VERSION is source-controlled release truth. Tag-triggered workflows must
 # check that GITHUB_REF_NAME equals v$(VERSION) before any publish step.
@@ -74,9 +74,11 @@ lint: docs-coverage docs-truth
 proto-lint:
 	buf lint protocols/policy-schema
 
-BUF_AGAINST ?= .git\#branch=main,subdir=protocols/policy-schema
 proto-breaking:
-	buf breaking protocols/policy-schema --against "$(BUF_AGAINST)"
+	bash scripts/ci/contract_breaking.sh proto
+
+openapi-breaking:
+	bash scripts/ci/contract_breaking.sh openapi
 
 docker-verify:
 	docker build -f Dockerfile -t helm-ai-kernel:verify-root .

--- a/scripts/ci/contract_breaking.sh
+++ b/scripts/ci/contract_breaking.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# HELM-151 / GATE 1 — contract breaking-change gate.
+#
+# Diffs an API contract surface against the PR's base branch and fails on a
+# backward-incompatible change, so a break cannot merge silently while the
+# version number claims compatibility. Two escapes, both explicit and visible:
+#   * major bump   — if the contract's major version was raised, the break is
+#                    intended and signalled by the version, so the gate passes.
+#   * label override — CONTRACT_BREAKING_APPROVED=1 (set by CI from the
+#                    `contract:breaking-approved` PR label) downgrades a failure
+#                    to a warning for deliberate pre-1.0 / pre-GA churn.
+#
+# Usage: contract_breaking.sh <openapi|proto>
+# Base ref comes from GITHUB_BASE_REF (default: main). Runs locally and in CI.
+set -euo pipefail
+
+kind="${1:?usage: contract_breaking.sh <openapi|proto>}"
+base_ref="${GITHUB_BASE_REF:-main}"
+approved="${CONTRACT_BREAKING_APPROVED:-0}"
+
+# Resolve the base to something git can read (prefer the remote-tracking ref).
+git fetch --quiet origin "$base_ref" 2>/dev/null || true
+base="origin/${base_ref}"
+git rev-parse --verify --quiet "${base}^{commit}" >/dev/null 2>&1 || base="$base_ref"
+
+major() { printf '%s' "${1%%.*}"; }              # "1.4.0" -> "1"
+
+is_approved() {                                  # portable lower-case (macOS bash 3.2 has no ${x,,})
+  case "$(printf '%s' "$approved" | tr '[:upper:]' '[:lower:]')" in
+  1 | true | yes | on) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+# $1 = surface label, $2 = differ output. Blocks unless the label override is set.
+report_break() {
+  if is_approved; then
+    printf '::warning::%s: backward-incompatible change present, overridden by the contract:breaking-approved label\n' "$1"
+    printf '%s\n' "$2"
+    return 0
+  fi
+  printf '::error::%s: backward-incompatible contract change without a major bump\n' "$1"
+  printf '%s\n' "$2"
+  # shellcheck disable=SC2016  # backticks are literal markdown, not a shell expansion
+  printf 'Fix it, bump the major version, or add the `contract:breaking-approved` label to override.\n'
+  return 1
+}
+
+openapi_version() {                              # <ref-or-WORKTREE> <spec-path>; "" if absent
+  { if [ "$1" = "WORKTREE" ]; then cat "$2" 2>/dev/null; else git show "$1:$2" 2>/dev/null; fi; } |
+    awk '/^[^[:space:]]/ { in_info = ($1 == "info:") }
+         in_info && $1 == "version:" { v = $2; gsub(/["'"'"' ]/, "", v); print v; exit }'
+}
+
+case "$kind" in
+openapi)
+  command -v oasdiff >/dev/null 2>&1 || {
+    echo "::error::oasdiff is required for the openapi breaking gate (brew install oasdiff, or go install github.com/oasdiff/oasdiff@latest)"
+    exit 2
+  }
+  specs=(api/openapi/helm.openapi.yaml protocols/specs/effects/openapi.yaml)
+  broke=1
+  for spec in "${specs[@]}"; do
+    if ! git cat-file -e "${base}:${spec}" 2>/dev/null; then
+      echo "openapi ${spec}: new on this branch (no base to diff) — skip"
+      continue
+    fi
+    cur_major="$(major "$(openapi_version WORKTREE "$spec")")"
+    base_major="$(major "$(openapi_version "$base" "$spec")")"
+    if [[ "$cur_major" =~ ^[0-9]+$ && "$base_major" =~ ^[0-9]+$ && "$cur_major" -gt "$base_major" ]]; then
+      echo "openapi ${spec}: major ${base_major} -> ${cur_major} — break allowed by version bump"
+      continue
+    fi
+    base_file="$(mktemp)"
+    git show "${base}:${spec}" >"$base_file"
+    # oasdiff `breaking` prints changes but exits 0 by default; --fail-on ERR
+    # makes it exit non-zero on an ERR-level (backward-incompatible) change.
+    if out="$(oasdiff breaking "$base_file" "$spec" --fail-on ERR 2>&1)"; then
+      echo "openapi ${spec}: no backward-incompatible changes vs ${base}"
+    else
+      report_break "openapi ${spec}" "$out" || broke=0
+    fi
+    rm -f "$base_file"
+  done
+  [ "$broke" -eq 0 ] && exit 1
+  echo "GATE 1 (openapi): pass"
+  ;;
+proto)
+  command -v buf >/dev/null 2>&1 || { echo "::error::buf is required for the proto breaking gate"; exit 2; }
+  cur_major="$(major "$(cat VERSION 2>/dev/null || echo 0)")"
+  base_major="$(major "$(git show "${base}:VERSION" 2>/dev/null || echo "$cur_major")")"
+  if [[ "$cur_major" =~ ^[0-9]+$ && "$base_major" =~ ^[0-9]+$ && "$cur_major" -gt "$base_major" ]]; then
+    echo "proto: major ${base_major} -> ${cur_major} — break allowed by version bump"
+    exit 0
+  fi
+  against=".git#ref=${base},subdir=protocols/policy-schema"
+  if out="$(buf breaking protocols/policy-schema --against "$against" 2>&1)"; then
+    echo "GATE 1 (proto): pass — no backward-incompatible changes vs ${base}"
+  else
+    report_break "proto (protocols/policy-schema)" "$out"
+  fi
+  ;;
+*)
+  echo "unknown kind: ${kind} (expected: openapi | proto)" >&2
+  exit 2
+  ;;
+esac

--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -19,7 +19,9 @@
         "python-sdk",
         "ts-sdk",
         "rust-sdk",
-        "java-sdk"
+        "java-sdk",
+        "proto-breaking",
+        "openapi-breaking"
       ]
     },
     "merge": {
@@ -471,6 +473,20 @@
       "timeout_seconds": 600,
       "paths": [
         "protocols/policy-schema/**",
+        "VERSION",
+        "scripts/ci/contract_breaking.sh",
+        "Makefile"
+      ]
+    },
+    {
+      "id": "openapi-breaking",
+      "title": "OpenAPI breaking-change check",
+      "command": "make openapi-breaking",
+      "timeout_seconds": 600,
+      "paths": [
+        "api/openapi/**",
+        "protocols/specs/effects/openapi.yaml",
+        "scripts/ci/contract_breaking.sh",
         "Makefile"
       ]
     },


### PR DESCRIPTION
## What & why

GATE 1 of the HELM-149 two-gate compatibility model, for the kernel (the richest contract surface). A PR that **backward-breaks a contract** should fail CI, so a break can't ship silently under a "minor" version — that's what makes the semver work of HELM-146/147 mean something.

**Gap this closes:** today the kernel checks breaking changes **only at release** (`proto-breaking` lives in the `release`/`nightly` profiles; the `merge` profile that also has it is not run by any workflow). On a **PR** there is no breaking check at all, and **OpenAPI has no breaking gate anywhere** (only `sdk-openapi-check`, which is SDK↔spec drift, not a backward-compat diff).

## Change

- **`scripts/ci/contract_breaking.sh`** — diffs a surface against the PR's base branch:
  - OpenAPI (`api/openapi/helm.openapi.yaml`, `protocols/specs/effects/openapi.yaml`) via `oasdiff breaking --fail-on ERR` (oasdiff prints but exits 0 by default — `--fail-on ERR` makes it fail).
  - proto (`protocols/policy-schema`) via `buf breaking --against <base>`.
  - Two **explicit, visible** escapes: a **major-version bump** (the break is intended and signalled by the version), and the **`contract:breaking-approved` PR label** (`CONTRACT_BREAKING_APPROVED=1` → break downgraded to a `::warning::` for deliberate pre-1.0 churn).
  - Portable: works on macOS bash 3.2 and needs no PyYAML (version parsed with awk); `shellcheck`-clean.
- **`Makefile`** — `openapi-breaking` (new) + `proto-breaking` routed through the wrapper (uniform escape/override).
- **`scripts/ci/quality-gates.json`** — new `openapi-breaking` gate; both breaking gates added to the **`pr` profile** (previously absent). `make quality-self-test` passes (45 gates, 11 profiles).
- **`.github/workflows/ci.yml`** — the `quality-pr` job now sets up `buf`, installs `oasdiff` (`go install …@v1.23.0`), and passes the label override env.

Because the gates hang off the existing `quality.py` profile runner (impact-filtered by `paths`), no parallel pipeline is introduced — the gate only runs when a contract file changes.

## Verified locally

| Case | Result |
| --- | --- |
| No contract change | pass (rc 0) |
| Removed endpoint (`/api/health`), no escape | **fail (rc 1)** + `::error::` |
| Same break + `contract:breaking-approved` label | pass (rc 0) + `::warning::` |
| Same break + major bump (`info.version` 0.7.2→1.0.0) | pass (rc 0, "break allowed by version bump") |
| proto, no change | pass |

Also confirmed `go install github.com/oasdiff/oasdiff@v1.23.0` builds the CLI (the CI install path).

## Out of scope / follow-ups

- **Operator step:** mark the `Quality PR profile` check required in branch protection (it already runs; this makes it blocking).
- **Phase 2:** the same gate on `svc-helm-control-plane` (oasdiff on its OpenAPI).
- **Phase 3:** document the mechanism in `docs_for_team/DEVOPS.md` (the GATE 1 row, which tool guards which contract, how to override).

Part of HELM-151 (GATE 1) → closes the last acceptance piece of HELM-149.
