### PR TITLE
[codex] feat(desktop): add authenticated transport v1

### DIFF
--- a/core/cmd/helm-ai-kernel/desktop_transport_v1.go
+++ b/core/cmd/helm-ai-kernel/desktop_transport_v1.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 )
 
@@ -20,6 +21,11 @@ const (
 	desktopTransportV1RecordPrefix = "HELM_DESKTOP_TRANSPORT_V1 "
 	desktopTransportV1RecordLimit  = 1024
 	desktopTransportV1SecretLength = 64
+
+	desktopTransportV1ProofPath            = "/api/v1/desktop/transport/proof"
+	desktopTransportV1ChallengeHeader      = "X-Helm-Desktop-Transport-Challenge"
+	desktopTransportV1ProofHeader          = "X-Helm-Desktop-Transport-Proof"
+	desktopTransportV1HandoffMessagePrefix = "helm-desktop-transport-v1-handoff"
 )
 
 // desktopTransportV1 is an opt-in direct-child readiness contract for the
@@ -58,14 +64,18 @@ func desktopTransportV1FromEnv() (*desktopTransportV1, error) {
 
 func desktopTransportV1SecretFromEnv(name string) (string, error) {
 	value := os.Getenv(name)
-	if len(value) != desktopTransportV1SecretLength {
-		return "", fmt.Errorf("%s must be %d lowercase hexadecimal characters", name, desktopTransportV1SecretLength)
-	}
-	decoded, err := hex.DecodeString(value)
-	if err != nil || hex.EncodeToString(decoded) != value {
+	if !desktopTransportV1IsLowerHex(value) {
 		return "", fmt.Errorf("%s must be %d lowercase hexadecimal characters", name, desktopTransportV1SecretLength)
 	}
 	return value, nil
+}
+
+func desktopTransportV1IsLowerHex(value string) bool {
+	if len(value) != desktopTransportV1SecretLength {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && hex.EncodeToString(decoded) == value
 }
 
 // bind reserves the dynamic loopback endpoint before it is disclosed. Do not
@@ -86,15 +96,11 @@ func (t *desktopTransportV1) bind() (net.Listener, string, error) {
 
 func (t *desktopTransportV1) readinessRecord(origin string) (string, error) {
 	message := desktopTransportV1Schema + "\n" + t.nonce + "\n" + origin
-	// The Desktop treats the canonical hex text as the HMAC key bytes; keep the
-	// cross-process contract literal instead of decoding it before signing.
-	mac := hmac.New(sha256.New, []byte(t.key))
-	_, _ = io.WriteString(mac, message)
 	record, err := json.Marshal(desktopTransportV1Record{
 		Schema: desktopTransportV1Schema,
 		Nonce:  t.nonce,
 		Origin: origin,
-		MAC:    hex.EncodeToString(mac.Sum(nil)),
+		MAC:    t.hmac(message),
 	})
 	if err != nil {
 		return "", fmt.Errorf("encode desktop transport readiness record: %w", err)
@@ -119,4 +125,53 @@ func (t *desktopTransportV1) writeReadinessRecord(out io.Writer, origin string) 
 		return io.ErrShortWrite
 	}
 	return nil
+}
+
+func (t *desktopTransportV1) hmac(message string) string {
+	// The Desktop treats the canonical hex text as the HMAC key bytes; keep the
+	// cross-process contract literal instead of decoding it before signing.
+	mac := hmac.New(sha256.New, []byte(t.key))
+	_, _ = io.WriteString(mac, message)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (t *desktopTransportV1) handoffProof(origin, challenge string) string {
+	return t.hmac(desktopTransportV1HandoffMessagePrefix + "\n" + t.nonce + "\n" + origin + "\n" + challenge)
+}
+
+// registerProofRoute exposes a no-bearer, direct-child proof only while the
+// Desktop transport owns the attested loopback listener. The fresh challenge
+// prevents a released-port claimant from replaying the startup record.
+func (t *desktopTransportV1) registerProofRoute(mux *http.ServeMux, origin string) {
+	mux.HandleFunc(desktopTransportV1ProofPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		challenge := r.Header.Get(desktopTransportV1ChallengeHeader)
+		if !desktopTransportV1IsLowerHex(challenge) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set(desktopTransportV1ProofHeader, t.handoffProof(origin, challenge))
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func registerDesktopTransportV1ProofRoute(mux *http.ServeMux, transport *desktopTransportV1, origin string) {
+	if transport != nil {
+		transport.registerProofRoute(mux, origin)
+	}
+}
+
+func desktopTransportV1SuppressesAuxiliaryHealth(transport *desktopTransportV1, healthPort int, metricsEnabled bool) (bool, error) {
+	if transport == nil || healthPort != 0 {
+		return false, nil
+	}
+	if metricsEnabled {
+		return false, fmt.Errorf("HELM_METRICS_ENABLED cannot be enabled when HELM_HEALTH_PORT=0")
+	}
+	return true, nil
 }

--- a/core/cmd/helm-ai-kernel/desktop_transport_v1.go
+++ b/core/cmd/helm-ai-kernel/desktop_transport_v1.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+)
+
+const (
+	desktopTransportV1EnabledEnv = "HELM_DESKTOP_TRANSPORT_V1"
+	desktopTransportV1KeyEnv     = "HELM_DESKTOP_TRANSPORT_KEY"
+	desktopTransportV1NonceEnv   = "HELM_DESKTOP_TRANSPORT_NONCE"
+
+	desktopTransportV1Schema       = "helm-desktop-transport-v1"
+	desktopTransportV1RecordPrefix = "HELM_DESKTOP_TRANSPORT_V1 "
+	desktopTransportV1RecordLimit  = 1024
+	desktopTransportV1SecretLength = 64
+)
+
+// desktopTransportV1 is an opt-in direct-child readiness contract for the
+// packaged Desktop. The key and nonce remain process environment only.
+type desktopTransportV1 struct {
+	key   string
+	nonce string
+}
+
+type desktopTransportV1Record struct {
+	Schema string `json:"schema"`
+	Nonce  string `json:"nonce"`
+	Origin string `json:"origin"`
+	MAC    string `json:"mac"`
+}
+
+func desktopTransportV1FromEnv() (*desktopTransportV1, error) {
+	enabled, present := os.LookupEnv(desktopTransportV1EnabledEnv)
+	if !present || enabled == "" {
+		return nil, nil
+	}
+	if enabled != "1" {
+		return nil, fmt.Errorf("%s must be exactly \"1\" when set", desktopTransportV1EnabledEnv)
+	}
+
+	key, err := desktopTransportV1SecretFromEnv(desktopTransportV1KeyEnv)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := desktopTransportV1SecretFromEnv(desktopTransportV1NonceEnv)
+	if err != nil {
+		return nil, err
+	}
+	return &desktopTransportV1{key: key, nonce: nonce}, nil
+}
+
+func desktopTransportV1SecretFromEnv(name string) (string, error) {
+	value := os.Getenv(name)
+	if len(value) != desktopTransportV1SecretLength {
+		return "", fmt.Errorf("%s must be %d lowercase hexadecimal characters", name, desktopTransportV1SecretLength)
+	}
+	decoded, err := hex.DecodeString(value)
+	if err != nil || hex.EncodeToString(decoded) != value {
+		return "", fmt.Errorf("%s must be %d lowercase hexadecimal characters", name, desktopTransportV1SecretLength)
+	}
+	return value, nil
+}
+
+// bind reserves the dynamic loopback endpoint before it is disclosed. Do not
+// replace this with an availability check followed by a later bind.
+func (t *desktopTransportV1) bind() (net.Listener, string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, "", fmt.Errorf("bind desktop transport listener: %w", err)
+	}
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok || !addr.IP.Equal(net.IPv4(127, 0, 0, 1)) || addr.Port <= 0 {
+		_ = listener.Close()
+		return nil, "", fmt.Errorf("desktop transport listener returned a non-loopback address")
+	}
+	return listener, fmt.Sprintf("http://127.0.0.1:%d", addr.Port), nil
+}
+
+func (t *desktopTransportV1) readinessRecord(origin string) (string, error) {
+	message := desktopTransportV1Schema + "\n" + t.nonce + "\n" + origin
+	// The Desktop treats the canonical hex text as the HMAC key bytes; keep the
+	// cross-process contract literal instead of decoding it before signing.
+	mac := hmac.New(sha256.New, []byte(t.key))
+	_, _ = io.WriteString(mac, message)
+	record, err := json.Marshal(desktopTransportV1Record{
+		Schema: desktopTransportV1Schema,
+		Nonce:  t.nonce,
+		Origin: origin,
+		MAC:    hex.EncodeToString(mac.Sum(nil)),
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode desktop transport readiness record: %w", err)
+	}
+	line := desktopTransportV1RecordPrefix + string(record)
+	if len(line)+1 > desktopTransportV1RecordLimit {
+		return "", fmt.Errorf("desktop transport readiness record exceeds %d bytes", desktopTransportV1RecordLimit)
+	}
+	return line, nil
+}
+
+func (t *desktopTransportV1) writeReadinessRecord(out io.Writer, origin string) error {
+	line, err := t.readinessRecord(origin)
+	if err != nil {
+		return err
+	}
+	written, err := io.WriteString(out, line+"\n")
+	if err != nil {
+		return fmt.Errorf("write desktop transport readiness record: %w", err)
+	}
+	if written != len(line)+1 {
+		return io.ErrShortWrite
+	}
+	return nil
+}

--- a/core/cmd/helm-ai-kernel/desktop_transport_v1_test.go
+++ b/core/cmd/helm-ai-kernel/desktop_transport_v1_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestDesktopTransportV1DisabledPreservesNormalMode(t *testing.T) {
+	t.Setenv(desktopTransportV1EnabledEnv, "")
+
+	transport, err := desktopTransportV1FromEnv()
+	if err != nil {
+		t.Fatalf("read desktop transport config: %v", err)
+	}
+	if transport != nil {
+		t.Fatal("disabled desktop transport must leave normal server mode available")
+	}
+}
+
+func TestDesktopTransportV1RejectsMissingOrBadConfig(t *testing.T) {
+	valid := strings.Repeat("a", desktopTransportV1SecretLength)
+	for name, tc := range map[string]struct {
+		key   string
+		nonce string
+	}{
+		"missing key":   {nonce: valid},
+		"missing nonce": {key: valid},
+		"uppercase key": {key: strings.ToUpper(valid), nonce: valid},
+		"short nonce":   {key: valid, nonce: valid[:desktopTransportV1SecretLength-1]},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(desktopTransportV1EnabledEnv, "1")
+			t.Setenv(desktopTransportV1KeyEnv, tc.key)
+			t.Setenv(desktopTransportV1NonceEnv, tc.nonce)
+			if transport, err := desktopTransportV1FromEnv(); err == nil || transport != nil {
+				t.Fatalf("bad desktop transport config must fail closed, transport=%#v err=%v", transport, err)
+			}
+		})
+	}
+
+	t.Setenv(desktopTransportV1EnabledEnv, "true")
+	if transport, err := desktopTransportV1FromEnv(); err == nil || transport != nil {
+		t.Fatalf("non-canonical transport gate must fail closed, transport=%#v err=%v", transport, err)
+	}
+
+	t.Setenv(desktopTransportV1EnabledEnv, "1")
+	t.Setenv(desktopTransportV1KeyEnv, valid)
+	t.Setenv(desktopTransportV1NonceEnv, strings.Repeat("b", desktopTransportV1SecretLength))
+	if transport, err := desktopTransportV1FromEnv(); err != nil || transport == nil {
+		t.Fatalf("valid desktop transport config was rejected, transport=%#v err=%v", transport, err)
+	}
+}
+
+func TestRunServerCommandRejectsBadDesktopTransportBeforeStartup(t *testing.T) {
+	t.Setenv(desktopTransportV1EnabledEnv, "1")
+	t.Setenv(desktopTransportV1KeyEnv, "")
+	t.Setenv(desktopTransportV1NonceEnv, "")
+
+	var stdout, stderr bytes.Buffer
+	code := runServerCommand("server", []string{"--desktop-transport-v1", "--port", "1"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("bad desktop transport config returned %d, want 1", code)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("server started despite bad desktop transport config: %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "desktop transport v1 configuration") {
+		t.Fatalf("missing configuration error: %q", stderr.String())
+	}
+}
+
+func TestDesktopTransportV1ReadinessRecordBindsNonceOriginAndMAC(t *testing.T) {
+	transport := &desktopTransportV1{
+		key:   strings.Repeat("a", desktopTransportV1SecretLength),
+		nonce: strings.Repeat("b", desktopTransportV1SecretLength),
+	}
+	listener, origin, err := transport.bind()
+	if err != nil {
+		t.Fatalf("bind desktop transport listener: %v", err)
+	}
+	defer listener.Close()
+	if !strings.HasPrefix(origin, "http://127.0.0.1:") {
+		t.Fatalf("origin %q is not canonical loopback", origin)
+	}
+	if replacement, err := net.Listen("tcp", listener.Addr().String()); err == nil {
+		_ = replacement.Close()
+		t.Fatal("dynamic desktop transport endpoint was not held by the Kernel listener")
+	}
+
+	var output bytes.Buffer
+	if err := transport.writeReadinessRecord(&output, origin); err != nil {
+		t.Fatalf("write readiness record: %v", err)
+	}
+	line := strings.TrimSuffix(output.String(), "\n")
+	if len(output.Bytes()) > desktopTransportV1RecordLimit {
+		t.Fatalf("readiness record is not bounded: %d bytes", len(output.Bytes()))
+	}
+	if strings.Contains(line, transport.key) {
+		t.Fatal("readiness record must not expose the transport key")
+	}
+	encoded, ok := strings.CutPrefix(line, desktopTransportV1RecordPrefix)
+	if !ok {
+		t.Fatalf("record missing prefix: %q", line)
+	}
+
+	var record desktopTransportV1Record
+	if err := json.Unmarshal([]byte(encoded), &record); err != nil {
+		t.Fatalf("decode readiness record: %v", err)
+	}
+	if record.Schema != desktopTransportV1Schema || record.Nonce != transport.nonce || record.Origin != origin {
+		t.Fatalf("unexpected readiness record: %#v", record)
+	}
+
+	expected := desktopTransportTestMAC(transport.key, transport.nonce, origin)
+	if !hmac.Equal([]byte(record.MAC), []byte(expected)) {
+		t.Fatalf("record MAC mismatch: got %q want %q", record.MAC, expected)
+	}
+	if record.MAC == desktopTransportTestMAC(transport.key, strings.Repeat("c", desktopTransportV1SecretLength), origin) {
+		t.Fatal("record MAC must bind the launch nonce")
+	}
+	if record.MAC == desktopTransportTestMAC(transport.key, transport.nonce, "http://127.0.0.1:1") {
+		t.Fatal("record MAC must bind the dynamic origin")
+	}
+}
+
+func desktopTransportTestMAC(key, nonce, origin string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	_, _ = mac.Write([]byte(desktopTransportV1Schema + "\n" + nonce + "\n" + origin))
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/core/cmd/helm-ai-kernel/desktop_transport_v1_test.go
+++ b/core/cmd/helm-ai-kernel/desktop_transport_v1_test.go
@@ -129,6 +129,27 @@ func TestDesktopTransportV1ReadinessRecordBindsNonceOriginAndMAC(t *testing.T) {
 	}
 }
 
+func TestDesktopTransportV1DoesNotDependOnLegacyFixedPortAvailability(t *testing.T) {
+	legacy, err := net.Listen("tcp", "127.0.0.1:8420")
+	if err != nil {
+		t.Skipf("cannot pre-bind legacy fixed port in this environment: %v", err)
+	}
+	defer legacy.Close()
+
+	transport := &desktopTransportV1{
+		key:   strings.Repeat("a", desktopTransportV1SecretLength),
+		nonce: strings.Repeat("b", desktopTransportV1SecretLength),
+	}
+	listener, origin, err := transport.bind()
+	if err != nil {
+		t.Fatalf("dynamic Desktop transport bind failed while legacy port was occupied: %v", err)
+	}
+	defer listener.Close()
+	if origin == "http://127.0.0.1:8420" {
+		t.Fatal("dynamic Desktop transport reused the pre-bound legacy port")
+	}
+}
+
 func desktopTransportTestMAC(key, nonce, origin string) string {
 	mac := hmac.New(sha256.New, []byte(key))
 	_, _ = mac.Write([]byte(desktopTransportV1Schema + "\n" + nonce + "\n" + origin))

--- a/core/cmd/helm-ai-kernel/desktop_transport_v1_test.go
+++ b/core/cmd/helm-ai-kernel/desktop_transport_v1_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -20,6 +22,23 @@ func TestDesktopTransportV1DisabledPreservesNormalMode(t *testing.T) {
 	}
 	if transport != nil {
 		t.Fatal("disabled desktop transport must leave normal server mode available")
+	}
+}
+
+func TestDesktopTransportV1RequiresTheExplicitServerOption(t *testing.T) {
+	valid := strings.Repeat("a", desktopTransportV1SecretLength)
+	t.Setenv(desktopTransportV1EnabledEnv, "1")
+	t.Setenv(desktopTransportV1KeyEnv, valid)
+	t.Setenv(desktopTransportV1NonceEnv, strings.Repeat("b", desktopTransportV1SecretLength))
+
+	transport, err := desktopTransportV1ForOptions(serverOptions{})
+	if err != nil || transport != nil {
+		t.Fatalf("transport env without the explicit server option must preserve normal mode, transport=%#v err=%v", transport, err)
+	}
+
+	transport, err = desktopTransportV1ForOptions(serverOptions{DesktopTransportV1: true})
+	if err != nil || transport == nil {
+		t.Fatalf("explicit transport option must accept valid transport env, transport=%#v err=%v", transport, err)
 	}
 }
 
@@ -72,6 +91,94 @@ func TestRunServerCommandRejectsBadDesktopTransportBeforeStartup(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "desktop transport v1 configuration") {
 		t.Fatalf("missing configuration error: %q", stderr.String())
+	}
+}
+
+func TestDesktopTransportV1ProofRouteIsModeLocalAndChallengeBound(t *testing.T) {
+	transport := &desktopTransportV1{
+		key:   strings.Repeat("a", desktopTransportV1SecretLength),
+		nonce: strings.Repeat("b", desktopTransportV1SecretLength),
+	}
+	origin := "http://127.0.0.1:45321"
+	challenge := strings.Repeat("c", desktopTransportV1SecretLength)
+
+	normalMux := http.NewServeMux()
+	registerDesktopTransportV1ProofRoute(normalMux, nil, origin)
+	normalResponse := httptest.NewRecorder()
+	normalMux.ServeHTTP(normalResponse, httptest.NewRequest(http.MethodGet, desktopTransportV1ProofPath, nil))
+	if normalResponse.Code != http.StatusNotFound {
+		t.Fatalf("normal mode registered Desktop proof route: status=%d", normalResponse.Code)
+	}
+
+	mux := http.NewServeMux()
+	registerDesktopTransportV1ProofRoute(mux, transport, origin)
+	request := httptest.NewRequest(http.MethodGet, desktopTransportV1ProofPath, nil)
+	request.Header.Set(desktopTransportV1ChallengeHeader, challenge)
+	response := httptest.NewRecorder()
+	mux.ServeHTTP(response, request)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("valid no-bearer proof request status=%d, want %d", response.Code, http.StatusNoContent)
+	}
+	if response.Body.Len() != 0 {
+		t.Fatalf("proof response body must be empty: %q", response.Body.String())
+	}
+	proof := response.Header().Get(desktopTransportV1ProofHeader)
+	expected := desktopTransportTestHandoffMAC(transport.key, transport.nonce, origin, challenge)
+	if !hmac.Equal([]byte(proof), []byte(expected)) {
+		t.Fatalf("proof mismatch: got %q want %q", proof, expected)
+	}
+	if response.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("proof response cache control=%q, want no-store", response.Header().Get("Cache-Control"))
+	}
+	if strings.Contains(proof, transport.key) {
+		t.Fatal("proof must not expose the transport key")
+	}
+
+	for _, challenge := range []string{"", strings.Repeat("a", desktopTransportV1SecretLength-1), strings.Repeat("A", desktopTransportV1SecretLength), strings.Repeat("g", desktopTransportV1SecretLength)} {
+		request := httptest.NewRequest(http.MethodGet, desktopTransportV1ProofPath, nil)
+		request.Header.Set(desktopTransportV1ChallengeHeader, challenge)
+		response := httptest.NewRecorder()
+		mux.ServeHTTP(response, request)
+		if response.Code != http.StatusBadRequest {
+			t.Fatalf("invalid challenge %q status=%d, want %d", challenge, response.Code, http.StatusBadRequest)
+		}
+		if response.Header().Get(desktopTransportV1ProofHeader) != "" {
+			t.Fatalf("invalid challenge %q returned a proof", challenge)
+		}
+	}
+
+	methodResponse := httptest.NewRecorder()
+	mux.ServeHTTP(methodResponse, httptest.NewRequest(http.MethodPost, desktopTransportV1ProofPath, nil))
+	if methodResponse.Code != http.StatusMethodNotAllowed || methodResponse.Header().Get("Allow") != http.MethodGet {
+		t.Fatalf("non-GET proof request status=%d allow=%q", methodResponse.Code, methodResponse.Header().Get("Allow"))
+	}
+}
+
+func TestDesktopTransportV1SuppressesAuxiliaryHealthAndRejectsMetrics(t *testing.T) {
+	transport := &desktopTransportV1{}
+	if suppress, err := desktopTransportV1SuppressesAuxiliaryHealth(transport, 0, false); err != nil || !suppress {
+		t.Fatalf("Desktop transport should suppress port-zero auxiliary health, suppress=%t err=%v", suppress, err)
+	}
+	if suppress, err := desktopTransportV1SuppressesAuxiliaryHealth(transport, 0, true); err == nil || suppress {
+		t.Fatalf("Desktop transport must reject metrics with port-zero auxiliary health, suppress=%t err=%v", suppress, err)
+	}
+	if suppress, err := desktopTransportV1SuppressesAuxiliaryHealth(nil, 0, true); err != nil || suppress {
+		t.Fatalf("normal mode must keep its existing health behavior, suppress=%t err=%v", suppress, err)
+	}
+
+	t.Setenv(desktopTransportV1EnabledEnv, "1")
+	t.Setenv(desktopTransportV1KeyEnv, strings.Repeat("a", desktopTransportV1SecretLength))
+	t.Setenv(desktopTransportV1NonceEnv, strings.Repeat("b", desktopTransportV1SecretLength))
+	t.Setenv("HELM_HEALTH_PORT", "0")
+	t.Setenv("HELM_METRICS_ENABLED", "1")
+	t.Setenv("HELM_METRICS_PORT", "")
+	var stdout, stderr bytes.Buffer
+	err := runServerWithOptions(serverOptions{DesktopTransportV1: true, Stdout: &stdout, Stderr: &stderr})
+	if err == nil || !strings.Contains(err.Error(), "HELM_METRICS_ENABLED") {
+		t.Fatalf("expected fail-closed auxiliary metrics configuration error, err=%v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("invalid auxiliary metrics configuration must fail before startup output: %q", stdout.String())
 	}
 }
 
@@ -153,5 +260,11 @@ func TestDesktopTransportV1DoesNotDependOnLegacyFixedPortAvailability(t *testing
 func desktopTransportTestMAC(key, nonce, origin string) string {
 	mac := hmac.New(sha256.New, []byte(key))
 	_, _ = mac.Write([]byte(desktopTransportV1Schema + "\n" + nonce + "\n" + origin))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func desktopTransportTestHandoffMAC(key, nonce, origin, challenge string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	_, _ = mac.Write([]byte("helm-desktop-transport-v1-handoff\n" + nonce + "\n" + origin + "\n" + challenge))
 	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -49,17 +50,18 @@ func main() {
 var startServer = runServer
 
 type serverOptions struct {
-	Mode       string
-	BindAddr   string
-	Port       int
-	DataDir    string
-	SQLitePath string
-	PolicyPath string
-	Quickstart *quickstartRuntime
-	OnReady    func(bindAddr string, port int)
-	JSON       bool
-	Stdout     io.Writer
-	Stderr     io.Writer
+	Mode               string
+	BindAddr           string
+	Port               int
+	DataDir            string
+	SQLitePath         string
+	PolicyPath         string
+	Quickstart         *quickstartRuntime
+	OnReady            func(bindAddr string, port int)
+	DesktopTransportV1 bool
+	JSON               bool
+	Stdout             io.Writer
+	Stderr             io.Writer
 }
 
 // Run is the entrypoint for testing
@@ -141,16 +143,25 @@ const (
 
 //nolint:gocognit,gocyclo
 func runServer() {
-	runServerWithOptions(serverOptions{Mode: "server", Stdout: os.Stdout, Stderr: os.Stderr})
+	if err := runServerWithOptions(serverOptions{Mode: "server", Stdout: os.Stdout, Stderr: os.Stderr}); err != nil {
+		log.Fatal(err)
+	}
 }
 
 //nolint:gocognit,gocyclo
-func runServerWithOptions(opts serverOptions) {
+func runServerWithOptions(opts serverOptions) error {
 	if opts.Stdout == nil {
 		opts.Stdout = os.Stdout
 	}
 	if opts.Stderr == nil {
 		opts.Stderr = os.Stderr
+	}
+	desktopTransport, transportErr := desktopTransportV1FromEnv()
+	if transportErr != nil {
+		return fmt.Errorf("desktop transport v1 configuration: %w", transportErr)
+	}
+	if opts.DesktopTransportV1 && desktopTransport == nil {
+		return fmt.Errorf("desktop transport v1 configuration: %s=1 is required", desktopTransportV1EnabledEnv)
 	}
 	fmt.Fprintf(opts.Stdout, "%sHELM AI Kernel starting...%s\n", ColorBold+ColorBlue, ColorReset)
 	ctx, runtimeCancel := context.WithCancel(context.Background())
@@ -403,6 +414,22 @@ func runServerWithOptions(opts serverOptions) {
 			port = p
 		}
 	}
+	var (
+		apiListener net.Listener
+		apiOrigin   string
+	)
+	if desktopTransport != nil {
+		listener, origin, err := desktopTransport.bind()
+		if err != nil {
+			return err
+		}
+		bindAddr = "127.0.0.1"
+		port = listener.Addr().(*net.TCPAddr).Port
+		opts.BindAddr = bindAddr
+		opts.Port = port
+		apiOrigin = origin
+		apiListener = listener
+	}
 	mux := http.NewServeMux()
 	if extraRoutes != nil {
 		extraRoutes(mux)
@@ -422,15 +449,25 @@ func runServerWithOptions(opts serverOptions) {
 		WriteTimeout:      60 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+	serveAPI := server.ListenAndServe
+	if apiListener != nil {
+		serveAPI = func() error { return server.Serve(apiListener) }
+	}
 	if bindAddr == "0.0.0.0" {
 		log.Printf("[helm] WARNING: API server binding to all interfaces (0.0.0.0:%d) — ensure firewall rules are in place", port)
 	}
 	go func() {
 		log.Printf("[helm] API server: %s:%d", bindAddr, port)
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := serveAPI(); err != nil && err != http.ErrServerClosed {
 			logger.Error("API server failed", "error", err)
 		}
 	}()
+	if desktopTransport != nil {
+		if err := desktopTransport.writeReadinessRecord(opts.Stdout, apiOrigin); err != nil {
+			_ = apiListener.Close()
+			return err
+		}
+	}
 
 	// Health Server
 	healthPort := 8081
@@ -524,6 +561,7 @@ func runServerWithOptions(opts serverOptions) {
 		}
 	}
 	log.Println("[helm] shutdown complete")
+	return nil
 }
 
 func servicesInitFailureIsFatal() bool {

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -148,6 +148,20 @@ func runServer() {
 	}
 }
 
+func desktopTransportV1ForOptions(opts serverOptions) (*desktopTransportV1, error) {
+	if !opts.DesktopTransportV1 {
+		return nil, nil
+	}
+	transport, err := desktopTransportV1FromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("desktop transport v1 configuration: %w", err)
+	}
+	if transport == nil {
+		return nil, fmt.Errorf("desktop transport v1 configuration: %s=1 is required", desktopTransportV1EnabledEnv)
+	}
+	return transport, nil
+}
+
 //nolint:gocognit,gocyclo
 func runServerWithOptions(opts serverOptions) error {
 	if opts.Stdout == nil {
@@ -156,12 +170,21 @@ func runServerWithOptions(opts serverOptions) error {
 	if opts.Stderr == nil {
 		opts.Stderr = os.Stderr
 	}
-	desktopTransport, transportErr := desktopTransportV1FromEnv()
+	desktopTransport, transportErr := desktopTransportV1ForOptions(opts)
 	if transportErr != nil {
-		return fmt.Errorf("desktop transport v1 configuration: %w", transportErr)
+		return transportErr
 	}
-	if opts.DesktopTransportV1 && desktopTransport == nil {
-		return fmt.Errorf("desktop transport v1 configuration: %s=1 is required", desktopTransportV1EnabledEnv)
+	healthPort := 8081
+	if envHP := os.Getenv("HELM_HEALTH_PORT"); envHP != "" {
+		if p, err := strconv.Atoi(envHP); err == nil {
+			healthPort = p
+		}
+	}
+	metricsPort := envInt("HELM_METRICS_PORT", healthPort)
+	metricsEnabled := envBool("HELM_METRICS_ENABLED")
+	suppressAuxiliaryHealth, auxiliaryHealthErr := desktopTransportV1SuppressesAuxiliaryHealth(desktopTransport, healthPort, metricsEnabled)
+	if auxiliaryHealthErr != nil {
+		return fmt.Errorf("desktop transport v1 configuration: %w", auxiliaryHealthErr)
 	}
 	fmt.Fprintf(opts.Stdout, "%sHELM AI Kernel starting...%s\n", ColorBold+ColorBlue, ColorReset)
 	ctx, runtimeCancel := context.WithCancel(context.Background())
@@ -434,6 +457,7 @@ func runServerWithOptions(opts serverOptions) error {
 	if extraRoutes != nil {
 		extraRoutes(mux)
 	}
+	registerDesktopTransportV1ProofRoute(mux, desktopTransport, apiOrigin)
 	rateLimiter := buildRuntimeRateLimiter()
 	server := &http.Server{
 		Addr: fmt.Sprintf("%s:%d", bindAddr, port),
@@ -469,39 +493,35 @@ func runServerWithOptions(opts serverOptions) error {
 		}
 	}
 
-	// Health Server
-	healthPort := 8081
-	if envHP := os.Getenv("HELM_HEALTH_PORT"); envHP != "" {
-		if p, err := strconv.Atoi(envHP); err == nil {
-			healthPort = p
+	// Auxiliary health is intentionally absent when the Desktop transport sets
+	// HELM_HEALTH_PORT=0; the attested API listener already serves /healthz.
+	var healthServer *http.Server
+	if !suppressAuxiliaryHealth {
+		healthMux := http.NewServeMux()
+		healthHandler := func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
 		}
-	}
-	healthMux := http.NewServeMux()
-	healthHandler := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("OK"))
-	}
-	healthMux.HandleFunc("/health", healthHandler)
-	healthMux.HandleFunc("/healthz", healthHandler)
-	metricsPort := envInt("HELM_METRICS_PORT", healthPort)
-	metricsEnabled := envBool("HELM_METRICS_ENABLED")
-	if metricsEnabled && metricsPort == healthPort {
-		healthMux.HandleFunc("/metrics", verificationMetrics.PrometheusHandler())
-	}
-	healthServer := &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", bindAddr, healthPort),
-		Handler:           healthMux,
-		ReadHeaderTimeout: 5 * time.Second,
-		ReadTimeout:       5 * time.Second,
-		WriteTimeout:      5 * time.Second,
-		IdleTimeout:       30 * time.Second,
-	}
-	go func() {
-		log.Printf("[helm] health server: %s:%d", bindAddr, healthPort)
-		if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("[helm] health server error: %v", err)
+		healthMux.HandleFunc("/health", healthHandler)
+		healthMux.HandleFunc("/healthz", healthHandler)
+		if metricsEnabled && metricsPort == healthPort {
+			healthMux.HandleFunc("/metrics", verificationMetrics.PrometheusHandler())
 		}
-	}()
+		healthServer = &http.Server{
+			Addr:              fmt.Sprintf("%s:%d", bindAddr, healthPort),
+			Handler:           healthMux,
+			ReadHeaderTimeout: 5 * time.Second,
+			ReadTimeout:       5 * time.Second,
+			WriteTimeout:      5 * time.Second,
+			IdleTimeout:       30 * time.Second,
+		}
+		go func() {
+			log.Printf("[helm] health server: %s:%d", bindAddr, healthPort)
+			if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Printf("[helm] health server error: %v", err)
+			}
+		}()
+	}
 	var metricsServer *http.Server
 	if metricsEnabled && metricsPort != healthPort {
 		metricsMux := http.NewServeMux()
@@ -552,8 +572,10 @@ func runServerWithOptions(opts serverOptions) error {
 	if err := server.Shutdown(shutdownCtx); err != nil {
 		log.Printf("[helm] API server shutdown error: %v", err)
 	}
-	if err := healthServer.Shutdown(shutdownCtx); err != nil {
-		log.Printf("[helm] health server shutdown error: %v", err)
+	if healthServer != nil {
+		if err := healthServer.Shutdown(shutdownCtx); err != nil {
+			log.Printf("[helm] health server shutdown error: %v", err)
+		}
 	}
 	if metricsServer != nil {
 		if err := metricsServer.Shutdown(shutdownCtx); err != nil {

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -57,7 +57,7 @@ func runQuickstartCmd(args []string, stdout, stderr io.Writer) int {
 
 	installQuickstartRuntimeEnv(prepared.Runtime)
 
-	runServerWithOptions(serverOptions{
+	if err := runServerWithOptions(serverOptions{
 		Mode:       "quickstart",
 		BindAddr:   opts.Addr,
 		Port:       opts.Port,
@@ -73,7 +73,10 @@ func runQuickstartCmd(args []string, stdout, stderr io.Writer) int {
 		},
 		Stdout: stdout,
 		Stderr: stderr,
-	})
+	}); err != nil {
+		fmt.Fprintf(stderr, "quickstart: %v\n", err)
+		return 1
+	}
 	return 0
 }
 

--- a/core/cmd/helm-ai-kernel/server_cmd.go
+++ b/core/cmd/helm-ai-kernel/server_cmd.go
@@ -26,6 +26,7 @@ func runServerCommand(name string, args []string, stdout, stderr io.Writer) int 
 	cmd.StringVar(&opts.BindAddr, "addr", "", "Bind address")
 	cmd.IntVar(&opts.Port, "port", 0, "Listen port")
 	cmd.StringVar(&opts.DataDir, "data-dir", "", "Data directory for local SQLite state and keys")
+	cmd.BoolVar(&opts.DesktopTransportV1, "desktop-transport-v1", false, "Enable the packaged Desktop transport (requires HELM_DESKTOP_TRANSPORT_V1=1 and transport env)")
 	cmd.BoolVar(&opts.JSON, "json", false, "Print startup status as JSON")
 
 	if err := cmd.Parse(args); err != nil {
@@ -79,6 +80,9 @@ func runServerCommand(name string, args []string, stdout, stderr io.Writer) int 
 		}
 	}
 
-	runServerWithOptions(opts)
+	if err := runServerWithOptions(opts); err != nil {
+		_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
+	}
 	return 0
 }


### PR DESCRIPTION
## Summary

- add an explicit, opt-in Desktop transport mode that atomically binds 127.0.0.1:0
- emit a bounded nonce-and-origin HMAC readiness record plus a no-bearer HMAC handoff-proof endpoint
- keep ordinary server and quickstart behavior unchanged unless the command flag and all transport environment values are present
- suppress the unused auxiliary health listener for Desktop transport and fail closed if metrics would need it

## Why

Desktop previously depended on a fixed-port availability check. A local process could claim that port before the Console sent its server-held Kernel credential. This adds direct-child origin attestation and a proof that a released-port claimant cannot forge.

## Validation

- go test -count=1 ./cmd/helm-ai-kernel
- focused transport tests under -race
- cross-repository local Kernel + Console proof/BFF smoke
- adversarial fake-listener smoke: only the no-bearer proof request reached the replacement listener

## Boundary

This is the Kernel leg of HELM-182. Packaged Desktop recovery/restart supervision remains HELM-202; no release or deployment claim is made.