### PR TITLE
fix(approval): reject legacy economic authority

### DIFF
--- a/core/pkg/contracts/economic/usage_balance.go
+++ b/core/pkg/contracts/economic/usage_balance.go
@@ -23,8 +23,9 @@ const (
 	BalanceMovementPromoCredit BalanceMovementType = "PROMO_CREDIT"
 	// BalanceMovementRefund returns funds for a reversed/failed usage debit.
 	BalanceMovementRefund BalanceMovementType = "REFUND"
-	// BalanceMovementCorrection is an append-only manual adjustment that requires
-	// an approval ceremony. It never edits prior history.
+	// BalanceMovementCorrection is an append-only manual adjustment. Production
+	// execution requires a source-owned, single-use approval grant; legacy
+	// ApprovalCeremony values are non-authoritative and fail closed.
 	BalanceMovementCorrection BalanceMovementType = "CORRECTION"
 	// BalanceMovementProviderCostAccrual accrues raw provider cost for export.
 	BalanceMovementProviderCostAccrual BalanceMovementType = "PROVIDER_COST_ACCRUAL"
@@ -37,6 +38,12 @@ const (
 	// bookkeeping-only and never moves the cash balance.
 	BalanceMovementTaxAccrual BalanceMovementType = "TAX_ACCRUAL"
 )
+
+// ErrLegacyApprovalCeremonyUnsupported reports that a caller tried to
+// authorize an economic correction with the legacy descriptive ceremony.
+// Corrections remain unavailable until the Kernel can atomically consume a
+// source-owned, single-use approval grant.
+var ErrLegacyApprovalCeremonyUnsupported = errors.New("balance_movement_receipt: legacy approval ceremony cannot authorize a correction; source-owned grant consumption is unavailable")
 
 // fundingDirection reports the credit/debit direction a funding movement posts
 // when the caller does not override it. Funding movements (top-up, promo,
@@ -68,30 +75,15 @@ func (t BalanceMovementType) LedgerEntryType() UsageLedgerEntryType {
 	}
 }
 
-// correctionApproved reports whether a sealed approval ceremony actually
-// authorizes a manual correction under dual control: the ceremony must be
-// approved and at least one approver must differ from the requester.
+// correctionApproved rejects the legacy ceremony as an authority source. The
+// argument remains in the wire contract for compatibility while the canonical
+// grant-consumption path is introduced, but no caller-provided ceremony can
+// authorize a balance mutation.
 func correctionApproved(a *contracts.ApprovalCeremony) error {
 	if a == nil {
 		return errors.New("balance_movement_receipt: correction requires an approval ceremony")
 	}
-	if err := a.Validate(); err != nil {
-		return err
-	}
-	if a.State != contracts.ApprovalCeremonyAllowed {
-		return errors.New("balance_movement_receipt: correction approval ceremony is not approved")
-	}
-	distinct := false
-	for _, approver := range a.Approvers {
-		if approver != "" && approver != a.RequestedBy {
-			distinct = true
-			break
-		}
-	}
-	if !distinct {
-		return errors.New("balance_movement_receipt: correction requires an approver distinct from the requester (dual control)")
-	}
-	return nil
+	return ErrLegacyApprovalCeremonyUnsupported
 }
 
 // BalanceMovementReceipt is the content-addressed receipt for one non-usage
@@ -110,7 +102,8 @@ type BalanceMovementReceipt struct {
 	Reason           string              `json:"reason,omitempty"`
 	// SourceReceiptHash links a REFUND back to the UsageReceipt it reverses.
 	SourceReceiptHash string `json:"source_receipt_hash,omitempty"`
-	// Approval is required for CORRECTION movements (the approval ceremony).
+	// Approval is retained for legacy decoding and evidence binding only. It is
+	// never executable authority for CORRECTION movements.
 	Approval        *contracts.ApprovalCeremony `json:"approval,omitempty"`
 	EvidencePackRef string                      `json:"evidence_pack_ref"`
 	CreatedAt       time.Time                   `json:"created_at"`

--- a/core/pkg/contracts/economic/usage_balance_test.go
+++ b/core/pkg/contracts/economic/usage_balance_test.go
@@ -1,6 +1,7 @@
 package economic
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -59,7 +60,7 @@ func TestBalanceMovementReceipt_RefundRequiresSource(t *testing.T) {
 	}
 }
 
-func TestBalanceMovementReceipt_CorrectionNeedsDualControl(t *testing.T) {
+func TestBalanceMovementReceipt_CorrectionRejectsLegacyCeremony(t *testing.T) {
 	base := func() *BalanceMovementReceipt {
 		r := NewBalanceMovementReceipt("mv-3", "t1", "b1", BalanceMovementCorrection, 250, "USD", "k3", "evidence://mv-3")
 		r.Direction = SettlementDebit
@@ -74,31 +75,32 @@ func TestBalanceMovementReceipt_CorrectionNeedsDualControl(t *testing.T) {
 		t.Fatalf("expected correction without approval to be invalid")
 	}
 
-	// Self-approval (approver == requester) is not dual control.
+	// A self-approved legacy ceremony cannot authorize the correction.
 	r = base()
 	r.Approval = sealedCeremony(t, "alice", []string{"alice"}, contracts.ApprovalCeremonyAllowed)
 	r.Reseal()
-	if err := r.Validate(); err == nil {
-		t.Fatalf("expected self-approved correction to be invalid")
+	if err := r.Validate(); !errors.Is(err, ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("self-approved legacy ceremony error = %v, want %v", err, ErrLegacyApprovalCeremonyUnsupported)
 	}
 
-	// Approved but distinct approver -> valid; entry type is ADJUSTMENT.
+	// Even a sealed, distinct-approver ceremony is descriptive evidence, not
+	// source-owned executable authority.
 	r = base()
 	r.Approval = sealedCeremony(t, "alice", []string{"bob"}, contracts.ApprovalCeremonyAllowed)
 	r.Reseal()
-	if err := r.Validate(); err != nil {
-		t.Fatalf("valid dual-control correction rejected: %v", err)
+	if err := r.Validate(); !errors.Is(err, ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("dual-control legacy ceremony error = %v, want %v", err, ErrLegacyApprovalCeremonyUnsupported)
 	}
 	if r.LedgerEntryType() != UsageLedgerAdjustment {
 		t.Fatalf("correction ledger entry type = %s, want ADJUSTMENT", r.LedgerEntryType())
 	}
 
-	// Pending (not approved) ceremony is refused even with a distinct approver.
+	// Pending legacy ceremonies fail at the same authority boundary.
 	r = base()
 	r.Approval = sealedCeremony(t, "alice", []string{"bob"}, contracts.ApprovalCeremonyPending)
 	r.Reseal()
-	if err := r.Validate(); err == nil {
-		t.Fatalf("expected pending-ceremony correction to be invalid")
+	if err := r.Validate(); !errors.Is(err, ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("pending legacy ceremony error = %v, want %v", err, ErrLegacyApprovalCeremonyUnsupported)
 	}
 }
 

--- a/core/pkg/inferencegateway/lifecycle.go
+++ b/core/pkg/inferencegateway/lifecycle.go
@@ -276,9 +276,10 @@ func (l *BalanceLedger) consumeReservationForDebit(reservationKey string) {
 	res.Consumed = true
 }
 
-// Adjust posts an append-only manual correction. It requires an approved,
-// dual-control approval ceremony and never edits prior history. A debit
-// correction respects the no-negative-balance rule unless invoicing is enabled.
+// Adjust is reserved for append-only manual corrections. Legacy approval
+// ceremonies are descriptive evidence only and are rejected by receipt
+// validation, so this method cannot mutate a balance until the Kernel wires
+// source-owned, single-use approval-grant consumption.
 func (l *BalanceLedger) Adjust(receiptID string, direction economic.SettlementDirection, amountCents int64, idempotencyKey, reason string, approval *contracts.ApprovalCeremony, evidencePackRef string) (*MovementResult, error) {
 	if direction != economic.SettlementDebit && direction != economic.SettlementCredit {
 		return nil, errors.New("inferencegateway: correction direction must be DEBIT or CREDIT")

--- a/core/pkg/inferencegateway/lifecycle_test.go
+++ b/core/pkg/inferencegateway/lifecycle_test.go
@@ -1,6 +1,7 @@
 package inferencegateway
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -116,9 +117,9 @@ func TestLifecycle_NoNegativeBalance(t *testing.T) {
 	l := newLedger(t, 1_000)
 	appr := approvedCeremony(t, "ops:alice", "finance:bob")
 
-	// A debit correction larger than the balance must be refused fail-closed.
-	if _, err := l.Adjust("corr-neg", economic.SettlementDebit, 5_000, "k-corr-neg", "overcharge clawback", appr, "evidence://corr"); err == nil {
-		t.Fatalf("expected debit correction beyond balance to be refused")
+	// Legacy ceremonies are refused before any balance rule is evaluated.
+	if _, err := l.Adjust("corr-neg", economic.SettlementDebit, 5_000, "k-corr-neg", "overcharge clawback", appr, "evidence://corr"); !errors.Is(err, economic.ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("legacy correction error = %v, want %v", err, economic.ErrLegacyApprovalCeremonyUnsupported)
 	}
 	if l.BalanceCents() != 1_000 {
 		t.Fatalf("balance changed on refused correction: %d", l.BalanceCents())
@@ -129,32 +130,32 @@ func TestLifecycle_NoNegativeBalance(t *testing.T) {
 		t.Fatalf("expected reservation beyond available funds to be refused")
 	}
 
-	// Enable enterprise invoicing: now a debit correction may go negative.
+	// Enterprise invoicing must not bypass the approval-authority boundary.
 	l.EnableEnterpriseInvoicing()
 	appr2 := approvedCeremony(t, "ops:alice", "finance:bob")
-	res, err := l.Adjust("corr-inv", economic.SettlementDebit, 5_000, "k-corr-inv", "deferred invoice charge", appr2, "evidence://corr2")
-	if err != nil {
-		t.Fatalf("invoicing correction: %v", err)
+	if _, err := l.Adjust("corr-inv", economic.SettlementDebit, 5_000, "k-corr-inv", "deferred invoice charge", appr2, "evidence://corr2"); !errors.Is(err, economic.ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("invoicing legacy correction error = %v, want %v", err, economic.ErrLegacyApprovalCeremonyUnsupported)
 	}
-	if res.BalanceAfterCents != -4_000 {
-		t.Fatalf("invoicing balance = %d, want -4000", res.BalanceAfterCents)
+	if l.BalanceCents() != 1_000 {
+		t.Fatalf("invoicing legacy correction changed balance: %d", l.BalanceCents())
 	}
 }
 
-// TestLifecycle_CorrectionRequiresApproval proves a manual correction is rejected
-// without a valid dual-control approval ceremony and accepted with one.
-func TestLifecycle_CorrectionRequiresApproval(t *testing.T) {
+// TestLifecycle_CorrectionRejectsLegacyApproval proves caller-constructed
+// ceremonies cannot authorize a balance mutation.
+func TestLifecycle_CorrectionRejectsLegacyApproval(t *testing.T) {
 	l := newLedger(t, 10_000)
+	entriesBefore := len(l.Entries())
 
 	// No ceremony.
 	if _, err := l.Adjust("corr-a", economic.SettlementCredit, 500, "k-a", "goodwill", nil, "evidence://a"); err == nil {
 		t.Fatalf("expected correction without ceremony to be refused")
 	}
 
-	// Single-party "approval" (approver == requester) violates dual control.
+	// Single-party legacy approval is non-authoritative.
 	self := approvedCeremony(t, "ops:alice", "ops:alice")
-	if _, err := l.Adjust("corr-b", economic.SettlementCredit, 500, "k-b", "goodwill", self, "evidence://b"); err == nil {
-		t.Fatalf("expected self-approved correction to be refused (dual control)")
+	if _, err := l.Adjust("corr-b", economic.SettlementCredit, 500, "k-b", "goodwill", self, "evidence://b"); !errors.Is(err, economic.ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("self-approved legacy correction error = %v, want %v", err, economic.ErrLegacyApprovalCeremonyUnsupported)
 	}
 
 	// Pending (not approved) ceremony is refused.
@@ -164,21 +165,20 @@ func TestLifecycle_CorrectionRequiresApproval(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reseal pending: %v", err)
 	}
-	if _, err := l.Adjust("corr-c", economic.SettlementCredit, 500, "k-c", "goodwill", &resealed, "evidence://c"); err == nil {
-		t.Fatalf("expected pending-ceremony correction to be refused")
+	if _, err := l.Adjust("corr-c", economic.SettlementCredit, 500, "k-c", "goodwill", &resealed, "evidence://c"); !errors.Is(err, economic.ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("pending legacy correction error = %v, want %v", err, economic.ErrLegacyApprovalCeremonyUnsupported)
 	}
 
-	// Valid dual-control approved correction posts an append-only ADJUSTMENT.
+	// A sealed dual-control ceremony is still not a source-owned single-use grant.
 	ok := approvedCeremony(t, "ops:alice", "finance:bob")
-	res, err := l.Adjust("corr-d", economic.SettlementCredit, 500, "k-d", "goodwill credit", ok, "evidence://d")
-	if err != nil {
-		t.Fatalf("valid correction: %v", err)
+	if _, err := l.Adjust("corr-d", economic.SettlementCredit, 500, "k-d", "goodwill credit", ok, "evidence://d"); !errors.Is(err, economic.ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("dual-control legacy correction error = %v, want %v", err, economic.ErrLegacyApprovalCeremonyUnsupported)
 	}
-	if res.Entry.Type != economic.UsageLedgerAdjustment {
-		t.Fatalf("correction entry type = %s, want ADJUSTMENT", res.Entry.Type)
+	if l.BalanceCents() != 10_000 {
+		t.Fatalf("legacy corrections changed balance: %d", l.BalanceCents())
 	}
-	if res.BalanceAfterCents != 10_500 {
-		t.Fatalf("balance after credit correction = %d, want 10500", res.BalanceAfterCents)
+	if got := len(l.Entries()); got != entriesBefore {
+		t.Fatalf("legacy corrections appended entries: %d != %d", got, entriesBefore)
 	}
 }
 

--- a/core/pkg/inferencegateway/reconciliation_test.go
+++ b/core/pkg/inferencegateway/reconciliation_test.go
@@ -1,6 +1,7 @@
 package inferencegateway
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -176,10 +177,9 @@ func TestFinanceExport_IncludesTaxBasisAndInvoiceAccrual(t *testing.T) {
 	}
 }
 
-// TestReconciliationResolution_RequiresApprovedCorrection proves an AMOUNT_MISMATCH
-// is resolved only through an approved, dual-control correction that posts an
-// append-only ADJUSTMENT entry — never by editing history.
-func TestReconciliationResolution_RequiresApprovedCorrection(t *testing.T) {
+// TestReconciliationResolution_RejectsLegacyCorrection proves an
+// AMOUNT_MISMATCH cannot be resolved by a caller-constructed legacy ceremony.
+func TestReconciliationResolution_RejectsLegacyCorrection(t *testing.T) {
 	h := newHarness(t)
 	settleOne(t, h, "idem-adj", "prov-req-adj", 100)
 
@@ -203,20 +203,12 @@ func TestReconciliationResolution_RequiresApprovedCorrection(t *testing.T) {
 		t.Fatalf("expected unapproved correction to be refused")
 	}
 
-	// Approved, dual-control correction posts an append-only ADJUSTMENT entry.
+	// A sealed dual-control legacy ceremony remains non-authoritative.
 	appr := approvedCeremony(t, "alice", "bob")
-	res, err := h.ledger.Adjust("adj-ok", economic.SettlementDebit, delta, "k-adj-ok", "reconciliation true-up for inv-adj", appr, "evidence://adj-ok")
-	if err != nil {
-		t.Fatalf("approved correction: %v", err)
+	if _, err := h.ledger.Adjust("adj-ok", economic.SettlementDebit, delta, "k-adj-ok", "reconciliation true-up for inv-adj", appr, "evidence://adj-ok"); !errors.Is(err, economic.ErrLegacyApprovalCeremonyUnsupported) {
+		t.Fatalf("legacy correction error = %v, want %v", err, economic.ErrLegacyApprovalCeremonyUnsupported)
 	}
-	if res.Entry.Type != economic.UsageLedgerAdjustment {
-		t.Fatalf("correction entry type = %s, want ADJUSTMENT", res.Entry.Type)
-	}
-	if res.Entry.SourceContentHash != res.Receipt.ContentHash {
-		t.Fatalf("correction entry not bound to its receipt hash")
-	}
-	// History is append-only: the prior entries are untouched, exactly one added.
-	if got := len(h.ledger.Entries()); got != entriesBefore+1 {
-		t.Fatalf("entries after correction = %d, want %d (append-only)", got, entriesBefore+1)
+	if got := len(h.ledger.Entries()); got != entriesBefore {
+		t.Fatalf("legacy correction appended an entry: %d != %d", got, entriesBefore)
 	}
 }


### PR DESCRIPTION
## Summary\n- Reject every caller-constructed legacy ApprovalCeremony as authority for balance corrections.\n- Keep BalanceLedger.Adjust fail closed before balance mutation or ledger append, including enterprise-invoicing mode.\n- Preserve the legacy field only for decoding and evidence binding while the Kernel-owned single-use grant path is built.\n\n## Validation\n- Go 1.25.12: go test ./pkg/contracts/economic ./pkg/inferencegateway -count=1\n- Go 1.25.12: go test -race ./pkg/contracts/economic ./pkg/inferencegateway -count=1\n- Go 1.25.12: go vet ./pkg/contracts/economic ./pkg/inferencegateway\n- git diff --check\n\n## Stack\n- Base: #549, which contains the fail-closed registry, route, CLI, MCP, and SDK containment.\n- This is a narrow economic-consumer containment slice.\n- Linear: HELM-142\n\n## Boundary\nThis PR does not create executable approval authority. Corrections remain unavailable until the Kernel owns durable challenge, quorum, signed grant issuance, atomic single-use consumption, and receipt/EvidencePack closure.\n\n## Merge authority\nDraft only. Do not merge independently of #549 or without the repository source-owned exact-head gates and machine interlock.