### PR TITLE
fix(setup): fail closed on ambiguous Codex ownership

### DIFF
--- a/core/cmd/helm-ai-kernel/codex_project_dir.go
+++ b/core/cmd/helm-ai-kernel/codex_project_dir.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+)
+
+var errCodexProjectDirNotFound = errors.New("Codex project config directory does not exist")
+
+// codexProjectDir keeps all project-scoped Codex configuration operations
+// rooted in the opened .codex directory. os.Root keeps the directory binding
+// stable across renames and refuses symlink traversal outside that root.
+type codexProjectDir struct {
+	root *os.Root
+}
+
+func openCodexProjectDir(workspace string, create bool) (*codexProjectDir, error) {
+	workspaceRoot, err := os.OpenRoot(workspace)
+	if err != nil {
+		return nil, fmt.Errorf("open project workspace %q: %w", workspace, err)
+	}
+	defer func() { _ = workspaceRoot.Close() }()
+
+	for {
+		info, err := workspaceRoot.Lstat(".codex")
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			if !create {
+				return nil, errCodexProjectDirNotFound
+			}
+			if err := workspaceRoot.Mkdir(".codex", 0o700); err != nil && !errors.Is(err, fs.ErrExist) {
+				return nil, fmt.Errorf("create project .codex directory: %w", err)
+			}
+			continue
+		case err != nil:
+			return nil, fmt.Errorf("inspect project .codex directory: %w", err)
+		case info.Mode()&os.ModeSymlink != 0:
+			return nil, fmt.Errorf("refuse symlinked project .codex directory")
+		case !info.IsDir():
+			return nil, fmt.Errorf("project .codex path is not a directory")
+		}
+
+		root, err := workspaceRoot.OpenRoot(".codex")
+		if err != nil {
+			return nil, fmt.Errorf("open project .codex directory: %w", err)
+		}
+		return &codexProjectDir{root: root}, nil
+	}
+}
+
+func (d *codexProjectDir) Close() error {
+	if d == nil || d.root == nil {
+		return nil
+	}
+	return d.root.Close()
+}
+
+func (d *codexProjectDir) readRegularFile(name string) ([]byte, error) {
+	if err := validateCodexProjectFileName(name); err != nil {
+		return nil, err
+	}
+	info, err := d.root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refuse symlinked project .codex/%s", name)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("project .codex/%s is not a regular file", name)
+	}
+	return d.root.ReadFile(name)
+}
+
+func (d *codexProjectDir) writePrivateFileAtomic(name string, data []byte) error {
+	if err := validateCodexProjectFileName(name); err != nil {
+		return err
+	}
+	if info, err := d.root.Lstat(name); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refuse symlinked project .codex/%s", name)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("project .codex/%s is not a regular file", name)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+
+	file, tempName, err := d.createPrivateTemp()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = d.root.Remove(tempName) }()
+	if n, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return err
+	} else if n != len(data) {
+		_ = file.Close()
+		return io.ErrShortWrite
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	return d.root.Rename(tempName, name)
+}
+
+func (d *codexProjectDir) createPrivateTemp() (*os.File, string, error) {
+	for range 100 {
+		var suffix [12]byte
+		if _, err := rand.Read(suffix[:]); err != nil {
+			return nil, "", fmt.Errorf("generate project config temp name: %w", err)
+		}
+		name := fmt.Sprintf(".helm-tmp-%x", suffix[:])
+		file, err := d.root.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			return file, name, nil
+		}
+		if !errors.Is(err, fs.ErrExist) {
+			return nil, "", err
+		}
+	}
+	return nil, "", fmt.Errorf("create project config temp file: exhausted unique names")
+}
+
+func validateCodexProjectFileName(name string) error {
+	switch name {
+	case "config.toml", "hooks.json":
+		return nil
+	default:
+		return fmt.Errorf("unsupported project .codex file %q", name)
+	}
+}
+
+var _ io.Closer = (*codexProjectDir)(nil)

--- a/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
+++ b/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
@@ -1,0 +1,416 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestCodexProjectSetupRejectsEmptyAndRootWorkspace(t *testing.T) {
+	tmp := t.TempDir()
+	dataDir := filepath.Join(tmp, "data")
+	for _, args := range [][]string{
+		{"setup", "codex", "--scope", "project", "--workspace=", "--dry-run", "--json", "--data-dir", dataDir},
+		{"setup", "codex", "--scope", "project", "--workspace", string(filepath.Separator), "--dry-run", "--json", "--data-dir", dataDir},
+	} {
+		var stdout, stderr bytes.Buffer
+		code := Run(append([]string{"helm-ai-kernel"}, args...), &stdout, &stderr)
+		if code != 2 {
+			t.Fatalf("%q exit=%d stderr=%s", strings.Join(args, " "), code, stderr.String())
+		}
+	}
+	if _, err := os.Stat(dataDir); !os.IsNotExist(err) {
+		t.Fatalf("invalid workspace created data dir: %v", err)
+	}
+}
+
+func TestClaudeProjectScopeKeepsCallerWorkingDirectory(t *testing.T) {
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	dataDir := filepath.Join(workspace, "data")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"helm-ai-kernel", "setup", "claude-code", "--scope", "project", "--dry-run", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("Claude project dry-run exit=%d stderr=%s", code, stderr.String())
+	}
+	var summary setupSummary
+	if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.ClientConfigPath != ".mcp.json" || summary.HookConfigPath != filepath.Join(".claude", "settings.json") {
+		t.Fatalf("Claude project paths = %#v", summary)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "setup", "claude-code", "--scope", "project", "--workspace", workspace, "--dry-run", "--data-dir", dataDir}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "only for Codex") {
+		t.Fatalf("Claude project workspace override exit=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestCodexProjectSetupRejectsSymlinkedConfigPathsWithoutExternalMutation(t *testing.T) {
+	for _, test := range []struct {
+		name  string
+		setup func(t *testing.T, workspace, external string) (map[string][]byte, map[string]string)
+	}{
+		{
+			name: "dot-codex-directory",
+			setup: func(t *testing.T, workspace, external string) (map[string][]byte, map[string]string) {
+				t.Helper()
+				config := []byte("model = \"external\"\n")
+				hooks := []byte("{\"hooks\":{\"PreToolUse\":[]}}\n")
+				mustWriteSetupFile(t, filepath.Join(external, "config.toml"), config)
+				mustWriteSetupFile(t, filepath.Join(external, "hooks.json"), hooks)
+				if err := os.Symlink(external, filepath.Join(workspace, ".codex")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				return map[string][]byte{
+					filepath.Join(external, "config.toml"): config,
+					filepath.Join(external, "hooks.json"):  hooks,
+				}, nil
+			},
+		},
+		{
+			name: "config-file",
+			setup: func(t *testing.T, workspace, external string) (map[string][]byte, map[string]string) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(workspace, ".codex"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+				config := []byte("model = \"external\"\n")
+				target := filepath.Join(external, "config.toml")
+				mustWriteSetupFile(t, target, config)
+				if err := os.Symlink(target, filepath.Join(workspace, ".codex", "config.toml")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				return map[string][]byte{target: config}, map[string]string{filepath.Join(workspace, ".codex", "hooks.json"): ""}
+			},
+		},
+		{
+			name: "hooks-file-preflight",
+			setup: func(t *testing.T, workspace, external string) (map[string][]byte, map[string]string) {
+				t.Helper()
+				configPath := filepath.Join(workspace, ".codex", "config.toml")
+				config := []byte("model = \"inside\"\n")
+				mustWriteSetupFile(t, configPath, config)
+				hooks := []byte("{\"hooks\":{\"PreToolUse\":[]}}\n")
+				target := filepath.Join(external, "hooks.json")
+				mustWriteSetupFile(t, target, hooks)
+				if err := os.Symlink(target, filepath.Join(workspace, ".codex", "hooks.json")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				return map[string][]byte{configPath: config, target: hooks}, nil
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			workspace := filepath.Join(t.TempDir(), "workspace")
+			external := filepath.Join(t.TempDir(), "external")
+			if err := os.MkdirAll(workspace, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(external, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			expected, absent := test.setup(t, workspace, external)
+			code, _, _, stderr := runCodexProjectSetupCommand(t, []string{
+				"setup", "codex", "--scope", "project", "--workspace", workspace,
+				"--data-dir", filepath.Join(t.TempDir(), "data"), "--no-quickstart", "--yes",
+			})
+			if code != 1 || !strings.Contains(stderr, "symlinked project .codex") {
+				t.Fatalf("symlinked project setup exit=%d stderr=%s", code, stderr)
+			}
+			for path, want := range expected {
+				got, err := os.ReadFile(path)
+				if err != nil {
+					t.Fatalf("read %s: %v", path, err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatalf("external or preflight file changed at %s:\n%s", path, got)
+				}
+			}
+			for path := range absent {
+				if _, err := os.Lstat(path); !os.IsNotExist(err) {
+					t.Fatalf("unexpected file at %s: %v", path, err)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexProjectSetupPreflightsIncompatibleHooksWithoutPartialMutation(t *testing.T) {
+	for _, hooks := range []string{
+		`{"hooks":"wrong-type"}` + "\n",
+		`{"hooks":{"PreToolUse":{}}}` + "\n",
+	} {
+		t.Run(hooks, func(t *testing.T) {
+			workspace := filepath.Join(t.TempDir(), "workspace")
+			configPath := filepath.Join(workspace, ".codex", "config.toml")
+			hooksPath := filepath.Join(workspace, ".codex", "hooks.json")
+			config := []byte("model = \"preserve\"\n")
+			mustWriteSetupFile(t, configPath, config)
+			mustWriteSetupFile(t, hooksPath, []byte(hooks))
+			dataDir := filepath.Join(t.TempDir(), "data")
+
+			for _, args := range [][]string{
+				{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"},
+				{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"},
+			} {
+				code, _, _, stderr := runCodexProjectSetupCommand(t, args)
+				if code != 1 || !strings.Contains(stderr, "Codex hooks") {
+					t.Fatalf("%q exit=%d stderr=%s", strings.Join(args, " "), code, stderr)
+				}
+				assertSetupFileBytes(t, configPath, config)
+				assertSetupFileBytes(t, hooksPath, []byte(hooks))
+			}
+		})
+	}
+}
+
+func TestCodexProjectSetupReplacesQuotedNestedOwnedTOMLTables(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	hooksPath := filepath.Join(workspace, ".codex", "hooks.json")
+	config := "model = \"gpt-5\"\n\n" +
+		"[mcp_servers.\"helm-ai-kernel-governance\"] # old owned table\n" +
+		"command = \"/old/helm-ai-kernel\"\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n\n" +
+		"[mcp_servers.\"helm-ai-kernel-governance\".env] # old owned nested table\n" +
+		"LEGACY = \"remove-me\"\n\n" +
+		"[mcp_servers.other]\ncommand = \"other\"\nargs = [\"serve\"]\n"
+	mustWriteSetupFile(t, configPath, []byte(config))
+	mustWriteSetupFile(t, hooksPath, []byte(`{"hooks":{"PreToolUse":[]}}`+"\n"))
+	apply := []string{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 0 {
+		t.Fatalf("quoted-table apply exit=%d stderr=%s", code, stderr)
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "LEGACY") || strings.Count(string(raw), setupMCPServerName) != 1 || !strings.Contains(string(raw), "[mcp_servers.other]") {
+		t.Fatalf("owned TOML replacement was not scoped correctly:\n%s", raw)
+	}
+	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 0 {
+		t.Fatalf("quoted-table remove exit=%d stderr=%s", code, stderr)
+	}
+	raw, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), setupMCPServerName) || !strings.Contains(string(raw), "[mcp_servers.other]") {
+		t.Fatalf("owned TOML removal was not scoped correctly:\n%s", raw)
+	}
+}
+
+func TestCodexProjectStatusBindsExactBinaryAndReportsFalseJSONFields(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	bin, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin, err = filepath.Abs(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := setupOptions{Target: "codex", Scope: "project", Workspace: workspace, DataDir: dataDir}
+	config := "[mcp_servers." + setupMCPServerName + "]\ncommand = \"/not/the/current/binary\"\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n"
+	mustWriteSetupFile(t, filepath.Join(workspace, ".codex", "config.toml"), []byte(config))
+	hooks := map[string]any{"hooks": map[string]any{"PreToolUse": []any{map[string]any{
+		"matcher": setupHookMatcher("codex"),
+		"hooks": []any{map[string]any{
+			"type":          "command",
+			"command":       setupHookCommand(opts, bin),
+			"timeout":       float64(30),
+			"statusMessage": "Checking HELM policy",
+		}},
+	}}}}
+	rawHooks, err := json.Marshal(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteSetupFile(t, filepath.Join(workspace, ".codex", "hooks.json"), append(rawHooks, '\n'))
+
+	code, summary, raw, stderr := runCodexProjectSetupCommand(t, []string{
+		"setup", "status", "codex", "--scope", "project", "--workspace", workspace,
+		"--data-dir", dataDir, "--no-quickstart", "--json",
+	})
+	if code != 1 || stderr != "" || summary.MCPInstalled || !summary.HookInstalled {
+		t.Fatalf("exact-binding status exit=%d summary=%#v stderr=%s", code, summary, stderr)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for field, want := range map[string]bool{"mcp_installed": false, "hook_installed": true} {
+		value, ok := fields[field]
+		if !ok {
+			t.Fatalf("status JSON omitted %s: %s", field, raw)
+		}
+		var got bool
+		if err := json.Unmarshal(value, &got); err != nil || got != want {
+			t.Fatalf("status JSON %s=%s, want %t err=%v", field, value, want, err)
+		}
+	}
+}
+
+func TestCodexProjectEmptyStatusAndRemovePreviewReportExplicitFalseState(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	dataDir := filepath.Join(t.TempDir(), "data")
+	for _, test := range []struct {
+		args       []string
+		code       int
+		operation  string
+		wantAction string
+	}{
+		{
+			args:       []string{"setup", "status", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--json"},
+			code:       1,
+			operation:  "status",
+			wantAction: "inspect the existing local integration without writing files",
+		},
+		{
+			args:       []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--dry-run", "--json"},
+			code:       0,
+			operation:  "preview_remove",
+			wantAction: "remove the HELM MCP server and PreToolUse hook from the selected scope",
+		},
+	} {
+		code, summary, raw, stderr := runCodexProjectSetupCommand(t, test.args)
+		if code != test.code || stderr != "" || summary.Operation != test.operation || summary.MCPInstalled || summary.HookInstalled || !equalSetupStrings(summary.PlannedActions, []string{test.wantAction}) {
+			t.Fatalf("%q exit=%d summary=%#v stderr=%s", strings.Join(test.args, " "), code, summary, stderr)
+		}
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			t.Fatal(err)
+		}
+		for _, field := range []string{"mcp_installed", "hook_installed"} {
+			value, ok := fields[field]
+			if !ok || string(value) != "false" {
+				t.Fatalf("%s summary omitted explicit false %s: %s", test.operation, field, raw)
+			}
+		}
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".codex")); !os.IsNotExist(err) {
+		t.Fatalf("read-only status/remove preview created .codex: %v", err)
+	}
+}
+
+func TestCodexProjectSetupPreservesNonHELMNamedMCPServer(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	config := []byte("[mcp_servers." + setupMCPServerName + "]\ncommand = \"/usr/local/bin/helm-ai-kernel-malware\"\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n")
+	mustWriteSetupFile(t, configPath, config)
+	mustWriteSetupFile(t, filepath.Join(workspace, ".codex", "hooks.json"), []byte(`{"hooks":{"PreToolUse":[]}}`+"\n"))
+	apply := []string{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 1 || !strings.Contains(stderr, "refuse to replace non-HELM") {
+		t.Fatalf("unowned named MCP apply exit=%d stderr=%s", code, stderr)
+	}
+	assertSetupFileBytes(t, configPath, config)
+	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 0 || stderr != "" {
+		t.Fatalf("unowned named MCP remove exit=%d stderr=%s", code, stderr)
+	}
+	assertSetupFileBytes(t, configPath, config)
+}
+
+func TestCodexProjectSetupMigratesOwnedHookOnBinaryRelocation(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	bin, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin, err = filepath.Abs(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := setupOptions{Target: "codex", Scope: "project", Workspace: workspace, DataDir: dataDir}
+	oldCommand := setupHookCommand(opts, "/Applications/HELM-old.app/Contents/MacOS/helm-ai-kernel")
+	lookalike := shellQuote("/usr/local/bin/custom-policy") + " hook pre-tool --client codex --data-dir " + shellQuote(dataDir)
+	hooks := map[string]any{"hooks": map[string]any{"PreToolUse": []any{map[string]any{
+		"matcher": "^Read$", // a shared user entry; migration must not widen it.
+		"hooks": []any{
+			map[string]any{"type": "command", "command": oldCommand, "timeout": float64(30), "statusMessage": "Checking HELM policy"},
+			map[string]any{"type": "command", "command": lookalike, "timeout": float64(30), "statusMessage": "A different product"},
+		},
+	}}}}
+	rawHooks, err := json.Marshal(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWriteSetupFile(t, filepath.Join(workspace, ".codex", "hooks.json"), append(rawHooks, '\n'))
+	apply := []string{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 0 {
+		t.Fatalf("relocation apply exit=%d stderr=%s", code, stderr)
+	}
+	updated, err := os.ReadFile(filepath.Join(workspace, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentCommand := setupHookCommand(opts, bin)
+	if strings.Contains(string(updated), oldCommand) || strings.Count(string(updated), currentCommand) != 1 || !strings.Contains(string(updated), lookalike) {
+		t.Fatalf("hook relocation did not migrate exactly the marked HELM hook:\n%s", updated)
+	}
+	status := []string{"setup", "status", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--json"}
+	if code, summary, _, stderr := runCodexProjectSetupCommand(t, status); code != 0 || !summary.HookInstalled || !summary.MCPInstalled || stderr != "" {
+		t.Fatalf("relocation status exit=%d summary=%#v stderr=%s", code, summary, stderr)
+	}
+	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 0 {
+		t.Fatalf("relocation remove exit=%d stderr=%s", code, stderr)
+	}
+	updated, err = os.ReadFile(filepath.Join(workspace, ".codex", "hooks.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(updated), currentCommand) || !strings.Contains(string(updated), lookalike) {
+		t.Fatalf("remove did not preserve unmarked lookalike:\n%s", updated)
+	}
+}
+
+func runCodexProjectSetupCommand(t *testing.T, args []string) (int, setupSummary, []byte, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run(append([]string{"helm-ai-kernel"}, args...), &stdout, &stderr)
+	var summary setupSummary
+	if strings.Contains(strings.Join(args, " "), " --json") || containsSetupString(args, "--json") {
+		if err := json.Unmarshal(stdout.Bytes(), &summary); err != nil {
+			t.Fatalf("decode setup JSON for %q: %v\n%s", strings.Join(args, " "), err, stdout.String())
+		}
+	}
+	return code, summary, stdout.Bytes(), stderr.String()
+}
+
+func mustWriteSetupFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertSetupFileBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("%s changed:\n%s", path, got)
+	}
+}

--- a/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
+++ b/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
@@ -344,7 +344,7 @@ func TestCodexProjectSetupMigratesOwnedHookOnBinaryRelocation(t *testing.T) {
 		"matcher": "^Read$", // a shared user entry; migration must not widen it.
 		"hooks": []any{
 			map[string]any{"type": "command", "command": oldCommand, "timeout": float64(30), "statusMessage": "Checking HELM policy"},
-			map[string]any{"type": "command", "command": lookalike, "timeout": float64(30), "statusMessage": "A different product"},
+			map[string]any{"type": "command", "command": lookalike, "timeout": float64(30), "statusMessage": "Checking HELM policy"},
 		},
 	}}}}
 	rawHooks, err := json.Marshal(hooks)

--- a/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
+++ b/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
@@ -382,6 +382,48 @@ func TestCodexProjectSetupRefusesExactBasenameForeignHookWithoutMutation(t *test
 	}
 }
 
+func TestCodexProjectSetupRejectsMixedForeignAndCurrentHooksWithoutMutation(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	foreignBin := filepath.Join(t.TempDir(), "helm-ai-kernel")
+	if err := os.WriteFile(foreignBin, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin, err = filepath.Abs(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := setupOptions{Target: "codex", Scope: "project", Workspace: workspace, DataDir: dataDir}
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	hooksPath := filepath.Join(workspace, ".codex", "hooks.json")
+	config := []byte("[mcp_servers." + setupMCPServerName + "]\ncommand = " + strconv.Quote(bin) + "\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n")
+	hooks := map[string]any{"hooks": map[string]any{"PreToolUse": []any{map[string]any{
+		"matcher": setupHookMatcher("codex"),
+		"hooks": []any{
+			map[string]any{"type": "command", "command": setupHookCommand(opts, foreignBin), "timeout": float64(30)},
+			map[string]any{"type": "command", "command": setupHookCommand(opts, bin), "timeout": float64(30)},
+		},
+	}}}}
+	rawHooks, err := json.Marshal(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreignAndCurrentHooks := append(rawHooks, '\n')
+	mustWriteSetupFile(t, configPath, config)
+	mustWriteSetupFile(t, hooksPath, foreignAndCurrentHooks)
+
+	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 1 || !strings.Contains(stderr, "manual remediation") {
+		t.Fatalf("mixed hooks remove exit=%d stderr=%s", code, stderr)
+	}
+	assertSetupFileBytes(t, configPath, config)
+	assertSetupFileBytes(t, hooksPath, foreignAndCurrentHooks)
+}
+
 func TestCodexProjectSetupPreservesExactBasenameForeignMCPServer(t *testing.T) {
 	workspace := filepath.Join(t.TempDir(), "workspace")
 	dataDir := filepath.Join(t.TempDir(), "data")
@@ -413,6 +455,49 @@ func TestCodexProjectSetupPreservesExactBasenameForeignMCPServer(t *testing.T) {
 	}
 	assertSetupFileBytes(t, configPath, config)
 	assertSetupFileBytes(t, hooksPath, hooks)
+}
+
+func TestCodexProjectSetupRejectsForeignMCPAlongsideCurrentHookWithoutMutation(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	foreignBin := filepath.Join(t.TempDir(), "helm-ai-kernel")
+	if err := os.WriteFile(foreignBin, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin, err = filepath.Abs(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := setupOptions{Target: "codex", Scope: "project", Workspace: workspace, DataDir: dataDir}
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	hooksPath := filepath.Join(workspace, ".codex", "hooks.json")
+	config := []byte("[mcp_servers." + setupMCPServerName + "]\ncommand = " + strconv.Quote(foreignBin) + "\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n")
+	hooks := map[string]any{"hooks": map[string]any{"PreToolUse": []any{map[string]any{
+		"matcher": setupHookMatcher("codex"),
+		"hooks": []any{map[string]any{
+			"type":    "command",
+			"command": setupHookCommand(opts, bin),
+			"timeout": float64(30),
+		}},
+	}}}}
+	rawHooks, err := json.Marshal(hooks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentHooks := append(rawHooks, '\n')
+	mustWriteSetupFile(t, configPath, config)
+	mustWriteSetupFile(t, hooksPath, currentHooks)
+
+	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 1 || !strings.Contains(stderr, "manual remediation") {
+		t.Fatalf("foreign MCP + current hook remove exit=%d stderr=%s", code, stderr)
+	}
+	assertSetupFileBytes(t, configPath, config)
+	assertSetupFileBytes(t, hooksPath, currentHooks)
 }
 
 func TestCodexProjectSetupCurrentBinaryApplyStatusRemove(t *testing.T) {

--- a/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
+++ b/core/cmd/helm-ai-kernel/codex_project_setup_security_test.go
@@ -176,11 +176,19 @@ func TestCodexProjectSetupPreflightsIncompatibleHooksWithoutPartialMutation(t *t
 func TestCodexProjectSetupReplacesQuotedNestedOwnedTOMLTables(t *testing.T) {
 	workspace := filepath.Join(t.TempDir(), "workspace")
 	dataDir := filepath.Join(t.TempDir(), "data")
+	bin, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin, err = filepath.Abs(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
 	configPath := filepath.Join(workspace, ".codex", "config.toml")
 	hooksPath := filepath.Join(workspace, ".codex", "hooks.json")
 	config := "model = \"gpt-5\"\n\n" +
 		"[mcp_servers.\"helm-ai-kernel-governance\"] # old owned table\n" +
-		"command = \"/old/helm-ai-kernel\"\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n\n" +
+		"command = " + strconv.Quote(bin) + "\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n\n" +
 		"[mcp_servers.\"helm-ai-kernel-governance\".env] # old owned nested table\n" +
 		"LEGACY = \"remove-me\"\n\n" +
 		"[mcp_servers.other]\ncommand = \"other\"\nargs = [\"serve\"]\n"
@@ -315,7 +323,7 @@ func TestCodexProjectSetupPreservesNonHELMNamedMCPServer(t *testing.T) {
 	mustWriteSetupFile(t, configPath, config)
 	mustWriteSetupFile(t, filepath.Join(workspace, ".codex", "hooks.json"), []byte(`{"hooks":{"PreToolUse":[]}}`+"\n"))
 	apply := []string{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
-	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 1 || !strings.Contains(stderr, "refuse to replace non-HELM") {
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 1 || !strings.Contains(stderr, "manual remediation") {
 		t.Fatalf("unowned named MCP apply exit=%d stderr=%s", code, stderr)
 	}
 	assertSetupFileBytes(t, configPath, config)
@@ -326,58 +334,107 @@ func TestCodexProjectSetupPreservesNonHELMNamedMCPServer(t *testing.T) {
 	assertSetupFileBytes(t, configPath, config)
 }
 
-func TestCodexProjectSetupMigratesOwnedHookOnBinaryRelocation(t *testing.T) {
+func TestCodexProjectSetupRefusesExactBasenameForeignHookWithoutMutation(t *testing.T) {
 	workspace := filepath.Join(t.TempDir(), "workspace")
 	dataDir := filepath.Join(t.TempDir(), "data")
-	bin, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-	bin, err = filepath.Abs(bin)
-	if err != nil {
+	foreignBin := filepath.Join(t.TempDir(), "helm-ai-kernel")
+	if err := os.WriteFile(foreignBin, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	opts := setupOptions{Target: "codex", Scope: "project", Workspace: workspace, DataDir: dataDir}
-	oldCommand := setupHookCommand(opts, "/Applications/HELM-old.app/Contents/MacOS/helm-ai-kernel")
-	lookalike := shellQuote("/usr/local/bin/custom-policy") + " hook pre-tool --client codex --data-dir " + shellQuote(dataDir)
 	hooks := map[string]any{"hooks": map[string]any{"PreToolUse": []any{map[string]any{
-		"matcher": "^Read$", // a shared user entry; migration must not widen it.
-		"hooks": []any{
-			map[string]any{"type": "command", "command": oldCommand, "timeout": float64(30), "statusMessage": "Checking HELM policy"},
-			map[string]any{"type": "command", "command": lookalike, "timeout": float64(30), "statusMessage": "Checking HELM policy"},
-		},
+		"matcher": setupHookMatcher("codex"),
+		"hooks": []any{map[string]any{
+			"type":    "command",
+			"command": setupHookCommand(opts, foreignBin),
+			"timeout": float64(30),
+		}},
 	}}}}
 	rawHooks, err := json.Marshal(hooks)
 	if err != nil {
 		t.Fatal(err)
 	}
-	mustWriteSetupFile(t, filepath.Join(workspace, ".codex", "hooks.json"), append(rawHooks, '\n'))
+	hooksPath := filepath.Join(workspace, ".codex", "hooks.json")
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	foreignHooks := append(rawHooks, '\n')
+	mustWriteSetupFile(t, hooksPath, foreignHooks)
+
 	apply := []string{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
-	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 0 {
-		t.Fatalf("relocation apply exit=%d stderr=%s", code, stderr)
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 1 || !strings.Contains(stderr, "manual remediation") {
+		t.Fatalf("foreign hook apply exit=%d stderr=%s", code, stderr)
 	}
-	updated, err := os.ReadFile(filepath.Join(workspace, ".codex", "hooks.json"))
-	if err != nil {
+	assertSetupFileBytes(t, hooksPath, foreignHooks)
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("foreign hook apply wrote MCP config: %v", err)
+	}
+
+	status := []string{"setup", "status", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--json"}
+	if code, summary, _, stderr := runCodexProjectSetupCommand(t, status); code != 1 || summary.HookInstalled || summary.MCPInstalled || stderr != "" {
+		t.Fatalf("foreign hook status exit=%d summary=%#v stderr=%s", code, summary, stderr)
+	}
+	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 0 || stderr != "" {
+		t.Fatalf("foreign hook remove exit=%d stderr=%s", code, stderr)
+	}
+	assertSetupFileBytes(t, hooksPath, foreignHooks)
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("foreign hook remove wrote MCP config: %v", err)
+	}
+}
+
+func TestCodexProjectSetupPreservesExactBasenameForeignMCPServer(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	foreignBin := filepath.Join(t.TempDir(), "helm-ai-kernel")
+	if err := os.WriteFile(foreignBin, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	currentCommand := setupHookCommand(opts, bin)
-	if strings.Contains(string(updated), oldCommand) || strings.Count(string(updated), currentCommand) != 1 || !strings.Contains(string(updated), lookalike) {
-		t.Fatalf("hook relocation did not migrate exactly the marked HELM hook:\n%s", updated)
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	hooksPath := filepath.Join(workspace, ".codex", "hooks.json")
+	config := []byte("[mcp_servers." + setupMCPServerName + "]\ncommand = " + strconv.Quote(foreignBin) + "\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", " + strconv.Quote(dataDir) + "]\n")
+	hooks := []byte(`{"hooks":{"PreToolUse":[]}}` + "\n")
+	mustWriteSetupFile(t, configPath, config)
+	mustWriteSetupFile(t, hooksPath, hooks)
+
+	apply := []string{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 1 || !strings.Contains(stderr, "manual remediation") {
+		t.Fatalf("foreign MCP apply exit=%d stderr=%s", code, stderr)
+	}
+	assertSetupFileBytes(t, configPath, config)
+	assertSetupFileBytes(t, hooksPath, hooks)
+
+	status := []string{"setup", "status", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--json"}
+	if code, summary, _, stderr := runCodexProjectSetupCommand(t, status); code != 1 || summary.HookInstalled || summary.MCPInstalled || stderr != "" {
+		t.Fatalf("foreign MCP status exit=%d summary=%#v stderr=%s", code, summary, stderr)
+	}
+	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 0 || stderr != "" {
+		t.Fatalf("foreign MCP remove exit=%d stderr=%s", code, stderr)
+	}
+	assertSetupFileBytes(t, configPath, config)
+	assertSetupFileBytes(t, hooksPath, hooks)
+}
+
+func TestCodexProjectSetupCurrentBinaryApplyStatusRemove(t *testing.T) {
+	workspace := filepath.Join(t.TempDir(), "workspace")
+	dataDir := filepath.Join(t.TempDir(), "data")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	apply := []string{"setup", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
+	if code, _, _, stderr := runCodexProjectSetupCommand(t, apply); code != 0 {
+		t.Fatalf("current-binary apply exit=%d stderr=%s", code, stderr)
 	}
 	status := []string{"setup", "status", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--json"}
 	if code, summary, _, stderr := runCodexProjectSetupCommand(t, status); code != 0 || !summary.HookInstalled || !summary.MCPInstalled || stderr != "" {
-		t.Fatalf("relocation status exit=%d summary=%#v stderr=%s", code, summary, stderr)
+		t.Fatalf("current-binary status exit=%d summary=%#v stderr=%s", code, summary, stderr)
 	}
 	remove := []string{"setup", "remove", "codex", "--scope", "project", "--workspace", workspace, "--data-dir", dataDir, "--no-quickstart", "--yes"}
 	if code, _, _, stderr := runCodexProjectSetupCommand(t, remove); code != 0 {
-		t.Fatalf("relocation remove exit=%d stderr=%s", code, stderr)
+		t.Fatalf("current-binary remove exit=%d stderr=%s", code, stderr)
 	}
-	updated, err = os.ReadFile(filepath.Join(workspace, ".codex", "hooks.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(updated), currentCommand) || !strings.Contains(string(updated), lookalike) {
-		t.Fatalf("remove did not preserve unmarked lookalike:\n%s", updated)
+	if code, summary, _, stderr := runCodexProjectSetupCommand(t, status); code != 1 || summary.HookInstalled || summary.MCPInstalled || stderr != "" {
+		t.Fatalf("post-remove status exit=%d summary=%#v stderr=%s", code, summary, stderr)
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/desktop_codex_bridge_contract_test.go
+++ b/core/cmd/helm-ai-kernel/desktop_codex_bridge_contract_test.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestDesktopCodexBridgeContractV1(t *testing.T) {
+	tmp := t.TempDir()
+	workspace := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	canonicalWorkspace, err := filepath.EvalSymlinks(workspace)
+	if err != nil {
+		t.Fatalf("resolve workspace: %v", err)
+	}
+	dataDir := filepath.Join(tmp, "desktop-data")
+	configPath := filepath.Join(canonicalWorkspace, ".codex", "config.toml")
+	hookPath := filepath.Join(canonicalWorkspace, ".codex", "hooks.json")
+
+	previewArgs := []string{
+		"setup", "codex", "--scope", "project", "--workspace", workspace,
+		"--data-dir", dataDir, "--no-quickstart", "--json", "--dry-run",
+	}
+	preview := runDesktopCodexSetupJSON(t, previewArgs)
+	assertDesktopCodexSetupSummary(t, preview, "preview", canonicalWorkspace, dataDir, false, false)
+	if _, err := os.Stat(dataDir); !os.IsNotExist(err) {
+		t.Fatalf("preview created data dir: %v", err)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Fatalf("preview created Codex config: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("model = \"gpt-5\"\n\n[mcp_servers.other]\ncommand = \"other-mcp\"\nargs = [\"serve\"]\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hookPath, []byte("{\"hooks\":{\"PreToolUse\":[{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\",\"command\":\"other-hook\"}]}]}}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	applyArgs := []string{
+		"setup", "codex", "--scope", "project", "--workspace", workspace,
+		"--data-dir", dataDir, "--no-quickstart", "--json", "--yes",
+	}
+	applied := runDesktopCodexSetupJSON(t, applyArgs)
+	assertDesktopCodexSetupSummary(t, applied, "install", canonicalWorkspace, dataDir, true, true)
+	if applied.KernelURL != "" || applied.QuickstartStarted {
+		t.Fatalf("headless apply advertised a Quickstart server: %#v", applied)
+	}
+	if got, want := applied.PlannedActions, []string{
+		"scan selected workspace and write draft-only inventory artifacts",
+		"configure the HELM MCP server with the selected local data directory",
+		"configure the HELM PreToolUse hook for supported Codex tools",
+	}; !equalSetupStrings(got, want) {
+		t.Fatalf("planned actions = %#v, want %#v", got, want)
+	}
+	var config codexProjectConfig
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Codex config: %v", err)
+	}
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		t.Fatalf("decode Codex config: %v\n%s", err, raw)
+	}
+	server := config.MCPServers[setupMCPServerName]
+	if got, want := server.Args, []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}; !equalSetupStrings(got, want) {
+		t.Fatalf("Codex MCP args = %#v, want %#v", got, want)
+	}
+	if !strings.Contains(string(raw), "[mcp_servers.other]") || !strings.Contains(string(raw), "model = \"gpt-5\"") {
+		t.Fatalf("apply did not preserve existing Codex config:\n%s", raw)
+	}
+
+	statusArgs := []string{
+		"setup", "status", "codex", "--scope", "project", "--workspace", workspace,
+		"--data-dir", dataDir, "--no-quickstart", "--json",
+	}
+	status := runDesktopCodexSetupJSON(t, statusArgs)
+	assertDesktopCodexSetupSummary(t, status, "status", canonicalWorkspace, dataDir, true, true)
+
+	removeArgs := []string{
+		"setup", "remove", "codex", "--scope", "project", "--workspace", workspace,
+		"--data-dir", dataDir, "--no-quickstart", "--json", "--yes",
+	}
+	removed := runDesktopCodexSetupJSON(t, removeArgs)
+	assertDesktopCodexSetupSummary(t, removed, "remove", canonicalWorkspace, dataDir, false, false)
+	raw, err = os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read Codex config after remove: %v", err)
+	}
+	if strings.Contains(string(raw), setupMCPServerName) || !strings.Contains(string(raw), "[mcp_servers.other]") {
+		t.Fatalf("remove did not preserve only the unrelated Codex config:\n%s", raw)
+	}
+	raw, err = os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("read hooks after remove: %v", err)
+	}
+	if strings.Contains(string(raw), "hook pre-tool --client codex") || !strings.Contains(string(raw), "other-hook") {
+		t.Fatalf("remove did not preserve only the unrelated Codex hook:\n%s", raw)
+	}
+}
+
+func TestDesktopCodexBridgeContractV1RequiresExplicitWorkspace(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"helm-ai-kernel", "setup", "codex", "--scope", "project", "--dry-run", "--json", "--data-dir", filepath.Join(t.TempDir(), "desktop-data"),
+	}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "requires an explicit --workspace") {
+		t.Fatalf("project setup without workspace code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestDesktopCodexBridgeContractV1DoesNotMutateWithoutYes(t *testing.T) {
+	tmp := t.TempDir()
+	workspace := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	dataDir := filepath.Join(tmp, "desktop-data")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"helm-ai-kernel", "setup", "codex", "--scope", "project", "--workspace", workspace,
+		"--data-dir", dataDir, "--no-quickstart", "--json",
+	}, &stdout, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "pass --yes") {
+		t.Fatalf("project setup without --yes code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(dataDir); !os.IsNotExist(err) {
+		t.Fatalf("setup without --yes created data dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(workspace, ".codex", "config.toml")); !os.IsNotExist(err) {
+		t.Fatalf("setup without --yes created Codex config: %v", err)
+	}
+}
+
+func TestDesktopCodexBridgeContractV1RejectsMalformedConfigWithoutOverwrite(t *testing.T) {
+	tmp := t.TempDir()
+	workspace := filepath.Join(tmp, "project")
+	configPath := filepath.Join(workspace, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	invalid := "[mcp_servers\ncommand = \"broken\"\n"
+	if err := os.WriteFile(configPath, []byte(invalid), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"helm-ai-kernel", "setup", "codex", "--scope", "project", "--workspace", workspace,
+		"--data-dir", filepath.Join(tmp, "desktop-data"), "--no-quickstart", "--yes",
+	}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "parse existing Codex config") {
+		t.Fatalf("malformed project config code=%d stderr=%s", code, stderr.String())
+	}
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read malformed config: %v", err)
+	}
+	if string(raw) != invalid {
+		t.Fatalf("malformed config was overwritten:\n%s", raw)
+	}
+}
+
+func TestDesktopCodexBridgeContractV1AcceptsServerTransportFlag(t *testing.T) {
+	valid := strings.Repeat("a", desktopTransportV1SecretLength)
+	t.Setenv(desktopTransportV1EnabledEnv, "1")
+	t.Setenv(desktopTransportV1KeyEnv, valid)
+	t.Setenv(desktopTransportV1NonceEnv, strings.Repeat("b", desktopTransportV1SecretLength))
+	t.Setenv("HELM_HEALTH_PORT", "0")
+	t.Setenv("HELM_METRICS_ENABLED", "1")
+	t.Setenv("HELM_METRICS_PORT", "")
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{
+		"helm-ai-kernel", "server", "--desktop-transport-v1", "--data-dir", filepath.Join(t.TempDir(), "desktop-data"),
+	}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "HELM_METRICS_ENABLED") {
+		t.Fatalf("server transport-v1 flag was not accepted before auxiliary-health validation: code=%d stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "flag provided but not defined") {
+		t.Fatalf("server rejected the transport-v1 flag: %s", stderr.String())
+	}
+}
+
+func TestDesktopCodexBridgeContractV1UsesDesktopMCPDataDir(t *testing.T) {
+	dataDir := filepath.Join(t.TempDir(), "desktop-data")
+	if err := serveLocalMCPStdioWithDataDir(strings.NewReader(""), io.Discard, dataDir); err != nil {
+		t.Fatalf("start MCP runtime with Desktop data dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, "root.key")); err != nil {
+		t.Fatalf("Desktop MCP data dir did not receive the signer root key: %v", err)
+	}
+}
+
+func runDesktopCodexSetupJSON(t *testing.T, args []string) setupSummary {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run(append([]string{"helm-ai-kernel"}, args...), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("%q exit=%d stderr=%s stdout=%s", strings.Join(args, " "), code, stderr.String(), stdout.String())
+	}
+	decoder := json.NewDecoder(&stdout)
+	var summary setupSummary
+	if err := decoder.Decode(&summary); err != nil {
+		t.Fatalf("decode %q JSON: %v\n%s", strings.Join(args, " "), err, stdout.String())
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		t.Fatalf("%q emitted more than one JSON value: extra=%#v err=%v stdout=%s", strings.Join(args, " "), extra, err, stdout.String())
+	}
+	return summary
+}
+
+func assertDesktopCodexSetupSummary(t *testing.T, summary setupSummary, operation, workspace, dataDir string, mcpInstalled, hookInstalled bool) {
+	t.Helper()
+	if summary.Operation != operation || summary.Target != "codex" || summary.Scope != "project" || summary.Workspace != workspace || summary.DataDir != dataDir {
+		t.Fatalf("unexpected Desktop Codex setup summary: %#v", summary)
+	}
+	if summary.ClientConfigPath != filepath.Join(workspace, ".codex", "config.toml") || summary.HookConfigPath != filepath.Join(workspace, ".codex", "hooks.json") {
+		t.Fatalf("summary did not use the selected project workspace: %#v", summary)
+	}
+	if summary.MCPInstalled != mcpInstalled || summary.HookInstalled != hookInstalled {
+		t.Fatalf("installed state mcp=%t hook=%t, want mcp=%t hook=%t", summary.MCPInstalled, summary.HookInstalled, mcpInstalled, hookInstalled)
+	}
+}

--- a/core/cmd/helm-ai-kernel/desktop_codex_bridge_contract_test.go
+++ b/core/cmd/helm-ai-kernel/desktop_codex_bridge_contract_test.go
@@ -93,7 +93,9 @@ func TestDesktopCodexBridgeContractV1(t *testing.T) {
 		"--data-dir", dataDir, "--no-quickstart", "--json", "--yes",
 	}
 	removed := runDesktopCodexSetupJSON(t, removeArgs)
-	assertDesktopCodexSetupSummary(t, removed, "remove", canonicalWorkspace, dataDir, false, false)
+	// Remove reports the safely observed pre-removal state so a Desktop client
+	// can tell which local integration it actually removed.
+	assertDesktopCodexSetupSummary(t, removed, "remove", canonicalWorkspace, dataDir, true, true)
 	raw, err = os.ReadFile(configPath)
 	if err != nil {
 		t.Fatalf("read Codex config after remove: %v", err)

--- a/core/cmd/helm-ai-kernel/lite_mode.go
+++ b/core/cmd/helm-ai-kernel/lite_mode.go
@@ -1,3 +1,5 @@
+// quantum_posture: lite mode provisions classical Ed25519 and optional ML-DSA
+// receipt keys locally; profile selection still fails closed on unknown values.
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/lite_mode.go
+++ b/core/cmd/helm-ai-kernel/lite_mode.go
@@ -6,10 +6,15 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
@@ -98,46 +103,26 @@ func loadOrGenerateSignerWithDataDir(dataDir string) (crypto.Signer, error) {
 
 func loadOrGenerateEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
 	keyPath := filepath.Join(dataDir, "root.key")
-	if _, err := os.Stat(keyPath); err == nil {
-		// Load existing key
-		keyHex, err := os.ReadFile(keyPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read root.key: %w", err)
-		}
-		seed, err := hex.DecodeString(string(keyHex))
-		if err != nil {
-			return nil, fmt.Errorf("invalid root.key format: %w", err)
-		}
-		priv := ed25519.NewKeyFromSeed(seed)
-		log.Printf("[helm] trust: loaded persistent root key")
-		return crypto.NewEd25519SignerFromKey(priv, "root"), nil
-	}
-
-	// Generate new persistent key if not in production
-	if envBool("HELM_PRODUCTION") {
-		return nil, fmt.Errorf("production mode requires root signing key to exist at %s", keyPath)
-	}
-
-	log.Printf("[helm] trust: generating new persistent root key at %s", keyPath)
-	fmt.Fprintf(os.Stderr, "\n%s⚠️  SECURITY WARNING: Using auto-generated root key.%s\n", ColorBold+ColorYellow, ColorReset)
-	fmt.Fprintf(os.Stderr, "   Key saved to: %s\n", keyPath)
-	fmt.Fprintf(os.Stderr, "   In production, use a hardware security module (HSM) or cloud KMS.\n\n")
-
-	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	seed, created, err := loadOrCreateHexSeed(keyPath, ed25519.SeedSize, !envBool("HELM_PRODUCTION"))
 	if err != nil {
-		return nil, err
+		if errors.Is(err, fs.ErrNotExist) && envBool("HELM_PRODUCTION") {
+			return nil, fmt.Errorf("production mode requires root signing key to exist at %s", keyPath)
+		}
+		return nil, fmt.Errorf("load root.key: %w", err)
 	}
-
-	seed := priv.Seed()
-	if err := os.WriteFile(keyPath, []byte(hex.EncodeToString(seed)), 0600); err != nil {
-		return nil, fmt.Errorf("failed to save root.key: %w", err)
+	priv := ed25519.NewKeyFromSeed(seed)
+	if created {
+		log.Printf("[helm] trust: generating new persistent root key at %s", keyPath)
+		fmt.Fprintf(os.Stderr, "\n%s⚠️  SECURITY WARNING: Using auto-generated root key.%s\n", ColorBold+ColorYellow, ColorReset)
+		fmt.Fprintf(os.Stderr, "   Key saved to: %s\n", keyPath)
+		fmt.Fprintf(os.Stderr, "   In production, use a hardware security module (HSM) or cloud KMS.\n\n")
+		pubPath := filepath.Join(dataDir, "root.pub")
+		if err := os.WriteFile(pubPath, []byte(hex.EncodeToString(priv.Public().(ed25519.PublicKey))), 0o644); err != nil {
+			log.Printf("⚠️  failed to save root.pub: %v", err)
+		}
+	} else {
+		log.Printf("[helm] trust: loaded persistent root key")
 	}
-
-	pubPath := filepath.Join(dataDir, "root.pub")
-	if err := os.WriteFile(pubPath, []byte(hex.EncodeToString(pub)), 0644); err != nil {
-		log.Printf("⚠️  failed to save root.pub: %v", err)
-	}
-
 	return crypto.NewEd25519SignerFromKey(priv, "root"), nil
 }
 
@@ -147,37 +132,98 @@ func loadOrGenerateEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
 // alongside the Ed25519 root key.
 func loadOrGenerateMLDSARoot(dataDir string) (*crypto.MLDSASigner, error) {
 	keyPath := filepath.Join(dataDir, "root.mldsa65.key")
-	if _, err := os.Stat(keyPath); err == nil {
-		keyHex, err := os.ReadFile(keyPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read root.mldsa65.key: %w", err)
-		}
-		seedBytes, err := hex.DecodeString(string(keyHex))
-		if err != nil {
-			return nil, fmt.Errorf("invalid root.mldsa65.key format: %w", err)
-		}
-		if len(seedBytes) != mldsa65.SeedSize {
-			return nil, fmt.Errorf("invalid root.mldsa65.key seed size: %d, expected %d", len(seedBytes), mldsa65.SeedSize)
-		}
-		var seed [mldsa65.SeedSize]byte
-		copy(seed[:], seedBytes)
-		_, priv := mldsa65.NewKeyFromSeed(&seed)
-		log.Printf("[helm] trust: loaded persistent ml-dsa-65 root key")
-		return crypto.NewMLDSASignerFromKey(priv, "root"), nil
-	}
-
-	if envBool("HELM_PRODUCTION") {
-		return nil, fmt.Errorf("production mode with hybrid receipt profile requires ml-dsa-65 root key to exist at %s", keyPath)
-	}
-
-	log.Printf("[helm] trust: generating new persistent ml-dsa-65 root key at %s", keyPath)
-	_, priv, err := mldsa65.GenerateKey(rand.Reader)
+	seedBytes, created, err := loadOrCreateHexSeed(keyPath, mldsa65.SeedSize, !envBool("HELM_PRODUCTION"))
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate ml-dsa-65 key: %w", err)
+		if errors.Is(err, fs.ErrNotExist) && envBool("HELM_PRODUCTION") {
+			return nil, fmt.Errorf("production mode with hybrid receipt profile requires ml-dsa-65 root key to exist at %s", keyPath)
+		}
+		return nil, fmt.Errorf("load root.mldsa65.key: %w", err)
 	}
-	seed := priv.Seed()
-	if err := os.WriteFile(keyPath, []byte(hex.EncodeToString(seed)), 0600); err != nil {
-		return nil, fmt.Errorf("failed to save root.mldsa65.key: %w", err)
+	var seed [mldsa65.SeedSize]byte
+	copy(seed[:], seedBytes)
+	_, priv := mldsa65.NewKeyFromSeed(&seed)
+	if created {
+		log.Printf("[helm] trust: generating new persistent ml-dsa-65 root key at %s", keyPath)
+	} else {
+		log.Printf("[helm] trust: loaded persistent ml-dsa-65 root key")
 	}
 	return crypto.NewMLDSASignerFromKey(priv, "root"), nil
+}
+
+const (
+	rootSeedLoadAttempts   = 25
+	rootSeedLoadRetryDelay = 10 * time.Millisecond
+)
+
+// loadOrCreateHexSeed is safe for concurrent first startup by independent
+// kernel processes. Only the exclusive creator may write the seed; contenders
+// reload the winner's durable file and fail closed if it remains malformed.
+func loadOrCreateHexSeed(path string, seedSize int, allowCreate bool) ([]byte, bool, error) {
+	var lastErr error
+	for attempt := 0; attempt < rootSeedLoadAttempts; attempt++ {
+		seed, err := loadHexSeed(path, seedSize)
+		if err == nil {
+			return seed, false, nil
+		}
+		if errors.Is(err, fs.ErrNotExist) {
+			if !allowCreate {
+				return nil, false, err
+			}
+			candidate := make([]byte, seedSize)
+			if _, err := rand.Read(candidate); err != nil {
+				return nil, false, fmt.Errorf("generate root seed: %w", err)
+			}
+			file, createErr := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+			switch {
+			case createErr == nil:
+				if err := writeHexSeed(file, candidate); err != nil {
+					_ = file.Close()
+					return nil, false, fmt.Errorf("save root seed: %w", err)
+				}
+				if err := file.Close(); err != nil {
+					return nil, false, fmt.Errorf("close root seed: %w", err)
+				}
+				return candidate, true, nil
+			case !errors.Is(createErr, fs.ErrExist):
+				return nil, false, fmt.Errorf("create root seed: %w", createErr)
+			}
+		}
+		lastErr = err
+		if attempt+1 < rootSeedLoadAttempts {
+			time.Sleep(rootSeedLoadRetryDelay)
+		}
+	}
+	return nil, false, fmt.Errorf("load concurrently initialized root seed after %d attempts: %w", rootSeedLoadAttempts, lastErr)
+}
+
+func loadHexSeed(path string, seedSize int) ([]byte, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(string(raw)))
+	if err != nil {
+		return nil, fmt.Errorf("invalid root seed format: %w", err)
+	}
+	if len(seed) != seedSize {
+		return nil, fmt.Errorf("invalid root seed size: %d, expected %d", len(seed), seedSize)
+	}
+	return seed, nil
+}
+
+func writeHexSeed(file *os.File, seed []byte) error {
+	data := []byte(hex.EncodeToString(seed))
+	for len(data) > 0 {
+		n, err := file.Write(data)
+		if n > 0 {
+			data = data[n:]
+		}
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+	}
+	return file.Sync()
 }

--- a/core/cmd/helm-ai-kernel/lite_mode_concurrency_test.go
+++ b/core/cmd/helm-ai-kernel/lite_mode_concurrency_test.go
@@ -1,3 +1,5 @@
+// quantum_posture: concurrency tests cover local classical Ed25519 signer
+// initialization and persistence; they do not claim hybrid/PQ enablement.
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/lite_mode_concurrency_test.go
+++ b/core/cmd/helm-ai-kernel/lite_mode_concurrency_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestLoadOrGenerateSignerWithDataDirConcurrentFirstInitialization(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "")
+	t.Setenv("HELM_RECEIPT_PROFILE", "")
+	dataDir := filepath.Join(t.TempDir(), "shared-data")
+
+	const starters = 32
+	start := make(chan struct{})
+	results := make(chan signerInitResult, starters)
+	var group sync.WaitGroup
+	for range starters {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+			if err != nil {
+				results <- signerInitResult{err: err}
+				return
+			}
+			results <- signerInitResult{publicKey: signer.PublicKey()}
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	var publicKey string
+	for result := range results {
+		if result.err != nil {
+			t.Fatalf("concurrent signer initialization: %v", result.err)
+		}
+		if publicKey == "" {
+			publicKey = result.publicKey
+			continue
+		}
+		if result.publicKey != publicKey {
+			t.Fatalf("concurrent signer public key = %q, want %q", result.publicKey, publicKey)
+		}
+	}
+	if publicKey == "" {
+		t.Fatal("no signer result")
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dataDir, "root.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	seed, err := hex.DecodeString(string(raw))
+	if err != nil {
+		t.Fatalf("decode persisted root seed: %v", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		t.Fatalf("persisted root seed size = %d, want %d", len(seed), ed25519.SeedSize)
+	}
+}
+
+type signerInitResult struct {
+	publicKey string
+	err       error
+}

--- a/core/cmd/helm-ai-kernel/mcp_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_cmd.go
@@ -1,3 +1,5 @@
+// quantum_posture: MCP CLI wiring may emit configs carrying receipt or auth
+// material, but cryptographic policy remains enforced in lower-level packages.
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/mcp_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_cmd.go
@@ -114,11 +114,13 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 		transport string
 		port      int
 		authMode  string
+		dataDir   string
 	)
 
 	cmd.StringVar(&transport, "transport", "stdio", "Transport: stdio, http")
 	cmd.IntVar(&port, "port", 9100, "Port for HTTP transport")
 	cmd.StringVar(&authMode, "auth", "none", "Auth mode: none, static-header, oauth")
+	cmd.StringVar(&dataDir, "data-dir", "data", "Data directory for local MCP signing state")
 
 	if err := cmd.Parse(args); err != nil {
 		return 2
@@ -130,13 +132,13 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "Error: stdio transport only supports --auth none")
 			return 2
 		}
-		if err := serveLocalMCPStdio(os.Stdin, stdout); err != nil {
+		if err := serveLocalMCPStdioWithDataDir(os.Stdin, stdout, dataDir); err != nil {
 			fmt.Fprintf(stderr, "Error: MCP stdio server failed: %v\n", err)
 			return 2
 		}
 		return 0
 	case "http":
-		server, err := newLocalMCPHTTPServer(port, authMode)
+		server, err := newLocalMCPHTTPServerWithDataDir(port, authMode, dataDir)
 		if err != nil {
 			fmt.Fprintf(stderr, "Error: %v\n", err)
 			return 2

--- a/core/cmd/helm-ai-kernel/mcp_runtime.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime.go
@@ -42,7 +42,11 @@ type mcpRPCError struct {
 }
 
 func newLocalMCPRuntime() (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
-	signer, err := loadOrGenerateSigner()
+	return newLocalMCPRuntimeWithDataDir("data")
+}
+
+func newLocalMCPRuntimeWithDataDir(dataDir string) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -199,7 +203,11 @@ func resolveLocalMCPPath(rawPath string) (string, error) {
 }
 
 func serveLocalMCPStdio(stdin io.Reader, stdout io.Writer) error {
-	catalog, executor, err := newLocalMCPRuntime()
+	return serveLocalMCPStdioWithDataDir(stdin, stdout, "data")
+}
+
+func serveLocalMCPStdioWithDataDir(stdin io.Reader, stdout io.Writer, dataDir string) error {
+	catalog, executor, err := newLocalMCPRuntimeWithDataDir(dataDir)
 	if err != nil {
 		return err
 	}
@@ -401,19 +409,24 @@ func handleMCPRPCRequest(req *mcpRPCRequest, catalog *mcppkg.ToolCatalog, execut
 }
 
 func newLocalMCPHTTPServer(port int, authMode string) (*http.Server, error) {
+	return newLocalMCPHTTPServerWithDataDir(port, authMode, "data")
+}
+
+func newLocalMCPHTTPServerWithDataDir(port int, authMode, dataDir string) (*http.Server, error) {
 	// SEC: Default to localhost to prevent accidental network exposure.
 	mcpBind := "127.0.0.1"
 	if envBind := os.Getenv("HELM_BIND_ADDR"); envBind != "" {
 		mcpBind = envBind
 	}
 	baseURL := fmt.Sprintf("http://%s:%d", mcpBind, port)
-	gateway, err := newConfiguredLocalMCPGateway(mcppkg.GatewayConfig{
-		BaseURL:  baseURL,
-		AuthMode: authMode,
-	})
+	catalog, executor, err := newLocalMCPRuntimeWithDataDir(dataDir)
 	if err != nil {
 		return nil, err
 	}
+	gateway := mcppkg.NewGateway(catalog, mcppkg.GatewayConfig{
+		BaseURL:  baseURL,
+		AuthMode: authMode,
+	}, mcppkg.WithExecutor(executor))
 
 	mux := http.NewServeMux()
 	gateway.RegisterRoutes(mux)

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -212,7 +212,7 @@ func runSetupStatusCmd(args []string, stdout, stderr io.Writer) int {
 			defer func() { _ = projectDir.Close() }()
 			summary.MCPInstalled, err = codexProjectMCPInstalled(projectDir, summary.BinaryPath, opts.DataDir)
 			if err == nil {
-				summary.HookInstalled, err = codexProjectHookInstalled(projectDir, setupHookCommand(opts, summary.BinaryPath))
+				summary.HookInstalled, err = codexProjectHookInstalled(projectDir, summary.BinaryPath, setupHookCommand(opts, summary.BinaryPath))
 			}
 			if err != nil {
 				fmt.Fprintf(stderr, "setup status: inspect project Codex config: %v\n", err)
@@ -264,14 +264,14 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 			defer func() { _ = projectDir.Close() }()
 			summary.MCPInstalled, err = codexProjectMCPInstalled(projectDir, summary.BinaryPath, opts.DataDir)
 			if err == nil {
-				summary.HookInstalled, err = codexProjectHookInstalled(projectDir, setupHookCommand(opts, summary.BinaryPath))
+				summary.HookInstalled, err = codexProjectHookInstalled(projectDir, summary.BinaryPath, setupHookCommand(opts, summary.BinaryPath))
 			}
 			if err != nil {
 				fmt.Fprintf(stderr, "setup remove: inspect project Codex config: %v\n", err)
 				return 1
 			}
 			if !opts.DryRun {
-				if err := removeCodexProjectSetup(projectDir); err != nil {
+				if err := removeCodexProjectSetup(projectDir, summary.BinaryPath); err != nil {
 					fmt.Fprintf(stderr, "setup remove: remove project Codex integration: %v\n", err)
 					return 1
 				}
@@ -290,7 +290,7 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 				fmt.Fprintf(stderr, "setup remove: remove hook: %v\n", err)
 				return 1
 			}
-			if err := removeSetupMCP(opts); err != nil {
+			if err := removeSetupMCP(opts, summary.BinaryPath); err != nil {
 				fmt.Fprintf(stderr, "setup remove: remove MCP server: %v\n", err)
 				return 1
 			}
@@ -585,7 +585,7 @@ func installSetupMCP(opts setupOptions, bin string) error {
 	}
 }
 
-func removeSetupMCP(opts setupOptions) error {
+func removeSetupMCP(opts setupOptions, bin string) error {
 	switch opts.Target {
 	case "claude-code":
 		return setupExecCommand("claude", "mcp", "remove", "--scope", opts.Scope, setupMCPServerName)
@@ -599,7 +599,7 @@ func removeSetupMCP(opts setupOptions) error {
 				return err
 			}
 			defer func() { _ = projectDir.Close() }()
-			return removeCodexProjectMCP(projectDir)
+			return removeCodexProjectMCP(projectDir, bin)
 		}
 		return setupExecCommand("codex", "mcp", "remove", setupMCPServerName)
 	default:
@@ -614,7 +614,7 @@ func installSetupHook(opts setupOptions, bin string) error {
 			return err
 		}
 		defer func() { _ = projectDir.Close() }()
-		return upsertCodexProjectHook(projectDir, setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
+		return upsertCodexProjectHook(projectDir, bin, setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
 	}
 	return upsertHookConfig(setupHookConfigPath(opts), setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
 }
@@ -629,7 +629,7 @@ func removeSetupHook(opts setupOptions, bin string) error {
 			return err
 		}
 		defer func() { _ = projectDir.Close() }()
-		return removeCodexProjectHook(projectDir)
+		return removeCodexProjectHook(projectDir, bin)
 	}
 	return removeHookConfig(setupHookConfigPath(opts), setupHookCommand(opts, bin))
 }
@@ -639,7 +639,7 @@ func installCodexProjectSetup(projectDir *codexProjectDir, opts setupOptions, bi
 	if err != nil {
 		return err
 	}
-	hooks, err := prepareCodexProjectHookUpsert(projectDir, setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
+	hooks, err := prepareCodexProjectHookUpsert(projectDir, bin, setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
 	if err != nil {
 		return err
 	}
@@ -656,12 +656,12 @@ func installCodexProjectSetup(projectDir *codexProjectDir, opts setupOptions, bi
 	return nil
 }
 
-func removeCodexProjectSetup(projectDir *codexProjectDir) error {
-	config, err := prepareCodexProjectMCPRemoval(projectDir)
+func removeCodexProjectSetup(projectDir *codexProjectDir, bin string) error {
+	config, err := prepareCodexProjectMCPRemoval(projectDir, bin)
 	if err != nil {
 		return err
 	}
-	hooks, err := prepareCodexProjectHookRemoval(projectDir)
+	hooks, err := prepareCodexProjectHookRemoval(projectDir, bin)
 	if err != nil {
 		return err
 	}
@@ -886,15 +886,15 @@ func hookCommandFromAny(v any) string {
 	return command
 }
 
-func upsertCodexProjectHook(projectDir *codexProjectDir, matcher, command string) error {
-	next, err := prepareCodexProjectHookUpsert(projectDir, matcher, command)
+func upsertCodexProjectHook(projectDir *codexProjectDir, bin, matcher, command string) error {
+	next, err := prepareCodexProjectHookUpsert(projectDir, bin, matcher, command)
 	if err != nil || next == nil {
 		return err
 	}
 	return projectDir.writePrivateFileAtomic("hooks.json", next)
 }
 
-func prepareCodexProjectHookUpsert(projectDir *codexProjectDir, matcher, command string) ([]byte, error) {
+func prepareCodexProjectHookUpsert(projectDir *codexProjectDir, bin, matcher, command string) ([]byte, error) {
 	root, hooks, pre, err := readCodexProjectHooks(projectDir)
 	if os.IsNotExist(err) {
 		root = map[string]any{}
@@ -905,7 +905,18 @@ func prepareCodexProjectHookUpsert(projectDir *codexProjectDir, matcher, command
 	if err != nil {
 		return nil, err
 	}
-	updated, found, changed := reconcileOwnedCodexHooks(pre, matcher, command)
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, hook := range arrayValue(obj, "hooks") {
+			if isAmbiguousCodexHook(hook, bin) {
+				return nil, fmt.Errorf("refuse to modify ambiguous Codex HELM hook; manual remediation required")
+			}
+		}
+	}
+	updated, found, changed := reconcileOwnedCodexHooks(pre, bin, matcher, command)
 	if found {
 		if !changed {
 			return nil, nil
@@ -930,15 +941,15 @@ func prepareCodexProjectHookUpsert(projectDir *codexProjectDir, matcher, command
 	return marshalCodexProjectHooks(root)
 }
 
-func removeCodexProjectHook(projectDir *codexProjectDir) error {
-	next, err := prepareCodexProjectHookRemoval(projectDir)
+func removeCodexProjectHook(projectDir *codexProjectDir, bin string) error {
+	next, err := prepareCodexProjectHookRemoval(projectDir, bin)
 	if err != nil || next == nil {
 		return err
 	}
 	return projectDir.writePrivateFileAtomic("hooks.json", next)
 }
 
-func prepareCodexProjectHookRemoval(projectDir *codexProjectDir) ([]byte, error) {
+func prepareCodexProjectHookRemoval(projectDir *codexProjectDir, bin string) ([]byte, error) {
 	root, hooks, pre, err := readCodexProjectHooks(projectDir)
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -961,7 +972,7 @@ func prepareCodexProjectHookRemoval(projectDir *codexProjectDir) ([]byte, error)
 		}
 		keptHooks := make([]any, 0, len(hookItems))
 		for _, hook := range hookItems {
-			if isOwnedCodexHook(hook) {
+			if isOwnedCodexHook(hook, bin) {
 				changed = true
 				continue
 			}
@@ -984,7 +995,7 @@ func prepareCodexProjectHookRemoval(projectDir *codexProjectDir) ([]byte, error)
 	return marshalCodexProjectHooks(root)
 }
 
-func codexProjectHookInstalled(projectDir *codexProjectDir, command string) (bool, error) {
+func codexProjectHookInstalled(projectDir *codexProjectDir, bin, command string) (bool, error) {
 	_, _, pre, err := readCodexProjectHooks(projectDir)
 	if os.IsNotExist(err) {
 		return false, nil
@@ -992,7 +1003,7 @@ func codexProjectHookInstalled(projectDir *codexProjectDir, command string) (boo
 	if err != nil {
 		return false, err
 	}
-	return currentOwnedCodexHookPresent(pre, command), nil
+	return currentOwnedCodexHookPresent(pre, bin, command), nil
 }
 
 func readCodexProjectHooks(projectDir *codexProjectDir) (map[string]any, map[string]any, []any, error) {
@@ -1034,7 +1045,7 @@ func marshalCodexProjectHooks(root map[string]any) ([]byte, error) {
 	return append(data, '\n'), nil
 }
 
-func currentOwnedCodexHookPresent(pre []any, command string) bool {
+func currentOwnedCodexHookPresent(pre []any, bin, command string) bool {
 	for _, item := range pre {
 		obj, ok := item.(map[string]any)
 		if !ok {
@@ -1045,7 +1056,7 @@ func currentOwnedCodexHookPresent(pre []any, command string) bool {
 			continue
 		}
 		for _, hook := range hooks {
-			if isOwnedCodexHook(hook) && hookCommandFromAny(hook) == command {
+			if isOwnedCodexHook(hook, bin) && hookCommandFromAny(hook) == command {
 				return true
 			}
 		}
@@ -1053,23 +1064,36 @@ func currentOwnedCodexHookPresent(pre []any, command string) bool {
 	return false
 }
 
-func isOwnedCodexHook(v any) bool {
+func isOwnedCodexHook(v any, bin string) bool {
 	obj, ok := v.(map[string]any)
-	if !ok || obj["type"] != "command" || obj["statusMessage"] != "Checking HELM policy" {
+	if !ok || obj["type"] != "command" {
 		return false
 	}
-	return isCodexHookCommand(hookCommandFromAny(v))
+	commandBin, ok := codexHookCommandBinary(hookCommandFromAny(v))
+	return ok && sameHELMKernelExecutable(commandBin, bin)
 }
 
-func isCodexHookCommand(command string) bool {
+func isAmbiguousCodexHook(v any, bin string) bool {
+	obj, ok := v.(map[string]any)
+	if !ok || obj["type"] != "command" {
+		return false
+	}
+	commandBin, ok := codexHookCommandBinary(hookCommandFromAny(v))
+	return ok && !sameHELMKernelExecutable(commandBin, bin)
+}
+
+func codexHookCommandBinary(command string) (string, bool) {
 	words, ok := splitSetupShellWords(command)
-	if !ok || len(words) != 7 || !isHELMKernelExecutable(words[0]) || words[6] == "" {
-		return false
+	if !ok || len(words) != 7 || words[0] == "" || words[6] == "" {
+		return "", false
 	}
-	return words[1] == "hook" && words[2] == "pre-tool" && words[3] == "--client" && words[4] == "codex" && words[5] == "--data-dir"
+	if words[1] != "hook" || words[2] != "pre-tool" || words[3] != "--client" || words[4] != "codex" || words[5] != "--data-dir" {
+		return "", false
+	}
+	return words[0], true
 }
 
-func reconcileOwnedCodexHooks(pre []any, matcher, command string) ([]any, bool, bool) {
+func reconcileOwnedCodexHooks(pre []any, bin, matcher, command string) ([]any, bool, bool) {
 	updated := make([]any, 0, len(pre))
 	found := false
 	changed := false
@@ -1087,13 +1111,13 @@ func reconcileOwnedCodexHooks(pre []any, matcher, command string) ([]any, bool, 
 		}
 		ownedCount := 0
 		for _, hook := range hookItems {
-			if isOwnedCodexHook(hook) {
+			if isOwnedCodexHook(hook, bin) {
 				ownedCount++
 			}
 		}
 		kept := make([]any, 0, len(hookItems))
 		for _, hook := range hookItems {
-			if !isOwnedCodexHook(hook) {
+			if !isOwnedCodexHook(hook, bin) {
 				kept = append(kept, hook)
 				continue
 			}
@@ -1232,8 +1256,8 @@ func prepareCodexProjectMCPUpsert(projectDir *codexProjectDir, bin, dataDir stri
 		if _, err := toml.Decode(current, &config); err != nil {
 			return nil, fmt.Errorf("parse existing Codex config: %w", err)
 		}
-		if server, exists := config.MCPServers[setupMCPServerName]; exists && !isOwnedCodexMCPServer(server) {
-			return nil, fmt.Errorf("refuse to replace non-HELM Codex MCP server %q", setupMCPServerName)
+		if server, exists := config.MCPServers[setupMCPServerName]; exists && !isOwnedCodexMCPServer(server, bin) {
+			return nil, fmt.Errorf("refuse to replace ambiguous Codex MCP server %q; manual remediation required", setupMCPServerName)
 		}
 	} else if !os.IsNotExist(err) {
 		return nil, err
@@ -1251,15 +1275,15 @@ func prepareCodexProjectMCPUpsert(projectDir *codexProjectDir, bin, dataDir stri
 	return []byte(next), nil
 }
 
-func removeCodexProjectMCP(projectDir *codexProjectDir) error {
-	next, err := prepareCodexProjectMCPRemoval(projectDir)
+func removeCodexProjectMCP(projectDir *codexProjectDir, bin string) error {
+	next, err := prepareCodexProjectMCPRemoval(projectDir, bin)
 	if err != nil || next == nil {
 		return err
 	}
 	return projectDir.writePrivateFileAtomic("config.toml", next)
 }
 
-func prepareCodexProjectMCPRemoval(projectDir *codexProjectDir) ([]byte, error) {
+func prepareCodexProjectMCPRemoval(projectDir *codexProjectDir, bin string) ([]byte, error) {
 	raw, err := projectDir.readRegularFile("config.toml")
 	if os.IsNotExist(err) {
 		return nil, nil
@@ -1275,7 +1299,7 @@ func prepareCodexProjectMCPRemoval(projectDir *codexProjectDir) ([]byte, error) 
 		return nil, fmt.Errorf("parse existing Codex config: %w", err)
 	}
 	server, exists := config.MCPServers[setupMCPServerName]
-	if !exists || !isOwnedCodexMCPServer(server) {
+	if !exists || !isOwnedCodexMCPServer(server, bin) {
 		return nil, nil
 	}
 	next := strings.TrimRight(removeTOMLTable(string(raw), "[mcp_servers."+setupMCPServerName+"]"), "\n") + "\n"
@@ -1294,8 +1318,8 @@ type codexMCPServer struct {
 	Args    []string `toml:"args"`
 }
 
-func isOwnedCodexMCPServer(server codexMCPServer) bool {
-	if !isHELMKernelExecutable(server.Command) {
+func isOwnedCodexMCPServer(server codexMCPServer, bin string) bool {
+	if !sameHELMKernelExecutable(server.Command, bin) {
 		return false
 	}
 	if len(server.Args) != 6 || server.Args[0] != "mcp" || server.Args[1] != "serve" || server.Args[2] != "--transport" || server.Args[3] != "stdio" || server.Args[4] != "--data-dir" {
@@ -1304,15 +1328,24 @@ func isOwnedCodexMCPServer(server codexMCPServer) bool {
 	return strings.TrimSpace(server.Args[5]) != ""
 }
 
-func isHELMKernelExecutable(command string) bool {
-	switch strings.ToLower(filepath.Base(strings.TrimSpace(command))) {
-	case "helm-ai-kernel", "helm-ai-kernel.exe", "helm-ai-kernel.test":
-		// Exact known HELM kernel executable names only. A named server is not
-		// ownership proof on its own, and lookalike executable names stay intact.
-		return true
-	default:
+func sameHELMKernelExecutable(command, current string) bool {
+	command = strings.TrimSpace(command)
+	current = strings.TrimSpace(current)
+	if command == "" || current == "" {
 		return false
 	}
+	if filepath.Clean(command) == filepath.Clean(current) {
+		return true
+	}
+	commandInfo, err := os.Stat(command)
+	if err != nil {
+		return false
+	}
+	currentInfo, err := os.Stat(current)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(commandInfo, currentInfo)
 }
 
 func validateCodexProjectTOML(raw string) error {
@@ -1337,7 +1370,7 @@ func codexProjectMCPInstalled(projectDir *codexProjectDir, bin, dataDir string) 
 		return false, fmt.Errorf("parse existing Codex config: %w", err)
 	}
 	server, ok := config.MCPServers[setupMCPServerName]
-	if !ok || server.Command != bin {
+	if !ok || !isOwnedCodexMCPServer(server, bin) {
 		return false, nil
 	}
 	return equalSetupStrings(server.Args, setupMCPArgs(dataDir)), nil

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -657,6 +657,13 @@ func installCodexProjectSetup(projectDir *codexProjectDir, opts setupOptions, bi
 }
 
 func removeCodexProjectSetup(projectDir *codexProjectDir, bin string) error {
+	blocked, err := codexProjectRemovalBlocked(projectDir, bin)
+	if err != nil {
+		return err
+	}
+	if blocked {
+		return fmt.Errorf("refuse to modify ambiguous Codex HELM setup; manual remediation required")
+	}
 	config, err := prepareCodexProjectMCPRemoval(projectDir, bin)
 	if err != nil {
 		return err
@@ -676,6 +683,18 @@ func removeCodexProjectSetup(projectDir *codexProjectDir, bin string) error {
 		}
 	}
 	return nil
+}
+
+func codexProjectRemovalBlocked(projectDir *codexProjectDir, bin string) (bool, error) {
+	ownsHook, hasAmbiguousHook, err := codexProjectHookOwnershipState(projectDir, bin)
+	if err != nil {
+		return false, err
+	}
+	ownsMCP, hasAmbiguousMCP, err := codexProjectMCPOwnershipState(projectDir, bin)
+	if err != nil {
+		return false, err
+	}
+	return (ownsHook || ownsMCP) && (hasAmbiguousHook || hasAmbiguousMCP), nil
 }
 
 func setupMCPInstalled(opts setupOptions, path, bin string) bool {
@@ -957,6 +976,22 @@ func prepareCodexProjectHookRemoval(projectDir *codexProjectDir, bin string) ([]
 	if err != nil {
 		return nil, err
 	}
+	owned, ambiguous := false, false
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, hook := range arrayValue(obj, "hooks") {
+			owned = owned || isOwnedCodexHook(hook, bin)
+			ambiguous = ambiguous || isAmbiguousCodexHook(hook, bin)
+		}
+	}
+	if owned && ambiguous {
+		// Do not partially remove a mixed file: the foreign HELM-shaped hook
+		// requires manual remediation before any Codex config is written.
+		return nil, fmt.Errorf("refuse to modify ambiguous Codex HELM hook; manual remediation required")
+	}
 	changed := false
 	filtered := make([]any, 0, len(pre))
 	for _, item := range pre {
@@ -1004,6 +1039,33 @@ func codexProjectHookInstalled(projectDir *codexProjectDir, bin, command string)
 		return false, err
 	}
 	return currentOwnedCodexHookPresent(pre, bin, command), nil
+}
+
+func codexProjectHookOwnershipState(projectDir *codexProjectDir, bin string) (bool, bool, error) {
+	_, _, pre, err := readCodexProjectHooks(projectDir)
+	if os.IsNotExist(err) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	ownsHook := false
+	hasAmbiguousHook := false
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, hook := range arrayValue(obj, "hooks") {
+			if isOwnedCodexHook(hook, bin) {
+				ownsHook = true
+			}
+			if isAmbiguousCodexHook(hook, bin) {
+				hasAmbiguousHook = true
+			}
+		}
+	}
+	return ownsHook, hasAmbiguousHook, nil
 }
 
 func readCodexProjectHooks(projectDir *codexProjectDir) (map[string]any, map[string]any, []any, error) {
@@ -1307,6 +1369,29 @@ func prepareCodexProjectMCPRemoval(projectDir *codexProjectDir, bin string) ([]b
 		return nil, fmt.Errorf("validate updated Codex config: %w", err)
 	}
 	return []byte(next), nil
+}
+
+func codexProjectMCPOwnershipState(projectDir *codexProjectDir, bin string) (bool, bool, error) {
+	raw, err := projectDir.readRegularFile("config.toml")
+	if os.IsNotExist(err) {
+		return false, false, nil
+	}
+	if err != nil {
+		return false, false, err
+	}
+	if err := validateCodexProjectTOML(string(raw)); err != nil {
+		return false, false, fmt.Errorf("parse existing Codex config: %w", err)
+	}
+	var config codexProjectConfig
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		return false, false, fmt.Errorf("parse existing Codex config: %w", err)
+	}
+	server, exists := config.MCPServers[setupMCPServerName]
+	if !exists {
+		return false, false, nil
+	}
+	ownsMCP := isOwnedCodexMCPServer(server, bin)
+	return ownsMCP, !ownsMCP, nil
 }
 
 type codexProjectConfig struct {

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -1063,7 +1063,7 @@ func isOwnedCodexHook(v any) bool {
 
 func isCodexHookCommand(command string) bool {
 	words, ok := splitSetupShellWords(command)
-	if !ok || len(words) != 7 || words[0] == "" || words[6] == "" {
+	if !ok || len(words) != 7 || !isHELMKernelExecutable(words[0]) || words[6] == "" {
 		return false
 	}
 	return words[1] == "hook" && words[2] == "pre-tool" && words[3] == "--client" && words[4] == "codex" && words[5] == "--data-dir"
@@ -1295,17 +1295,24 @@ type codexMCPServer struct {
 }
 
 func isOwnedCodexMCPServer(server codexMCPServer) bool {
-	switch strings.ToLower(filepath.Base(strings.TrimSpace(server.Command))) {
-	case "helm-ai-kernel", "helm-ai-kernel.exe", "helm-ai-kernel.test":
-		// Exact known HELM kernel executable names only. A named server is not
-		// ownership proof on its own, and lookalike executable names stay intact.
-	default:
+	if !isHELMKernelExecutable(server.Command) {
 		return false
 	}
 	if len(server.Args) != 6 || server.Args[0] != "mcp" || server.Args[1] != "serve" || server.Args[2] != "--transport" || server.Args[3] != "stdio" || server.Args[4] != "--data-dir" {
 		return false
 	}
 	return strings.TrimSpace(server.Args[5]) != ""
+}
+
+func isHELMKernelExecutable(command string) bool {
+	switch strings.ToLower(filepath.Base(strings.TrimSpace(command))) {
+	case "helm-ai-kernel", "helm-ai-kernel.exe", "helm-ai-kernel.test":
+		// Exact known HELM kernel executable names only. A named server is not
+		// ownership proof on its own, and lookalike executable names stay intact.
+		return true
+	default:
+		return false
+	}
 }
 
 func validateCodexProjectTOML(raw string) error {

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -52,8 +53,8 @@ type setupSummary struct {
 	DraftPolicyPath   string   `json:"draft_policy_path"`
 	UninstallCommand  string   `json:"uninstall_command"`
 	Scope             string   `json:"scope,omitempty"`
-	MCPInstalled      bool     `json:"mcp_installed,omitempty"`
-	HookInstalled     bool     `json:"hook_installed,omitempty"`
+	MCPInstalled      bool     `json:"mcp_installed"`
+	HookInstalled     bool     `json:"hook_installed"`
 	QuickstartStarted bool     `json:"quickstart_started"`
 	PlannedActions    []string `json:"planned_actions"`
 }
@@ -141,6 +142,12 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup: create data dir: %v\n", err)
 		return 1
 	}
+	if opts.Target == "codex" && opts.Scope == "project" {
+		if _, err := loadOrGenerateSignerWithDataDir(opts.DataDir); err != nil {
+			fmt.Fprintf(stderr, "setup: initialize shared receipt signer: %v\n", err)
+			return 1
+		}
+	}
 	grade, policyPath, err := runSetupAutoconfigure(opts.DataDir, opts.Workspace)
 	if err != nil {
 		fmt.Fprintf(stderr, "setup: autoconfigure: %v\n", err)
@@ -148,13 +155,26 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 	}
 	summary.ScanGrade = grade
 	summary.DraftPolicyPath = policyPath
-	if err := installSetupMCP(opts, summary.BinaryPath); err != nil {
-		fmt.Fprintf(stderr, "setup: install MCP server: %v\n", err)
-		return 1
-	}
-	if err := installSetupHook(opts, summary.BinaryPath); err != nil {
-		fmt.Fprintf(stderr, "setup: install pre-tool hook: %v\n", err)
-		return 1
+	if opts.Target == "codex" && opts.Scope == "project" {
+		projectDir, err := openCodexProjectDir(opts.Workspace, true)
+		if err != nil {
+			fmt.Fprintf(stderr, "setup: open project Codex config: %v\n", err)
+			return 1
+		}
+		defer func() { _ = projectDir.Close() }()
+		if err := installCodexProjectSetup(projectDir, opts, summary.BinaryPath); err != nil {
+			fmt.Fprintf(stderr, "setup: install project Codex integration: %v\n", err)
+			return 1
+		}
+	} else {
+		if err := installSetupMCP(opts, summary.BinaryPath); err != nil {
+			fmt.Fprintf(stderr, "setup: install MCP server: %v\n", err)
+			return 1
+		}
+		if err := installSetupHook(opts, summary.BinaryPath); err != nil {
+			fmt.Fprintf(stderr, "setup: install pre-tool hook: %v\n", err)
+			return 1
+		}
 	}
 	summary.MCPInstalled = true
 	summary.HookInstalled = true
@@ -185,8 +205,29 @@ func runSetupStatusCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup status: %v\n", err)
 		return 2
 	}
-	summary.MCPInstalled = setupMCPInstalled(opts, summary.ClientConfigPath)
-	summary.HookInstalled = setupHookInstalled(opts, summary.HookConfigPath, summary.BinaryPath)
+	if opts.Target == "codex" && opts.Scope == "project" {
+		projectDir, err := openCodexProjectDir(opts.Workspace, false)
+		switch {
+		case err == nil:
+			defer func() { _ = projectDir.Close() }()
+			summary.MCPInstalled, err = codexProjectMCPInstalled(projectDir, summary.BinaryPath, opts.DataDir)
+			if err == nil {
+				summary.HookInstalled, err = codexProjectHookInstalled(projectDir, setupHookCommand(opts, summary.BinaryPath))
+			}
+			if err != nil {
+				fmt.Fprintf(stderr, "setup status: inspect project Codex config: %v\n", err)
+				return 2
+			}
+		case err == errCodexProjectDirNotFound:
+			// An unconfigured project is a truthful incomplete status, not an error.
+		default:
+			fmt.Fprintf(stderr, "setup status: open project Codex config: %v\n", err)
+			return 2
+		}
+	} else {
+		summary.MCPInstalled = setupMCPInstalled(opts, summary.ClientConfigPath, summary.BinaryPath)
+		summary.HookInstalled = setupHookInstalled(opts, summary.HookConfigPath, summary.BinaryPath)
+	}
 	if grade := readSetupScanGrade(filepath.Join(opts.DataDir, "autoconfigure", "inventory.json")); grade != "" {
 		summary.ScanGrade = grade
 	}
@@ -216,14 +257,43 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup remove: %v\n", err)
 		return 2
 	}
-	if !opts.DryRun {
-		if err := removeSetupHook(opts, summary.BinaryPath); err != nil {
-			fmt.Fprintf(stderr, "setup remove: remove hook: %v\n", err)
+	if opts.Target == "codex" && opts.Scope == "project" {
+		projectDir, err := openCodexProjectDir(opts.Workspace, false)
+		switch {
+		case err == nil:
+			defer func() { _ = projectDir.Close() }()
+			summary.MCPInstalled, err = codexProjectMCPInstalled(projectDir, summary.BinaryPath, opts.DataDir)
+			if err == nil {
+				summary.HookInstalled, err = codexProjectHookInstalled(projectDir, setupHookCommand(opts, summary.BinaryPath))
+			}
+			if err != nil {
+				fmt.Fprintf(stderr, "setup remove: inspect project Codex config: %v\n", err)
+				return 1
+			}
+			if !opts.DryRun {
+				if err := removeCodexProjectSetup(projectDir); err != nil {
+					fmt.Fprintf(stderr, "setup remove: remove project Codex integration: %v\n", err)
+					return 1
+				}
+			}
+		case err == errCodexProjectDirNotFound:
+			// Nothing is installed in this project yet.
+		default:
+			fmt.Fprintf(stderr, "setup remove: open project Codex config: %v\n", err)
 			return 1
 		}
-		if err := removeSetupMCP(opts); err != nil {
-			fmt.Fprintf(stderr, "setup remove: remove MCP server: %v\n", err)
-			return 1
+	} else {
+		summary.MCPInstalled = setupMCPInstalled(opts, summary.ClientConfigPath, summary.BinaryPath)
+		summary.HookInstalled = setupHookInstalled(opts, summary.HookConfigPath, summary.BinaryPath)
+		if !opts.DryRun {
+			if err := removeSetupHook(opts, summary.BinaryPath); err != nil {
+				fmt.Fprintf(stderr, "setup remove: remove hook: %v\n", err)
+				return 1
+			}
+			if err := removeSetupMCP(opts); err != nil {
+				fmt.Fprintf(stderr, "setup remove: remove MCP server: %v\n", err)
+				return 1
+			}
 		}
 	}
 	printSetupSummary(stdout, summary, opts.JSON)
@@ -318,12 +388,16 @@ func normalizeSetupOptions(opts setupOptions, stderr io.Writer) (setupOptions, i
 		fmt.Fprintf(stderr, "setup: --scope must be user or project, got %q\n", opts.Scope)
 		return opts, 2
 	}
-	if opts.Scope == "project" && !opts.WorkspaceSet {
-		fmt.Fprintln(stderr, "setup: --scope project requires an explicit --workspace DIR")
+	if opts.Target != "codex" && opts.WorkspaceSet {
+		fmt.Fprintln(stderr, "setup: --workspace is currently supported only for Codex project scope")
 		return opts, 2
 	}
-	if opts.Scope == "user" && opts.WorkspaceSet {
-		fmt.Fprintln(stderr, "setup: --workspace is only valid with --scope project")
+	if opts.Target == "codex" && opts.Scope == "project" && (!opts.WorkspaceSet || strings.TrimSpace(opts.Workspace) == "") {
+		fmt.Fprintln(stderr, "setup: Codex --scope project requires an explicit --workspace DIR with a non-empty value")
+		return opts, 2
+	}
+	if opts.Target == "codex" && opts.Scope == "user" && opts.WorkspaceSet {
+		fmt.Fprintln(stderr, "setup: --workspace is only valid with Codex --scope project")
 		return opts, 2
 	}
 	if opts.DataDir == "" {
@@ -345,6 +419,11 @@ func normalizeSetupOptions(opts setupOptions, stderr io.Writer) (setupOptions, i
 	}
 	if resolved, err := filepath.EvalSymlinks(opts.Workspace); err == nil {
 		opts.Workspace = resolved
+	}
+	opts.Workspace = filepath.Clean(opts.Workspace)
+	if opts.Target == "codex" && opts.Scope == "project" && filepath.Dir(opts.Workspace) == opts.Workspace {
+		fmt.Fprintln(stderr, "setup: workspace must not be the filesystem root")
+		return opts, 2
 	}
 	info, err := os.Stat(opts.Workspace)
 	if err != nil {
@@ -396,15 +475,28 @@ func buildSetupSummary(opts setupOptions) (setupSummary, error) {
 }
 
 func setupPlannedActions(opts setupOptions) []string {
-	actions := []string{
-		"scan selected workspace and write draft-only inventory artifacts",
-		"configure the HELM MCP server with the selected local data directory",
-		"configure the HELM PreToolUse hook for supported Codex tools",
-	}
-	if opts.NoQuickstart {
+	switch opts.Operation {
+	case "preview", "install":
+		hookAction := "configure the HELM PreToolUse hook for the selected client"
+		if opts.Target == "codex" {
+			hookAction = "configure the HELM PreToolUse hook for supported Codex tools"
+		}
+		actions := []string{
+			"scan selected workspace and write draft-only inventory artifacts",
+			"configure the HELM MCP server with the selected local data directory",
+			hookAction,
+		}
+		if !opts.NoQuickstart {
+			actions = append(actions, "start the local Quickstart proof path")
+		}
 		return actions
+	case "status":
+		return []string{"inspect the existing local integration without writing files"}
+	case "preview_remove", "remove":
+		return []string{"remove the HELM MCP server and PreToolUse hook from the selected scope"}
+	default:
+		return nil
 	}
-	return append(actions, "start the local Quickstart proof path")
 }
 
 func setupKernelURL(opts setupOptions) string {
@@ -416,7 +508,7 @@ func setupKernelURL(opts setupOptions) string {
 
 func setupUninstallCommand(opts setupOptions) string {
 	workspace := ""
-	if opts.Scope == "project" {
+	if opts.Target == "codex" && opts.Scope == "project" {
 		workspace = " --workspace " + shellQuote(opts.Workspace)
 	}
 	return fmt.Sprintf(
@@ -480,7 +572,12 @@ func installSetupMCP(opts setupOptions, bin string) error {
 		return setupExecCommand("claude", "mcp", "add", "--transport", "stdio", "--scope", opts.Scope, setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
 	case "codex":
 		if opts.Scope == "project" {
-			return upsertCodexProjectMCP(setupClientConfigPath(opts), bin, opts.DataDir)
+			projectDir, err := openCodexProjectDir(opts.Workspace, true)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = projectDir.Close() }()
+			return upsertCodexProjectMCP(projectDir, bin, opts.DataDir)
 		}
 		return setupExecCommand("codex", "mcp", "add", setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
 	default:
@@ -494,7 +591,15 @@ func removeSetupMCP(opts setupOptions) error {
 		return setupExecCommand("claude", "mcp", "remove", "--scope", opts.Scope, setupMCPServerName)
 	case "codex":
 		if opts.Scope == "project" {
-			return removeCodexProjectMCP(setupClientConfigPath(opts))
+			projectDir, err := openCodexProjectDir(opts.Workspace, false)
+			if err == errCodexProjectDirNotFound {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			defer func() { _ = projectDir.Close() }()
+			return removeCodexProjectMCP(projectDir)
 		}
 		return setupExecCommand("codex", "mcp", "remove", setupMCPServerName)
 	default:
@@ -503,17 +608,77 @@ func removeSetupMCP(opts setupOptions) error {
 }
 
 func installSetupHook(opts setupOptions, bin string) error {
+	if opts.Target == "codex" && opts.Scope == "project" {
+		projectDir, err := openCodexProjectDir(opts.Workspace, true)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = projectDir.Close() }()
+		return upsertCodexProjectHook(projectDir, setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
+	}
 	return upsertHookConfig(setupHookConfigPath(opts), setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
 }
 
 func removeSetupHook(opts setupOptions, bin string) error {
+	if opts.Target == "codex" && opts.Scope == "project" {
+		projectDir, err := openCodexProjectDir(opts.Workspace, false)
+		if err == errCodexProjectDirNotFound {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		defer func() { _ = projectDir.Close() }()
+		return removeCodexProjectHook(projectDir)
+	}
 	return removeHookConfig(setupHookConfigPath(opts), setupHookCommand(opts, bin))
 }
 
-func setupMCPInstalled(opts setupOptions, path string) bool {
-	if opts.Target == "codex" && opts.Scope == "project" {
-		return codexProjectMCPInstalled(path, opts.DataDir)
+func installCodexProjectSetup(projectDir *codexProjectDir, opts setupOptions, bin string) error {
+	config, err := prepareCodexProjectMCPUpsert(projectDir, bin, opts.DataDir)
+	if err != nil {
+		return err
 	}
+	hooks, err := prepareCodexProjectHookUpsert(projectDir, setupHookMatcher(opts.Target), setupHookCommand(opts, bin))
+	if err != nil {
+		return err
+	}
+	if config != nil {
+		if err := projectDir.writePrivateFileAtomic("config.toml", config); err != nil {
+			return err
+		}
+	}
+	if hooks != nil {
+		if err := projectDir.writePrivateFileAtomic("hooks.json", hooks); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeCodexProjectSetup(projectDir *codexProjectDir) error {
+	config, err := prepareCodexProjectMCPRemoval(projectDir)
+	if err != nil {
+		return err
+	}
+	hooks, err := prepareCodexProjectHookRemoval(projectDir)
+	if err != nil {
+		return err
+	}
+	if hooks != nil {
+		if err := projectDir.writePrivateFileAtomic("hooks.json", hooks); err != nil {
+			return err
+		}
+	}
+	if config != nil {
+		if err := projectDir.writePrivateFileAtomic("config.toml", config); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func setupMCPInstalled(opts setupOptions, path, bin string) bool {
 	return fileContains(path, setupMCPServerName)
 }
 
@@ -540,7 +705,7 @@ func setupClientConfigPath(opts setupOptions) string {
 	switch opts.Target {
 	case "claude-code":
 		if opts.Scope == "project" {
-			return filepath.Join(opts.Workspace, ".mcp.json")
+			return ".mcp.json"
 		}
 		return filepath.Join(homeDirOrDot(), ".claude.json")
 	case "codex":
@@ -557,7 +722,7 @@ func setupHookConfigPath(opts setupOptions) string {
 	switch opts.Target {
 	case "claude-code":
 		if opts.Scope == "project" {
-			return filepath.Join(opts.Workspace, ".claude", "settings.json")
+			return filepath.Join(".claude", "settings.json")
 		}
 		return filepath.Join(homeDirOrDot(), ".claude", "settings.json")
 	case "codex":
@@ -721,15 +886,357 @@ func hookCommandFromAny(v any) string {
 	return command
 }
 
-func upsertCodexProjectMCP(path, bin, dataDir string) error {
+func upsertCodexProjectHook(projectDir *codexProjectDir, matcher, command string) error {
+	next, err := prepareCodexProjectHookUpsert(projectDir, matcher, command)
+	if err != nil || next == nil {
+		return err
+	}
+	return projectDir.writePrivateFileAtomic("hooks.json", next)
+}
+
+func prepareCodexProjectHookUpsert(projectDir *codexProjectDir, matcher, command string) ([]byte, error) {
+	root, hooks, pre, err := readCodexProjectHooks(projectDir)
+	if os.IsNotExist(err) {
+		root = map[string]any{}
+		hooks = map[string]any{}
+		pre = []any{}
+		err = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	updated, found, changed := reconcileOwnedCodexHooks(pre, matcher, command)
+	if found {
+		if !changed {
+			return nil, nil
+		}
+		hooks["PreToolUse"] = updated
+		root["hooks"] = hooks
+		return marshalCodexProjectHooks(root)
+	}
+	entry := map[string]any{
+		"matcher": matcher,
+		"hooks": []any{
+			map[string]any{
+				"type":          "command",
+				"command":       command,
+				"timeout":       float64(30),
+				"statusMessage": "Checking HELM policy",
+			},
+		},
+	}
+	hooks["PreToolUse"] = append(pre, entry)
+	root["hooks"] = hooks
+	return marshalCodexProjectHooks(root)
+}
+
+func removeCodexProjectHook(projectDir *codexProjectDir) error {
+	next, err := prepareCodexProjectHookRemoval(projectDir)
+	if err != nil || next == nil {
+		return err
+	}
+	return projectDir.writePrivateFileAtomic("hooks.json", next)
+}
+
+func prepareCodexProjectHookRemoval(projectDir *codexProjectDir) ([]byte, error) {
+	root, hooks, pre, err := readCodexProjectHooks(projectDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	changed := false
+	filtered := make([]any, 0, len(pre))
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		hookItems, ok := obj["hooks"].([]any)
+		if !ok {
+			filtered = append(filtered, item)
+			continue
+		}
+		keptHooks := make([]any, 0, len(hookItems))
+		for _, hook := range hookItems {
+			if isOwnedCodexHook(hook) {
+				changed = true
+				continue
+			}
+			keptHooks = append(keptHooks, hook)
+		}
+		if len(keptHooks) > 0 {
+			obj["hooks"] = keptHooks
+			filtered = append(filtered, obj)
+		} else if len(hookItems) > 0 {
+			changed = true
+		} else {
+			filtered = append(filtered, obj)
+		}
+	}
+	if !changed {
+		return nil, nil
+	}
+	hooks["PreToolUse"] = filtered
+	root["hooks"] = hooks
+	return marshalCodexProjectHooks(root)
+}
+
+func codexProjectHookInstalled(projectDir *codexProjectDir, command string) (bool, error) {
+	_, _, pre, err := readCodexProjectHooks(projectDir)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return currentOwnedCodexHookPresent(pre, command), nil
+}
+
+func readCodexProjectHooks(projectDir *codexProjectDir) (map[string]any, map[string]any, []any, error) {
+	raw, err := projectDir.readRegularFile("hooks.json")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return nil, nil, nil, fmt.Errorf("parse existing Codex hooks: %w", err)
+	}
+	if root == nil {
+		return nil, nil, nil, fmt.Errorf("parse existing Codex hooks: root must be an object")
+	}
+	hooksValue, hasHooks := root["hooks"]
+	if !hasHooks {
+		return root, map[string]any{}, []any{}, nil
+	}
+	hooks, ok := hooksValue.(map[string]any)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("parse existing Codex hooks: hooks must be an object")
+	}
+	preValue, hasPre := hooks["PreToolUse"]
+	if !hasPre {
+		return root, hooks, []any{}, nil
+	}
+	pre, ok := preValue.([]any)
+	if !ok {
+		return nil, nil, nil, fmt.Errorf("parse existing Codex hooks: hooks.PreToolUse must be an array")
+	}
+	return root, hooks, pre, nil
+}
+
+func marshalCodexProjectHooks(root map[string]any) ([]byte, error) {
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+func currentOwnedCodexHookPresent(pre []any, command string) bool {
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooks, ok := obj["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, hook := range hooks {
+			if isOwnedCodexHook(hook) && hookCommandFromAny(hook) == command {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isOwnedCodexHook(v any) bool {
+	obj, ok := v.(map[string]any)
+	if !ok || obj["type"] != "command" || obj["statusMessage"] != "Checking HELM policy" {
+		return false
+	}
+	return isCodexHookCommand(hookCommandFromAny(v))
+}
+
+func isCodexHookCommand(command string) bool {
+	words, ok := splitSetupShellWords(command)
+	if !ok || len(words) != 7 || words[0] == "" || words[6] == "" {
+		return false
+	}
+	return words[1] == "hook" && words[2] == "pre-tool" && words[3] == "--client" && words[4] == "codex" && words[5] == "--data-dir"
+}
+
+func reconcileOwnedCodexHooks(pre []any, matcher, command string) ([]any, bool, bool) {
+	updated := make([]any, 0, len(pre))
+	found := false
+	changed := false
+	var dedicatedOwned map[string]any
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			updated = append(updated, item)
+			continue
+		}
+		hookItems, ok := obj["hooks"].([]any)
+		if !ok {
+			updated = append(updated, item)
+			continue
+		}
+		ownedCount := 0
+		for _, hook := range hookItems {
+			if isOwnedCodexHook(hook) {
+				ownedCount++
+			}
+		}
+		kept := make([]any, 0, len(hookItems))
+		for _, hook := range hookItems {
+			if !isOwnedCodexHook(hook) {
+				kept = append(kept, hook)
+				continue
+			}
+			if found {
+				changed = true
+				continue
+			}
+			found = true
+			owned := cloneSetupJSONObject(hook.(map[string]any))
+			if owned["command"] != command || owned["timeout"] != float64(30) {
+				changed = true
+			}
+			owned["command"] = command
+			owned["timeout"] = float64(30)
+			if entryMatcher, _ := obj["matcher"].(string); entryMatcher != matcher && len(hookItems) != ownedCount {
+				// Do not widen a shared user entry. Move the marked HELM hook
+				// into a dedicated entry with the current matcher instead.
+				dedicatedOwned = owned
+				changed = true
+				continue
+			}
+			if obj["matcher"] != matcher {
+				obj["matcher"] = matcher
+				changed = true
+			}
+			kept = append(kept, owned)
+		}
+		if len(kept) > 0 {
+			if len(kept) != len(hookItems) || changed {
+				obj["hooks"] = kept
+			}
+			updated = append(updated, obj)
+		} else if len(hookItems) > 0 {
+			changed = true
+		} else {
+			updated = append(updated, obj)
+		}
+	}
+	if dedicatedOwned != nil {
+		updated = append(updated, map[string]any{
+			"matcher": matcher,
+			"hooks":   []any{dedicatedOwned},
+		})
+	}
+	return updated, found, changed
+}
+
+func cloneSetupJSONObject(input map[string]any) map[string]any {
+	clone := make(map[string]any, len(input))
+	for key, value := range input {
+		clone[key] = value
+	}
+	return clone
+}
+
+// splitSetupShellWords accepts the small, deterministic shell-quoting subset
+// emitted by shellQuote. It deliberately does not execute or interpret shell
+// expansions; it is used only to recognize a HELM-owned hook during removal.
+func splitSetupShellWords(input string) ([]string, bool) {
+	var words []string
+	var word strings.Builder
+	inWord := false
+	inSingle := false
+	inDouble := false
+	for i := 0; i < len(input); i++ {
+		ch := input[i]
+		switch {
+		case inSingle:
+			if ch == 0x27 {
+				inSingle = false
+			} else {
+				word.WriteByte(ch)
+			}
+		case inDouble:
+			switch ch {
+			case '"':
+				inDouble = false
+			case '\\':
+				i++
+				if i >= len(input) {
+					return nil, false
+				}
+				word.WriteByte(input[i])
+			default:
+				word.WriteByte(ch)
+			}
+		case ch == 0x27:
+			inSingle = true
+			inWord = true
+		case ch == '"':
+			inDouble = true
+			inWord = true
+		case ch == '\\':
+			i++
+			if i >= len(input) {
+				return nil, false
+			}
+			word.WriteByte(input[i])
+			inWord = true
+		case ch == ' ' || ch == '\t' || ch == '\n':
+			if inWord {
+				words = append(words, word.String())
+				word.Reset()
+				inWord = false
+			}
+		default:
+			word.WriteByte(ch)
+			inWord = true
+		}
+	}
+	if inSingle || inDouble {
+		return nil, false
+	}
+	if inWord {
+		words = append(words, word.String())
+	}
+	return words, true
+}
+
+func upsertCodexProjectMCP(projectDir *codexProjectDir, bin, dataDir string) error {
+	next, err := prepareCodexProjectMCPUpsert(projectDir, bin, dataDir)
+	if err != nil || next == nil {
+		return err
+	}
+	return projectDir.writePrivateFileAtomic("config.toml", next)
+}
+
+func prepareCodexProjectMCPUpsert(projectDir *codexProjectDir, bin, dataDir string) ([]byte, error) {
 	current := ""
-	if raw, err := os.ReadFile(path); err == nil {
+	if raw, err := projectDir.readRegularFile("config.toml"); err == nil {
 		current = string(raw)
 		if err := validateCodexProjectTOML(current); err != nil {
-			return fmt.Errorf("parse existing Codex config: %w", err)
+			return nil, fmt.Errorf("parse existing Codex config: %w", err)
+		}
+		var config codexProjectConfig
+		if _, err := toml.Decode(current, &config); err != nil {
+			return nil, fmt.Errorf("parse existing Codex config: %w", err)
+		}
+		if server, exists := config.MCPServers[setupMCPServerName]; exists && !isOwnedCodexMCPServer(server) {
+			return nil, fmt.Errorf("refuse to replace non-HELM Codex MCP server %q", setupMCPServerName)
 		}
 	} else if !os.IsNotExist(err) {
-		return err
+		return nil, err
 	}
 	current = removeTOMLTable(current, "[mcp_servers."+setupMCPServerName+"]")
 	block := fmt.Sprintf("[mcp_servers.%s]\ncommand = %q\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", %q]\n", setupMCPServerName, bin, dataDir)
@@ -739,27 +1246,43 @@ func upsertCodexProjectMCP(path, bin, dataDir string) error {
 	}
 	next += block
 	if err := validateCodexProjectTOML(next); err != nil {
-		return fmt.Errorf("validate updated Codex config: %w", err)
+		return nil, fmt.Errorf("validate updated Codex config: %w", err)
 	}
-	return writePrivateFileAtomic(path, []byte(next))
+	return []byte(next), nil
 }
 
-func removeCodexProjectMCP(path string) error {
-	raw, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
+func removeCodexProjectMCP(projectDir *codexProjectDir) error {
+	next, err := prepareCodexProjectMCPRemoval(projectDir)
+	if err != nil || next == nil {
 		return err
 	}
+	return projectDir.writePrivateFileAtomic("config.toml", next)
+}
+
+func prepareCodexProjectMCPRemoval(projectDir *codexProjectDir) ([]byte, error) {
+	raw, err := projectDir.readRegularFile("config.toml")
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
 	if err := validateCodexProjectTOML(string(raw)); err != nil {
-		return fmt.Errorf("parse existing Codex config: %w", err)
+		return nil, fmt.Errorf("parse existing Codex config: %w", err)
+	}
+	var config codexProjectConfig
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		return nil, fmt.Errorf("parse existing Codex config: %w", err)
+	}
+	server, exists := config.MCPServers[setupMCPServerName]
+	if !exists || !isOwnedCodexMCPServer(server) {
+		return nil, nil
 	}
 	next := strings.TrimRight(removeTOMLTable(string(raw), "[mcp_servers."+setupMCPServerName+"]"), "\n") + "\n"
 	if err := validateCodexProjectTOML(next); err != nil {
-		return fmt.Errorf("validate updated Codex config: %w", err)
+		return nil, fmt.Errorf("validate updated Codex config: %w", err)
 	}
-	return writePrivateFileAtomic(path, []byte(next))
+	return []byte(next), nil
 }
 
 type codexProjectConfig struct {
@@ -771,6 +1294,20 @@ type codexMCPServer struct {
 	Args    []string `toml:"args"`
 }
 
+func isOwnedCodexMCPServer(server codexMCPServer) bool {
+	switch strings.ToLower(filepath.Base(strings.TrimSpace(server.Command))) {
+	case "helm-ai-kernel", "helm-ai-kernel.exe", "helm-ai-kernel.test":
+		// Exact known HELM kernel executable names only. A named server is not
+		// ownership proof on its own, and lookalike executable names stay intact.
+	default:
+		return false
+	}
+	if len(server.Args) != 6 || server.Args[0] != "mcp" || server.Args[1] != "serve" || server.Args[2] != "--transport" || server.Args[3] != "stdio" || server.Args[4] != "--data-dir" {
+		return false
+	}
+	return strings.TrimSpace(server.Args[5]) != ""
+}
+
 func validateCodexProjectTOML(raw string) error {
 	if strings.TrimSpace(raw) == "" {
 		return nil
@@ -780,21 +1317,27 @@ func validateCodexProjectTOML(raw string) error {
 	return err
 }
 
-func codexProjectMCPInstalled(path, dataDir string) bool {
-	raw, err := os.ReadFile(path)
+func codexProjectMCPInstalled(projectDir *codexProjectDir, bin, dataDir string) (bool, error) {
+	raw, err := projectDir.readRegularFile("config.toml")
+	if os.IsNotExist(err) {
+		return false, nil
+	}
 	if err != nil {
-		return false
+		return false, err
 	}
 	var config codexProjectConfig
 	if _, err := toml.Decode(string(raw), &config); err != nil {
-		return false
+		return false, fmt.Errorf("parse existing Codex config: %w", err)
 	}
 	server, ok := config.MCPServers[setupMCPServerName]
-	if !ok || strings.TrimSpace(server.Command) == "" {
-		return false
+	if !ok || server.Command != bin {
+		return false, nil
 	}
-	wantArgs := []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}
-	return equalSetupStrings(server.Args, wantArgs)
+	return equalSetupStrings(server.Args, setupMCPArgs(dataDir)), nil
+}
+
+func setupMCPArgs(dataDir string) []string {
+	return []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}
 }
 
 func equalSetupStrings(left, right []string) bool {
@@ -809,48 +1352,160 @@ func equalSetupStrings(left, right []string) bool {
 	return true
 }
 
-func writePrivateFileAtomic(path string, data []byte) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".helm-tmp-*")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer func() { _ = os.Remove(tmpPath) }()
-	if err := tmp.Chmod(0o600); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpPath, path)
-}
-
 func removeTOMLTable(input, table string) string {
+	target, ok := tomlTableHeader(strings.TrimSpace(table))
+	if !ok {
+		return strings.TrimRight(input, "\n")
+	}
 	lines := strings.Split(input, "\n")
 	out := make([]string, 0, len(lines))
 	skipping := false
 	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		if trimmed == table {
-			skipping = true
-			continue
-		}
-		if skipping && strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
-			skipping = false
+		if header, ok := tomlTableHeader(trimmed); ok {
+			skipping = tomlTableIsOwnedBy(header, target)
 		}
 		if !skipping {
 			out = append(out, line)
 		}
 	}
 	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+func tomlTableIsOwnedBy(header, target []string) bool {
+	if len(header) < len(target) {
+		return false
+	}
+	for i := range target {
+		if header[i] != target[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func tomlTableHeader(line string) ([]string, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "[") {
+		return nil, false
+	}
+	array := strings.HasPrefix(line, "[[")
+	start := 1
+	if array {
+		start = 2
+	}
+	inBasic := false
+	inLiteral := false
+	escaped := false
+	for i := start; i < len(line); i++ {
+		ch := line[i]
+		switch {
+		case inBasic:
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+			} else if ch == '"' {
+				inBasic = false
+			}
+		case inLiteral:
+			if ch == '\'' {
+				inLiteral = false
+			}
+		case ch == '"':
+			inBasic = true
+		case ch == '\'':
+			inLiteral = true
+		case ch == ']':
+			end := i + 1
+			if array {
+				if end >= len(line) || line[end] != ']' {
+					return nil, false
+				}
+				end++
+			}
+			rest := strings.TrimSpace(line[end:])
+			if rest != "" && !strings.HasPrefix(rest, "#") {
+				return nil, false
+			}
+			return parseTOMLDottedKey(line[start:i])
+		}
+	}
+	return nil, false
+}
+
+func parseTOMLDottedKey(input string) ([]string, bool) {
+	var segments []string
+	for i := 0; ; {
+		for i < len(input) && (input[i] == ' ' || input[i] == '\t') {
+			i++
+		}
+		if i >= len(input) {
+			return nil, false
+		}
+		var segment string
+		switch input[i] {
+		case '"':
+			start := i
+			i++
+			escaped := false
+			for i < len(input) {
+				if escaped {
+					escaped = false
+					i++
+					continue
+				}
+				if input[i] == '\\' {
+					escaped = true
+				} else if input[i] == '"' {
+					i++
+					value, err := strconv.Unquote(input[start:i])
+					if err != nil {
+						return nil, false
+					}
+					segment = value
+					break
+				}
+				i++
+			}
+			if segment == "" && (i == len(input) || input[i-1] != '"') {
+				return nil, false
+			}
+		case '\'':
+			i++
+			start := i
+			for i < len(input) && input[i] != '\'' {
+				i++
+			}
+			if i >= len(input) {
+				return nil, false
+			}
+			segment = input[start:i]
+			i++
+		default:
+			start := i
+			for i < len(input) && input[i] != '.' && input[i] != ' ' && input[i] != '\t' {
+				i++
+			}
+			segment = input[start:i]
+		}
+		if segment == "" {
+			return nil, false
+		}
+		segments = append(segments, segment)
+		for i < len(input) && (input[i] == ' ' || input[i] == '\t') {
+			i++
+		}
+		if i == len(input) {
+			return segments, true
+		}
+		if input[i] != '.' {
+			return nil, false
+		}
+		i++
+	}
 }
 
 func readSetupScanGrade(path string) string {

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/shadow"
 )
 
@@ -26,27 +27,35 @@ var (
 )
 
 type setupOptions struct {
-	Target  string
-	Scope   string
-	Yes     bool
-	DryRun  bool
-	JSON    bool
-	DataDir string
+	Target       string
+	Operation    string
+	Scope        string
+	Workspace    string
+	WorkspaceSet bool
+	Yes          bool
+	DryRun       bool
+	JSON         bool
+	NoQuickstart bool
+	DataDir      string
 }
 
 type setupSummary struct {
-	Target           string `json:"target"`
-	BinaryPath       string `json:"binary_path"`
-	ClientConfigPath string `json:"client_config_path"`
-	HookConfigPath   string `json:"hook_config_path"`
-	DataDir          string `json:"data_dir"`
-	KernelURL        string `json:"kernel_url"`
-	ScanGrade        string `json:"scan_grade"`
-	DraftPolicyPath  string `json:"draft_policy_path"`
-	UninstallCommand string `json:"uninstall_command"`
-	Scope            string `json:"scope,omitempty"`
-	MCPInstalled     bool   `json:"mcp_installed,omitempty"`
-	HookInstalled    bool   `json:"hook_installed,omitempty"`
+	Operation         string   `json:"operation"`
+	Target            string   `json:"target"`
+	Workspace         string   `json:"workspace"`
+	BinaryPath        string   `json:"binary_path"`
+	ClientConfigPath  string   `json:"client_config_path"`
+	HookConfigPath    string   `json:"hook_config_path"`
+	DataDir           string   `json:"data_dir"`
+	KernelURL         string   `json:"kernel_url"`
+	ScanGrade         string   `json:"scan_grade"`
+	DraftPolicyPath   string   `json:"draft_policy_path"`
+	UninstallCommand  string   `json:"uninstall_command"`
+	Scope             string   `json:"scope,omitempty"`
+	MCPInstalled      bool     `json:"mcp_installed,omitempty"`
+	HookInstalled     bool     `json:"hook_installed,omitempty"`
+	QuickstartStarted bool     `json:"quickstart_started"`
+	PlannedActions    []string `json:"planned_actions"`
 }
 
 func init() {
@@ -110,6 +119,11 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 	if code != 0 {
 		return code
 	}
+	if opts.DryRun {
+		opts.Operation = "preview"
+	} else {
+		opts.Operation = "install"
+	}
 	if !opts.Yes && !opts.DryRun {
 		fmt.Fprintln(stderr, "setup: pass --yes to install local config, or --dry-run to preview changes")
 		return 2
@@ -127,7 +141,7 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup: create data dir: %v\n", err)
 		return 1
 	}
-	grade, policyPath, err := runSetupAutoconfigure(opts.DataDir)
+	grade, policyPath, err := runSetupAutoconfigure(opts.DataDir, opts.Workspace)
 	if err != nil {
 		fmt.Fprintf(stderr, "setup: autoconfigure: %v\n", err)
 		return 1
@@ -145,6 +159,9 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 	summary.MCPInstalled = true
 	summary.HookInstalled = true
 	printSetupSummary(stdout, summary, opts.JSON)
+	if opts.NoQuickstart {
+		return 0
+	}
 	if !opts.JSON {
 		fmt.Fprintln(stdout)
 		fmt.Fprintln(stdout, "Leave this terminal open. HELM is starting the local Kernel proof path now.")
@@ -162,6 +179,7 @@ func runSetupStatusCmd(args []string, stdout, stderr io.Writer) int {
 	if code != 0 {
 		return code
 	}
+	opts.Operation = "status"
 	summary, err := buildSetupSummary(opts)
 	if err != nil {
 		fmt.Fprintf(stderr, "setup status: %v\n", err)
@@ -183,6 +201,11 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 	opts, code := parseSetupInspectArgs("setup remove", args, stderr, true)
 	if code != 0 {
 		return code
+	}
+	if opts.DryRun {
+		opts.Operation = "preview_remove"
+	} else {
+		opts.Operation = "remove"
 	}
 	if !opts.Yes && !opts.DryRun {
 		fmt.Fprintln(stderr, "setup remove: pass --yes to remove local config, or --dry-run to preview changes")
@@ -218,8 +241,9 @@ func printSetupUsage(w io.Writer) {
 	fmt.Fprintln(w, "  helm-ai-kernel setup --json")
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "Manage:")
-	fmt.Fprintln(w, "  helm-ai-kernel setup status <claude-code|codex> [--scope user|project] [--json] [--data-dir DIR]")
-	fmt.Fprintln(w, "  helm-ai-kernel setup remove <claude-code|codex> [--scope user|project] [--yes] [--dry-run] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "  helm-ai-kernel setup codex --scope project --workspace DIR --dry-run --json")
+	fmt.Fprintln(w, "  helm-ai-kernel setup status <claude-code|codex> [--scope user|project] [--workspace DIR] [--json] [--data-dir DIR]")
+	fmt.Fprintln(w, "  helm-ai-kernel setup remove <claude-code|codex> [--scope user|project] [--workspace DIR] [--yes] [--dry-run] [--json] [--data-dir DIR]")
 	fmt.Fprintln(w, "")
 	printSupportMatrix(w)
 	fmt.Fprintln(w, "")
@@ -231,13 +255,20 @@ func parseSetupInstallArgs(args []string, stderr io.Writer) (setupOptions, int) 
 	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.StringVar(&opts.Scope, "scope", opts.Scope, "Install scope: user or project")
+	fs.StringVar(&opts.Workspace, "workspace", "", "Workspace to scan and configure (required for project scope)")
 	fs.BoolVar(&opts.Yes, "yes", false, "Install without prompting")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "Print planned changes without writing config")
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
+	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Install without starting the blocking Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
 	if err := fs.Parse(args[1:]); err != nil {
 		return opts, 2
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "workspace" {
+			opts.WorkspaceSet = true
+		}
+	})
 	opts.Target = args[0]
 	return normalizeSetupOptions(opts, stderr)
 }
@@ -251,8 +282,10 @@ func parseSetupInspectArgs(name string, args []string, stderr io.Writer, include
 	fs := flag.NewFlagSet(name, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	fs.StringVar(&opts.Scope, "scope", opts.Scope, "Install scope: user or project")
+	fs.StringVar(&opts.Workspace, "workspace", "", "Workspace to inspect or remove from (required for project scope)")
 	fs.BoolVar(&opts.DryRun, "dry-run", false, "Print planned changes without writing config")
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
+	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Report a headless setup without a Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
 	if includeYes {
 		fs.BoolVar(&opts.Yes, "yes", false, "Remove without prompting")
@@ -260,6 +293,11 @@ func parseSetupInspectArgs(name string, args []string, stderr io.Writer, include
 	if err := fs.Parse(args[1:]); err != nil {
 		return opts, 2
 	}
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "workspace" {
+			opts.WorkspaceSet = true
+		}
+	})
 	if fs.NArg() != 0 {
 		fmt.Fprintf(stderr, "%s: unexpected argument %q\n", name, fs.Arg(0))
 		return opts, 2
@@ -280,11 +318,42 @@ func normalizeSetupOptions(opts setupOptions, stderr io.Writer) (setupOptions, i
 		fmt.Fprintf(stderr, "setup: --scope must be user or project, got %q\n", opts.Scope)
 		return opts, 2
 	}
+	if opts.Scope == "project" && !opts.WorkspaceSet {
+		fmt.Fprintln(stderr, "setup: --scope project requires an explicit --workspace DIR")
+		return opts, 2
+	}
+	if opts.Scope == "user" && opts.WorkspaceSet {
+		fmt.Fprintln(stderr, "setup: --workspace is only valid with --scope project")
+		return opts, 2
+	}
 	if opts.DataDir == "" {
 		opts.DataDir = defaultSetupDataDir()
 	}
 	if abs, err := filepath.Abs(opts.DataDir); err == nil {
 		opts.DataDir = abs
+	}
+	if opts.Workspace == "" {
+		workspace, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintf(stderr, "setup: determine workspace: %v\n", err)
+			return opts, 2
+		}
+		opts.Workspace = workspace
+	}
+	if abs, err := filepath.Abs(opts.Workspace); err == nil {
+		opts.Workspace = abs
+	}
+	if resolved, err := filepath.EvalSymlinks(opts.Workspace); err == nil {
+		opts.Workspace = resolved
+	}
+	info, err := os.Stat(opts.Workspace)
+	if err != nil {
+		fmt.Fprintf(stderr, "setup: workspace: %v\n", err)
+		return opts, 2
+	}
+	if !info.IsDir() {
+		fmt.Fprintf(stderr, "setup: workspace must be a directory, got %q\n", opts.Workspace)
+		return opts, 2
 	}
 	return opts, 0
 }
@@ -309,17 +378,54 @@ func buildSetupSummary(opts setupOptions) (setupSummary, error) {
 		bin = abs
 	}
 	return setupSummary{
-		Target:           opts.Target,
-		BinaryPath:       bin,
-		ClientConfigPath: setupClientConfigPath(opts),
-		HookConfigPath:   setupHookConfigPath(opts),
-		DataDir:          opts.DataDir,
-		KernelURL:        "http://127.0.0.1:7714",
-		ScanGrade:        "not_run",
-		DraftPolicyPath:  filepath.Join(opts.DataDir, "autoconfigure", "policy.draft.json"),
-		UninstallCommand: fmt.Sprintf("helm-ai-kernel setup remove %s --scope %s --yes --data-dir %s", opts.Target, opts.Scope, shellQuote(opts.DataDir)),
-		Scope:            opts.Scope,
+		Operation:         opts.Operation,
+		Target:            opts.Target,
+		Workspace:         opts.Workspace,
+		BinaryPath:        bin,
+		ClientConfigPath:  setupClientConfigPath(opts),
+		HookConfigPath:    setupHookConfigPath(opts),
+		DataDir:           opts.DataDir,
+		KernelURL:         setupKernelURL(opts),
+		ScanGrade:         "not_run",
+		DraftPolicyPath:   filepath.Join(opts.DataDir, "autoconfigure", "policy.draft.json"),
+		UninstallCommand:  setupUninstallCommand(opts),
+		Scope:             opts.Scope,
+		QuickstartStarted: opts.Operation == "install" && !opts.NoQuickstart,
+		PlannedActions:    setupPlannedActions(opts),
 	}, nil
+}
+
+func setupPlannedActions(opts setupOptions) []string {
+	actions := []string{
+		"scan selected workspace and write draft-only inventory artifacts",
+		"configure the HELM MCP server with the selected local data directory",
+		"configure the HELM PreToolUse hook for supported Codex tools",
+	}
+	if opts.NoQuickstart {
+		return actions
+	}
+	return append(actions, "start the local Quickstart proof path")
+}
+
+func setupKernelURL(opts setupOptions) string {
+	if opts.NoQuickstart {
+		return ""
+	}
+	return "http://127.0.0.1:7714"
+}
+
+func setupUninstallCommand(opts setupOptions) string {
+	workspace := ""
+	if opts.Scope == "project" {
+		workspace = " --workspace " + shellQuote(opts.Workspace)
+	}
+	return fmt.Sprintf(
+		"helm-ai-kernel setup remove %s --scope %s%s --yes --data-dir %s",
+		opts.Target,
+		opts.Scope,
+		workspace,
+		shellQuote(opts.DataDir),
+	)
 }
 
 func printSetupSummary(stdout io.Writer, summary setupSummary, jsonOut bool) {
@@ -328,6 +434,7 @@ func printSetupSummary(stdout io.Writer, summary setupSummary, jsonOut bool) {
 		return
 	}
 	fmt.Fprintf(stdout, "HELM setup for %s\n", summary.Target)
+	fmt.Fprintf(stdout, "  Workspace:     %s\n", summary.Workspace)
 	fmt.Fprintf(stdout, "  MCP config:    %s\n", summary.ClientConfigPath)
 	fmt.Fprintf(stdout, "  Hook config:   %s\n", summary.HookConfigPath)
 	fmt.Fprintf(stdout, "  Data dir:      %s\n", summary.DataDir)
@@ -335,14 +442,20 @@ func printSetupSummary(stdout io.Writer, summary setupSummary, jsonOut bool) {
 	fmt.Fprintf(stdout, "  Scan grade:    %s\n", summary.ScanGrade)
 	fmt.Fprintf(stdout, "  Draft policy:  %s\n", summary.DraftPolicyPath)
 	fmt.Fprintf(stdout, "  Uninstall:     %s\n", summary.UninstallCommand)
+	if len(summary.PlannedActions) > 0 {
+		fmt.Fprintln(stdout, "  Planned:")
+		for _, action := range summary.PlannedActions {
+			fmt.Fprintf(stdout, "    - %s\n", action)
+		}
+	}
 	if summary.MCPInstalled || summary.HookInstalled {
 		fmt.Fprintf(stdout, "  Installed:     mcp=%v hook=%v\n", summary.MCPInstalled, summary.HookInstalled)
 	}
 }
 
-func runSetupAutoconfigure(dataDir string) (string, string, error) {
+func runSetupAutoconfigure(dataDir, workspace string) (string, string, error) {
 	outDir := filepath.Join(dataDir, "autoconfigure")
-	report, err := shadow.NewScanner().Scan(".")
+	report, err := shadow.NewScanner().Scan(workspace)
 	if err != nil {
 		return "", "", err
 	}
@@ -367,7 +480,7 @@ func installSetupMCP(opts setupOptions, bin string) error {
 		return setupExecCommand("claude", "mcp", "add", "--transport", "stdio", "--scope", opts.Scope, setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
 	case "codex":
 		if opts.Scope == "project" {
-			return upsertCodexProjectMCP(setupClientConfigPath(opts), bin)
+			return upsertCodexProjectMCP(setupClientConfigPath(opts), bin, opts.DataDir)
 		}
 		return setupExecCommand("codex", "mcp", "add", setupMCPServerName, "--", bin, "mcp", "serve", "--transport", "stdio")
 	default:
@@ -398,14 +511,22 @@ func removeSetupHook(opts setupOptions, bin string) error {
 }
 
 func setupMCPInstalled(opts setupOptions, path string) bool {
-	if opts.Target == "claude-code" && opts.Scope == "user" {
-		return fileContains(path, setupMCPServerName)
+	if opts.Target == "codex" && opts.Scope == "project" {
+		return codexProjectMCPInstalled(path, opts.DataDir)
 	}
 	return fileContains(path, setupMCPServerName)
 }
 
 func setupHookInstalled(opts setupOptions, path, bin string) bool {
-	return fileContains(path, setupHookCommand(opts, bin))
+	root, err := readJSONObject(path)
+	if err != nil {
+		return false
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	return hookCommandPresent(arrayValue(hooks, "PreToolUse"), setupHookCommand(opts, bin))
 }
 
 func setupQuickstartProfile(target string) string {
@@ -419,12 +540,12 @@ func setupClientConfigPath(opts setupOptions) string {
 	switch opts.Target {
 	case "claude-code":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".mcp.json")
+			return filepath.Join(opts.Workspace, ".mcp.json")
 		}
 		return filepath.Join(homeDirOrDot(), ".claude.json")
 	case "codex":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".codex", "config.toml")
+			return filepath.Join(opts.Workspace, ".codex", "config.toml")
 		}
 		return filepath.Join(homeDirOrDot(), ".codex", "config.toml")
 	default:
@@ -436,12 +557,12 @@ func setupHookConfigPath(opts setupOptions) string {
 	switch opts.Target {
 	case "claude-code":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".claude", "settings.json")
+			return filepath.Join(opts.Workspace, ".claude", "settings.json")
 		}
 		return filepath.Join(homeDirOrDot(), ".claude", "settings.json")
 	case "codex":
 		if opts.Scope == "project" {
-			return filepath.Join(".", ".codex", "hooks.json")
+			return filepath.Join(opts.Workspace, ".codex", "hooks.json")
 		}
 		return filepath.Join(homeDirOrDot(), ".codex", "hooks.json")
 	default:
@@ -600,24 +721,27 @@ func hookCommandFromAny(v any) string {
 	return command
 }
 
-func upsertCodexProjectMCP(path, bin string) error {
+func upsertCodexProjectMCP(path, bin, dataDir string) error {
 	current := ""
 	if raw, err := os.ReadFile(path); err == nil {
 		current = string(raw)
+		if err := validateCodexProjectTOML(current); err != nil {
+			return fmt.Errorf("parse existing Codex config: %w", err)
+		}
 	} else if !os.IsNotExist(err) {
 		return err
 	}
 	current = removeTOMLTable(current, "[mcp_servers."+setupMCPServerName+"]")
-	block := fmt.Sprintf("[mcp_servers.%s]\ncommand = %q\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\"]\n", setupMCPServerName, bin)
+	block := fmt.Sprintf("[mcp_servers.%s]\ncommand = %q\nargs = [\"mcp\", \"serve\", \"--transport\", \"stdio\", \"--data-dir\", %q]\n", setupMCPServerName, bin, dataDir)
 	next := strings.TrimRight(current, "\n")
 	if next != "" {
 		next += "\n\n"
 	}
 	next += block
-	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
-		return err
+	if err := validateCodexProjectTOML(next); err != nil {
+		return fmt.Errorf("validate updated Codex config: %w", err)
 	}
-	return os.WriteFile(path, []byte(next), 0o600)
+	return writePrivateFileAtomic(path, []byte(next))
 }
 
 func removeCodexProjectMCP(path string) error {
@@ -628,8 +752,85 @@ func removeCodexProjectMCP(path string) error {
 	if err != nil {
 		return err
 	}
-	next := removeTOMLTable(string(raw), "[mcp_servers."+setupMCPServerName+"]")
-	return os.WriteFile(path, []byte(strings.TrimRight(next, "\n")+"\n"), 0o600)
+	if err := validateCodexProjectTOML(string(raw)); err != nil {
+		return fmt.Errorf("parse existing Codex config: %w", err)
+	}
+	next := strings.TrimRight(removeTOMLTable(string(raw), "[mcp_servers."+setupMCPServerName+"]"), "\n") + "\n"
+	if err := validateCodexProjectTOML(next); err != nil {
+		return fmt.Errorf("validate updated Codex config: %w", err)
+	}
+	return writePrivateFileAtomic(path, []byte(next))
+}
+
+type codexProjectConfig struct {
+	MCPServers map[string]codexMCPServer `toml:"mcp_servers"`
+}
+
+type codexMCPServer struct {
+	Command string   `toml:"command"`
+	Args    []string `toml:"args"`
+}
+
+func validateCodexProjectTOML(raw string) error {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var config map[string]any
+	_, err := toml.Decode(raw, &config)
+	return err
+}
+
+func codexProjectMCPInstalled(path, dataDir string) bool {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var config codexProjectConfig
+	if _, err := toml.Decode(string(raw), &config); err != nil {
+		return false
+	}
+	server, ok := config.MCPServers[setupMCPServerName]
+	if !ok || strings.TrimSpace(server.Command) == "" {
+		return false
+	}
+	wantArgs := []string{"mcp", "serve", "--transport", "stdio", "--data-dir", dataDir}
+	return equalSetupStrings(server.Args, wantArgs)
+}
+
+func equalSetupStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func writePrivateFileAtomic(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".helm-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func removeTOMLTable(input, table string) string {

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -168,16 +168,15 @@ func TestSetupInstallClaudeWritesHookAndRunsQuickstart(t *testing.T) {
 
 func TestSetupInstallJSONKeepsQuickstartOutputOffStdout(t *testing.T) {
 	tmp := t.TempDir()
-	oldWD, _ := os.Getwd()
-	if err := os.Chdir(tmp); err != nil {
+	workspace := filepath.Join(tmp, "workspace")
+	if err := os.MkdirAll(workspace, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { _ = os.Chdir(oldWD) })
 	stubSetupSideEffects(t)
 
 	var stdout, stderr bytes.Buffer
 	dataDir := filepath.Join(tmp, "helm")
-	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--workspace", workspace, "--yes", "--json", "--data-dir", dataDir}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("setup exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
 	}
@@ -206,7 +205,7 @@ func TestSetupCodexProjectRemoveUndoLocalConfig(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	dataDir := filepath.Join(tmp, "helm")
-	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	code := Run([]string{"helm-ai-kernel", "setup", "codex", "--scope", "project", "--workspace", tmp, "--yes", "--data-dir", dataDir}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("setup exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
 	}
@@ -232,7 +231,7 @@ func TestSetupCodexProjectRemoveUndoLocalConfig(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	code = Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--yes", "--data-dir", dataDir}, &stdout, &stderr)
+	code = Run([]string{"helm-ai-kernel", "setup", "remove", "codex", "--scope", "project", "--workspace", tmp, "--yes", "--data-dir", dataDir}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("remove exit = %d stderr = %s stdout = %s", code, stderr.String(), stdout.String())
 	}


### PR DESCRIPTION
## Scope
- Adds the Codex project setup/removal contract needed by the desktop bridge branch.
- Treats project-scoped Codex hook/MCP ownership as the exact current HELM kernel binary, not a basename match.
- Fails closed with manual remediation when a project contains ambiguous same-name or mixed owned/foreign Codex setup, instead of partially mutating it.
- Preserves the stacked branch's required `quantum_posture` annotations on crypto-touching CLI files.

## Validation
- `go test ./core/cmd/helm-ai-kernel -run 'TestCodexProjectSetup(RejectsMixedForeignAndCurrentHooksWithoutMutation|RejectsForeignMCPAlongsideCurrentHookWithoutMutation|CurrentBinaryApplyStatusRemove|PreservesExactBasenameForeignMCPServer|RefusesExactBasenameForeignHookWithoutMutation)' -count=1`
- `make quality-pr`

## Notes
- This targets `codex/helm-182-kernel-transport-v2`; it is not a release branch and does not claim packaged desktop completion.
- Desktop wrapper work remains blocked on Console vendor provenance: the current Console Enterprise blob still has no canonical producer ref, so no safe partial consumer sync is being claimed here.
