### PR TITLE
HELM-245: kernel principal↔tenant binding registry + admin endpoint

### DIFF
--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -162,10 +162,11 @@ func runServerWithOptions(opts serverOptions) {
 	}
 
 	var (
-		db           *sql.DB
-		receiptStore store.ReceiptStore
-		err          error
-		databaseMode = "sqlite"
+		db                    *sql.DB
+		receiptStore          store.ReceiptStore
+		principalBindingStore store.PrincipalBindingStore
+		err                   error
+		databaseMode          = "sqlite"
 	)
 
 	// 0.2 Connect to Database (Infrastructure)
@@ -180,6 +181,10 @@ func runServerWithOptions(opts serverOptions) {
 		}
 		if err != nil {
 			log.Fatalf("Failed to setup Lite Mode: %v", err)
+		}
+		principalBindingStore, err = store.NewSQLitePrincipalBindingStore(db)
+		if err != nil {
+			log.Fatalf("Failed to init sqlite principal binding store: %v", err)
 		}
 	} else {
 		databaseMode = "postgres"
@@ -209,6 +214,11 @@ func runServerWithOptions(opts serverOptions) {
 			log.Fatalf("Failed to init receipt store: %v", err)
 		}
 		receiptStore = ps
+		pbs, pbErr := store.NewPostgresPrincipalBindingStore(db)
+		if pbErr != nil {
+			log.Fatalf("Failed to init postgres principal binding store: %v", pbErr)
+		}
+		principalBindingStore = pbs
 	}
 
 	// 1. Initialize Kernel Layers
@@ -356,6 +366,7 @@ func runServerWithOptions(opts serverOptions) {
 		services.Guardian = guard
 		services.ReceiptStore = receiptStore
 		services.ReceiptSigner = signer
+		services.PrincipalBindings = principalBindingStore
 		services.PolicyReconciler = policyReconciler
 		services.PolicySnapshotStore = policyStore
 		services.PolicyScope = policyScope
@@ -381,6 +392,7 @@ func runServerWithOptions(opts serverOptions) {
 			RegisterSubsystemRoutes(mux, services)
 			RegisterConsoleRoutes(mux, services, opts)
 			RegisterLocalFirstRunRoutes(mux, services, opts)
+			RegisterPrincipalBindingRoutes(mux, services, opts)
 		}
 	}
 

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -367,6 +367,7 @@ func runServerWithOptions(opts serverOptions) {
 		services.ReceiptStore = receiptStore
 		services.ReceiptSigner = signer
 		services.PrincipalBindings = principalBindingStore
+		SetPrincipalBindingStore(principalBindingStore)
 		services.PolicyReconciler = policyReconciler
 		services.PolicySnapshotStore = policyStore
 		services.PolicyScope = policyScope

--- a/core/cmd/helm-ai-kernel/principal_binding_integration_test.go
+++ b/core/cmd/helm-ai-kernel/principal_binding_integration_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestPrincipalBindingEndpointToGateSharedStoreInvariant proves the
+// endpoint-write is visible to the gate-read through the SAME store
+// instance — the exact end-to-end property the feature exists for. Task 2's
+// admin endpoint (RegisterPrincipalBindingRoutes) and Task 3's tenant gate
+// (requireRuntimeTenant, via SetPrincipalBindingStore) each hold their own
+// handle to a store.PrincipalBindingStore: *Services.PrincipalBindings for
+// the endpoint, the package-level principalBindingStore for the gate. In
+// production both are wired to the same instance in main.go (lines
+// ~369-370); this test is the only place that wiring is verified rather than
+// merely inspected — a future refactor that splits the two sinks apart
+// would be caught here.
+func TestPrincipalBindingEndpointToGateSharedStoreInvariant(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	sharedStore, err := store.NewSQLitePrincipalBindingStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wire the ONE store instance both ways, exactly as main.go does at
+	// registration: onto *Services for the admin endpoint, and into the
+	// gate via SetPrincipalBindingStore.
+	svc := &Services{PrincipalBindings: sharedStore}
+	SetPrincipalBindingStore(sharedStore)
+	t.Cleanup(func() { SetPrincipalBindingStore(nil) })
+
+	mux := http.NewServeMux()
+	RegisterPrincipalBindingRoutes(mux, svc, serverOptions{Mode: "serve"})
+
+	// 1. Register a NON-env (tenant, principal) pair through the admin
+	// endpoint — the same path an operator would use.
+	body, _ := json.Marshal(map[string]string{"tenant_id": "tenant-x", "principal_id": "principal-x"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/principal-bindings", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code < 200 || rec.Code >= 300 {
+		t.Fatalf("principal binding registration status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// 2. Drive the tenant gate with the pair just registered — it must be
+	// accepted through the SAME store instance the endpoint just wrote to.
+	gate := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	gateReq := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	gateReq.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	gateReq.Header.Set(tenantHeader, "tenant-x")
+	gateReq.Header.Set(principalHeader, "principal-x")
+	gateRec := httptest.NewRecorder()
+	gate(gateRec, gateReq)
+
+	if gateRec.Code != http.StatusNoContent {
+		t.Fatalf("tenant gate for endpoint-registered pair status = %d, want %d body=%s", gateRec.Code, http.StatusNoContent, gateRec.Body.String())
+	}
+
+	// 3. Negative control: an unregistered non-env pair must still 403 —
+	// proving acceptance above came from the shared store, not from a gate
+	// that accepts anything once the store is non-nil.
+	negReq := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	negReq.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	negReq.Header.Set(tenantHeader, "tenant-y")
+	negReq.Header.Set(principalHeader, "principal-y")
+	negRec := httptest.NewRecorder()
+	gate(negRec, negReq)
+
+	if negRec.Code != http.StatusForbidden {
+		t.Fatalf("tenant gate for unregistered non-env pair status = %d, want %d body=%s", negRec.Code, http.StatusForbidden, negRec.Body.String())
+	}
+}

--- a/core/cmd/helm-ai-kernel/principal_binding_routes.go
+++ b/core/cmd/helm-ai-kernel/principal_binding_routes.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/api"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
+)
+
+var errPrincipalBindingsUnavailable = errors.New("principal binding store not configured")
+
+type principalBindingRequest struct {
+	TenantID    string `json:"tenant_id"`
+	PrincipalID string `json:"principal_id"`
+}
+
+// RegisterPrincipalBindingRoutes exposes the admin-only endpoint used to
+// register (tenant_id, principal_id) bindings so the kernel can authorize
+// many tenants instead of a single env-configured pair (see
+// pkg/store.PrincipalBindingStore).
+func RegisterPrincipalBindingRoutes(mux *http.ServeMux, svc *Services, opts serverOptions) {
+	mux.HandleFunc("/api/v1/admin/principal-bindings", protectRuntimeHandler(RouteAuthAdmin, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			api.WriteMethodNotAllowed(w)
+			return
+		}
+		var req principalBindingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			api.WriteBadRequest(w, "Invalid JSON body")
+			return
+		}
+		tenantID := strings.TrimSpace(req.TenantID)
+		principalID := strings.TrimSpace(req.PrincipalID)
+		if tenantID == "" || principalID == "" {
+			api.WriteBadRequest(w, "tenant_id and principal_id are required")
+			return
+		}
+		if svc == nil || svc.PrincipalBindings == nil {
+			api.WriteInternal(w, errPrincipalBindingsUnavailable)
+			return
+		}
+		if err := svc.PrincipalBindings.Upsert(r.Context(), store.PrincipalBinding{
+			TenantID:    tenantID,
+			PrincipalID: principalID,
+		}); err != nil {
+			api.WriteInternal(w, err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(principalBindingRequest{
+			TenantID:    tenantID,
+			PrincipalID: principalID,
+		})
+	}))
+}

--- a/core/cmd/helm-ai-kernel/principal_binding_routes_test.go
+++ b/core/cmd/helm-ai-kernel/principal_binding_routes_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
+
+	_ "modernc.org/sqlite"
+)
+
+func newPrincipalBindingTestServices(t *testing.T) (*Services, store.PrincipalBindingStore, func()) {
+	t.Helper()
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindingStore, err := store.NewSQLitePrincipalBindingStore(db)
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	return &Services{PrincipalBindings: bindingStore}, bindingStore, func() { _ = db.Close() }
+}
+
+func postPrincipalBindingForTest(mux *http.ServeMux, bearer, tenantID, principalID string) *httptest.ResponseRecorder {
+	body, _ := json.Marshal(map[string]string{"tenant_id": tenantID, "principal_id": principalID})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/principal-bindings", bytes.NewReader(body))
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestPrincipalBindingRoutesUpsertsAndIsIdempotent(t *testing.T) {
+	svc, bindingStore, cleanup := newPrincipalBindingTestServices(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	RegisterPrincipalBindingRoutes(mux, svc, serverOptions{Mode: "serve"})
+
+	rec := postPrincipalBindingForTest(mux, testAdminAPIKey, "acme", "acme-admin")
+	if rec.Code != http.StatusOK && rec.Code != http.StatusCreated {
+		t.Fatalf("principal binding register status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	ok, err := bindingStore.Exists(context.Background(), "acme", "acme-admin")
+	if err != nil {
+		t.Fatalf("Exists returned error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected binding to exist after registration")
+	}
+
+	// Re-POST the same pair must remain idempotent (still 2xx).
+	rec2 := postPrincipalBindingForTest(mux, testAdminAPIKey, "acme", "acme-admin")
+	if rec2.Code < 200 || rec2.Code >= 300 {
+		t.Fatalf("repeat principal binding register status = %d body=%s", rec2.Code, rec2.Body.String())
+	}
+}
+
+func TestPrincipalBindingRoutesRejectMissingBearer(t *testing.T) {
+	svc, _, cleanup := newPrincipalBindingTestServices(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	RegisterPrincipalBindingRoutes(mux, svc, serverOptions{Mode: "serve"})
+
+	rec := postPrincipalBindingForTest(mux, "", "acme", "acme-admin")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("principal binding register without bearer status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPrincipalBindingRoutesRejectInvalidBearer(t *testing.T) {
+	svc, _, cleanup := newPrincipalBindingTestServices(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	RegisterPrincipalBindingRoutes(mux, svc, serverOptions{Mode: "serve"})
+
+	rec := postPrincipalBindingForTest(mux, "not-the-admin-key", "acme", "acme-admin")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("principal binding register with invalid bearer status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestPrincipalBindingRoutesRejectMissingFields(t *testing.T) {
+	svc, _, cleanup := newPrincipalBindingTestServices(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	RegisterPrincipalBindingRoutes(mux, svc, serverOptions{Mode: "serve"})
+
+	rec := postPrincipalBindingForTest(mux, testAdminAPIKey, "", "x")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("principal binding register with missing tenant_id status = %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	rec2 := postPrincipalBindingForTest(mux, testAdminAPIKey, "acme", "")
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("principal binding register with missing principal_id status = %d body=%s", rec2.Code, rec2.Body.String())
+	}
+}

--- a/core/cmd/helm-ai-kernel/route_auth.go
+++ b/core/cmd/helm-ai-kernel/route_auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/subtle"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -9,7 +10,24 @@ import (
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/api"
 	helmauth "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/auth"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
 )
+
+// principalBindingStore is the package-level registry consulted by
+// requireRuntimeTenant to accept (tenant, principal) pairs beyond the single
+// env-configured pair. It is nil unless SetPrincipalBindingStore is called
+// during server startup (see main.go registration), matching
+// requireRuntimeTenant's existing pattern of reading global os.Getenv state.
+// nil => env-pair-only behavior (current behavior, no panic).
+var principalBindingStore store.PrincipalBindingStore
+
+// SetPrincipalBindingStore injects the registry consulted by the tenant gate.
+// Call once during server registration (guarded by services != nil); tests
+// may call it with a fake/in-memory store and must reset it via
+// SetPrincipalBindingStore(nil) in t.Cleanup.
+func SetPrincipalBindingStore(s store.PrincipalBindingStore) {
+	principalBindingStore = s
+}
 
 const (
 	tenantHeader           = "X-Helm-Tenant-ID"
@@ -74,28 +92,38 @@ func requireRuntimeTenant(handler http.HandlerFunc) http.HandlerFunc {
 			api.WriteForbidden(w, "Tenant-scoped route requires explicit tenant binding")
 			return
 		}
-		if requestedTenantID != tenantID {
-			api.WriteForbidden(w, "Tenant-scoped route tenant mismatch")
-			return
-		}
 
 		principalID := configuredRuntimePrincipalID(adminPrincipal)
-		if principalID == "" {
-			api.WriteForbidden(w, "Tenant-scoped route principal could not be resolved")
-			return
-		}
 		requestedPrincipalID := strings.TrimSpace(r.Header.Get(principalHeader))
 		if requestedPrincipalID == "" {
 			api.WriteForbidden(w, "Tenant-scoped route requires explicit principal binding")
 			return
 		}
-		if requestedPrincipalID != principalID {
+
+		// env path first: no DB hit for the common single-tenant/quickstart case.
+		envMatch := requestedTenantID == tenantID && principalID != "" && requestedPrincipalID == principalID
+		registered := false
+		if !envMatch && principalBindingStore != nil {
+			ok, err := principalBindingStore.Exists(r.Context(), requestedTenantID, requestedPrincipalID)
+			if err != nil {
+				// Fail closed: a store error must not be treated as a match.
+				log.Printf("[helm] principal binding lookup failed, denying tenant-scoped request: %v", err)
+			} else {
+				registered = ok
+			}
+		}
+		if !envMatch && !registered {
+			if requestedTenantID != tenantID {
+				api.WriteForbidden(w, "Tenant-scoped route tenant mismatch")
+				return
+			}
 			api.WriteForbidden(w, "Tenant-scoped route principal mismatch")
 			return
 		}
+
 		principal := &helmauth.BasePrincipal{
-			ID:       principalID,
-			TenantID: tenantID,
+			ID:       requestedPrincipalID,
+			TenantID: requestedTenantID,
 			Roles:    append([]string(nil), adminPrincipal.GetRoles()...),
 		}
 		handler(w, r.WithContext(helmauth.WithPrincipal(r.Context(), principal)))

--- a/core/cmd/helm-ai-kernel/route_auth_test.go
+++ b/core/cmd/helm-ai-kernel/route_auth_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,6 +15,29 @@ import (
 
 	_ "modernc.org/sqlite"
 )
+
+// recordingPrincipalBindingStore is a fake store.PrincipalBindingStore that
+// records every Exists call and panics if invoked with an empty tenant or
+// principal ID — this pins down that requireRuntimeTenant must reject empty
+// headers before ever reaching the store. existsErr/existsOK control the
+// (bool, error) returned for non-empty lookups.
+type recordingPrincipalBindingStore struct {
+	calls     int
+	existsOK  bool
+	existsErr error
+}
+
+func (s *recordingPrincipalBindingStore) Upsert(ctx context.Context, b store.PrincipalBinding) error {
+	return nil
+}
+
+func (s *recordingPrincipalBindingStore) Exists(ctx context.Context, tenantID, principalID string) (bool, error) {
+	s.calls++
+	if tenantID == "" || principalID == "" {
+		panic("Exists called with an empty tenantID/principalID; the empty-header 403 must fire before any store lookup")
+	}
+	return s.existsOK, s.existsErr
+}
 
 // newRouteAuthTestBindingStore returns a fresh in-memory SQLite-backed
 // store.PrincipalBindingStore for tenant-gate registry tests.
@@ -324,6 +349,65 @@ func TestTenantScopedRuntimeAuthNilStoreRejectsNonEnvPair(t *testing.T) {
 
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("tenant-scoped route with nil store and non-env pair status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantScopedRuntimeAuthEmptyPrincipalHeaderSkipsStoreLookup(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+
+	fake := &recordingPrincipalBindingStore{existsOK: true}
+	SetPrincipalBindingStore(fake)
+	t.Cleanup(func() { SetPrincipalBindingStore(nil) })
+
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("tenant-scoped handler should not run without explicit principal binding")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	req.Header.Set(tenantHeader, "tenant-a")
+	// principalHeader intentionally left unset (empty).
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("tenant-scoped route with empty principal header status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "requires explicit principal binding") {
+		t.Fatalf("body = %s, want message containing %q", rec.Body.String(), "requires explicit principal binding")
+	}
+	if fake.calls != 0 {
+		t.Fatalf("store.Exists called %d time(s), want 0 (empty-header 403 must precede any store lookup)", fake.calls)
+	}
+}
+
+func TestTenantScopedRuntimeAuthStoreErrorFailsClosed(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+
+	fake := &recordingPrincipalBindingStore{existsOK: false, existsErr: errors.New("store unavailable")}
+	SetPrincipalBindingStore(fake)
+	t.Cleanup(func() { SetPrincipalBindingStore(nil) })
+
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("tenant-scoped handler should not run when the binding store errors")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	req.Header.Set(tenantHeader, "tenant-b")
+	req.Header.Set(principalHeader, "principal-b")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("tenant-scoped route with store error status = %d, want %d (fail closed) body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if fake.calls == 0 {
+		t.Fatal("expected store.Exists to be called for the non-env pair")
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/route_auth_test.go
+++ b/core/cmd/helm-ai-kernel/route_auth_test.go
@@ -1,13 +1,34 @@
 package main
 
 import (
+	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	helmauth "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/auth"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
+
+	_ "modernc.org/sqlite"
 )
+
+// newRouteAuthTestBindingStore returns a fresh in-memory SQLite-backed
+// store.PrincipalBindingStore for tenant-gate registry tests.
+func newRouteAuthTestBindingStore(t *testing.T) (store.PrincipalBindingStore, func()) {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := store.NewSQLitePrincipalBindingStore(db)
+	if err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	return s, func() { _ = db.Close() }
+}
 
 func TestTenantScopedRuntimeAuthRejectsMissingTenantBinding(t *testing.T) {
 	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
@@ -187,6 +208,122 @@ func TestServiceInternalRuntimeAuthFailsClosedWhenUnconfigured(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("service-internal route without configured token status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantScopedRuntimeAuthAllowsRegisteredNonEnvBinding(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+
+	bindingStore, cleanup := newRouteAuthTestBindingStore(t)
+	defer cleanup()
+	if err := bindingStore.Upsert(context.Background(), store.PrincipalBinding{
+		TenantID:    "tenant-b",
+		PrincipalID: "principal-b",
+	}); err != nil {
+		t.Fatalf("seeding binding store: %v", err)
+	}
+	SetPrincipalBindingStore(bindingStore)
+	t.Cleanup(func() { SetPrincipalBindingStore(nil) })
+
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		principal, err := helmauth.GetPrincipal(r.Context())
+		if err != nil {
+			t.Fatalf("principal missing from tenant-scoped context: %v", err)
+		}
+		if principal.GetTenantID() != "tenant-b" {
+			t.Fatalf("tenant = %q, want tenant-b", principal.GetTenantID())
+		}
+		if principal.GetID() != "principal-b" {
+			t.Fatalf("principal = %q, want principal-b", principal.GetID())
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	req.Header.Set(tenantHeader, "tenant-b")
+	req.Header.Set(principalHeader, "principal-b")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("tenant-scoped route with registered non-env binding status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantScopedRuntimeAuthRejectsNonEnvPairNotInStore(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+
+	bindingStore, cleanup := newRouteAuthTestBindingStore(t)
+	defer cleanup()
+	SetPrincipalBindingStore(bindingStore)
+	t.Cleanup(func() { SetPrincipalBindingStore(nil) })
+
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("tenant-scoped handler should not run for an unregistered non-env pair")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	req.Header.Set(tenantHeader, "tenant-c")
+	req.Header.Set(principalHeader, "principal-c")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("tenant-scoped route with unregistered non-env pair status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantScopedRuntimeAuthNilStoreAllowsEnvPair(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+
+	SetPrincipalBindingStore(nil)
+	t.Cleanup(func() { SetPrincipalBindingStore(nil) })
+
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	req.Header.Set(tenantHeader, "tenant-a")
+	req.Header.Set(principalHeader, "principal-a")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("tenant-scoped route with nil store and env pair status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestTenantScopedRuntimeAuthNilStoreRejectsNonEnvPair(t *testing.T) {
+	t.Setenv("HELM_ADMIN_API_KEY", testAdminAPIKey)
+	t.Setenv(runtimeTenantIDEnv, "tenant-a")
+	t.Setenv(runtimePrincipalIDEnv, "principal-a")
+
+	SetPrincipalBindingStore(nil)
+	t.Cleanup(func() { SetPrincipalBindingStore(nil) })
+
+	handler := protectRuntimeHandler(RouteAuthTenant, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("tenant-scoped handler should not run for a non-env pair when store is nil")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/receipts", nil)
+	req.Header.Set("Authorization", "Bearer "+testAdminAPIKey)
+	req.Header.Set(tenantHeader, "tenant-b")
+	req.Header.Set(principalHeader, "principal-b")
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("tenant-scoped route with nil store and non-env pair status = %d body=%s", rec.Code, rec.Body.String())
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -68,9 +68,10 @@ type Services struct {
 	EmergencyStops   *kernel.ScopedStopStore
 
 	// --- Evidence ---
-	Evidence      *evidence.DefaultExporter
-	ReceiptStore  store.ReceiptStore
-	ReceiptSigner helmcrypto.Signer
+	Evidence          *evidence.DefaultExporter
+	ReceiptStore      store.ReceiptStore
+	ReceiptSigner     helmcrypto.Signer
+	PrincipalBindings store.PrincipalBindingStore
 
 	// --- Receipt Transparency Log (RFC 6962) ---
 	// TranspLog anchors every issued receipt hash in an append-only Merkle

--- a/core/pkg/store/principal_binding_store.go
+++ b/core/pkg/store/principal_binding_store.go
@@ -1,0 +1,83 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// PrincipalBinding records that a principal is authorized to act as/for a
+// given tenant. The pair (TenantID, PrincipalID) is the natural key.
+type PrincipalBinding struct {
+	TenantID    string
+	PrincipalID string
+	CreatedAt   time.Time
+}
+
+// PrincipalBindingStore persists the registry of (tenant_id, principal_id)
+// bindings so the kernel can authorize many tenants, not just a single
+// env-configured pair.
+type PrincipalBindingStore interface {
+	// Upsert inserts a binding, idempotent on (tenant_id, principal_id).
+	Upsert(ctx context.Context, b PrincipalBinding) error
+	// Exists reports whether the given (tenant_id, principal_id) pair is bound.
+	Exists(ctx context.Context, tenantID, principalID string) (bool, error)
+}
+
+// PostgresPrincipalBindingStore is a durable SQL-based implementation backed
+// by Postgres.
+type PostgresPrincipalBindingStore struct {
+	db *sql.DB
+}
+
+// NewPostgresPrincipalBindingStore constructs a PostgresPrincipalBindingStore
+// and ensures the backing table exists.
+func NewPostgresPrincipalBindingStore(db *sql.DB) (*PostgresPrincipalBindingStore, error) {
+	s := &PostgresPrincipalBindingStore{db: db}
+	if err := s.migrate(context.Background()); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *PostgresPrincipalBindingStore) migrate(ctx context.Context) error {
+	query := `
+		CREATE TABLE IF NOT EXISTS principal_bindings (
+			tenant_id TEXT NOT NULL,
+			principal_id TEXT NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			PRIMARY KEY (tenant_id, principal_id)
+		);`
+	_, err := s.db.ExecContext(ctx, query)
+	return err
+}
+
+// Upsert inserts a binding, idempotent on (tenant_id, principal_id).
+func (s *PostgresPrincipalBindingStore) Upsert(ctx context.Context, b PrincipalBinding) error {
+	query := `
+		INSERT INTO principal_bindings (tenant_id, principal_id, created_at)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (tenant_id, principal_id) DO NOTHING
+	`
+	createdAt := b.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, query, b.TenantID, b.PrincipalID, createdAt)
+	return err
+}
+
+// Exists reports whether the given (tenant_id, principal_id) pair is bound.
+func (s *PostgresPrincipalBindingStore) Exists(ctx context.Context, tenantID, principalID string) (bool, error) {
+	query := `SELECT 1 FROM principal_bindings WHERE tenant_id = $1 AND principal_id = $2 LIMIT 1`
+	var one int
+	err := s.db.QueryRowContext(ctx, query, tenantID, principalID).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/core/pkg/store/principal_binding_store_sqlite.go
+++ b/core/pkg/store/principal_binding_store_sqlite.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// SQLitePrincipalBindingStore is the dependency-free local default
+// implementation of PrincipalBindingStore.
+type SQLitePrincipalBindingStore struct {
+	db *sql.DB
+}
+
+// NewSQLitePrincipalBindingStore constructs a SQLitePrincipalBindingStore and
+// ensures the backing table exists. It uses the passed db as-is; callers own
+// the shared pool/pragma configuration (see SQLiteReceiptStore).
+func NewSQLitePrincipalBindingStore(db *sql.DB) (*SQLitePrincipalBindingStore, error) {
+	s := &SQLitePrincipalBindingStore{db: db}
+	if err := s.migrate(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *SQLitePrincipalBindingStore) migrate() error {
+	query := `
+		CREATE TABLE IF NOT EXISTS principal_bindings (
+			tenant_id TEXT NOT NULL,
+			principal_id TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (tenant_id, principal_id)
+		);`
+	_, err := s.db.ExecContext(context.Background(), query)
+	return err
+}
+
+// Upsert inserts a binding, idempotent on (tenant_id, principal_id).
+func (s *SQLitePrincipalBindingStore) Upsert(ctx context.Context, b PrincipalBinding) error {
+	query := `
+		INSERT INTO principal_bindings (tenant_id, principal_id, created_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT (tenant_id, principal_id) DO NOTHING
+	`
+	createdAt := b.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx, query, b.TenantID, b.PrincipalID, createdAt.Format(time.RFC3339Nano))
+	return err
+}
+
+// Exists reports whether the given (tenant_id, principal_id) pair is bound.
+func (s *SQLitePrincipalBindingStore) Exists(ctx context.Context, tenantID, principalID string) (bool, error) {
+	query := `SELECT 1 FROM principal_bindings WHERE tenant_id = ? AND principal_id = ? LIMIT 1`
+	var one int
+	err := s.db.QueryRowContext(ctx, query, tenantID, principalID).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/core/pkg/store/principal_binding_store_test.go
+++ b/core/pkg/store/principal_binding_store_test.go
@@ -1,0 +1,40 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestPrincipalBindingStoreSQLite(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	s, err := NewSQLitePrincipalBindingStore(db)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	ok, err := s.Exists(ctx, "acme", "acme-admin")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	require.NoError(t, s.Upsert(ctx, PrincipalBinding{TenantID: "acme", PrincipalID: "acme-admin"}))
+	ok, err = s.Exists(ctx, "acme", "acme-admin")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// idempotent
+	require.NoError(t, s.Upsert(ctx, PrincipalBinding{TenantID: "acme", PrincipalID: "acme-admin"}))
+
+	// distinct pair not matched
+	ok, err = s.Exists(ctx, "acme", "someone-else")
+	require.NoError(t, err)
+	require.False(t, ok)
+	ok, err = s.Exists(ctx, "other", "acme-admin")
+	require.NoError(t, err)
+	require.False(t, ok)
+}


### PR DESCRIPTION
## Summary

Add a **persisted principal↔tenant binding registry** so the kernel can authorize many companies' tenant-scoped requests at runtime, not just the single env-configured pair. This is the kernel half of HELM-245 — it unblocks end-to-end company enrollment (the control-plane half, `HTTPKernelBinder`, is a companion PR on `svc-helm-control-plane`).

Design: `dev-orchestration/docs/superpowers/specs/2026-07-18-kernel-principal-binding-design.md`

## Problem

`requireRuntimeTenant` accepts a tenant-scoped request only when its `X-Helm-Tenant-ID` + `X-Helm-Principal-ID` match **one** env-configured pair (`HELM_RUNTIME_TENANT_ID`/`HELM_RUNTIME_PRINCIPAL_ID`, default `default`). Company enrollment provisions a distinct tenant + admin principal per company, so their `/api/v1/evaluate` calls 403 — first seen on stand dev-1 (docs_for_team REPORTS/030 finding 3), and the reason the control-plane ships `DisabledKernelBinder`.

## What's included

- **`PrincipalBindingStore`** (`core/pkg/store/`) — interface + SQLite and Postgres impls over the shared `*sql.DB`, mirroring `ReceiptStore`. Idempotent `Upsert` (`ON CONFLICT (tenant_id, principal_id) DO NOTHING`), `Exists`. Inline `CREATE TABLE IF NOT EXISTS` migrate (the repo's actual store idiom), no shared-pool reconfig.
- **`POST /api/v1/admin/principal-bindings`** — `RouteAuthAdmin` (existing `HELM_ADMIN_API_KEY` bearer), body `{tenant_id, principal_id}`, validates non-empty, idempotent, 201. This is the endpoint the control-plane calls per enrollment.
- **`requireRuntimeTenant` consults the registry** — **strictly additive**: accept if the pair matches the env config (checked first, no DB hit — quickstart/`default` unchanged) **or** is registered in the store. Empty headers still 403 (before any lookup); store errors fail closed (403, not 500); the `BasePrincipal` carries the *requested* tenant (no cross-tenant wiring). Wired via a package-level store set once at startup; nil → env-only.

## Storage

The binding store rides the kernel's existing shared `db`, so it's Postgres in production (`DATABASE_URL` set) and SQLite locally. Production runs the kernel in Postgres mode against its **own `helm_kernel` database** (kernel is the source of truth — never shares tables with the enterprise mirror). Flipping the deployed kernel `storage.type: sqlite → postgres` + provisioning `helm_kernel` + injecting `DATABASE_URL` (SOPS) is an **operator/gitops step** (flag to Sergey), not in this PR.

## How it was built

Subagent-driven TDD across 5 commits, each task independently reviewed (the auth-gate change got an opus security review confirming it's **provably strictly-additive** — no cross-tenant widening), plus an opus whole-branch review that verified the endpoint-write and gate-read share one store instance in both runtime modes. Regression tests lock the empty-header (Exists never reached), store-error-fail-closed, and endpoint→gate shared-store-invariant paths. `go build ./...`, `go vet`, and the `cmd/helm-ai-kernel` + `pkg/store` suites are green.

## Note

IDs are compared verbatim after `TrimSpace` (write and read normalize identically — no case-folding). The control-plane companion PR sends `tenant_id = <uuid>.String()`, `principal_id = <principal string>`.

## Test plan

- `cd core && go test ./cmd/helm-ai-kernel/ ./pkg/store/` — green · `go build ./...` · `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
