### PR TITLE
fix(conform): require adversarial evidence coverage

### DIFF
--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -40,9 +40,20 @@ func EvaluateCoverage(evidenceDir string, opts VerificationOptions) CoverageResu
 }
 
 // EvaluateCoverageWithOptions proves positive controls using externally rooted
-// cryptographic evidence, then copies and mutates the pack so each detector's
-// negative path is exercised without modifying the source EvidencePack.
+// cryptographic evidence, then uses one bounded snapshot for all mutations so
+// each detector's negative path is exercised without modifying the source
+// EvidencePack or multiplying untrusted pack I/O by the suite count.
 func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) CoverageResult {
+	workspace, cleanup, err := newCoverageMutationWorkspace(evidenceDir)
+	if err != nil {
+		return unavailableCoverageResult(opts)
+	}
+	defer cleanup()
+	result, _ := evaluateCoverageInWorkspace(workspace, opts)
+	return result
+}
+
+func evaluateCoverageInWorkspace(evidenceDir string, opts VerificationOptions) (CoverageResult, map[string]*SuiteResult) {
 	receiptFiles, _ := filepath.Glob(filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts", "*.json"))
 	receipts := make([]map[string]interface{}, 0, len(receiptFiles))
 	for _, path := range receiptFiles {
@@ -66,6 +77,10 @@ func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) C
 	for _, suite := range suites {
 		suitesByID[suite.ID] = suite
 	}
+	baselineResults := make(map[string]*SuiteResult, len(suites))
+	for _, suite := range suites {
+		baselineResults[suite.ID] = suite.Run(evidenceDir)
+	}
 	mutations := mandatoryCoverageMutations()
 	for index := range checks {
 		check := &checks[index]
@@ -80,7 +95,7 @@ func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) C
 			check.Reason = "missing: mandatory detector mutation is not registered"
 			continue
 		}
-		check.PositiveControlPassed = suitePassesExpectedTest(suite.Run(evidenceDir), mutation.ExpectedTestID)
+		check.PositiveControlPassed = suitePassesExpectedTest(baselineResults[check.SuiteID], mutation.ExpectedTestID)
 		if !check.PositiveControlPassed {
 			check.Covered = false
 			check.Reason = "missing: detector did not pass its unchanged positive control"
@@ -107,7 +122,25 @@ func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) C
 		result.Pass = false
 		result.MissingSuites++
 	}
-	return result
+	return result, baselineResults
+}
+
+func unavailableCoverageResult(opts VerificationOptions) CoverageResult {
+	suites := AllSuitesWithOptions(opts)
+	mutations := mandatoryCoverageMutations()
+	checks := make([]CoverageCheck, 0, len(suites))
+	for _, suite := range suites {
+		checks = append(checks, CoverageCheck{
+			SuiteID:    suite.ID,
+			MutationID: mutations[suite.ID].ID,
+			Reason:     "missing: bounded mutation snapshot could not be created",
+		})
+	}
+	return CoverageResult{
+		Pass:          false,
+		MissingSuites: len(checks),
+		Checks:        checks,
+	}
 }
 
 func receiptSequenceCoverage(receipts []map[string]interface{}) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -96,20 +96,28 @@ func policyDecisionCoverage(receipts []map[string]interface{}, opts Verification
 
 func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
 	referenceIndex := receiptReferenceIndex(receipts)
+	receiptsByIdentity := make(map[string]map[string]interface{}, len(receipts))
+	for _, receipt := range receipts {
+		if identity := receiptIdentity(receipt); identity != "" {
+			receiptsByIdentity[identity] = receipt
+		}
+	}
 	count := 0
 	for _, receipt := range receipts {
 		child := receiptIdentity(receipt)
+		childSeq, childSequenced := receiptSequence(receipt)
 		parents, _ := receipt["parent_receipt_hashes"].([]interface{})
 		for _, rawParent := range parents {
 			parent, valid := rawParent.(string)
 			parent = strings.TrimSpace(parent)
 			parentTarget, exists := referenceIndex[parent]
-			if valid && parent != "" && parent != "genesis" && child != "" && exists && parentTarget != "" && parentTarget != child {
+			parentSeq, parentSequenced := receiptSequence(receiptsByIdentity[parentTarget])
+			if valid && parent != "" && parent != "genesis" && child != "" && exists && parentTarget != "" && parentTarget != child && childSequenced && parentSequenced && parentSeq < childSeq {
 				count++
 			}
 		}
 	}
-	return coverageCheck("ADV-03", count > 0, count, "requires at least one non-genesis parent edge that resolves to another included receipt")
+	return coverageCheck("ADV-03", count > 0, count, "requires at least one causal non-genesis parent edge that resolves to an earlier included receipt")
 }
 
 func budgetBoundaryCoverage(receipts []map[string]interface{}) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -1,7 +1,7 @@
 package adversarial
 
-// quantum_posture: this slice validates classical Ed25519 signature shape
-// only; cryptographic verification and post-quantum assurance are not claimed.
+// quantum_posture: campaign authorization uses classical Ed25519 verification;
+// no post-quantum assurance is claimed.
 
 import (
 	"encoding/json"
@@ -32,6 +32,12 @@ type CoverageCheck struct {
 // detectors run. The canonical EvidencePack verifier is responsible for
 // proving that these files are indexed, hashed, and sealed.
 func EvaluateCoverage(evidenceDir string) CoverageResult {
+	return EvaluateCoverageWithOptions(evidenceDir, VerificationOptions{})
+}
+
+// EvaluateCoverageWithOptions proves positive controls using externally rooted
+// cryptographic evidence where a suite contract requires authorization.
+func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) CoverageResult {
 	receiptFiles, _ := filepath.Glob(filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts", "*.json"))
 	receipts := make([]map[string]interface{}, 0, len(receiptFiles))
 	for _, path := range receiptFiles {
@@ -40,15 +46,15 @@ func EvaluateCoverage(evidenceDir string) CoverageResult {
 
 	checks := []CoverageCheck{
 		receiptSequenceCoverage(receipts),
-		policyDecisionCoverage(receipts),
+		policyDecisionCoverage(receipts, opts),
 		proofGraphParentCoverage(receipts),
 		budgetBoundaryCoverage(receipts),
 		envelopeBindingCoverage(receipts),
 		tapeCoverage(evidenceDir),
 		tenantCoverage(receipts),
-		toolManifestCoverage(evidenceDir),
+		toolManifestCoverage(evidenceDir, opts),
 		panicBoundaryCoverage(evidenceDir),
-		highFinalityApprovalCoverage(receipts),
+		highFinalityApprovalCoverage(receipts, opts),
 	}
 	result := CoverageResult{Pass: true, Checks: checks}
 	for _, check := range checks {
@@ -65,25 +71,26 @@ func EvaluateCoverage(evidenceDir string) CoverageResult {
 func receiptSequenceCoverage(receipts []map[string]interface{}) CoverageCheck {
 	count := 0
 	for _, receipt := range receipts {
-		if _, ok := receipt["seq"].(float64); ok {
+		if _, ok := receiptSequence(receipt); ok {
 			count++
 		}
 	}
 	return coverageCheck("ADV-01", count >= 2, count, "requires at least two sequenced receipts")
 }
 
-func policyDecisionCoverage(receipts []map[string]interface{}) CoverageCheck {
+func policyDecisionCoverage(receipts []map[string]interface{}, opts VerificationOptions) CoverageCheck {
 	count := 0
 	for _, receipt := range receipts {
-		if receipt["action_type"] != "effect_attempt" {
+		action, _ := receipt["action_type"].(string)
+		if !isEffectAction(action) {
 			continue
 		}
 		decisionID, _ := receipt["decision_id"].(string)
-		if decisionID != "" && hasPolicyReceipt(receipts, decisionID) {
+		if decisionID != "" && hasBoundAuthorization(receipts, receipt, "policy_decision", opts) {
 			count++
 		}
 	}
-	return coverageCheck("ADV-02", count > 0, count, "requires an effect_attempt with a matching policy_decision")
+	return coverageCheck("ADV-02", count > 0, count, "requires an effect action with a preceding, ancestor-linked, envelope-bound, trusted policy_decision")
 }
 
 func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
@@ -169,7 +176,7 @@ func tenantCoverage(receipts []map[string]interface{}) CoverageCheck {
 	return coverageCheck("ADV-07", count > 0, count, "requires tenant-bound receipts")
 }
 
-func toolManifestCoverage(evidenceDir string) CoverageCheck {
+func toolManifestCoverage(evidenceDir string, opts VerificationOptions) CoverageCheck {
 	files := toolManifestFiles(evidenceDir)
 	count := 0
 	for _, path := range files {
@@ -178,11 +185,11 @@ func toolManifestCoverage(evidenceDir string) CoverageCheck {
 		if err != nil || json.Unmarshal(data, &manifest) != nil {
 			continue
 		}
-		if hasStructuredSignatures(manifest) {
+		if verifyCampaignSignatures(manifest, "signatures", opts.CampaignPublicKeyHex) {
 			count++
 		}
 	}
-	return coverageCheck("ADV-08", count > 0, count, "requires a canonical tool manifest with a structurally valid Ed25519 signature")
+	return coverageCheck("ADV-08", count > 0, count, "requires a canonical tool manifest signed by the external campaign trust root")
 }
 
 func panicBoundaryCoverage(evidenceDir string) CoverageCheck {
@@ -208,7 +215,7 @@ func panicBoundaryCoverage(evidenceDir string) CoverageCheck {
 	return coverageCheck("ADV-09", true, count, "requires every present panic boundary record to be readable")
 }
 
-func highFinalityApprovalCoverage(receipts []map[string]interface{}) CoverageCheck {
+func highFinalityApprovalCoverage(receipts []map[string]interface{}, opts VerificationOptions) CoverageCheck {
 	count := 0
 	for _, receipt := range receipts {
 		action, _ := receipt["action_type"].(string)
@@ -217,11 +224,11 @@ func highFinalityApprovalCoverage(receipts []map[string]interface{}) CoverageChe
 			continue
 		}
 		decisionID, _ := receipt["decision_id"].(string)
-		if decisionID != "" && hasApprovalReceipt(receipts, decisionID) {
+		if decisionID != "" && hasBoundAuthorization(receipts, receipt, "approval_action", opts) {
 			count++
 		}
 	}
-	return coverageCheck("ADV-10", count > 0, count, "requires a high-finality action with a matching approval_action")
+	return coverageCheck("ADV-10", count > 0, count, "requires a high-finality action with a preceding, ancestor-linked, envelope-bound, trusted approval_action")
 }
 
 func hasPolicyReceipt(receipts []map[string]interface{}, decisionID string) bool {
@@ -248,11 +255,4 @@ func coverageCheck(suiteID string, covered bool, count int, requirement string) 
 		reason = "missing: " + requirement
 	}
 	return CoverageCheck{SuiteID: suiteID, Covered: covered, EvidenceCount: count, Reason: reason}
-}
-
-func boolCount(value bool) int {
-	if value {
-		return 1
-	}
-	return 0
 }

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -212,7 +212,7 @@ func panicBoundaryCoverage(evidenceDir string) CoverageCheck {
 		if json.Unmarshal(data, &panicRecord) != nil {
 			return coverageCheck("ADV-09", false, count, "requires every present panic boundary record to be readable")
 		}
-		if _, ok := panicRecord["last_good_seq"].(float64); !ok {
+		if _, ok := receiptSequence(map[string]interface{}{"seq": panicRecord["last_good_seq"]}); !ok {
 			return coverageCheck("ADV-09", false, count, "requires every present panic boundary record to contain last_good_seq")
 		}
 		count++

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // CoverageResult proves that the supplied EvidencePack contains enough
@@ -95,29 +94,9 @@ func policyDecisionCoverage(receipts []map[string]interface{}, opts Verification
 }
 
 func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
-	referenceIndex := receiptReferenceIndex(receipts)
-	receiptsByIdentity := make(map[string]map[string]interface{}, len(receipts))
-	for _, receipt := range receipts {
-		if identity := receiptIdentity(receipt); identity != "" {
-			receiptsByIdentity[identity] = receipt
-		}
-	}
-	count := 0
-	for _, receipt := range receipts {
-		child := receiptIdentity(receipt)
-		childSeq, childSequenced := receiptSequence(receipt)
-		parents, _ := receipt["parent_receipt_hashes"].([]interface{})
-		for _, rawParent := range parents {
-			parent, valid := rawParent.(string)
-			parent = strings.TrimSpace(parent)
-			parentTarget, exists := referenceIndex[parent]
-			parentSeq, parentSequenced := receiptSequence(receiptsByIdentity[parentTarget])
-			if valid && parent != "" && parent != "genesis" && child != "" && exists && parentTarget != "" && parentTarget != child && childSequenced && parentSequenced && parentSeq < childSeq {
-				count++
-			}
-		}
-	}
-	return coverageCheck("ADV-03", count > 0, count, "requires at least one causal non-genesis parent edge that resolves to an earlier included receipt")
+	analysis := analyzeReceiptProofGraph(receipts, nil)
+	covered := analysis.causalEdges > 0 && analysis.forks == 0 && analysis.invalidParents == 0 && analysis.genesisClaims == 1 && analysis.cycles == 0
+	return coverageCheck("ADV-03", covered, analysis.causalEdges, "requires a valid single-root connected proof graph with at least one causal non-genesis edge")
 }
 
 func budgetBoundaryCoverage(receipts []map[string]interface{}) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -9,10 +9,10 @@ import (
 	"path/filepath"
 )
 
-// CoverageResult proves that the supplied EvidencePack contains enough
-// positive-control artifacts to exercise every mandatory detector. It is
-// separate from suite pass/fail: a missing artifact is incomplete coverage,
-// never a successful adversarial result.
+// CoverageResult proves both that the supplied EvidencePack contains a valid
+// positive control and that every mandatory detector rejects its deterministic
+// negative mutation. It is separate from suite pass/fail: a missing control or
+// an accepted mutation is incomplete coverage, never a successful result.
 type CoverageResult struct {
 	Pass          bool            `json:"pass"`
 	CoveredSuites int             `json:"covered_suites"`
@@ -22,21 +22,25 @@ type CoverageResult struct {
 
 // CoverageCheck records the source-owned minimum evidence for one suite.
 type CoverageCheck struct {
-	SuiteID       string `json:"suite_id"`
-	Covered       bool   `json:"covered"`
-	EvidenceCount int    `json:"evidence_count"`
-	Reason        string `json:"reason"`
+	SuiteID          string `json:"suite_id"`
+	Covered          bool   `json:"covered"`
+	EvidenceCount    int    `json:"evidence_count"`
+	MutationID       string `json:"mutation_id"`
+	MutationApplied  bool   `json:"mutation_applied"`
+	MutationRejected bool   `json:"mutation_rejected"`
+	Reason           string `json:"reason"`
 }
 
-// EvaluateCoverage checks for positive controls before the adversarial
-// detectors run. The canonical EvidencePack verifier is responsible for
-// proving that these files are indexed, hashed, and sealed.
+// EvaluateCoverage checks positive controls and detector-rejection mutations.
+// The canonical EvidencePack verifier is responsible for proving that the
+// source files are indexed, hashed, and sealed before this function is called.
 func EvaluateCoverage(evidenceDir string, opts VerificationOptions) CoverageResult {
 	return EvaluateCoverageWithOptions(evidenceDir, opts)
 }
 
 // EvaluateCoverageWithOptions proves positive controls using externally rooted
-// cryptographic evidence where a suite contract requires authorization.
+// cryptographic evidence, then copies and mutates the pack so each detector's
+// negative path is exercised without modifying the source EvidencePack.
 func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) CoverageResult {
 	receiptFiles, _ := filepath.Glob(filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts", "*.json"))
 	receipts := make([]map[string]interface{}, 0, len(receiptFiles))
@@ -55,6 +59,37 @@ func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) C
 		toolManifestCoverage(evidenceDir, opts),
 		panicBoundaryCoverage(evidenceDir),
 		highFinalityApprovalCoverage(receipts, opts),
+	}
+	suites := AllSuitesWithOptions(opts)
+	suitesByID := make(map[string]*Suite, len(suites))
+	for _, suite := range suites {
+		suitesByID[suite.ID] = suite
+	}
+	mutations := mandatoryCoverageMutations()
+	for index := range checks {
+		check := &checks[index]
+		mutation, mutationExists := mutations[check.SuiteID]
+		check.MutationID = mutation.ID
+		if !check.Covered {
+			continue
+		}
+		suite, suiteExists := suitesByID[check.SuiteID]
+		if !mutationExists || !suiteExists {
+			check.Covered = false
+			check.Reason = "missing: mandatory detector mutation is not registered"
+			continue
+		}
+		check.MutationApplied, check.MutationRejected = runCoverageMutation(evidenceDir, suite, mutation)
+		switch {
+		case !check.MutationApplied:
+			check.Covered = false
+			check.Reason = "missing: deterministic mutation could not be applied to the positive control"
+		case !check.MutationRejected:
+			check.Covered = false
+			check.Reason = "missing: detector accepted deterministic mutation " + mutation.ID
+		default:
+			check.Reason += "; detector rejected mutation " + mutation.ID
+		}
 	}
 	result := CoverageResult{Pass: true, Checks: checks}
 	for _, check := range checks {
@@ -170,7 +205,7 @@ func tenantCoverage(receipts []map[string]interface{}) CoverageCheck {
 			count++
 		}
 	}
-	return coverageCheck("ADV-07", count > 0, count, "requires tenant-bound receipts")
+	return coverageCheck("ADV-07", count >= 2, count, "requires at least two tenant-bound receipts")
 }
 
 func toolManifestCoverage(evidenceDir string, opts VerificationOptions) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // CoverageResult proves that the supplied EvidencePack contains enough
@@ -94,17 +95,21 @@ func policyDecisionCoverage(receipts []map[string]interface{}, opts Verification
 }
 
 func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
+	referenceIndex := receiptReferenceIndex(receipts)
 	count := 0
 	for _, receipt := range receipts {
+		child := receiptIdentity(receipt)
 		parents, _ := receipt["parent_receipt_hashes"].([]interface{})
 		for _, rawParent := range parents {
-			parent, _ := rawParent.(string)
-			if parent != "" && parent != "genesis" {
+			parent, valid := rawParent.(string)
+			parent = strings.TrimSpace(parent)
+			parentTarget, exists := referenceIndex[parent]
+			if valid && parent != "" && parent != "genesis" && child != "" && exists && parentTarget != child {
 				count++
 			}
 		}
 	}
-	return coverageCheck("ADV-03", count > 0, count, "requires at least one non-genesis parent edge")
+	return coverageCheck("ADV-03", count > 0, count, "requires at least one non-genesis parent edge that resolves to another included receipt")
 }
 
 func budgetBoundaryCoverage(receipts []map[string]interface{}) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -1,0 +1,250 @@
+package adversarial
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// CoverageResult proves that the supplied EvidencePack contains enough
+// positive-control artifacts to exercise every mandatory detector. It is
+// separate from suite pass/fail: a missing artifact is incomplete coverage,
+// never a successful adversarial result.
+type CoverageResult struct {
+	Pass          bool            `json:"pass"`
+	CoveredSuites int             `json:"covered_suites"`
+	MissingSuites int             `json:"missing_suites"`
+	Checks        []CoverageCheck `json:"checks"`
+}
+
+// CoverageCheck records the source-owned minimum evidence for one suite.
+type CoverageCheck struct {
+	SuiteID       string `json:"suite_id"`
+	Covered       bool   `json:"covered"`
+	EvidenceCount int    `json:"evidence_count"`
+	Reason        string `json:"reason"`
+}
+
+// EvaluateCoverage checks for positive controls before the adversarial
+// detectors run. The canonical EvidencePack verifier is responsible for
+// proving that these files are indexed, hashed, and sealed.
+func EvaluateCoverage(evidenceDir string) CoverageResult {
+	receiptFiles, _ := filepath.Glob(filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts", "*.json"))
+	receipts := make([]map[string]interface{}, 0, len(receiptFiles))
+	for _, path := range receiptFiles {
+		receipts = append(receipts, loadReceipt(path))
+	}
+
+	checks := []CoverageCheck{
+		receiptSequenceCoverage(receipts),
+		policyDecisionCoverage(receipts),
+		proofGraphParentCoverage(receipts),
+		budgetBoundaryCoverage(receipts),
+		envelopeBindingCoverage(receipts),
+		tapeCoverage(evidenceDir),
+		tenantCoverage(receipts),
+		toolManifestCoverage(evidenceDir),
+		panicBoundaryCoverage(evidenceDir),
+		highFinalityApprovalCoverage(receipts),
+	}
+	result := CoverageResult{Pass: true, Checks: checks}
+	for _, check := range checks {
+		if check.Covered {
+			result.CoveredSuites++
+			continue
+		}
+		result.Pass = false
+		result.MissingSuites++
+	}
+	return result
+}
+
+func receiptSequenceCoverage(receipts []map[string]interface{}) CoverageCheck {
+	count := 0
+	for _, receipt := range receipts {
+		if _, ok := receipt["seq"].(float64); ok {
+			count++
+		}
+	}
+	return coverageCheck("ADV-01", count >= 2, count, "requires at least two sequenced receipts")
+}
+
+func policyDecisionCoverage(receipts []map[string]interface{}) CoverageCheck {
+	count := 0
+	for _, receipt := range receipts {
+		if receipt["action_type"] != "effect_attempt" {
+			continue
+		}
+		decisionID, _ := receipt["decision_id"].(string)
+		if decisionID != "" && hasPolicyReceipt(receipts, decisionID) {
+			count++
+		}
+	}
+	return coverageCheck("ADV-02", count > 0, count, "requires an effect_attempt with a matching policy_decision")
+}
+
+func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
+	count := 0
+	for _, receipt := range receipts {
+		parents, _ := receipt["parent_receipt_hashes"].([]interface{})
+		for _, rawParent := range parents {
+			parent, _ := rawParent.(string)
+			if parent != "" && parent != "genesis" {
+				count++
+			}
+		}
+	}
+	return coverageCheck("ADV-03", count > 0, count, "requires at least one non-genesis parent edge")
+}
+
+func budgetBoundaryCoverage(receipts []map[string]interface{}) CoverageCheck {
+	var exhaustedAt float64
+	for _, receipt := range receipts {
+		if receipt["action_type"] != "budget_exhausted" {
+			continue
+		}
+		seq, ok := receipt["seq"].(float64)
+		if ok && (exhaustedAt == 0 || seq < exhaustedAt) {
+			exhaustedAt = seq
+		}
+	}
+	count := 0
+	if exhaustedAt > 0 {
+		for _, receipt := range receipts {
+			seq, ok := receipt["seq"].(float64)
+			if ok && seq < exhaustedAt && receipt["action_type"] == "budget_decrement" {
+				count++
+			}
+		}
+	}
+	return coverageCheck("ADV-04", count > 0, count, "requires budget_decrement followed by budget_exhausted")
+}
+
+func envelopeBindingCoverage(receipts []map[string]interface{}) CoverageCheck {
+	count := 0
+	for _, receipt := range receipts {
+		action, _ := receipt["action_type"].(string)
+		if action != "effect_attempt" && action != "tool_call" && action != "connector_call" {
+			continue
+		}
+		envelopeID, _ := receipt["envelope_id"].(string)
+		envelopeHash, _ := receipt["envelope_hash"].(string)
+		if envelopeID != "" && envelopeHash != "" {
+			count++
+		}
+	}
+	return coverageCheck("ADV-05", count > 0, count, "requires at least one envelope-bound effect")
+}
+
+func tapeCoverage(evidenceDir string) CoverageCheck {
+	files, _ := filepath.Glob(filepath.Join(evidenceDir, "08_TAPES", "entry_*.json"))
+	count := 0
+	for _, path := range files {
+		var entry map[string]interface{}
+		data, err := os.ReadFile(path)
+		if err != nil || json.Unmarshal(data, &entry) != nil {
+			continue
+		}
+		valueHash, _ := entry["value_hash"].(string)
+		dataClass, _ := entry["data_class"].(string)
+		if valueHash != "" && dataClass != "" {
+			count++
+		}
+	}
+	return coverageCheck("ADV-06", count > 0, count, "requires at least one valid replay tape entry")
+}
+
+func tenantCoverage(receipts []map[string]interface{}) CoverageCheck {
+	count := 0
+	for _, receipt := range receipts {
+		if tenantID, _ := receipt["tenant_id"].(string); tenantID != "" {
+			count++
+		}
+	}
+	return coverageCheck("ADV-07", count > 0, count, "requires tenant-bound receipts")
+}
+
+func toolManifestCoverage(evidenceDir string) CoverageCheck {
+	files := toolManifestFiles(evidenceDir)
+	count := 0
+	for _, path := range files {
+		var manifest map[string]interface{}
+		data, err := os.ReadFile(path)
+		if err != nil || json.Unmarshal(data, &manifest) != nil {
+			continue
+		}
+		switch signatures := manifest["signatures"].(type) {
+		case []interface{}:
+			if len(signatures) > 0 {
+				count++
+			}
+		case string:
+			if signatures != "" {
+				count++
+			}
+		}
+	}
+	return coverageCheck("ADV-08", count > 0, count, "requires a tool manifest with a non-empty signatures field")
+}
+
+func panicBoundaryCoverage(evidenceDir string) CoverageCheck {
+	data, err := os.ReadFile(panicEvidencePath(evidenceDir))
+	if err != nil {
+		return coverageCheck("ADV-09", false, 0, "requires a readable panic boundary record")
+	}
+	var panicRecord map[string]interface{}
+	if json.Unmarshal(data, &panicRecord) != nil {
+		return coverageCheck("ADV-09", false, 0, "requires a readable panic boundary record")
+	}
+	_, ok := panicRecord["last_good_seq"].(float64)
+	return coverageCheck("ADV-09", ok, boolCount(ok), "requires a readable panic boundary record")
+}
+
+func highFinalityApprovalCoverage(receipts []map[string]interface{}) CoverageCheck {
+	count := 0
+	for _, receipt := range receipts {
+		action, _ := receipt["action_type"].(string)
+		effectClass, _ := receipt["effect_class"].(string)
+		if !isHighFinality(effectClass, action) {
+			continue
+		}
+		decisionID, _ := receipt["decision_id"].(string)
+		if decisionID != "" && hasApprovalReceipt(receipts, decisionID) {
+			count++
+		}
+	}
+	return coverageCheck("ADV-10", count > 0, count, "requires a high-finality action with a matching approval_action")
+}
+
+func hasPolicyReceipt(receipts []map[string]interface{}, decisionID string) bool {
+	for _, receipt := range receipts {
+		if receipt["action_type"] == "policy_decision" && receipt["decision_id"] == decisionID {
+			return true
+		}
+	}
+	return false
+}
+
+func hasApprovalReceipt(receipts []map[string]interface{}, decisionID string) bool {
+	for _, receipt := range receipts {
+		if receipt["action_type"] == "approval_action" && receipt["decision_id"] == decisionID {
+			return true
+		}
+	}
+	return false
+}
+
+func coverageCheck(suiteID string, covered bool, count int, requirement string) CoverageCheck {
+	reason := "covered: " + requirement
+	if !covered {
+		reason = "missing: " + requirement
+	}
+	return CoverageCheck{SuiteID: suiteID, Covered: covered, EvidenceCount: count, Reason: reason}
+}
+
+func boolCount(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -108,28 +108,35 @@ func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
 }
 
 func budgetBoundaryCoverage(receipts []map[string]interface{}) CoverageCheck {
-	var exhaustedAt float64
-	foundBoundary := false
+	exhaustedAt := make(map[string][]float64)
 	for _, receipt := range receipts {
 		if receipt["action_type"] != "budget_exhausted" {
 			continue
 		}
-		seq, ok := receipt["seq"].(float64)
-		if ok && (!foundBoundary || seq < exhaustedAt) {
-			exhaustedAt = seq
-			foundBoundary = true
+		scope := budgetScope(receipt)
+		seq, ok := receiptSequence(receipt)
+		if scope != "" && ok {
+			exhaustedAt[scope] = append(exhaustedAt[scope], seq)
 		}
 	}
 	count := 0
-	if foundBoundary {
-		for _, receipt := range receipts {
-			seq, ok := receipt["seq"].(float64)
-			if ok && seq < exhaustedAt && receipt["action_type"] == "budget_decrement" {
+	for _, receipt := range receipts {
+		if receipt["action_type"] != "budget_decrement" {
+			continue
+		}
+		scope := budgetScope(receipt)
+		seq, ok := receiptSequence(receipt)
+		if scope == "" || !ok {
+			continue
+		}
+		for _, boundary := range exhaustedAt[scope] {
+			if seq < boundary {
 				count++
+				break
 			}
 		}
 	}
-	return coverageCheck("ADV-04", count > 0, count, "requires budget_decrement followed by budget_exhausted")
+	return coverageCheck("ADV-04", count > 0, count, "requires budget_decrement followed by budget_exhausted for the same explicit budget scope")
 }
 
 func envelopeBindingCoverage(receipts []map[string]interface{}) CoverageCheck {
@@ -157,13 +164,11 @@ func tapeCoverage(evidenceDir string) CoverageCheck {
 		if err != nil || json.Unmarshal(data, &entry) != nil {
 			continue
 		}
-		valueHash, _ := entry["value_hash"].(string)
-		dataClass, _ := entry["data_class"].(string)
-		if valueHash != "" && dataClass != "" {
+		if validTapeEntry(entry) {
 			count++
 		}
 	}
-	return coverageCheck("ADV-06", count > 0, count, "requires at least one valid replay tape entry")
+	return coverageCheck("ADV-06", count > 0, count, "requires a replay tape entry whose value_hash matches its decoded value")
 }
 
 func tenantCoverage(receipts []map[string]interface{}) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -104,7 +104,7 @@ func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
 			parent, valid := rawParent.(string)
 			parent = strings.TrimSpace(parent)
 			parentTarget, exists := referenceIndex[parent]
-			if valid && parent != "" && parent != "genesis" && child != "" && exists && parentTarget != child {
+			if valid && parent != "" && parent != "genesis" && child != "" && exists && parentTarget != "" && parentTarget != child {
 				count++
 			}
 		}
@@ -195,7 +195,7 @@ func toolManifestCoverage(evidenceDir string, opts VerificationOptions) Coverage
 		if err != nil || json.Unmarshal(data, &manifest) != nil {
 			continue
 		}
-		if verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, opts.CampaignPublicKeyHex) {
+		if campaignBindingMatches(manifest, opts) && verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, opts.CampaignPublicKeyHex) {
 			count++
 		}
 	}

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -29,6 +29,7 @@ type CoverageCheck struct {
 	PositiveControlPassed bool   `json:"positive_control_passed"`
 	MutationApplied       bool   `json:"mutation_applied"`
 	MutationRejected      bool   `json:"mutation_rejected"`
+	MutationRestored      bool   `json:"mutation_restored"`
 	Reason                string `json:"reason"`
 }
 
@@ -44,9 +45,9 @@ func EvaluateCoverage(evidenceDir string, opts VerificationOptions) CoverageResu
 // each detector's negative path is exercised without modifying the source
 // EvidencePack or multiplying untrusted pack I/O by the suite count.
 func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) CoverageResult {
-	workspace, cleanup, err := newCoverageMutationWorkspace(evidenceDir)
+	workspace, cleanup, err := newCoverageMutationWorkspace(evidenceDir, opts)
 	if err != nil {
-		return unavailableCoverageResult(opts)
+		return unavailableCoverageResult(opts, err)
 	}
 	defer cleanup()
 	result, _ := evaluateCoverageInWorkspace(workspace, opts)
@@ -82,11 +83,17 @@ func evaluateCoverageInWorkspace(evidenceDir string, opts VerificationOptions) (
 		baselineResults[suite.ID] = suite.Run(evidenceDir)
 	}
 	mutations := mandatoryCoverageMutations()
+	workspaceHealthy := true
 	for index := range checks {
 		check := &checks[index]
 		mutation, mutationExists := mutations[check.SuiteID]
 		check.MutationID = mutation.ID
 		if !check.Covered {
+			continue
+		}
+		if !workspaceHealthy {
+			check.Covered = false
+			check.Reason = "missing: mutation workspace integrity was lost after an earlier restore failure"
 			continue
 		}
 		suite, suiteExists := suitesByID[check.SuiteID]
@@ -101,11 +108,15 @@ func evaluateCoverageInWorkspace(evidenceDir string, opts VerificationOptions) (
 			check.Reason = "missing: detector did not pass its unchanged positive control"
 			continue
 		}
-		check.MutationApplied, check.MutationRejected = runCoverageMutation(evidenceDir, suite, mutation)
+		check.MutationApplied, check.MutationRejected, check.MutationRestored = runCoverageMutation(evidenceDir, suite, mutation)
 		switch {
 		case !check.MutationApplied:
 			check.Covered = false
 			check.Reason = "missing: deterministic mutation could not be applied to the positive control"
+		case !check.MutationRestored:
+			check.Covered = false
+			check.Reason = "missing: deterministic mutation could not be restored byte-for-byte"
+			workspaceHealthy = false
 		case !check.MutationRejected:
 			check.Covered = false
 			check.Reason = "missing: detector accepted deterministic mutation " + mutation.ID
@@ -125,15 +136,19 @@ func evaluateCoverageInWorkspace(evidenceDir string, opts VerificationOptions) (
 	return result, baselineResults
 }
 
-func unavailableCoverageResult(opts VerificationOptions) CoverageResult {
+func unavailableCoverageResult(opts VerificationOptions, cause error) CoverageResult {
 	suites := AllSuitesWithOptions(opts)
 	mutations := mandatoryCoverageMutations()
+	reason := "missing: bounded mutation snapshot could not be created and bound to externally verified EvidencePack roots"
+	if cause != nil {
+		reason += ": " + cause.Error()
+	}
 	checks := make([]CoverageCheck, 0, len(suites))
 	for _, suite := range suites {
 		checks = append(checks, CoverageCheck{
 			SuiteID:    suite.ID,
 			MutationID: mutations[suite.ID].ID,
-			Reason:     "missing: bounded mutation snapshot could not be created",
+			Reason:     reason,
 		})
 	}
 	return CoverageResult{

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -1,5 +1,8 @@
 package adversarial
 
+// quantum_posture: this slice validates classical Ed25519 signature shape
+// only; cryptographic verification and post-quantum assurance are not claimed.
+
 import (
 	"encoding/json"
 	"os"
@@ -99,17 +102,19 @@ func proofGraphParentCoverage(receipts []map[string]interface{}) CoverageCheck {
 
 func budgetBoundaryCoverage(receipts []map[string]interface{}) CoverageCheck {
 	var exhaustedAt float64
+	foundBoundary := false
 	for _, receipt := range receipts {
 		if receipt["action_type"] != "budget_exhausted" {
 			continue
 		}
 		seq, ok := receipt["seq"].(float64)
-		if ok && (exhaustedAt == 0 || seq < exhaustedAt) {
+		if ok && (!foundBoundary || seq < exhaustedAt) {
 			exhaustedAt = seq
+			foundBoundary = true
 		}
 	}
 	count := 0
-	if exhaustedAt > 0 {
+	if foundBoundary {
 		for _, receipt := range receipts {
 			seq, ok := receipt["seq"].(float64)
 			if ok && seq < exhaustedAt && receipt["action_type"] == "budget_decrement" {
@@ -173,31 +178,34 @@ func toolManifestCoverage(evidenceDir string) CoverageCheck {
 		if err != nil || json.Unmarshal(data, &manifest) != nil {
 			continue
 		}
-		switch signatures := manifest["signatures"].(type) {
-		case []interface{}:
-			if len(signatures) > 0 {
-				count++
-			}
-		case string:
-			if signatures != "" {
-				count++
-			}
+		if hasStructuredSignatures(manifest) {
+			count++
 		}
 	}
-	return coverageCheck("ADV-08", count > 0, count, "requires a tool manifest with a non-empty signatures field")
+	return coverageCheck("ADV-08", count > 0, count, "requires a canonical tool manifest with a structurally valid Ed25519 signature")
 }
 
 func panicBoundaryCoverage(evidenceDir string) CoverageCheck {
-	data, err := os.ReadFile(panicEvidencePath(evidenceDir))
-	if err != nil {
+	files := panicEvidenceFiles(evidenceDir)
+	if len(files) == 0 {
 		return coverageCheck("ADV-09", false, 0, "requires a readable panic boundary record")
 	}
-	var panicRecord map[string]interface{}
-	if json.Unmarshal(data, &panicRecord) != nil {
-		return coverageCheck("ADV-09", false, 0, "requires a readable panic boundary record")
+	count := 0
+	for _, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return coverageCheck("ADV-09", false, count, "requires every present panic boundary record to be readable")
+		}
+		var panicRecord map[string]interface{}
+		if json.Unmarshal(data, &panicRecord) != nil {
+			return coverageCheck("ADV-09", false, count, "requires every present panic boundary record to be readable")
+		}
+		if _, ok := panicRecord["last_good_seq"].(float64); !ok {
+			return coverageCheck("ADV-09", false, count, "requires every present panic boundary record to contain last_good_seq")
+		}
+		count++
 	}
-	_, ok := panicRecord["last_good_seq"].(float64)
-	return coverageCheck("ADV-09", ok, boolCount(ok), "requires a readable panic boundary record")
+	return coverageCheck("ADV-09", true, count, "requires every present panic boundary record to be readable")
 }
 
 func highFinalityApprovalCoverage(receipts []map[string]interface{}) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -190,7 +190,7 @@ func toolManifestCoverage(evidenceDir string, opts VerificationOptions) Coverage
 		if err != nil || json.Unmarshal(data, &manifest) != nil {
 			continue
 		}
-		if verifyCampaignSignatures(manifest, "signatures", opts.CampaignPublicKeyHex) {
+		if verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, opts.CampaignPublicKeyHex) {
 			count++
 		}
 	}

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -31,8 +31,8 @@ type CoverageCheck struct {
 // EvaluateCoverage checks for positive controls before the adversarial
 // detectors run. The canonical EvidencePack verifier is responsible for
 // proving that these files are indexed, hashed, and sealed.
-func EvaluateCoverage(evidenceDir string) CoverageResult {
-	return EvaluateCoverageWithOptions(evidenceDir, VerificationOptions{})
+func EvaluateCoverage(evidenceDir string, opts VerificationOptions) CoverageResult {
+	return EvaluateCoverageWithOptions(evidenceDir, opts)
 }
 
 // EvaluateCoverageWithOptions proves positive controls using externally rooted
@@ -229,24 +229,6 @@ func highFinalityApprovalCoverage(receipts []map[string]interface{}, opts Verifi
 		}
 	}
 	return coverageCheck("ADV-10", count > 0, count, "requires a high-finality action with a preceding, ancestor-linked, envelope-bound, trusted approval_action")
-}
-
-func hasPolicyReceipt(receipts []map[string]interface{}, decisionID string) bool {
-	for _, receipt := range receipts {
-		if receipt["action_type"] == "policy_decision" && receipt["decision_id"] == decisionID {
-			return true
-		}
-	}
-	return false
-}
-
-func hasApprovalReceipt(receipts []map[string]interface{}, decisionID string) bool {
-	for _, receipt := range receipts {
-		if receipt["action_type"] == "approval_action" && receipt["decision_id"] == decisionID {
-			return true
-		}
-	}
-	return false
 }
 
 func coverageCheck(suiteID string, covered bool, count int, requirement string) CoverageCheck {

--- a/core/pkg/conform/adversarial/coverage.go
+++ b/core/pkg/conform/adversarial/coverage.go
@@ -22,13 +22,14 @@ type CoverageResult struct {
 
 // CoverageCheck records the source-owned minimum evidence for one suite.
 type CoverageCheck struct {
-	SuiteID          string `json:"suite_id"`
-	Covered          bool   `json:"covered"`
-	EvidenceCount    int    `json:"evidence_count"`
-	MutationID       string `json:"mutation_id"`
-	MutationApplied  bool   `json:"mutation_applied"`
-	MutationRejected bool   `json:"mutation_rejected"`
-	Reason           string `json:"reason"`
+	SuiteID               string `json:"suite_id"`
+	Covered               bool   `json:"covered"`
+	EvidenceCount         int    `json:"evidence_count"`
+	MutationID            string `json:"mutation_id"`
+	PositiveControlPassed bool   `json:"positive_control_passed"`
+	MutationApplied       bool   `json:"mutation_applied"`
+	MutationRejected      bool   `json:"mutation_rejected"`
+	Reason                string `json:"reason"`
 }
 
 // EvaluateCoverage checks positive controls and detector-rejection mutations.
@@ -77,6 +78,12 @@ func EvaluateCoverageWithOptions(evidenceDir string, opts VerificationOptions) C
 		if !mutationExists || !suiteExists {
 			check.Covered = false
 			check.Reason = "missing: mandatory detector mutation is not registered"
+			continue
+		}
+		check.PositiveControlPassed = suitePassesExpectedTest(suite.Run(evidenceDir), mutation.ExpectedTestID)
+		if !check.PositiveControlPassed {
+			check.Covered = false
+			check.Reason = "missing: detector did not pass its unchanged positive control"
 			continue
 		}
 		check.MutationApplied, check.MutationRejected = runCoverageMutation(evidenceDir, suite, mutation)

--- a/core/pkg/conform/adversarial/coverage_mutations.go
+++ b/core/pkg/conform/adversarial/coverage_mutations.go
@@ -56,7 +56,7 @@ func newCoverageMutationWorkspace(evidenceDir string, opts VerificationOptions) 
 	}
 	cleanup := func() { _ = os.RemoveAll(tempDir) }
 	mutationRoot := filepath.Join(tempDir, "evidence-pack")
-	if err := copyCoverageMutationTree(evidenceDir, mutationRoot); err != nil {
+	if err := copyCoverageMutationTree(evidenceDir, mutationRoot, opts.AllowVerifiedConformanceSignature); err != nil {
 		cleanup()
 		return "", func() {}, err
 	}
@@ -105,7 +105,7 @@ func canonicalSHA256Digest(name, value string) (string, error) {
 	return value, nil
 }
 
-func copyCoverageMutationTree(source, destination string) error {
+func copyCoverageMutationTree(source, destination string, omitVerifiedConformanceSignature bool) error {
 	var copiedBytes int64
 	entries := 0
 	return filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
@@ -133,6 +133,9 @@ func copyCoverageMutationTree(source, destination string) error {
 		}
 		if !info.Mode().IsRegular() {
 			return fmt.Errorf("mutation snapshot rejects non-regular file: %s", entry.Name())
+		}
+		if omitVerifiedConformanceSignature && filepath.ToSlash(rel) == "07_ATTESTATIONS/conformance_report.sig" {
+			return nil
 		}
 		copiedBytes += info.Size()
 		if info.Size() > maxCoverageMutationBytes || copiedBytes > maxCoverageMutationBytes {

--- a/core/pkg/conform/adversarial/coverage_mutations.go
+++ b/core/pkg/conform/adversarial/coverage_mutations.go
@@ -54,6 +54,18 @@ func runCoverageMutation(evidenceDir string, suite *Suite, mutation coverageMuta
 	return true, false
 }
 
+func suitePassesExpectedTest(result *SuiteResult, expectedTestID string) bool {
+	if result == nil || !result.Pass || expectedTestID == "" {
+		return false
+	}
+	for _, test := range result.TestResults {
+		if test.TestID == expectedTestID {
+			return test.Pass
+		}
+	}
+	return false
+}
+
 func mutateReceiptSequenceGap(evidenceDir string) bool {
 	files := receiptFiles(evidenceDir)
 	var targetPath string

--- a/core/pkg/conform/adversarial/coverage_mutations.go
+++ b/core/pkg/conform/adversarial/coverage_mutations.go
@@ -2,15 +2,24 @@ package adversarial
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
+const (
+	maxCoverageMutationEntries = 4096
+	maxCoverageMutationBytes   = 32 << 20
+)
+
+type restoreCoverageMutation func() bool
+
 type coverageMutation struct {
 	ID             string
 	ExpectedTestID string
-	Apply          func(string) bool
+	Apply          func(string) (restoreCoverageMutation, bool)
 }
 
 func mandatoryCoverageMutations() map[string]coverageMutation {
@@ -28,30 +37,117 @@ func mandatoryCoverageMutations() map[string]coverageMutation {
 	}
 }
 
-func runCoverageMutation(evidenceDir string, suite *Suite, mutation coverageMutation) (bool, bool) {
-	tempDir, err := os.MkdirTemp("", "helm-adversarial-mutation-*")
+func newCoverageMutationWorkspace(evidenceDir string) (string, func(), error) {
+	tempDir, err := os.MkdirTemp("", "helm-adversarial-mutations-*")
 	if err != nil {
-		return false, false
+		return "", func() {}, err
 	}
-	defer os.RemoveAll(tempDir) //nolint:errcheck
+	cleanup := func() { _ = os.RemoveAll(tempDir) }
+	mutationRoot := filepath.Join(tempDir, "evidence-pack")
+	if err := copyCoverageMutationTree(evidenceDir, mutationRoot); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return mutationRoot, cleanup, nil
+}
 
-	mutantDir := filepath.Join(tempDir, "evidence-pack")
-	if err := os.CopyFS(mutantDir, os.DirFS(evidenceDir)); err != nil {
+func copyCoverageMutationTree(source, destination string) error {
+	var copiedBytes int64
+	entries := 0
+	return filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("mutation snapshot rejects symlink: %s", entry.Name())
+		}
+		entries++
+		if entries > maxCoverageMutationEntries {
+			return fmt.Errorf("mutation snapshot exceeds %d entries", maxCoverageMutationEntries)
+		}
+		rel, err := filepath.Rel(source, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(destination, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o750)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("mutation snapshot rejects non-regular file: %s", entry.Name())
+		}
+		copiedBytes += info.Size()
+		if info.Size() > maxCoverageMutationBytes || copiedBytes > maxCoverageMutationBytes {
+			return fmt.Errorf("mutation snapshot exceeds %d bytes", maxCoverageMutationBytes)
+		}
+		input, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		openedInfo, statErr := input.Stat()
+		if statErr != nil || !os.SameFile(info, openedInfo) || !openedInfo.Mode().IsRegular() {
+			_ = input.Close()
+			return fmt.Errorf("EvidencePack changed while snapshotting: %s", entry.Name())
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o750); err != nil {
+			_ = input.Close()
+			return err
+		}
+		output, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			_ = input.Close()
+			return err
+		}
+		copied, copyErr := io.Copy(output, io.LimitReader(input, info.Size()+1))
+		closeOutputErr := output.Close()
+		closeInputErr := input.Close()
+		switch {
+		case copyErr != nil:
+			return copyErr
+		case closeOutputErr != nil:
+			return closeOutputErr
+		case closeInputErr != nil:
+			return closeInputErr
+		case copied != info.Size():
+			return fmt.Errorf("EvidencePack changed while snapshotting: %s", entry.Name())
+		}
+		return nil
+	})
+}
+
+func runCoverageMutation(evidenceDir string, suite *Suite, mutation coverageMutation) (bool, bool) {
+	if mutation.Apply == nil || mutation.ExpectedTestID == "" {
 		return false, false
 	}
-	if mutation.Apply == nil || mutation.ExpectedTestID == "" || !mutation.Apply(mutantDir) {
+	restore, applied := mutation.Apply(evidenceDir)
+	if !applied || restore == nil {
 		return false, false
 	}
-	result := suite.Run(mutantDir)
-	if result == nil || result.Pass {
-		return true, false
-	}
-	for _, test := range result.TestResults {
-		if test.TestID == mutation.ExpectedTestID && !test.Pass {
-			return true, true
+	restored := false
+	defer func() {
+		if !restored {
+			_ = restore()
+		}
+	}()
+	result := suite.Run(evidenceDir)
+	rejected := false
+	if result != nil && !result.Pass {
+		for _, test := range result.TestResults {
+			if test.TestID == mutation.ExpectedTestID && !test.Pass {
+				rejected = true
+				break
+			}
 		}
 	}
-	return true, false
+	restored = restore()
+	if !restored {
+		return true, false
+	}
+	return true, rejected
 }
 
 func suitePassesExpectedTest(result *SuiteResult, expectedTestID string) bool {
@@ -66,10 +162,9 @@ func suitePassesExpectedTest(result *SuiteResult, expectedTestID string) bool {
 	return false
 }
 
-func mutateReceiptSequenceGap(evidenceDir string) bool {
+func mutateReceiptSequenceGap(evidenceDir string) (restoreCoverageMutation, bool) {
 	files := receiptFiles(evidenceDir)
 	var targetPath string
-	var target map[string]interface{}
 	var maxSequence float64 = -1
 	validSequences := 0
 	for _, path := range files {
@@ -82,29 +177,29 @@ func mutateReceiptSequenceGap(evidenceDir string) bool {
 		if sequence > maxSequence {
 			maxSequence = sequence
 			targetPath = path
-			target = receipt
 		}
 	}
-	if validSequences < 2 || target == nil {
-		return false
+	if validSequences < 2 || targetPath == "" {
+		return nil, false
 	}
 	const maxExactJSONInteger = 1<<53 - 1
-	if maxSequence < maxExactJSONInteger {
-		target["seq"] = maxSequence + 1
-	} else {
-		target["seq"] = float64(0)
-	}
-	return writeMutationJSON(targetPath, target)
+	return applyJSONMutation(targetPath, func(target map[string]interface{}) {
+		if maxSequence < maxExactJSONInteger {
+			target["seq"] = maxSequence + 1
+		} else {
+			target["seq"] = float64(0)
+		}
+	})
 }
 
-func mutatePolicyBinding(evidenceDir string) bool {
+func mutatePolicyBinding(evidenceDir string) (restoreCoverageMutation, bool) {
 	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
 		action, _ := receipt["action_type"].(string)
 		return isEffectAction(action)
 	}, mutateDecisionID)
 }
 
-func mutateProofGraphParent(evidenceDir string) bool {
+func mutateProofGraphParent(evidenceDir string) (restoreCoverageMutation, bool) {
 	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
 		sequence, ok := receiptSequence(receipt)
 		return ok && sequence > 1
@@ -113,7 +208,7 @@ func mutateProofGraphParent(evidenceDir string) bool {
 	})
 }
 
-func mutateBudgetBoundary(evidenceDir string) bool {
+func mutateBudgetBoundary(evidenceDir string) (restoreCoverageMutation, bool) {
 	type exhaustion struct {
 		scope    string
 		sequence float64
@@ -142,15 +237,16 @@ func mutateBudgetBoundary(evidenceDir string) bool {
 		}
 		for _, boundary := range exhaustions {
 			if boundary.scope == scope && sequence < boundary.sequence {
-				receipt["seq"] = boundary.sequence
-				return writeMutationJSON(path, receipt)
+				return applyJSONMutation(path, func(target map[string]interface{}) {
+					target["seq"] = boundary.sequence
+				})
 			}
 		}
 	}
-	return false
+	return nil, false
 }
 
-func mutateEnvelopeBinding(evidenceDir string) bool {
+func mutateEnvelopeBinding(evidenceDir string) (restoreCoverageMutation, bool) {
 	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
 		action, _ := receipt["action_type"].(string)
 		return isEffectAction(action)
@@ -159,21 +255,22 @@ func mutateEnvelopeBinding(evidenceDir string) bool {
 	})
 }
 
-func mutateTapeHash(evidenceDir string) bool {
+func mutateTapeHash(evidenceDir string) (restoreCoverageMutation, bool) {
 	files, _ := filepath.Glob(filepath.Join(evidenceDir, "08_TAPES", "entry_*.json"))
 	for _, path := range files {
 		entry := loadMutationJSON(path)
 		if entry == nil || !validTapeEntry(entry) {
 			continue
 		}
-		current, _ := entry["value_hash"].(string)
-		entry["value_hash"] = differentMutationValue(current)
-		return writeMutationJSON(path, entry)
+		return applyJSONMutation(path, func(target map[string]interface{}) {
+			current, _ := target["value_hash"].(string)
+			target["value_hash"] = differentMutationValue(current)
+		})
 	}
-	return false
+	return nil, false
 }
 
-func mutateTenantBinding(evidenceDir string) bool {
+func mutateTenantBinding(evidenceDir string) (restoreCoverageMutation, bool) {
 	seenTenant := ""
 	seenReceipts := 0
 	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
@@ -193,19 +290,20 @@ func mutateTenantBinding(evidenceDir string) bool {
 	})
 }
 
-func mutateToolSignature(evidenceDir string) bool {
+func mutateToolSignature(evidenceDir string) (restoreCoverageMutation, bool) {
 	for _, path := range toolManifestFiles(evidenceDir) {
 		manifest := loadMutationJSON(path)
 		if manifest == nil {
 			continue
 		}
-		delete(manifest, "signatures")
-		return writeMutationJSON(path, manifest)
+		return applyJSONMutation(path, func(target map[string]interface{}) {
+			delete(target, "signatures")
+		})
 	}
-	return false
+	return nil, false
 }
 
-func mutatePanicBoundary(evidenceDir string) bool {
+func mutatePanicBoundary(evidenceDir string) (restoreCoverageMutation, bool) {
 	maxSequence := float64(-1)
 	for _, path := range receiptFiles(evidenceDir) {
 		if sequence, ok := receiptSequence(loadReceipt(path)); ok && sequence > maxSequence {
@@ -213,20 +311,21 @@ func mutatePanicBoundary(evidenceDir string) bool {
 		}
 	}
 	if maxSequence < 1 {
-		return false
+		return nil, false
 	}
 	for _, path := range panicEvidenceFiles(evidenceDir) {
 		panicRecord := loadMutationJSON(path)
 		if panicRecord == nil {
 			continue
 		}
-		panicRecord["last_good_seq"] = maxSequence - 1
-		return writeMutationJSON(path, panicRecord)
+		return applyJSONMutation(path, func(target map[string]interface{}) {
+			target["last_good_seq"] = maxSequence - 1
+		})
 	}
-	return false
+	return nil, false
 }
 
-func mutateApprovalBinding(evidenceDir string) bool {
+func mutateApprovalBinding(evidenceDir string) (restoreCoverageMutation, bool) {
 	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
 		action, _ := receipt["action_type"].(string)
 		effectClass, _ := receipt["effect_class"].(string)
@@ -239,16 +338,15 @@ func mutateDecisionID(receipt map[string]interface{}) {
 	receipt["decision_id"] = differentMutationValue(current)
 }
 
-func mutateFirstReceipt(evidenceDir string, match func(map[string]interface{}) bool, mutate func(map[string]interface{})) bool {
+func mutateFirstReceipt(evidenceDir string, match func(map[string]interface{}) bool, mutate func(map[string]interface{})) (restoreCoverageMutation, bool) {
 	for _, path := range receiptFiles(evidenceDir) {
 		receipt := loadReceipt(path)
 		if receipt == nil || !match(receipt) {
 			continue
 		}
-		mutate(receipt)
-		return writeMutationJSON(path, receipt)
+		return applyJSONMutation(path, mutate)
 	}
-	return false
+	return nil, false
 }
 
 func receiptFiles(evidenceDir string) []string {
@@ -266,6 +364,30 @@ func loadMutationJSON(path string) map[string]interface{} {
 		return nil
 	}
 	return value
+}
+
+func applyJSONMutation(path string, mutate func(map[string]interface{})) (restoreCoverageMutation, bool) {
+	original, err := os.ReadFile(path)
+	if err != nil {
+		return nil, false
+	}
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return nil, false
+	}
+	var value map[string]interface{}
+	if json.Unmarshal(original, &value) != nil {
+		return nil, false
+	}
+	mutate(value)
+	mutated, err := json.Marshal(value)
+	if err != nil || os.WriteFile(path, mutated, info.Mode().Perm()) != nil {
+		return nil, false
+	}
+	restore := func() bool {
+		return os.WriteFile(path, original, info.Mode().Perm()) == nil
+	}
+	return restore, true
 }
 
 func writeMutationJSON(path string, value map[string]interface{}) bool {

--- a/core/pkg/conform/adversarial/coverage_mutations.go
+++ b/core/pkg/conform/adversarial/coverage_mutations.go
@@ -1,6 +1,11 @@
 package adversarial
 
+// quantum_posture: SHA-256 is used only to detect a torn local snapshot read;
+// campaign authorization remains externally rooted and makes no PQ claim.
+
 import (
+	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -102,7 +107,8 @@ func copyCoverageMutationTree(source, destination string) error {
 			_ = input.Close()
 			return err
 		}
-		copied, copyErr := io.Copy(output, io.LimitReader(input, info.Size()+1))
+		copiedHasher := sha256.New()
+		copied, copyErr := io.Copy(io.MultiWriter(output, copiedHasher), io.LimitReader(input, info.Size()+1))
 		closeOutputErr := output.Close()
 		closeInputErr := input.Close()
 		switch {
@@ -113,6 +119,28 @@ func copyCoverageMutationTree(source, destination string) error {
 		case closeInputErr != nil:
 			return closeInputErr
 		case copied != info.Size():
+			return fmt.Errorf("EvidencePack changed while snapshotting: %s", entry.Name())
+		}
+		verificationInput, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		verificationInfo, statErr := verificationInput.Stat()
+		if statErr != nil || !os.SameFile(info, verificationInfo) || !verificationInfo.Mode().IsRegular() || verificationInfo.Size() != info.Size() || !verificationInfo.ModTime().Equal(info.ModTime()) {
+			_ = verificationInput.Close()
+			return fmt.Errorf("EvidencePack changed while snapshotting: %s", entry.Name())
+		}
+		verificationHasher := sha256.New()
+		verified, verificationErr := io.Copy(verificationHasher, io.LimitReader(verificationInput, info.Size()+1))
+		closeVerificationErr := verificationInput.Close()
+		switch {
+		case verificationErr != nil:
+			return verificationErr
+		case closeVerificationErr != nil:
+			return closeVerificationErr
+		case verified != info.Size():
+			return fmt.Errorf("EvidencePack changed while snapshotting: %s", entry.Name())
+		case !bytes.Equal(copiedHasher.Sum(nil), verificationHasher.Sum(nil)):
 			return fmt.Errorf("EvidencePack changed while snapshotting: %s", entry.Name())
 		}
 		return nil

--- a/core/pkg/conform/adversarial/coverage_mutations.go
+++ b/core/pkg/conform/adversarial/coverage_mutations.go
@@ -1,0 +1,269 @@
+package adversarial
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type coverageMutation struct {
+	ID             string
+	ExpectedTestID string
+	Apply          func(string) bool
+}
+
+func mandatoryCoverageMutations() map[string]coverageMutation {
+	return map[string]coverageMutation{
+		"ADV-01": {ID: "receipt-sequence-gap/v1", ExpectedTestID: "ADV-01-T1", Apply: mutateReceiptSequenceGap},
+		"ADV-02": {ID: "policy-decision-bypass/v1", ExpectedTestID: "ADV-02-T1", Apply: mutatePolicyBinding},
+		"ADV-03": {ID: "proofgraph-dangling-parent/v1", ExpectedTestID: "ADV-03-T1", Apply: mutateProofGraphParent},
+		"ADV-04": {ID: "budget-overdraft/v1", ExpectedTestID: "ADV-04-T1", Apply: mutateBudgetBoundary},
+		"ADV-05": {ID: "envelope-binding-removal/v1", ExpectedTestID: "ADV-05-T1", Apply: mutateEnvelopeBinding},
+		"ADV-06": {ID: "tape-value-hash-tamper/v1", ExpectedTestID: "ADV-06-T1", Apply: mutateTapeHash},
+		"ADV-07": {ID: "cross-tenant-replay/v1", ExpectedTestID: "ADV-07-T1", Apply: mutateTenantBinding},
+		"ADV-08": {ID: "unsigned-tool-manifest/v1", ExpectedTestID: "ADV-08-T1", Apply: mutateToolSignature},
+		"ADV-09": {ID: "post-panic-receipt/v1", ExpectedTestID: "ADV-09-T1", Apply: mutatePanicBoundary},
+		"ADV-10": {ID: "high-finality-approval-bypass/v1", ExpectedTestID: "ADV-10-T1", Apply: mutateApprovalBinding},
+	}
+}
+
+func runCoverageMutation(evidenceDir string, suite *Suite, mutation coverageMutation) (bool, bool) {
+	tempDir, err := os.MkdirTemp("", "helm-adversarial-mutation-*")
+	if err != nil {
+		return false, false
+	}
+	defer os.RemoveAll(tempDir) //nolint:errcheck
+
+	mutantDir := filepath.Join(tempDir, "evidence-pack")
+	if err := os.CopyFS(mutantDir, os.DirFS(evidenceDir)); err != nil {
+		return false, false
+	}
+	if mutation.Apply == nil || mutation.ExpectedTestID == "" || !mutation.Apply(mutantDir) {
+		return false, false
+	}
+	result := suite.Run(mutantDir)
+	if result == nil || result.Pass {
+		return true, false
+	}
+	for _, test := range result.TestResults {
+		if test.TestID == mutation.ExpectedTestID && !test.Pass {
+			return true, true
+		}
+	}
+	return true, false
+}
+
+func mutateReceiptSequenceGap(evidenceDir string) bool {
+	files := receiptFiles(evidenceDir)
+	var targetPath string
+	var target map[string]interface{}
+	var maxSequence float64 = -1
+	validSequences := 0
+	for _, path := range files {
+		receipt := loadReceipt(path)
+		sequence, ok := receiptSequence(receipt)
+		if !ok {
+			continue
+		}
+		validSequences++
+		if sequence > maxSequence {
+			maxSequence = sequence
+			targetPath = path
+			target = receipt
+		}
+	}
+	if validSequences < 2 || target == nil {
+		return false
+	}
+	const maxExactJSONInteger = 1<<53 - 1
+	if maxSequence < maxExactJSONInteger {
+		target["seq"] = maxSequence + 1
+	} else {
+		target["seq"] = float64(0)
+	}
+	return writeMutationJSON(targetPath, target)
+}
+
+func mutatePolicyBinding(evidenceDir string) bool {
+	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
+		action, _ := receipt["action_type"].(string)
+		return isEffectAction(action)
+	}, mutateDecisionID)
+}
+
+func mutateProofGraphParent(evidenceDir string) bool {
+	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
+		sequence, ok := receiptSequence(receipt)
+		return ok && sequence > 1
+	}, func(receipt map[string]interface{}) {
+		receipt["parent_receipt_hashes"] = []string{"sha256:helm-mutation-missing-parent"}
+	})
+}
+
+func mutateBudgetBoundary(evidenceDir string) bool {
+	type exhaustion struct {
+		scope    string
+		sequence float64
+	}
+	files := receiptFiles(evidenceDir)
+	exhaustions := make([]exhaustion, 0)
+	for _, path := range files {
+		receipt := loadReceipt(path)
+		if receipt["action_type"] != "budget_exhausted" {
+			continue
+		}
+		sequence, ok := receiptSequence(receipt)
+		if scope := budgetScope(receipt); ok && scope != "" {
+			exhaustions = append(exhaustions, exhaustion{scope: scope, sequence: sequence})
+		}
+	}
+	for _, path := range files {
+		receipt := loadReceipt(path)
+		if receipt["action_type"] != "budget_decrement" {
+			continue
+		}
+		sequence, ok := receiptSequence(receipt)
+		scope := budgetScope(receipt)
+		if !ok || scope == "" {
+			continue
+		}
+		for _, boundary := range exhaustions {
+			if boundary.scope == scope && sequence < boundary.sequence {
+				receipt["seq"] = boundary.sequence
+				return writeMutationJSON(path, receipt)
+			}
+		}
+	}
+	return false
+}
+
+func mutateEnvelopeBinding(evidenceDir string) bool {
+	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
+		action, _ := receipt["action_type"].(string)
+		return isEffectAction(action)
+	}, func(receipt map[string]interface{}) {
+		delete(receipt, "envelope_hash")
+	})
+}
+
+func mutateTapeHash(evidenceDir string) bool {
+	files, _ := filepath.Glob(filepath.Join(evidenceDir, "08_TAPES", "entry_*.json"))
+	for _, path := range files {
+		entry := loadMutationJSON(path)
+		if entry == nil || !validTapeEntry(entry) {
+			continue
+		}
+		current, _ := entry["value_hash"].(string)
+		entry["value_hash"] = differentMutationValue(current)
+		return writeMutationJSON(path, entry)
+	}
+	return false
+}
+
+func mutateTenantBinding(evidenceDir string) bool {
+	seenTenant := ""
+	seenReceipts := 0
+	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
+		tenant, _ := receipt["tenant_id"].(string)
+		tenant = strings.TrimSpace(tenant)
+		if tenant == "" {
+			return false
+		}
+		seenReceipts++
+		if seenTenant == "" {
+			seenTenant = tenant
+			return false
+		}
+		return seenReceipts >= 2
+	}, func(receipt map[string]interface{}) {
+		receipt["tenant_id"] = differentMutationValue(seenTenant)
+	})
+}
+
+func mutateToolSignature(evidenceDir string) bool {
+	for _, path := range toolManifestFiles(evidenceDir) {
+		manifest := loadMutationJSON(path)
+		if manifest == nil {
+			continue
+		}
+		delete(manifest, "signatures")
+		return writeMutationJSON(path, manifest)
+	}
+	return false
+}
+
+func mutatePanicBoundary(evidenceDir string) bool {
+	maxSequence := float64(-1)
+	for _, path := range receiptFiles(evidenceDir) {
+		if sequence, ok := receiptSequence(loadReceipt(path)); ok && sequence > maxSequence {
+			maxSequence = sequence
+		}
+	}
+	if maxSequence < 1 {
+		return false
+	}
+	for _, path := range panicEvidenceFiles(evidenceDir) {
+		panicRecord := loadMutationJSON(path)
+		if panicRecord == nil {
+			continue
+		}
+		panicRecord["last_good_seq"] = maxSequence - 1
+		return writeMutationJSON(path, panicRecord)
+	}
+	return false
+}
+
+func mutateApprovalBinding(evidenceDir string) bool {
+	return mutateFirstReceipt(evidenceDir, func(receipt map[string]interface{}) bool {
+		action, _ := receipt["action_type"].(string)
+		effectClass, _ := receipt["effect_class"].(string)
+		return isHighFinality(effectClass, action)
+	}, mutateDecisionID)
+}
+
+func mutateDecisionID(receipt map[string]interface{}) {
+	current, _ := receipt["decision_id"].(string)
+	receipt["decision_id"] = differentMutationValue(current)
+}
+
+func mutateFirstReceipt(evidenceDir string, match func(map[string]interface{}) bool, mutate func(map[string]interface{})) bool {
+	for _, path := range receiptFiles(evidenceDir) {
+		receipt := loadReceipt(path)
+		if receipt == nil || !match(receipt) {
+			continue
+		}
+		mutate(receipt)
+		return writeMutationJSON(path, receipt)
+	}
+	return false
+}
+
+func receiptFiles(evidenceDir string) []string {
+	files, _ := filepath.Glob(filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts", "*.json"))
+	return files
+}
+
+func loadMutationJSON(path string) map[string]interface{} {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var value map[string]interface{}
+	if json.Unmarshal(data, &value) != nil {
+		return nil
+	}
+	return value
+}
+
+func writeMutationJSON(path string, value map[string]interface{}) bool {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+	return os.WriteFile(path, data, 0o600) == nil
+}
+
+func differentMutationValue(current string) string {
+	return current + ":helm-mutation"
+}

--- a/core/pkg/conform/adversarial/coverage_mutations.go
+++ b/core/pkg/conform/adversarial/coverage_mutations.go
@@ -6,12 +6,15 @@ package adversarial
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
 )
 
 const (
@@ -42,7 +45,11 @@ func mandatoryCoverageMutations() map[string]coverageMutation {
 	}
 }
 
-func newCoverageMutationWorkspace(evidenceDir string) (string, func(), error) {
+func newCoverageMutationWorkspace(evidenceDir string, opts VerificationOptions) (string, func(), error) {
+	expectedRoots, err := externallyVerifiedEvidenceRoots(opts)
+	if err != nil {
+		return "", func() {}, err
+	}
 	tempDir, err := os.MkdirTemp("", "helm-adversarial-mutations-*")
 	if err != nil {
 		return "", func() {}, err
@@ -53,7 +60,49 @@ func newCoverageMutationWorkspace(evidenceDir string) (string, func(), error) {
 		cleanup()
 		return "", func() {}, err
 	}
+	verifiedRoots, err := evidence.VerifyEvidencePackIndexRoots(mutationRoot)
+	if err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("verify mutation snapshot inventory: %w", err)
+	}
+	if verifiedRoots != expectedRoots {
+		cleanup()
+		return "", func() {}, fmt.Errorf(
+			"mutation snapshot roots differ from externally verified EvidencePack roots: index_hash=%s merkle_root=%s entry_count=%d",
+			verifiedRoots.IndexHash,
+			verifiedRoots.MerkleRoot,
+			verifiedRoots.EntryCount,
+		)
+	}
 	return mutationRoot, cleanup, nil
+}
+
+func externallyVerifiedEvidenceRoots(opts VerificationOptions) (evidence.EvidencePackIndexRoots, error) {
+	indexHash, err := canonicalSHA256Digest("verified EvidencePack index hash", opts.VerifiedEvidenceIndexHash)
+	if err != nil {
+		return evidence.EvidencePackIndexRoots{}, err
+	}
+	merkleRoot, err := canonicalSHA256Digest("verified EvidencePack Merkle root", opts.VerifiedEvidenceMerkleRoot)
+	if err != nil {
+		return evidence.EvidencePackIndexRoots{}, err
+	}
+	if opts.VerifiedEvidenceEntryCount < 0 {
+		return evidence.EvidencePackIndexRoots{}, fmt.Errorf("verified EvidencePack entry count must be non-negative")
+	}
+	return evidence.EvidencePackIndexRoots{
+		IndexHash:  indexHash,
+		MerkleRoot: merkleRoot,
+		EntryCount: opts.VerifiedEvidenceEntryCount,
+	}, nil
+}
+
+func canonicalSHA256Digest(name, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	digest, err := hex.DecodeString(value)
+	if err != nil || len(digest) != sha256.Size || hex.EncodeToString(digest) != value {
+		return "", fmt.Errorf("%s must be a canonical lowercase %d-byte SHA-256 hex digest", name, sha256.Size)
+	}
+	return value, nil
 }
 
 func copyCoverageMutationTree(source, destination string) error {
@@ -147,13 +196,13 @@ func copyCoverageMutationTree(source, destination string) error {
 	})
 }
 
-func runCoverageMutation(evidenceDir string, suite *Suite, mutation coverageMutation) (bool, bool) {
+func runCoverageMutation(evidenceDir string, suite *Suite, mutation coverageMutation) (bool, bool, bool) {
 	if mutation.Apply == nil || mutation.ExpectedTestID == "" {
-		return false, false
+		return false, false, false
 	}
 	restore, applied := mutation.Apply(evidenceDir)
 	if !applied || restore == nil {
-		return false, false
+		return false, false, false
 	}
 	restored := false
 	defer func() {
@@ -173,9 +222,9 @@ func runCoverageMutation(evidenceDir string, suite *Suite, mutation coverageMuta
 	}
 	restored = restore()
 	if !restored {
-		return true, false
+		return true, rejected, false
 	}
-	return true, rejected
+	return true, rejected, true
 }
 
 func suitePassesExpectedTest(result *SuiteResult, expectedTestID string) bool {
@@ -416,14 +465,6 @@ func applyJSONMutation(path string, mutate func(map[string]interface{})) (restor
 		return os.WriteFile(path, original, info.Mode().Perm()) == nil
 	}
 	return restore, true
-}
-
-func writeMutationJSON(path string, value map[string]interface{}) bool {
-	data, err := json.Marshal(value)
-	if err != nil {
-		return false
-	}
-	return os.WriteFile(path, data, 0o600) == nil
 }
 
 func differentMutationValue(current string) string {

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -58,6 +58,12 @@ func TestCoverageRejectsLegacyToolDirectoryAndPlaceholderSignature(t *testing.T)
 	if check := toolManifestCoverage(dir, VerificationOptions{}); check.Covered {
 		t.Fatalf("legacy tool directory unexpectedly covered ADV-08: %+v", check)
 	}
+	privateKey, publicKeyHex := campaignTestKey()
+	validManifest := signCampaignDocument(t, map[string]any{"name": "canonical"}, "signatures", campaignToolManifestSignatureDomain, privateKey)
+	writeJSON(t, filepath.Join(canonicalDir, "canonical.json"), validManifest)
+	if result := adv08ToolManifestForge(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+		t.Fatalf("legacy manifest was ignored beside a valid canonical manifest: %+v", result)
+	}
 	writeJSON(t, filepath.Join(canonicalDir, "canonical.json"), map[string]any{"signatures": []string{"placeholder"}})
 	if check := toolManifestCoverage(dir, VerificationOptions{}); check.Covered {
 		t.Fatalf("placeholder signature unexpectedly covered ADV-08: %+v", check)

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -133,8 +133,7 @@ func signCampaignDocument(t *testing.T, document map[string]any, field, domain s
 	if err != nil {
 		t.Fatal(err)
 	}
-	signedMessage := make([]byte, 0, len(domain)+1+len(canonical))
-	signedMessage = append(signedMessage, domain...)
+	signedMessage := []byte(domain)
 	signedMessage = append(signedMessage, 0)
 	signedMessage = append(signedMessage, canonical...)
 	publicKey := privateKey.Public().(ed25519.PublicKey)

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestEvaluateCoverageRejectsMissingPositiveControls(t *testing.T) {
-	result := EvaluateCoverage(t.TempDir())
+	result := EvaluateCoverage(t.TempDir(), VerificationOptions{})
 	if result.Pass || result.CoveredSuites != 0 || result.MissingSuites != 10 || len(result.Checks) != 10 {
 		t.Fatalf("empty coverage result=%+v, want 10 missing suites", result)
 	}

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -1,12 +1,17 @@
 package adversarial
 
-// quantum_posture: fixtures exercise classical Ed25519 signature shape and do
-// not represent cryptographic verification or post-quantum assurance.
+// quantum_posture: fixtures exercise deterministic classical Ed25519 keys and
+// do not represent post-quantum assurance.
 
 import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 )
 
 func TestEvaluateCoverageRejectsMissingPositiveControls(t *testing.T) {
@@ -18,9 +23,9 @@ func TestEvaluateCoverageRejectsMissingPositiveControls(t *testing.T) {
 
 func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	dir := t.TempDir()
-	writePassingCoverageArtifacts(t, dir)
+	publicKeyHex := writePassingCoverageArtifacts(t, dir)
 
-	result := EvaluateCoverage(dir)
+	result := EvaluateCoverageWithOptions(dir, VerificationOptions{CampaignPublicKeyHex: publicKeyHex})
 	if !result.Pass || result.CoveredSuites != 10 || result.MissingSuites != 0 || len(result.Checks) != 10 {
 		t.Fatalf("complete coverage result=%+v, want all suites covered", result)
 	}
@@ -33,7 +38,7 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, "08_TAPES", "entry_001.json")); err != nil {
 		t.Fatal(err)
 	}
-	result = EvaluateCoverage(dir)
+	result = EvaluateCoverageWithOptions(dir, VerificationOptions{CampaignPublicKeyHex: publicKeyHex})
 	if result.Pass || result.MissingSuites != 1 || result.Checks[5].SuiteID != "ADV-06" || result.Checks[5].Covered {
 		t.Fatalf("missing tape coverage result=%+v, want only ADV-06 missing", result)
 	}
@@ -50,17 +55,18 @@ func TestCoverageRejectsLegacyToolDirectoryAndPlaceholderSignature(t *testing.T)
 		t.Fatal(err)
 	}
 	writeJSON(t, filepath.Join(legacyDir, "legacy.json"), map[string]any{"signatures": []string{"placeholder"}})
-	if check := toolManifestCoverage(dir); check.Covered {
+	if check := toolManifestCoverage(dir, VerificationOptions{}); check.Covered {
 		t.Fatalf("legacy tool directory unexpectedly covered ADV-08: %+v", check)
 	}
 	writeJSON(t, filepath.Join(canonicalDir, "canonical.json"), map[string]any{"signatures": []string{"placeholder"}})
-	if check := toolManifestCoverage(dir); check.Covered {
+	if check := toolManifestCoverage(dir, VerificationOptions{}); check.Covered {
 		t.Fatalf("placeholder signature unexpectedly covered ADV-08: %+v", check)
 	}
 }
 
-func writePassingCoverageArtifacts(t *testing.T, dir string) {
+func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 	t.Helper()
+	privateKey, publicKeyHex := campaignTestKey()
 	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
 	for _, path := range []string{receiptsDir, filepath.Join(dir, "08_TAPES"), filepath.Join(dir, "99_EXT", "adversarial", "tools"), filepath.Join(dir, "06_LOGS")} {
 		if err := os.MkdirAll(path, 0o750); err != nil {
@@ -68,24 +74,48 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) {
 		}
 	}
 	receipts := []map[string]any{
-		{"seq": 1, "action_type": "policy_decision", "decision_id": "decision-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"genesis"}},
-		{"seq": 2, "action_type": "budget_decrement", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
-		{"seq": 3, "action_type": "budget_exhausted", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
-		{"seq": 4, "action_type": "approval_action", "decision_id": "decision-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-3"}},
-		{"seq": 5, "action_type": "effect_attempt", "decision_id": "decision-1", "effect_class": "E4", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-4"}},
+		{"receipt_id": "receipt-1", "receipt_hash": "receipt-1", "seq": 1, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}},
+		{"receipt_id": "receipt-2", "receipt_hash": "receipt-2", "seq": 2, "action_type": "budget_decrement", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
+		{"receipt_id": "receipt-3", "receipt_hash": "receipt-3", "seq": 3, "action_type": "budget_exhausted", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
+		{"receipt_id": "receipt-4", "receipt_hash": "receipt-4", "seq": 4, "action_type": "approval_action", "status": "APPROVED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-3"}},
+		{"receipt_id": "receipt-5", "receipt_hash": "receipt-5", "seq": 5, "action_type": "effect_attempt", "decision_id": "decision-1", "effect_class": "E4", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-4"}},
 	}
+	receipts[0] = signCampaignDocument(t, receipts[0], "campaign_signatures", privateKey)
+	receipts[3] = signCampaignDocument(t, receipts[3], "campaign_signatures", privateKey)
 	for i, receipt := range receipts {
 		writeJSON(t, filepath.Join(receiptsDir, []string{"001.json", "002.json", "003.json", "004.json", "005.json"}[i]), receipt)
 	}
 	writeJSON(t, filepath.Join(dir, "08_TAPES", "entry_001.json"), map[string]any{"value_hash": "sha256:value", "data_class": "internal"})
-	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), map[string]any{
-		"name": "covered-tool",
-		"signatures": []map[string]any{{
-			"algorithm": "ed25519",
-			"key_id":    "sha256:campaign-key",
-			"signature": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
-				"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-		}},
-	})
+	toolManifest := signCampaignDocument(t, map[string]any{"name": "covered-tool"}, "signatures", privateKey)
+	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), toolManifest)
 	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 5})
+	return publicKeyHex
+}
+
+func campaignTestKey() (ed25519.PrivateKey, string) {
+	seed := sha256.Sum256([]byte("helm-adversarial-campaign-test-key-v1"))
+	privateKey := ed25519.NewKeyFromSeed(seed[:])
+	return privateKey, hex.EncodeToString(privateKey.Public().(ed25519.PublicKey))
+}
+
+func signCampaignDocument(t *testing.T, document map[string]any, field string, privateKey ed25519.PrivateKey) map[string]any {
+	t.Helper()
+	payload := make(map[string]any, len(document))
+	for key, value := range document {
+		if key != field {
+			payload[key] = value
+		}
+	}
+	canonical, err := canonicalize.JCS(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	keyHash := sha256.Sum256(publicKey)
+	payload[field] = []any{map[string]any{
+		"algorithm": "ed25519",
+		"key_id":    "sha256:" + hex.EncodeToString(keyHash[:]),
+		"signature": hex.EncodeToString(ed25519.Sign(privateKey, canonical)),
+	}}
+	return payload
 }

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -4,6 +4,7 @@ package adversarial
 // do not represent post-quantum assurance.
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
@@ -24,15 +25,27 @@ func TestEvaluateCoverageRejectsMissingPositiveControls(t *testing.T) {
 func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	dir := t.TempDir()
 	publicKeyHex := writePassingCoverageArtifacts(t, dir)
+	sourceReceipt := filepath.Join(dir, "02_PROOFGRAPH", "receipts", "005.json")
+	sourceBefore, err := os.ReadFile(sourceReceipt)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
 	if !result.Pass || result.CoveredSuites != 10 || result.MissingSuites != 0 || len(result.Checks) != 10 {
 		t.Fatalf("complete coverage result=%+v, want all suites covered", result)
 	}
 	for _, check := range result.Checks {
-		if !check.Covered || check.EvidenceCount == 0 {
-			t.Fatalf("coverage check=%+v, want positive evidence", check)
+		if !check.Covered || check.EvidenceCount == 0 || check.MutationID == "" || !check.MutationApplied || !check.MutationRejected {
+			t.Fatalf("coverage check=%+v, want positive evidence and a rejected deterministic mutation", check)
 		}
+	}
+	sourceAfter, err := os.ReadFile(sourceReceipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(sourceBefore, sourceAfter) {
+		t.Fatal("coverage mutations modified the source EvidencePack")
 	}
 
 	if err := os.Remove(filepath.Join(dir, "08_TAPES", "entry_001.json")); err != nil {
@@ -41,6 +54,33 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	result = EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
 	if result.Pass || result.MissingSuites != 1 || result.Checks[5].SuiteID != "ADV-06" || result.Checks[5].Covered {
 		t.Fatalf("missing tape coverage result=%+v, want only ADV-06 missing", result)
+	}
+}
+
+func TestCoverageRequiresTheExpectedDetectorToRejectItsMutation(t *testing.T) {
+	dir := t.TempDir()
+	_ = writePassingCoverageArtifacts(t, dir)
+	mutation := mandatoryCoverageMutations()["ADV-01"]
+	alwaysPass := &Suite{ID: "ADV-01", Run: func(string) *SuiteResult {
+		return &SuiteResult{SuiteID: "ADV-01", Pass: true}
+	}}
+	applied, rejected := runCoverageMutation(dir, alwaysPass, mutation)
+	if !applied || rejected {
+		t.Fatalf("mutation probe applied=%t rejected=%t, want applied mutation and fail-closed rejection proof", applied, rejected)
+	}
+	unrelatedFailure := &Suite{ID: "ADV-01", Run: func(string) *SuiteResult {
+		return &SuiteResult{
+			SuiteID: "ADV-01",
+			Pass:    false,
+			TestResults: []TestResult{{
+				TestID: "UNRELATED-T1",
+				Pass:   false,
+			}},
+		}
+	}}
+	applied, rejected = runCoverageMutation(dir, unrelatedFailure, mutation)
+	if !applied || rejected {
+		t.Fatalf("unrelated failure applied=%t rejected=%t, want only the expected detector to prove rejection", applied, rejected)
 	}
 }
 

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -83,6 +83,11 @@ func TestCampaignSignaturesAreDomainSeparated(t *testing.T) {
 	if !verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, publicKeyHex) {
 		t.Fatal("domain-bound tool-manifest signature was rejected")
 	}
+	signature := manifest["signatures"].([]any)[0].(map[string]any)
+	signature["signature"] = "hex:" + signature["signature"].(string)
+	if verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, publicKeyHex) {
+		t.Fatal("non-canonical hex-prefixed signature was accepted")
+	}
 }
 
 func writePassingCoverageArtifacts(t *testing.T, dir string) string {

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -1,5 +1,8 @@
 package adversarial
 
+// quantum_posture: fixtures exercise classical Ed25519 signature shape and do
+// not represent cryptographic verification or post-quantum assurance.
+
 import (
 	"os"
 	"path/filepath"
@@ -36,6 +39,26 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	}
 }
 
+func TestCoverageRejectsLegacyToolDirectoryAndPlaceholderSignature(t *testing.T) {
+	dir := t.TempDir()
+	legacyDir := filepath.Join(dir, "10_TOOLS")
+	canonicalDir := filepath.Join(dir, "99_EXT", "adversarial", "tools")
+	if err := os.MkdirAll(legacyDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(canonicalDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(legacyDir, "legacy.json"), map[string]any{"signatures": []string{"placeholder"}})
+	if check := toolManifestCoverage(dir); check.Covered {
+		t.Fatalf("legacy tool directory unexpectedly covered ADV-08: %+v", check)
+	}
+	writeJSON(t, filepath.Join(canonicalDir, "canonical.json"), map[string]any{"signatures": []string{"placeholder"}})
+	if check := toolManifestCoverage(dir); check.Covered {
+		t.Fatalf("placeholder signature unexpectedly covered ADV-08: %+v", check)
+	}
+}
+
 func writePassingCoverageArtifacts(t *testing.T, dir string) {
 	t.Helper()
 	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
@@ -55,6 +78,14 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) {
 		writeJSON(t, filepath.Join(receiptsDir, []string{"001.json", "002.json", "003.json", "004.json", "005.json"}[i]), receipt)
 	}
 	writeJSON(t, filepath.Join(dir, "08_TAPES", "entry_001.json"), map[string]any{"value_hash": "sha256:value", "data_class": "internal"})
-	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), map[string]any{"name": "covered-tool", "signatures": []string{"sha256:signature"}})
+	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), map[string]any{
+		"name": "covered-tool",
+		"signatures": []map[string]any{{
+			"algorithm": "ed25519",
+			"key_id":    "sha256:campaign-key",
+			"signature": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" +
+				"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		}},
+	})
 	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 5})
 }

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -64,6 +64,21 @@ func TestCoverageRejectsLegacyToolDirectoryAndPlaceholderSignature(t *testing.T)
 	}
 }
 
+func TestCampaignSignaturesAreDomainSeparated(t *testing.T) {
+	privateKey, publicKeyHex := campaignTestKey()
+	receipt := signCampaignDocument(t, map[string]any{"name": "repurposed-receipt"}, "campaign_signatures", campaignReceiptSignatureDomain, privateKey)
+	receipt["signatures"] = receipt["campaign_signatures"]
+	delete(receipt, "campaign_signatures")
+
+	if verifyCampaignSignatures(receipt, "signatures", campaignToolManifestSignatureDomain, publicKeyHex) {
+		t.Fatal("receipt signature was accepted in the tool-manifest domain")
+	}
+	manifest := signCampaignDocument(t, map[string]any{"name": "real-tool"}, "signatures", campaignToolManifestSignatureDomain, privateKey)
+	if !verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, publicKeyHex) {
+		t.Fatal("domain-bound tool-manifest signature was rejected")
+	}
+}
+
 func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 	t.Helper()
 	privateKey, publicKeyHex := campaignTestKey()
@@ -75,20 +90,20 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 	}
 	receipts := []map[string]any{
 		{"receipt_id": "receipt-1", "receipt_hash": "receipt-1", "seq": 1, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}},
-		{"receipt_id": "receipt-2", "receipt_hash": "receipt-2", "seq": 2, "action_type": "budget_decrement", "budget_id": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
-		{"receipt_id": "receipt-3", "receipt_hash": "receipt-3", "seq": 3, "action_type": "budget_exhausted", "budget_id": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
+		{"receipt_id": "receipt-2", "receipt_hash": "receipt-2", "seq": 2, "action_type": "budget_decrement", "budget_snapshot_ref": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
+		{"receipt_id": "receipt-3", "receipt_hash": "receipt-3", "seq": 3, "action_type": "budget_exhausted", "budget_snapshot_ref": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
 		{"receipt_id": "receipt-4", "receipt_hash": "receipt-4", "seq": 4, "action_type": "approval_action", "status": "APPROVED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-3"}},
 		{"receipt_id": "receipt-5", "receipt_hash": "receipt-5", "seq": 5, "action_type": "effect_attempt", "decision_id": "decision-1", "effect_class": "E4", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-4"}},
 	}
-	receipts[0] = signCampaignDocument(t, receipts[0], "campaign_signatures", privateKey)
-	receipts[3] = signCampaignDocument(t, receipts[3], "campaign_signatures", privateKey)
+	receipts[0] = signCampaignDocument(t, receipts[0], "campaign_signatures", campaignReceiptSignatureDomain, privateKey)
+	receipts[3] = signCampaignDocument(t, receipts[3], "campaign_signatures", campaignReceiptSignatureDomain, privateKey)
 	for i, receipt := range receipts {
 		writeJSON(t, filepath.Join(receiptsDir, []string{"001.json", "002.json", "003.json", "004.json", "005.json"}[i]), receipt)
 	}
 	value := []byte("campaign-tape-value")
 	valueHash := sha256.Sum256(value)
 	writeJSON(t, filepath.Join(dir, "08_TAPES", "entry_001.json"), map[string]any{"value": value, "value_hash": hex.EncodeToString(valueHash[:]), "data_class": "internal"})
-	toolManifest := signCampaignDocument(t, map[string]any{"name": "covered-tool"}, "signatures", privateKey)
+	toolManifest := signCampaignDocument(t, map[string]any{"name": "covered-tool"}, "signatures", campaignToolManifestSignatureDomain, privateKey)
 	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), toolManifest)
 	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 5})
 	return publicKeyHex
@@ -100,7 +115,7 @@ func campaignTestKey() (ed25519.PrivateKey, string) {
 	return privateKey, hex.EncodeToString(privateKey.Public().(ed25519.PublicKey))
 }
 
-func signCampaignDocument(t *testing.T, document map[string]any, field string, privateKey ed25519.PrivateKey) map[string]any {
+func signCampaignDocument(t *testing.T, document map[string]any, field, domain string, privateKey ed25519.PrivateKey) map[string]any {
 	t.Helper()
 	payload := make(map[string]any, len(document))
 	for key, value := range document {
@@ -112,12 +127,16 @@ func signCampaignDocument(t *testing.T, document map[string]any, field string, p
 	if err != nil {
 		t.Fatal(err)
 	}
+	signedMessage := make([]byte, 0, len(domain)+1+len(canonical))
+	signedMessage = append(signedMessage, domain...)
+	signedMessage = append(signedMessage, 0)
+	signedMessage = append(signedMessage, canonical...)
 	publicKey := privateKey.Public().(ed25519.PublicKey)
 	keyHash := sha256.Sum256(publicKey)
 	payload[field] = []any{map[string]any{
 		"algorithm": "ed25519",
 		"key_id":    "sha256:" + hex.EncodeToString(keyHash[:]),
-		"signature": hex.EncodeToString(ed25519.Sign(privateKey, canonical)),
+		"signature": hex.EncodeToString(ed25519.Sign(privateKey, signedMessage)),
 	}}
 	return payload
 }

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -25,7 +25,7 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	dir := t.TempDir()
 	publicKeyHex := writePassingCoverageArtifacts(t, dir)
 
-	result := EvaluateCoverageWithOptions(dir, VerificationOptions{CampaignPublicKeyHex: publicKeyHex})
+	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
 	if !result.Pass || result.CoveredSuites != 10 || result.MissingSuites != 0 || len(result.Checks) != 10 {
 		t.Fatalf("complete coverage result=%+v, want all suites covered", result)
 	}
@@ -38,7 +38,7 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, "08_TAPES", "entry_001.json")); err != nil {
 		t.Fatal(err)
 	}
-	result = EvaluateCoverageWithOptions(dir, VerificationOptions{CampaignPublicKeyHex: publicKeyHex})
+	result = EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
 	if result.Pass || result.MissingSuites != 1 || result.Checks[5].SuiteID != "ADV-06" || result.Checks[5].Covered {
 		t.Fatalf("missing tape coverage result=%+v, want only ADV-06 missing", result)
 	}
@@ -59,9 +59,9 @@ func TestCoverageRejectsLegacyToolDirectoryAndPlaceholderSignature(t *testing.T)
 		t.Fatalf("legacy tool directory unexpectedly covered ADV-08: %+v", check)
 	}
 	privateKey, publicKeyHex := campaignTestKey()
-	validManifest := signCampaignDocument(t, map[string]any{"name": "canonical"}, "signatures", campaignToolManifestSignatureDomain, privateKey)
+	validManifest := signCampaignDocument(t, map[string]any{"name": "canonical", "campaign_id": testCampaignID, "run_id": testCampaignRunID}, "signatures", campaignToolManifestSignatureDomain, privateKey)
 	writeJSON(t, filepath.Join(canonicalDir, "canonical.json"), validManifest)
-	if result := adv08ToolManifestForge(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+	if result := adv08ToolManifestForge(campaignVerificationOptions(publicKeyHex)).Run(dir); result.Pass {
 		t.Fatalf("legacy manifest was ignored beside a valid canonical manifest: %+v", result)
 	}
 	writeJSON(t, filepath.Join(canonicalDir, "canonical.json"), map[string]any{"signatures": []string{"placeholder"}})
@@ -106,6 +106,10 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 		{"receipt_id": "receipt-4", "receipt_hash": "receipt-4", "seq": 4, "action_type": "approval_action", "status": "APPROVED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-3"}},
 		{"receipt_id": "receipt-5", "receipt_hash": "receipt-5", "seq": 5, "action_type": "effect_attempt", "decision_id": "decision-1", "effect_class": "E4", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-4"}},
 	}
+	for _, receipt := range receipts {
+		receipt["campaign_id"] = testCampaignID
+		receipt["run_id"] = testCampaignRunID
+	}
 	receipts[0] = signCampaignDocument(t, receipts[0], "campaign_signatures", campaignReceiptSignatureDomain, privateKey)
 	receipts[3] = signCampaignDocument(t, receipts[3], "campaign_signatures", campaignReceiptSignatureDomain, privateKey)
 	for i, receipt := range receipts {
@@ -114,7 +118,7 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 	value := []byte("campaign-tape-value")
 	valueHash := sha256.Sum256(value)
 	writeJSON(t, filepath.Join(dir, "08_TAPES", "entry_001.json"), map[string]any{"value": value, "value_hash": hex.EncodeToString(valueHash[:]), "data_class": "internal"})
-	toolManifest := signCampaignDocument(t, map[string]any{"name": "covered-tool"}, "signatures", campaignToolManifestSignatureDomain, privateKey)
+	toolManifest := signCampaignDocument(t, map[string]any{"name": "covered-tool", "campaign_id": testCampaignID, "run_id": testCampaignRunID}, "signatures", campaignToolManifestSignatureDomain, privateKey)
 	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), toolManifest)
 	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 5})
 	return publicKeyHex
@@ -124,6 +128,19 @@ func campaignTestKey() (ed25519.PrivateKey, string) {
 	seed := sha256.Sum256([]byte("helm-adversarial-campaign-test-key-v1"))
 	privateKey := ed25519.NewKeyFromSeed(seed[:])
 	return privateKey, hex.EncodeToString(privateKey.Public().(ed25519.PublicKey))
+}
+
+const (
+	testCampaignID    = "campaign:test-clean-room"
+	testCampaignRunID = "run:test-001"
+)
+
+func campaignVerificationOptions(publicKeyHex string) VerificationOptions {
+	return VerificationOptions{
+		CampaignPublicKeyHex: publicKeyHex,
+		CampaignID:           testCampaignID,
+		RunID:                testCampaignRunID,
+	}
 }
 
 func signCampaignDocument(t *testing.T, document map[string]any, field, domain string, privateKey ed25519.PrivateKey) map[string]any {

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -75,8 +75,8 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 	}
 	receipts := []map[string]any{
 		{"receipt_id": "receipt-1", "receipt_hash": "receipt-1", "seq": 1, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}},
-		{"receipt_id": "receipt-2", "receipt_hash": "receipt-2", "seq": 2, "action_type": "budget_decrement", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
-		{"receipt_id": "receipt-3", "receipt_hash": "receipt-3", "seq": 3, "action_type": "budget_exhausted", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
+		{"receipt_id": "receipt-2", "receipt_hash": "receipt-2", "seq": 2, "action_type": "budget_decrement", "budget_id": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
+		{"receipt_id": "receipt-3", "receipt_hash": "receipt-3", "seq": 3, "action_type": "budget_exhausted", "budget_id": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
 		{"receipt_id": "receipt-4", "receipt_hash": "receipt-4", "seq": 4, "action_type": "approval_action", "status": "APPROVED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-3"}},
 		{"receipt_id": "receipt-5", "receipt_hash": "receipt-5", "seq": 5, "action_type": "effect_attempt", "decision_id": "decision-1", "effect_class": "E4", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-4"}},
 	}
@@ -85,7 +85,9 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 	for i, receipt := range receipts {
 		writeJSON(t, filepath.Join(receiptsDir, []string{"001.json", "002.json", "003.json", "004.json", "005.json"}[i]), receipt)
 	}
-	writeJSON(t, filepath.Join(dir, "08_TAPES", "entry_001.json"), map[string]any{"value_hash": "sha256:value", "data_class": "internal"})
+	value := []byte("campaign-tape-value")
+	valueHash := sha256.Sum256(value)
+	writeJSON(t, filepath.Join(dir, "08_TAPES", "entry_001.json"), map[string]any{"value": value, "value_hash": hex.EncodeToString(valueHash[:]), "data_class": "internal"})
 	toolManifest := signCampaignDocument(t, map[string]any{"name": "covered-tool"}, "signatures", privateKey)
 	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), toolManifest)
 	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 5})

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -36,7 +36,7 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 		t.Fatalf("complete coverage result=%+v, want all suites covered", result)
 	}
 	for _, check := range result.Checks {
-		if !check.Covered || check.EvidenceCount == 0 || check.MutationID == "" || !check.MutationApplied || !check.MutationRejected {
+		if !check.Covered || check.EvidenceCount == 0 || check.MutationID == "" || !check.PositiveControlPassed || !check.MutationApplied || !check.MutationRejected {
 			t.Fatalf("coverage check=%+v, want positive evidence and a rejected deterministic mutation", check)
 		}
 	}
@@ -54,6 +54,23 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	result = EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
 	if result.Pass || result.MissingSuites != 1 || result.Checks[5].SuiteID != "ADV-06" || result.Checks[5].Covered {
 		t.Fatalf("missing tape coverage result=%+v, want only ADV-06 missing", result)
+	}
+}
+
+func TestCoverageRejectsAnAlreadyFailingPositiveControl(t *testing.T) {
+	dir := t.TempDir()
+	publicKeyHex := writePassingCoverageArtifacts(t, dir)
+	receiptPath := filepath.Join(dir, "02_PROOFGRAPH", "receipts", "005.json")
+	receipt := loadMutationJSON(receiptPath)
+	receipt["seq"] = float64(7)
+	if !writeMutationJSON(receiptPath, receipt) {
+		t.Fatal("could not create pre-failing positive control")
+	}
+
+	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	check := result.Checks[0]
+	if check.SuiteID != "ADV-01" || check.Covered || check.PositiveControlPassed || check.MutationApplied || check.MutationRejected {
+		t.Fatalf("pre-failing control check=%+v, want fail-closed differential coverage", check)
 	}
 }
 

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -95,7 +95,7 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 		}
 	}
 	receipts := []map[string]any{
-		{"receipt_id": "receipt-1", "receipt_hash": "receipt-1", "seq": 1, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}},
+		{"receipt_id": "receipt-1", "receipt_hash": "receipt-1", "seq": 1, "action_type": "policy_decision", "status": "ALLOW", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}},
 		{"receipt_id": "receipt-2", "receipt_hash": "receipt-2", "seq": 2, "action_type": "budget_decrement", "budget_snapshot_ref": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
 		{"receipt_id": "receipt-3", "receipt_hash": "receipt-3", "seq": 3, "action_type": "budget_exhausted", "budget_snapshot_ref": "budget-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
 		{"receipt_id": "receipt-4", "receipt_hash": "receipt-4", "seq": 4, "action_type": "approval_action", "status": "APPROVED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-3"}},

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -142,6 +142,39 @@ func TestCoverageSnapshotMustMatchExternallyVerifiedRoots(t *testing.T) {
 	})
 }
 
+func TestCoverageOmitsOnlyAnExternallyVerifiedDetachedConformanceSignature(t *testing.T) {
+	dir := t.TempDir()
+	publicKeyHex := writePassingCoverageArtifacts(t, dir)
+	opts := campaignVerificationOptionsForPack(t, dir, publicKeyHex)
+	signaturePath := filepath.Join(dir, "07_ATTESTATIONS", "conformance_report.sig")
+	if err := os.MkdirAll(filepath.Dir(signaturePath), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(signaturePath, []byte(`{"signature":"externally-verified-fixture"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	strictResult := EvaluateCoverageWithOptions(dir, opts)
+	if strictResult.Pass || strictResult.CoveredSuites != 0 || strictResult.MissingSuites != 10 {
+		t.Fatalf("unverified detached signature result=%+v, want all coverage to fail closed", strictResult)
+	}
+	opts.AllowVerifiedConformanceSignature = true
+	allowedResult := EvaluateCoverageWithOptions(dir, opts)
+	if !allowedResult.Pass || allowedResult.CoveredSuites != 10 || allowedResult.MissingSuites != 0 {
+		t.Fatalf("externally verified detached signature result=%+v, want complete coverage", allowedResult)
+	}
+	if _, err := os.Stat(signaturePath); err != nil {
+		t.Fatalf("source detached signature was modified: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "unexpected-unindexed.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	unexpectedResult := EvaluateCoverageWithOptions(dir, opts)
+	if unexpectedResult.Pass || unexpectedResult.CoveredSuites != 0 || unexpectedResult.MissingSuites != 10 {
+		t.Fatalf("unexpected unindexed file result=%+v, want all coverage to fail closed", unexpectedResult)
+	}
+}
+
 func TestCoverageMutationRestoresTheWorkspace(t *testing.T) {
 	dir := t.TempDir()
 	_ = writePassingCoverageArtifacts(t, dir)

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -74,6 +74,53 @@ func TestCoverageRejectsAnAlreadyFailingPositiveControl(t *testing.T) {
 	}
 }
 
+func TestCoverageRejectsMutationWorkspaceOverTheByteLimit(t *testing.T) {
+	dir := t.TempDir()
+	publicKeyHex := writePassingCoverageArtifacts(t, dir)
+	oversized := filepath.Join(dir, "oversized-untrusted-artifact.bin")
+	if err := os.WriteFile(oversized, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Truncate(oversized, maxCoverageMutationBytes+1); err != nil {
+		t.Fatal(err)
+	}
+
+	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	if result.Pass || result.CoveredSuites != 0 || result.MissingSuites != 10 {
+		t.Fatalf("oversized mutation workspace result=%+v, want all coverage to fail closed", result)
+	}
+	for _, check := range result.Checks {
+		if check.PositiveControlPassed || check.MutationApplied || check.MutationRejected {
+			t.Fatalf("oversized workspace check=%+v, want no unbounded control or mutation execution", check)
+		}
+	}
+	aggregate := RunAllWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	if aggregate.Pass || aggregate.PassedSuites != 0 || aggregate.FailedSuites != 10 || len(aggregate.Suites) != 10 {
+		t.Fatalf("oversized aggregate=%+v, want all suites to fail closed before unbounded reads", aggregate)
+	}
+}
+
+func TestCoverageMutationRestoresTheWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	_ = writePassingCoverageArtifacts(t, dir)
+	receiptPath := filepath.Join(dir, "02_PROOFGRAPH", "receipts", "005.json")
+	before, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	applied, rejected := runCoverageMutation(dir, adv01ReceiptGapInjection(), mandatoryCoverageMutations()["ADV-01"])
+	if !applied || !rejected {
+		t.Fatalf("mutation applied=%t rejected=%t, want exact detector rejection", applied, rejected)
+	}
+	after, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Fatal("coverage mutation was not restored byte-for-byte")
+	}
+}
+
 func TestCoverageRequiresTheExpectedDetectorToRejectItsMutation(t *testing.T) {
 	dir := t.TempDir()
 	_ = writePassingCoverageArtifacts(t, dir)

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -1,0 +1,60 @@
+package adversarial
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEvaluateCoverageRejectsMissingPositiveControls(t *testing.T) {
+	result := EvaluateCoverage(t.TempDir())
+	if result.Pass || result.CoveredSuites != 0 || result.MissingSuites != 10 || len(result.Checks) != 10 {
+		t.Fatalf("empty coverage result=%+v, want 10 missing suites", result)
+	}
+}
+
+func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
+	dir := t.TempDir()
+	writePassingCoverageArtifacts(t, dir)
+
+	result := EvaluateCoverage(dir)
+	if !result.Pass || result.CoveredSuites != 10 || result.MissingSuites != 0 || len(result.Checks) != 10 {
+		t.Fatalf("complete coverage result=%+v, want all suites covered", result)
+	}
+	for _, check := range result.Checks {
+		if !check.Covered || check.EvidenceCount == 0 {
+			t.Fatalf("coverage check=%+v, want positive evidence", check)
+		}
+	}
+
+	if err := os.Remove(filepath.Join(dir, "08_TAPES", "entry_001.json")); err != nil {
+		t.Fatal(err)
+	}
+	result = EvaluateCoverage(dir)
+	if result.Pass || result.MissingSuites != 1 || result.Checks[5].SuiteID != "ADV-06" || result.Checks[5].Covered {
+		t.Fatalf("missing tape coverage result=%+v, want only ADV-06 missing", result)
+	}
+}
+
+func writePassingCoverageArtifacts(t *testing.T, dir string) {
+	t.Helper()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	for _, path := range []string{receiptsDir, filepath.Join(dir, "08_TAPES"), filepath.Join(dir, "99_EXT", "adversarial", "tools"), filepath.Join(dir, "06_LOGS")} {
+		if err := os.MkdirAll(path, 0o750); err != nil {
+			t.Fatal(err)
+		}
+	}
+	receipts := []map[string]any{
+		{"seq": 1, "action_type": "policy_decision", "decision_id": "decision-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"genesis"}},
+		{"seq": 2, "action_type": "budget_decrement", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-1"}},
+		{"seq": 3, "action_type": "budget_exhausted", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-2"}},
+		{"seq": 4, "action_type": "approval_action", "decision_id": "decision-1", "tenant_id": "tenant-1", "parent_receipt_hashes": []string{"receipt-3"}},
+		{"seq": 5, "action_type": "effect_attempt", "decision_id": "decision-1", "effect_class": "E4", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"receipt-4"}},
+	}
+	for i, receipt := range receipts {
+		writeJSON(t, filepath.Join(receiptsDir, []string{"001.json", "002.json", "003.json", "004.json", "005.json"}[i]), receipt)
+	}
+	writeJSON(t, filepath.Join(dir, "08_TAPES", "entry_001.json"), map[string]any{"value_hash": "sha256:value", "data_class": "internal"})
+	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), map[string]any{"name": "covered-tool", "signatures": []string{"sha256:signature"}})
+	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 5})
+}

--- a/core/pkg/conform/adversarial/coverage_test.go
+++ b/core/pkg/conform/adversarial/coverage_test.go
@@ -8,11 +8,14 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
 )
 
 func TestEvaluateCoverageRejectsMissingPositiveControls(t *testing.T) {
@@ -30,13 +33,14 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	opts := campaignVerificationOptionsForPack(t, dir, publicKeyHex)
 
-	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	result := EvaluateCoverageWithOptions(dir, opts)
 	if !result.Pass || result.CoveredSuites != 10 || result.MissingSuites != 0 || len(result.Checks) != 10 {
 		t.Fatalf("complete coverage result=%+v, want all suites covered", result)
 	}
 	for _, check := range result.Checks {
-		if !check.Covered || check.EvidenceCount == 0 || check.MutationID == "" || !check.PositiveControlPassed || !check.MutationApplied || !check.MutationRejected {
+		if !check.Covered || check.EvidenceCount == 0 || check.MutationID == "" || !check.PositiveControlPassed || !check.MutationApplied || !check.MutationRejected || !check.MutationRestored {
 			t.Fatalf("coverage check=%+v, want positive evidence and a rejected deterministic mutation", check)
 		}
 	}
@@ -51,7 +55,8 @@ func TestEvaluateCoverageAcceptsAllPositiveControls(t *testing.T) {
 	if err := os.Remove(filepath.Join(dir, "08_TAPES", "entry_001.json")); err != nil {
 		t.Fatal(err)
 	}
-	result = EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	writeCoverageIndex(t, dir)
+	result = EvaluateCoverageWithOptions(dir, campaignVerificationOptionsForPack(t, dir, publicKeyHex))
 	if result.Pass || result.MissingSuites != 1 || result.Checks[5].SuiteID != "ADV-06" || result.Checks[5].Covered {
 		t.Fatalf("missing tape coverage result=%+v, want only ADV-06 missing", result)
 	}
@@ -63,13 +68,14 @@ func TestCoverageRejectsAnAlreadyFailingPositiveControl(t *testing.T) {
 	receiptPath := filepath.Join(dir, "02_PROOFGRAPH", "receipts", "005.json")
 	receipt := loadMutationJSON(receiptPath)
 	receipt["seq"] = float64(7)
-	if !writeMutationJSON(receiptPath, receipt) {
+	if !writeTestMutationJSON(receiptPath, receipt) {
 		t.Fatal("could not create pre-failing positive control")
 	}
+	writeCoverageIndex(t, dir)
 
-	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptionsForPack(t, dir, publicKeyHex))
 	check := result.Checks[0]
-	if check.SuiteID != "ADV-01" || check.Covered || check.PositiveControlPassed || check.MutationApplied || check.MutationRejected {
+	if check.SuiteID != "ADV-01" || check.Covered || check.PositiveControlPassed || check.MutationApplied || check.MutationRejected || check.MutationRestored {
 		t.Fatalf("pre-failing control check=%+v, want fail-closed differential coverage", check)
 	}
 }
@@ -77,6 +83,7 @@ func TestCoverageRejectsAnAlreadyFailingPositiveControl(t *testing.T) {
 func TestCoverageRejectsMutationWorkspaceOverTheByteLimit(t *testing.T) {
 	dir := t.TempDir()
 	publicKeyHex := writePassingCoverageArtifacts(t, dir)
+	opts := campaignVerificationOptionsForPack(t, dir, publicKeyHex)
 	oversized := filepath.Join(dir, "oversized-untrusted-artifact.bin")
 	if err := os.WriteFile(oversized, nil, 0o600); err != nil {
 		t.Fatal(err)
@@ -85,19 +92,54 @@ func TestCoverageRejectsMutationWorkspaceOverTheByteLimit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result := EvaluateCoverageWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	result := EvaluateCoverageWithOptions(dir, opts)
 	if result.Pass || result.CoveredSuites != 0 || result.MissingSuites != 10 {
 		t.Fatalf("oversized mutation workspace result=%+v, want all coverage to fail closed", result)
 	}
 	for _, check := range result.Checks {
-		if check.PositiveControlPassed || check.MutationApplied || check.MutationRejected {
+		if check.PositiveControlPassed || check.MutationApplied || check.MutationRejected || check.MutationRestored {
 			t.Fatalf("oversized workspace check=%+v, want no unbounded control or mutation execution", check)
 		}
 	}
-	aggregate := RunAllWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	aggregate := RunAllWithOptions(dir, opts)
 	if aggregate.Pass || aggregate.PassedSuites != 0 || aggregate.FailedSuites != 10 || len(aggregate.Suites) != 10 {
 		t.Fatalf("oversized aggregate=%+v, want all suites to fail closed before unbounded reads", aggregate)
 	}
+}
+
+func TestCoverageSnapshotMustMatchExternallyVerifiedRoots(t *testing.T) {
+	t.Run("unindexed post-verification file", func(t *testing.T) {
+		dir := t.TempDir()
+		publicKeyHex := writePassingCoverageArtifacts(t, dir)
+		opts := campaignVerificationOptionsForPack(t, dir, publicKeyHex)
+		if err := os.WriteFile(filepath.Join(dir, "post-verification.json"), []byte(`{}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		result := EvaluateCoverageWithOptions(dir, opts)
+		if result.Pass || result.CoveredSuites != 0 || result.MissingSuites != 10 {
+			t.Fatalf("post-verification addition result=%+v, want all coverage to fail closed", result)
+		}
+	})
+
+	t.Run("reindexed pack requires a newly verified root", func(t *testing.T) {
+		dir := t.TempDir()
+		publicKeyHex := writePassingCoverageArtifacts(t, dir)
+		oldOpts := campaignVerificationOptionsForPack(t, dir, publicKeyHex)
+		if err := os.WriteFile(filepath.Join(dir, "99_EXT", "adversarial", "campaign-context.json"), []byte(`{"version":"v2"}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		writeCoverageIndex(t, dir)
+
+		staleResult := EvaluateCoverageWithOptions(dir, oldOpts)
+		if staleResult.Pass || staleResult.CoveredSuites != 0 || staleResult.MissingSuites != 10 {
+			t.Fatalf("stale root result=%+v, want all coverage to fail closed", staleResult)
+		}
+		freshResult := EvaluateCoverageWithOptions(dir, campaignVerificationOptionsForPack(t, dir, publicKeyHex))
+		if !freshResult.Pass || freshResult.CoveredSuites != 10 {
+			t.Fatalf("newly verified root result=%+v, want complete coverage", freshResult)
+		}
+	})
 }
 
 func TestCoverageMutationRestoresTheWorkspace(t *testing.T) {
@@ -108,9 +150,9 @@ func TestCoverageMutationRestoresTheWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	applied, rejected := runCoverageMutation(dir, adv01ReceiptGapInjection(), mandatoryCoverageMutations()["ADV-01"])
-	if !applied || !rejected {
-		t.Fatalf("mutation applied=%t rejected=%t, want exact detector rejection", applied, rejected)
+	applied, rejected, restored := runCoverageMutation(dir, adv01ReceiptGapInjection(), mandatoryCoverageMutations()["ADV-01"])
+	if !applied || !rejected || !restored {
+		t.Fatalf("mutation applied=%t rejected=%t restored=%t, want exact detector rejection and restoration", applied, rejected, restored)
 	}
 	after, err := os.ReadFile(receiptPath)
 	if err != nil {
@@ -128,9 +170,9 @@ func TestCoverageRequiresTheExpectedDetectorToRejectItsMutation(t *testing.T) {
 	alwaysPass := &Suite{ID: "ADV-01", Run: func(string) *SuiteResult {
 		return &SuiteResult{SuiteID: "ADV-01", Pass: true}
 	}}
-	applied, rejected := runCoverageMutation(dir, alwaysPass, mutation)
-	if !applied || rejected {
-		t.Fatalf("mutation probe applied=%t rejected=%t, want applied mutation and fail-closed rejection proof", applied, rejected)
+	applied, rejected, restored := runCoverageMutation(dir, alwaysPass, mutation)
+	if !applied || rejected || !restored {
+		t.Fatalf("mutation probe applied=%t rejected=%t restored=%t, want applied mutation without detector rejection", applied, rejected, restored)
 	}
 	unrelatedFailure := &Suite{ID: "ADV-01", Run: func(string) *SuiteResult {
 		return &SuiteResult{
@@ -142,9 +184,26 @@ func TestCoverageRequiresTheExpectedDetectorToRejectItsMutation(t *testing.T) {
 			}},
 		}
 	}}
-	applied, rejected = runCoverageMutation(dir, unrelatedFailure, mutation)
-	if !applied || rejected {
-		t.Fatalf("unrelated failure applied=%t rejected=%t, want only the expected detector to prove rejection", applied, rejected)
+	applied, rejected, restored = runCoverageMutation(dir, unrelatedFailure, mutation)
+	if !applied || rejected || !restored {
+		t.Fatalf("unrelated failure applied=%t rejected=%t restored=%t, want only the expected detector to prove rejection", applied, rejected, restored)
+	}
+}
+
+func TestCoverageMutationReportsRestoreFailure(t *testing.T) {
+	mutation := coverageMutation{
+		ID:             "restore-failure/v1",
+		ExpectedTestID: "ADV-01-T1",
+		Apply: func(string) (restoreCoverageMutation, bool) {
+			return func() bool { return false }, true
+		},
+	}
+	suite := &Suite{ID: "ADV-01", Run: func(string) *SuiteResult {
+		return &SuiteResult{SuiteID: "ADV-01", Pass: false, TestResults: []TestResult{{TestID: "ADV-01-T1", Pass: false}}}
+	}}
+	applied, rejected, restored := runCoverageMutation(t.TempDir(), suite, mutation)
+	if !applied || !rejected || restored {
+		t.Fatalf("restore failure applied=%t rejected=%t restored=%t, want explicit dirty-workspace signal", applied, rejected, restored)
 	}
 }
 
@@ -225,7 +284,46 @@ func writePassingCoverageArtifacts(t *testing.T, dir string) string {
 	toolManifest := signCampaignDocument(t, map[string]any{"name": "covered-tool", "campaign_id": testCampaignID, "run_id": testCampaignRunID}, "signatures", campaignToolManifestSignatureDomain, privateKey)
 	writeJSON(t, filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json"), toolManifest)
 	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 5})
+	writeCoverageIndex(t, dir)
 	return publicKeyHex
+}
+
+func writeCoverageIndex(t *testing.T, dir string) {
+	t.Helper()
+	entries := make([]map[string]string, 0)
+	if err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "00_INDEX.json" || rel == evidence.EvidencePackSealPath {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		digest := sha256.Sum256(data)
+		entries = append(entries, map[string]string{"path": rel, "sha256": hex.EncodeToString(digest[:])})
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i]["path"] < entries[j]["path"] })
+	data, err := json.MarshalIndent(map[string]any{"version": "1.0.0", "entries": entries}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "00_INDEX.json"), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func campaignTestKey() (ed25519.PrivateKey, string) {
@@ -245,6 +343,27 @@ func campaignVerificationOptions(publicKeyHex string) VerificationOptions {
 		CampaignID:           testCampaignID,
 		RunID:                testCampaignRunID,
 	}
+}
+
+func campaignVerificationOptionsForPack(t *testing.T, dir, publicKeyHex string) VerificationOptions {
+	t.Helper()
+	roots, err := evidence.VerifyEvidencePackIndexRoots(dir)
+	if err != nil {
+		t.Fatalf("verify fixture EvidencePack roots: %v", err)
+	}
+	opts := campaignVerificationOptions(publicKeyHex)
+	opts.VerifiedEvidenceIndexHash = roots.IndexHash
+	opts.VerifiedEvidenceMerkleRoot = roots.MerkleRoot
+	opts.VerifiedEvidenceEntryCount = roots.EntryCount
+	return opts
+}
+
+func writeTestMutationJSON(path string, value map[string]interface{}) bool {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+	return os.WriteFile(path, data, 0o600) == nil
 }
 
 func signCampaignDocument(t *testing.T, document map[string]any, field, domain string, privateKey ed25519.PrivateKey) map[string]any {

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -47,7 +47,7 @@ func RunAllWithOptions(evidenceDir string, opts VerificationOptions) *AggregateR
 			result.Pass = false
 			result.TestResults = append(result.TestResults, TestResult{
 				TestID: suite.ID + "-COVERAGE",
-				Name:   "Positive-control coverage",
+				Name:   "Positive-control and mutation coverage",
 				Pass:   false,
 				Reason: check.Reason,
 			})

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -11,6 +11,11 @@ import (
 // Returns an aggregate result. Any single suite failure means overall failure.
 func RunAll(evidenceDir string) *AggregateResult {
 	suites := AllSuites()
+	coverage := EvaluateCoverage(evidenceDir)
+	coverageBySuite := make(map[string]CoverageCheck, len(coverage.Checks))
+	for _, check := range coverage.Checks {
+		coverageBySuite[check.SuiteID] = check
+	}
 	aggregate := &AggregateResult{
 		EvidenceDir: evidenceDir,
 		Pass:        true,
@@ -19,6 +24,15 @@ func RunAll(evidenceDir string) *AggregateResult {
 
 	for _, suite := range suites {
 		result := suite.Run(evidenceDir)
+		if check, ok := coverageBySuite[suite.ID]; ok && !check.Covered && result.Pass {
+			result.Pass = false
+			result.TestResults = append(result.TestResults, TestResult{
+				TestID: suite.ID + "-COVERAGE",
+				Name:   "Positive-control coverage",
+				Pass:   false,
+				Reason: check.Reason,
+			})
+		}
 		aggregate.Suites = append(aggregate.Suites, result)
 		if !result.Pass {
 			aggregate.Pass = false

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -5,12 +5,17 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 const (
-	CampaignPublicKeyEnv = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
-	CampaignIDEnv        = "HELM_BOUNTY_CAMPAIGN_ID"
-	CampaignRunIDEnv     = "HELM_BOUNTY_RUN_ID"
+	CampaignPublicKeyEnv          = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
+	CampaignIDEnv                 = "HELM_BOUNTY_CAMPAIGN_ID"
+	CampaignRunIDEnv              = "HELM_BOUNTY_RUN_ID"
+	VerifiedEvidenceIndexHashEnv  = "HELM_BOUNTY_VERIFIED_EVIDENCE_INDEX_HASH"
+	VerifiedEvidenceMerkleRootEnv = "HELM_BOUNTY_VERIFIED_EVIDENCE_MERKLE_ROOT"
+	VerifiedEvidenceEntryCountEnv = "HELM_BOUNTY_VERIFIED_EVIDENCE_ENTRY_COUNT"
 )
 
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
@@ -19,10 +24,17 @@ const (
 // suites fail closed when the variable is absent or invalid; explicit callers
 // should use RunAllWithOptions.
 func RunAll(evidenceDir string) *AggregateResult {
+	verifiedEntryCount, err := strconv.Atoi(strings.TrimSpace(os.Getenv(VerifiedEvidenceEntryCountEnv)))
+	if err != nil {
+		verifiedEntryCount = -1
+	}
 	return RunAllWithOptions(evidenceDir, VerificationOptions{
-		CampaignPublicKeyHex: os.Getenv(CampaignPublicKeyEnv),
-		CampaignID:           os.Getenv(CampaignIDEnv),
-		RunID:                os.Getenv(CampaignRunIDEnv),
+		CampaignPublicKeyHex:       os.Getenv(CampaignPublicKeyEnv),
+		CampaignID:                 os.Getenv(CampaignIDEnv),
+		RunID:                      os.Getenv(CampaignRunIDEnv),
+		VerifiedEvidenceIndexHash:  os.Getenv(VerifiedEvidenceIndexHashEnv),
+		VerifiedEvidenceMerkleRoot: os.Getenv(VerifiedEvidenceMerkleRootEnv),
+		VerifiedEvidenceEntryCount: verifiedEntryCount,
 	})
 }
 
@@ -30,9 +42,9 @@ func RunAll(evidenceDir string) *AggregateResult {
 // root. Evidence stored inside the candidate pack never establishes trust.
 func RunAllWithOptions(evidenceDir string, opts VerificationOptions) *AggregateResult {
 	suites := AllSuitesWithOptions(opts)
-	workspace, cleanup, workspaceErr := newCoverageMutationWorkspace(evidenceDir)
+	workspace, cleanup, workspaceErr := newCoverageMutationWorkspace(evidenceDir, opts)
 	defer cleanup()
-	coverage := unavailableCoverageResult(opts)
+	coverage := unavailableCoverageResult(opts, workspaceErr)
 	baselineResults := make(map[string]*SuiteResult, len(suites))
 	if workspaceErr == nil {
 		coverage, baselineResults = evaluateCoverageInWorkspace(workspace, opts)

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -7,7 +7,11 @@ import (
 	"path/filepath"
 )
 
-const CampaignPublicKeyEnv = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
+const (
+	CampaignPublicKeyEnv = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
+	CampaignIDEnv        = "HELM_BOUNTY_CAMPAIGN_ID"
+	CampaignRunIDEnv     = "HELM_BOUNTY_RUN_ID"
+)
 
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
 // It preserves the original single-argument API and reads the campaign trust
@@ -15,7 +19,11 @@ const CampaignPublicKeyEnv = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
 // suites fail closed when the variable is absent or invalid; explicit callers
 // should use RunAllWithOptions.
 func RunAll(evidenceDir string) *AggregateResult {
-	return RunAllWithOptions(evidenceDir, VerificationOptions{CampaignPublicKeyHex: os.Getenv(CampaignPublicKeyEnv)})
+	return RunAllWithOptions(evidenceDir, VerificationOptions{
+		CampaignPublicKeyHex: os.Getenv(CampaignPublicKeyEnv),
+		CampaignID:           os.Getenv(CampaignIDEnv),
+		RunID:                os.Getenv(CampaignRunIDEnv),
+	})
 }
 
 // RunAllWithOptions executes every suite against an external campaign trust

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -10,8 +10,14 @@ import (
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
 // Returns an aggregate result. Any single suite failure means overall failure.
 func RunAll(evidenceDir string) *AggregateResult {
-	suites := AllSuites()
-	coverage := EvaluateCoverage(evidenceDir)
+	return RunAllWithOptions(evidenceDir, VerificationOptions{})
+}
+
+// RunAllWithOptions executes every suite against an external campaign trust
+// root. Evidence stored inside the candidate pack never establishes trust.
+func RunAllWithOptions(evidenceDir string, opts VerificationOptions) *AggregateResult {
+	suites := AllSuitesWithOptions(opts)
+	coverage := EvaluateCoverageWithOptions(evidenceDir, opts)
 	coverageBySuite := make(map[string]CoverageCheck, len(coverage.Checks))
 	for _, check := range coverage.Checks {
 		coverageBySuite[check.SuiteID] = check

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -8,8 +8,14 @@ import (
 )
 
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
-// Returns an aggregate result. Any single suite failure means overall failure.
-func RunAll(evidenceDir string, opts VerificationOptions) *AggregateResult {
+// The optional argument preserves source compatibility with the original
+// RunAll(evidenceDir) API; omitting the external campaign root fails closed in
+// the signature-dependent suites and their positive-control coverage.
+func RunAll(evidenceDir string, options ...VerificationOptions) *AggregateResult {
+	opts := VerificationOptions{}
+	if len(options) == 1 {
+		opts = options[0]
+	}
 	return RunAllWithOptions(evidenceDir, opts)
 }
 

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -9,8 +9,8 @@ import (
 
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
 // Returns an aggregate result. Any single suite failure means overall failure.
-func RunAll(evidenceDir string) *AggregateResult {
-	return RunAllWithOptions(evidenceDir, VerificationOptions{})
+func RunAll(evidenceDir string, opts VerificationOptions) *AggregateResult {
+	return RunAllWithOptions(evidenceDir, opts)
 }
 
 // RunAllWithOptions executes every suite against an external campaign trust

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	CampaignPublicKeyEnv          = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
-	CampaignIDEnv                 = "HELM_BOUNTY_CAMPAIGN_ID"
-	CampaignRunIDEnv              = "HELM_BOUNTY_RUN_ID"
-	VerifiedEvidenceIndexHashEnv  = "HELM_BOUNTY_VERIFIED_EVIDENCE_INDEX_HASH"
-	VerifiedEvidenceMerkleRootEnv = "HELM_BOUNTY_VERIFIED_EVIDENCE_MERKLE_ROOT"
-	VerifiedEvidenceEntryCountEnv = "HELM_BOUNTY_VERIFIED_EVIDENCE_ENTRY_COUNT"
+	CampaignPublicKeyEnv                 = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
+	CampaignIDEnv                        = "HELM_BOUNTY_CAMPAIGN_ID"
+	CampaignRunIDEnv                     = "HELM_BOUNTY_RUN_ID"
+	VerifiedEvidenceIndexHashEnv         = "HELM_BOUNTY_VERIFIED_EVIDENCE_INDEX_HASH"
+	VerifiedEvidenceMerkleRootEnv        = "HELM_BOUNTY_VERIFIED_EVIDENCE_MERKLE_ROOT"
+	VerifiedEvidenceEntryCountEnv        = "HELM_BOUNTY_VERIFIED_EVIDENCE_ENTRY_COUNT"
+	AllowVerifiedConformanceSignatureEnv = "HELM_BOUNTY_ALLOW_VERIFIED_CONFORMANCE_SIGNATURE"
 )
 
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
@@ -28,13 +29,18 @@ func RunAll(evidenceDir string) *AggregateResult {
 	if err != nil {
 		verifiedEntryCount = -1
 	}
+	allowVerifiedConformanceSignature, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(AllowVerifiedConformanceSignatureEnv)))
+	if err != nil {
+		allowVerifiedConformanceSignature = false
+	}
 	return RunAllWithOptions(evidenceDir, VerificationOptions{
-		CampaignPublicKeyHex:       os.Getenv(CampaignPublicKeyEnv),
-		CampaignID:                 os.Getenv(CampaignIDEnv),
-		RunID:                      os.Getenv(CampaignRunIDEnv),
-		VerifiedEvidenceIndexHash:  os.Getenv(VerifiedEvidenceIndexHashEnv),
-		VerifiedEvidenceMerkleRoot: os.Getenv(VerifiedEvidenceMerkleRootEnv),
-		VerifiedEvidenceEntryCount: verifiedEntryCount,
+		CampaignPublicKeyHex:              os.Getenv(CampaignPublicKeyEnv),
+		CampaignID:                        os.Getenv(CampaignIDEnv),
+		RunID:                             os.Getenv(CampaignRunIDEnv),
+		VerifiedEvidenceIndexHash:         os.Getenv(VerifiedEvidenceIndexHashEnv),
+		VerifiedEvidenceMerkleRoot:        os.Getenv(VerifiedEvidenceMerkleRootEnv),
+		VerifiedEvidenceEntryCount:        verifiedEntryCount,
+		AllowVerifiedConformanceSignature: allowVerifiedConformanceSignature,
 	})
 }
 

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -30,7 +30,13 @@ func RunAll(evidenceDir string) *AggregateResult {
 // root. Evidence stored inside the candidate pack never establishes trust.
 func RunAllWithOptions(evidenceDir string, opts VerificationOptions) *AggregateResult {
 	suites := AllSuitesWithOptions(opts)
-	coverage := EvaluateCoverageWithOptions(evidenceDir, opts)
+	workspace, cleanup, workspaceErr := newCoverageMutationWorkspace(evidenceDir)
+	defer cleanup()
+	coverage := unavailableCoverageResult(opts)
+	baselineResults := make(map[string]*SuiteResult, len(suites))
+	if workspaceErr == nil {
+		coverage, baselineResults = evaluateCoverageInWorkspace(workspace, opts)
+	}
 	coverageBySuite := make(map[string]CoverageCheck, len(coverage.Checks))
 	for _, check := range coverage.Checks {
 		coverageBySuite[check.SuiteID] = check
@@ -42,8 +48,15 @@ func RunAllWithOptions(evidenceDir string, opts VerificationOptions) *AggregateR
 	}
 
 	for _, suite := range suites {
-		result := suite.Run(evidenceDir)
-		if check, ok := coverageBySuite[suite.ID]; ok && !check.Covered && result.Pass {
+		result := baselineResults[suite.ID]
+		if result == nil {
+			result = &SuiteResult{SuiteID: suite.ID, Name: suite.Name, Pass: true}
+		}
+		check, covered := coverageBySuite[suite.ID]
+		if !covered {
+			check = CoverageCheck{SuiteID: suite.ID, Reason: "missing: mandatory coverage check is not registered"}
+		}
+		if !check.Covered && result.Pass {
 			result.Pass = false
 			result.TestResults = append(result.TestResults, TestResult{
 				TestID: suite.ID + "-COVERAGE",

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -8,15 +8,11 @@ import (
 )
 
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
-// The optional argument preserves source compatibility with the original
-// RunAll(evidenceDir) API; omitting the external campaign root fails closed in
-// the signature-dependent suites and their positive-control coverage.
-func RunAll(evidenceDir string, options ...VerificationOptions) *AggregateResult {
-	opts := VerificationOptions{}
-	if len(options) == 1 {
-		opts = options[0]
-	}
-	return RunAllWithOptions(evidenceDir, opts)
+// It preserves the original single-argument API. Signature-dependent suites
+// fail closed without an external campaign root; keyed callers must use
+// RunAllWithOptions.
+func RunAll(evidenceDir string) *AggregateResult {
+	return RunAllWithOptions(evidenceDir, VerificationOptions{})
 }
 
 // RunAllWithOptions executes every suite against an external campaign trust

--- a/core/pkg/conform/adversarial/runner.go
+++ b/core/pkg/conform/adversarial/runner.go
@@ -7,12 +7,15 @@ import (
 	"path/filepath"
 )
 
+const CampaignPublicKeyEnv = "HELM_BOUNTY_CAMPAIGN_PUBLIC_KEY_HEX"
+
 // RunAll executes all 10 mandatory adversarial suites against an EvidencePack.
-// It preserves the original single-argument API. Signature-dependent suites
-// fail closed without an external campaign root; keyed callers must use
-// RunAllWithOptions.
+// It preserves the original single-argument API and reads the campaign trust
+// root only from the operator-controlled environment. Signature-dependent
+// suites fail closed when the variable is absent or invalid; explicit callers
+// should use RunAllWithOptions.
 func RunAll(evidenceDir string) *AggregateResult {
-	return RunAllWithOptions(evidenceDir, VerificationOptions{})
+	return RunAllWithOptions(evidenceDir, VerificationOptions{CampaignPublicKeyHex: os.Getenv(CampaignPublicKeyEnv)})
 }
 
 // RunAllWithOptions executes every suite against an external campaign trust

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 )
 
+var _ func(string) *AggregateResult = RunAll
+
 func TestRunAllEmptyEvidenceFailsClosedAndWritesReport(t *testing.T) {
 	dir := t.TempDir()
 
@@ -104,7 +106,7 @@ func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 		"last_good_seq": 4,
 	})
 
-	result := RunAll(dir, VerificationOptions{})
+	result := RunAll(dir)
 	if result.Pass || result.FailedSuites != 10 || result.PassedSuites != 0 {
 		t.Fatalf("bad evidence result = %+v, want all suites failing", result)
 	}
@@ -317,6 +319,23 @@ func TestMalformedTapeAndMissingTenantFailClosed(t *testing.T) {
 		}
 		if result := adv06TapeReplayTamper().Run(dir); result.Pass {
 			t.Fatalf("malformed tape passed beside valid tape: %+v", result)
+		}
+	})
+
+	t.Run("unknown tape data class", func(t *testing.T) {
+		dir := t.TempDir()
+		tapesDir := filepath.Join(dir, "08_TAPES")
+		if err := os.MkdirAll(tapesDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		value := []byte("classified")
+		digest := sha256.Sum256(value)
+		writeJSON(t, filepath.Join(tapesDir, "entry_001.json"), map[string]any{"value": value, "value_hash": hex.EncodeToString(digest[:]), "data_class": "invented-class"})
+		if result := adv06TapeReplayTamper().Run(dir); result.Pass {
+			t.Fatalf("unknown tape data class passed: %+v", result)
+		}
+		if coverage := tapeCoverage(dir); coverage.Covered {
+			t.Fatalf("unknown tape data class satisfied ADV-06 coverage: %+v", coverage)
 		}
 	})
 

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -56,6 +56,11 @@ func TestRunAllAcceptsCompletePositiveControls(t *testing.T) {
 	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 || len(result.Suites) != 10 {
 		t.Fatalf("complete evidence result = %+v, want all suites passing", result)
 	}
+	t.Setenv(CampaignPublicKeyEnv, publicKeyHex)
+	result = RunAll(dir)
+	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 {
+		t.Fatalf("environment-bound RunAll result = %+v, want all suites passing", result)
+	}
 }
 
 func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
@@ -166,6 +171,29 @@ func TestAdversarialSuiteHelpers(t *testing.T) {
 	}
 }
 
+func TestAuthorizationOutcomeRequiresExplicitAllow(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		actionType string
+		receipt    map[string]any
+		want       bool
+	}{
+		{name: "policy applied without verdict", actionType: "policy_decision", receipt: map[string]any{"status": "APPLIED"}},
+		{name: "approval applied without verdict", actionType: "approval_action", receipt: map[string]any{"status": "APPLIED"}},
+		{name: "policy applied allow", actionType: "policy_decision", receipt: map[string]any{"status": "APPLIED", "verdict": "ALLOW"}, want: true},
+		{name: "approval applied approved", actionType: "approval_action", receipt: map[string]any{"status": "APPLIED", "verdict": "APPROVED"}, want: true},
+		{name: "policy applied approval verdict", actionType: "policy_decision", receipt: map[string]any{"status": "APPLIED", "verdict": "APPROVED"}},
+		{name: "direct allow contradicted", actionType: "policy_decision", receipt: map[string]any{"status": "ALLOW", "verdict": "DENY"}},
+		{name: "direct approved", actionType: "approval_action", receipt: map[string]any{"status": "APPROVED"}, want: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := authorizationReceiptAccepted(test.receipt, test.actionType); got != test.want {
+				t.Fatalf("authorizationReceiptAccepted() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestIndividualSuitePassingBranches(t *testing.T) {
 	dir := t.TempDir()
 	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
@@ -261,7 +289,7 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 			t.Fatal(err)
 		}
 		effect := map[string]any{"receipt_id": "effect", "receipt_hash": "effect", "seq": 1, "action_type": "effect_attempt", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
-		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
+		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "action_type": "policy_decision", "status": "ALLOW", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
 		writeJSON(t, filepath.Join(receiptsDir, "001.json"), effect)
 		writeJSON(t, filepath.Join(receiptsDir, "002.json"), signCampaignDocument(t, policy, "campaign_signatures", campaignReceiptSignatureDomain, privateKey))
 		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -16,7 +17,8 @@ var _ func(string) *AggregateResult = RunAll
 func TestRunAllEmptyEvidenceFailsClosedAndWritesReport(t *testing.T) {
 	dir := t.TempDir()
 
-	result := RunAll(dir)
+	writeCoverageIndex(t, dir)
+	result := RunAllWithOptions(dir, campaignVerificationOptionsForPack(t, dir, ""))
 	if result.Pass || result.PassedSuites != 0 || result.FailedSuites != 10 || len(result.Suites) != 10 {
 		t.Fatalf("empty evidence result = %+v, want all suites rejected for missing positive controls", result)
 	}
@@ -51,17 +53,42 @@ func TestRunAllEmptyEvidenceFailsClosedAndWritesReport(t *testing.T) {
 func TestRunAllAcceptsCompletePositiveControls(t *testing.T) {
 	dir := t.TempDir()
 	publicKeyHex := writePassingCoverageArtifacts(t, dir)
+	opts := campaignVerificationOptionsForPack(t, dir, publicKeyHex)
 
-	result := RunAllWithOptions(dir, campaignVerificationOptions(publicKeyHex))
+	result := RunAllWithOptions(dir, opts)
 	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 || len(result.Suites) != 10 {
 		t.Fatalf("complete evidence result = %+v, want all suites passing", result)
 	}
 	t.Setenv(CampaignPublicKeyEnv, publicKeyHex)
 	t.Setenv(CampaignIDEnv, testCampaignID)
 	t.Setenv(CampaignRunIDEnv, testCampaignRunID)
+	t.Setenv(VerifiedEvidenceIndexHashEnv, opts.VerifiedEvidenceIndexHash)
+	t.Setenv(VerifiedEvidenceMerkleRootEnv, opts.VerifiedEvidenceMerkleRoot)
+	t.Setenv(VerifiedEvidenceEntryCountEnv, strconv.Itoa(opts.VerifiedEvidenceEntryCount))
 	result = RunAll(dir)
 	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 {
 		t.Fatalf("environment-bound RunAll result = %+v, want all suites passing", result)
+	}
+}
+
+func TestRunAllFailsClosedWithoutExternallyVerifiedEvidenceRoots(t *testing.T) {
+	dir := t.TempDir()
+	publicKeyHex := writePassingCoverageArtifacts(t, dir)
+	t.Setenv(CampaignPublicKeyEnv, publicKeyHex)
+	t.Setenv(CampaignIDEnv, testCampaignID)
+	t.Setenv(CampaignRunIDEnv, testCampaignRunID)
+	t.Setenv(VerifiedEvidenceIndexHashEnv, "")
+	t.Setenv(VerifiedEvidenceMerkleRootEnv, "")
+	t.Setenv(VerifiedEvidenceEntryCountEnv, "")
+
+	result := RunAll(dir)
+	if result.Pass || result.PassedSuites != 0 || result.FailedSuites != 10 {
+		t.Fatalf("unbound environment result=%+v, want all suites to fail closed", result)
+	}
+	for _, suite := range result.Suites {
+		if len(suite.TestResults) != 1 || !strings.Contains(suite.TestResults[0].Reason, "verified EvidencePack index hash") {
+			t.Fatalf("suite=%+v, want explicit missing external root reason", suite)
+		}
 	}
 }
 
@@ -113,7 +140,8 @@ func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 		"last_good_seq": 4,
 	})
 
-	result := RunAll(dir)
+	writeCoverageIndex(t, dir)
+	result := RunAllWithOptions(dir, campaignVerificationOptionsForPack(t, dir, ""))
 	if result.Pass || result.FailedSuites != 10 || result.PassedSuites != 0 {
 		t.Fatalf("bad evidence result = %+v, want all suites failing", result)
 	}

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -52,11 +52,13 @@ func TestRunAllAcceptsCompletePositiveControls(t *testing.T) {
 	dir := t.TempDir()
 	publicKeyHex := writePassingCoverageArtifacts(t, dir)
 
-	result := RunAllWithOptions(dir, VerificationOptions{CampaignPublicKeyHex: publicKeyHex})
+	result := RunAllWithOptions(dir, campaignVerificationOptions(publicKeyHex))
 	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 || len(result.Suites) != 10 {
 		t.Fatalf("complete evidence result = %+v, want all suites passing", result)
 	}
 	t.Setenv(CampaignPublicKeyEnv, publicKeyHex)
+	t.Setenv(CampaignIDEnv, testCampaignID)
+	t.Setenv(CampaignRunIDEnv, testCampaignRunID)
 	result = RunAll(dir)
 	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 {
 		t.Fatalf("environment-bound RunAll result = %+v, want all suites passing", result)
@@ -238,6 +240,22 @@ func TestPanicEvidenceCannotBeShadowedByCanonicalRecord(t *testing.T) {
 	}
 }
 
+func TestPanicBoundaryRejectsUnsequencedReceipts(t *testing.T) {
+	dir := t.TempDir()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(filepath.Join(dir, "06_LOGS"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 1})
+	writeJSON(t, filepath.Join(receiptsDir, "unknown.json"), map[string]any{"action_type": "effect_attempt"})
+	if result := adv09ReceiptEmissionPanicHijack().Run(dir); result.Pass || !strings.Contains(result.TestResults[0].Reason, "invalid sequence") {
+		t.Fatalf("unsequenced receipt passed panic boundary: %+v", result)
+	}
+}
+
 func TestReceiptSequenceRejectsDuplicateAndMissingValues(t *testing.T) {
 	for name, seqs := range map[string][]any{
 		"duplicate":       {1, 1},
@@ -276,7 +294,7 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 		}
 		manifest["name"] = "forged-tool"
 		writeJSON(t, path, manifest)
-		if result := adv08ToolManifestForge(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+		if result := adv08ToolManifestForge(campaignVerificationOptions(publicKeyHex)).Run(dir); result.Pass {
 			t.Fatalf("tampered tool manifest passed: %+v", result)
 		}
 	})
@@ -288,12 +306,44 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 		if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
 			t.Fatal(err)
 		}
-		effect := map[string]any{"receipt_id": "effect", "receipt_hash": "effect", "seq": 1, "action_type": "effect_attempt", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
-		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "action_type": "policy_decision", "status": "ALLOW", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
+		effect := map[string]any{"receipt_id": "effect", "receipt_hash": "effect", "seq": 1, "campaign_id": testCampaignID, "run_id": testCampaignRunID, "action_type": "effect_attempt", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
+		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "campaign_id": testCampaignID, "run_id": testCampaignRunID, "action_type": "policy_decision", "status": "ALLOW", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
 		writeJSON(t, filepath.Join(receiptsDir, "001.json"), effect)
 		writeJSON(t, filepath.Join(receiptsDir, "002.json"), signCampaignDocument(t, policy, "campaign_signatures", campaignReceiptSignatureDomain, privateKey))
-		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+		if result := adv02PolicyBypass(campaignVerificationOptions(publicKeyHex)).Run(dir); result.Pass {
 			t.Fatalf("post-hoc policy passed: %+v", result)
+		}
+	})
+
+	t.Run("cross-campaign replay", func(t *testing.T) {
+		dir := t.TempDir()
+		privateKey, publicKeyHex := campaignTestKey()
+		receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+		if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		policy := map[string]any{"receipt_id": "policy-id", "receipt_hash": "policy-hash", "seq": 1, "campaign_id": "campaign:old", "run_id": "run:old", "action_type": "policy_decision", "status": "ALLOW", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
+		effect := map[string]any{"receipt_id": "effect-id", "receipt_hash": "effect-hash", "seq": 2, "campaign_id": testCampaignID, "run_id": testCampaignRunID, "action_type": "effect_attempt", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"policy-id"}}
+		writeJSON(t, filepath.Join(receiptsDir, "001.json"), signCampaignDocument(t, policy, "campaign_signatures", campaignReceiptSignatureDomain, privateKey))
+		writeJSON(t, filepath.Join(receiptsDir, "002.json"), effect)
+		if result := adv02PolicyBypass(campaignVerificationOptions(publicKeyHex)).Run(dir); result.Pass {
+			t.Fatalf("authorization replayed across campaign/run boundary: %+v", result)
+		}
+	})
+
+	t.Run("receipt id ancestry alias", func(t *testing.T) {
+		dir := t.TempDir()
+		privateKey, publicKeyHex := campaignTestKey()
+		receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+		if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		policy := map[string]any{"receipt_id": "policy-id", "receipt_hash": "policy-hash", "seq": 1, "campaign_id": testCampaignID, "run_id": testCampaignRunID, "action_type": "policy_decision", "status": "ALLOW", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
+		effect := map[string]any{"receipt_id": "effect-id", "receipt_hash": "effect-hash", "seq": 2, "campaign_id": testCampaignID, "run_id": testCampaignRunID, "action_type": "effect_attempt", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"policy-id"}}
+		writeJSON(t, filepath.Join(receiptsDir, "001.json"), signCampaignDocument(t, policy, "campaign_signatures", campaignReceiptSignatureDomain, privateKey))
+		writeJSON(t, filepath.Join(receiptsDir, "002.json"), effect)
+		if result := adv02PolicyBypass(campaignVerificationOptions(publicKeyHex)).Run(dir); !result.Pass {
+			t.Fatalf("valid receipt_id ancestry alias was rejected: %+v", result)
 		}
 	})
 
@@ -310,7 +360,7 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 		policy["tenant_id"] = "tenant-b"
 		policy = signCampaignDocument(t, policy, "campaign_signatures", campaignReceiptSignatureDomain, privateKey)
 		writeJSON(t, path, policy)
-		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+		if result := adv02PolicyBypass(campaignVerificationOptions(publicKeyHex)).Run(dir); result.Pass {
 			t.Fatalf("cross-tenant policy passed: %+v", result)
 		}
 	})
@@ -472,6 +522,20 @@ func TestDAGRejectsDanglingAndSelfParents(t *testing.T) {
 	writeJSON(t, filepath.Join(receiptsDir, "003.json"), map[string]any{"receipt_id": "sibling", "receipt_hash": "sibling", "seq": 3, "parent_receipt_hashes": []string{"parent-hash"}})
 	if result := adv03DAGFork().Run(dir); result.Pass {
 		t.Fatalf("same parent referenced through id and hash aliases passed ADV-03: %+v", result)
+	}
+}
+
+func TestDAGRejectsReceiptIdentityCollisions(t *testing.T) {
+	dir := t.TempDir()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(receiptsDir, "001.json"), map[string]any{"receipt_id": "receipt-a", "receipt_hash": "shared-hash", "seq": 1, "parent_receipt_hashes": []string{"genesis"}})
+	writeJSON(t, filepath.Join(receiptsDir, "002.json"), map[string]any{"receipt_id": "receipt-b", "receipt_hash": "shared-hash", "seq": 2, "parent_receipt_hashes": []string{"genesis"}})
+	writeJSON(t, filepath.Join(receiptsDir, "003.json"), map[string]any{"receipt_id": "receipt-c", "receipt_hash": "receipt-c", "seq": 3, "parent_receipt_hashes": []string{"receipt-a"}})
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("colliding receipt identities passed ADV-03: %+v", result)
 	}
 }
 

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -513,8 +513,18 @@ func TestDAGRejectsDanglingAndSelfParents(t *testing.T) {
 	if coverage := proofGraphParentCoverage(receipts); !coverage.Covered {
 		t.Fatalf("resolved parent edge did not satisfy ADV-03 coverage: %+v", coverage)
 	}
+	writeJSON(t, parentPath, map[string]any{"receipt_id": "parent-id", "receipt_hash": "parent-hash", "seq": 2, "parent_receipt_hashes": []string{"genesis"}})
+	writeJSON(t, childPath, map[string]any{"receipt_id": "child", "receipt_hash": "child", "seq": 1, "parent_receipt_hashes": []string{"parent-id"}})
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("future parent edge passed ADV-03: %+v", result)
+	}
+	receipts[0], receipts[1] = loadReceipt(parentPath), loadReceipt(childPath)
+	if coverage := proofGraphParentCoverage(receipts); coverage.Covered {
+		t.Fatalf("future parent edge satisfied ADV-03 coverage: %+v", coverage)
+	}
 
 	writeJSON(t, parentPath, map[string]any{"receipt_id": "parent-id", "receipt_hash": "parent-hash", "seq": 1, "parent_receipt_hashes": []string{"child"}})
+	writeJSON(t, childPath, map[string]any{"receipt_id": "child", "receipt_hash": "child", "seq": 2, "parent_receipt_hashes": []string{"parent-id"}})
 	if result := adv03DAGFork().Run(dir); result.Pass {
 		t.Fatalf("cyclic parent graph passed ADV-03: %+v", result)
 	}

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -14,7 +14,7 @@ import (
 func TestRunAllEmptyEvidenceFailsClosedAndWritesReport(t *testing.T) {
 	dir := t.TempDir()
 
-	result := RunAll(dir, VerificationOptions{})
+	result := RunAll(dir)
 	if result.Pass || result.PassedSuites != 0 || result.FailedSuites != 10 || len(result.Suites) != 10 {
 		t.Fatalf("empty evidence result = %+v, want all suites rejected for missing positive controls", result)
 	}
@@ -68,10 +68,10 @@ func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 	}
 
 	writeJSON(t, filepath.Join(receiptsDir, "001_budget_exhausted.json"), map[string]any{
-		"seq":         1,
-		"action_type": "budget_exhausted",
-		"budget_id":   "budget-1",
-		"tenant_id":   "tenant-a",
+		"seq":                 1,
+		"action_type":         "budget_exhausted",
+		"budget_snapshot_ref": "budget-1",
+		"tenant_id":           "tenant-a",
 	})
 	writeJSON(t, filepath.Join(receiptsDir, "003_effect_without_policy.json"), map[string]any{
 		"seq":                   3,
@@ -84,7 +84,7 @@ func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 	writeJSON(t, filepath.Join(receiptsDir, "004_budget_decrement.json"), map[string]any{
 		"seq":                   4,
 		"action_type":           "budget_decrement",
-		"budget_id":             "budget-1",
+		"budget_snapshot_ref":   "budget-1",
 		"tenant_id":             "tenant-a",
 		"parent_receipt_hashes": []string{"parent-fork"},
 	})
@@ -208,10 +208,9 @@ func TestPanicEvidenceCannotBeShadowedByCanonicalRecord(t *testing.T) {
 	}
 }
 
-func TestReceiptSequenceRejectsDuplicateDecreasingAndMissingValues(t *testing.T) {
+func TestReceiptSequenceRejectsDuplicateAndMissingValues(t *testing.T) {
 	for name, seqs := range map[string][]any{
 		"duplicate":       {1, 1},
-		"decreasing":      {2, 1},
 		"missing":         {1, nil},
 		"missing genesis": {2, 3},
 	} {
@@ -262,7 +261,7 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 		effect := map[string]any{"receipt_id": "effect", "receipt_hash": "effect", "seq": 1, "action_type": "effect_attempt", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
 		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
 		writeJSON(t, filepath.Join(receiptsDir, "001.json"), effect)
-		writeJSON(t, filepath.Join(receiptsDir, "002.json"), signCampaignDocument(t, policy, "campaign_signatures", privateKey))
+		writeJSON(t, filepath.Join(receiptsDir, "002.json"), signCampaignDocument(t, policy, "campaign_signatures", campaignReceiptSignatureDomain, privateKey))
 		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
 			t.Fatalf("post-hoc policy passed: %+v", result)
 		}
@@ -279,7 +278,7 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 			t.Fatalf("read policy receipt: %v", err)
 		}
 		policy["tenant_id"] = "tenant-b"
-		policy = signCampaignDocument(t, policy, "campaign_signatures", privateKey)
+		policy = signCampaignDocument(t, policy, "campaign_signatures", campaignReceiptSignatureDomain, privateKey)
 		writeJSON(t, path, policy)
 		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
 			t.Fatalf("cross-tenant policy passed: %+v", result)
@@ -342,8 +341,8 @@ func TestBudgetBoundaryUsesExplicitScope(t *testing.T) {
 	}
 	exhaustedPath := filepath.Join(receiptsDir, "999.json")
 	decrementPath := filepath.Join(receiptsDir, "001.json")
-	writeJSON(t, exhaustedPath, map[string]any{"seq": 1, "action_type": "budget_exhausted", "budget_id": "budget-a"})
-	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "budget_id": "budget-b"})
+	writeJSON(t, exhaustedPath, map[string]any{"seq": 1, "action_type": "budget_exhausted", "budget_snapshot_ref": "budget-a"})
+	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "budget_snapshot_ref": "budget-b"})
 
 	if result := adv04BudgetOverdraft().Run(dir); !result.Pass {
 		t.Fatalf("unrelated budget decrement was treated as overdraft: %+v", result)
@@ -353,9 +352,32 @@ func TestBudgetBoundaryUsesExplicitScope(t *testing.T) {
 		t.Fatalf("unrelated budgets satisfied ADV-04 coverage: %+v", coverage)
 	}
 
-	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "budget_id": "budget-a"})
+	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "budget_snapshot_ref": "budget-a"})
 	if result := adv04BudgetOverdraft().Run(dir); result.Pass || result.TestResults[0].Reason != "BUDGET_OVERDRAFT" {
 		t.Fatalf("same-budget overdraft was accepted: %+v", result)
+	}
+
+	writeJSON(t, exhaustedPath, map[string]any{"seq": 1, "action_type": "budget_exhausted", "budget_id": "budget-a"})
+	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "decision_id": "budget-a"})
+	if result := adv04BudgetOverdraft().Run(dir); result.Pass || result.TestResults[0].Reason != "budget boundary contains an unscoped or unsequenced receipt" {
+		t.Fatalf("mixed fallback scope keys bypassed budget boundary: %+v", result)
+	}
+	coverage = budgetBoundaryCoverage([]map[string]interface{}{loadReceipt(exhaustedPath), loadReceipt(decrementPath)})
+	if coverage.Covered {
+		t.Fatalf("mixed fallback scope keys satisfied ADV-04 coverage: %+v", coverage)
+	}
+}
+
+func TestReceiptSequenceIgnoresFilenameOrder(t *testing.T) {
+	dir := t.TempDir()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(receiptsDir, "999.json"), map[string]any{"seq": 1})
+	writeJSON(t, filepath.Join(receiptsDir, "001.json"), map[string]any{"seq": 2})
+	if result := adv01ReceiptGapInjection().Run(dir); !result.Pass {
+		t.Fatalf("contiguous receipts were rejected because filenames were reordered: %+v", result)
 	}
 }
 

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -549,6 +549,53 @@ func TestDAGRejectsReceiptIdentityCollisions(t *testing.T) {
 	}
 }
 
+func TestDAGRejectsDisconnectedAndMultipleRootProofGraphs(t *testing.T) {
+	dir := t.TempDir()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	rootPath := filepath.Join(receiptsDir, "001.json")
+	childPath := filepath.Join(receiptsDir, "002.json")
+	strayPath := filepath.Join(receiptsDir, "003.json")
+	writeJSON(t, rootPath, map[string]any{"receipt_id": "root", "receipt_hash": "root", "seq": 1, "parent_receipt_hashes": []string{"genesis"}})
+	writeJSON(t, childPath, map[string]any{"receipt_id": "child", "receipt_hash": "child", "seq": 2, "parent_receipt_hashes": []string{"root"}})
+	writeJSON(t, strayPath, map[string]any{"receipt_id": "stray", "receipt_hash": "stray", "seq": 3})
+
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("disconnected receipt without parents passed ADV-03: %+v", result)
+	}
+	receipts := []map[string]interface{}{loadReceipt(rootPath), loadReceipt(childPath), loadReceipt(strayPath)}
+	if coverage := proofGraphParentCoverage(receipts); coverage.Covered {
+		t.Fatalf("disconnected receipt satisfied ADV-03 coverage: %+v", coverage)
+	}
+
+	writeJSON(t, strayPath, map[string]any{"receipt_id": "stray", "receipt_hash": "stray", "seq": 3, "parent_receipt_hashes": []string{"genesis"}})
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("multiple-root proof graph passed ADV-03: %+v", result)
+	}
+	receipts[2] = loadReceipt(strayPath)
+	if coverage := proofGraphParentCoverage(receipts); coverage.Covered {
+		t.Fatalf("multiple-root proof graph satisfied ADV-03 coverage: %+v", coverage)
+	}
+}
+
+func TestDAGRejectsEmptyAndMalformedParentSets(t *testing.T) {
+	dir := t.TempDir()
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("empty proof graph passed ADV-03: %+v", result)
+	}
+
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(receiptsDir, "001.json"), map[string]any{"receipt_id": "root", "receipt_hash": "root", "seq": 1, "parent_receipt_hashes": "genesis"})
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("malformed parent set passed ADV-03: %+v", result)
+	}
+}
+
 func writeJSON(t *testing.T, path string, value any) {
 	t.Helper()
 	data, err := json.Marshal(value)

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -12,7 +12,7 @@ import (
 func TestRunAllEmptyEvidenceFailsClosedAndWritesReport(t *testing.T) {
 	dir := t.TempDir()
 
-	result := RunAll(dir)
+	result := RunAll(dir, VerificationOptions{})
 	if result.Pass || result.PassedSuites != 0 || result.FailedSuites != 10 || len(result.Suites) != 10 {
 		t.Fatalf("empty evidence result = %+v, want all suites rejected for missing positive controls", result)
 	}
@@ -100,7 +100,7 @@ func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 		"last_good_seq": 4,
 	})
 
-	result := RunAll(dir)
+	result := RunAll(dir, VerificationOptions{})
 	if result.Pass || result.FailedSuites != 10 || result.PassedSuites != 0 {
 		t.Fatalf("bad evidence result = %+v, want all suites failing", result)
 	}
@@ -255,12 +255,59 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 		if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
 			t.Fatal(err)
 		}
-		effect := map[string]any{"receipt_id": "effect", "receipt_hash": "effect", "seq": 1, "action_type": "effect_attempt", "decision_id": "decision-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
-		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
+		effect := map[string]any{"receipt_id": "effect", "receipt_hash": "effect", "seq": 1, "action_type": "effect_attempt", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
+		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "tenant_id": "tenant-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
 		writeJSON(t, filepath.Join(receiptsDir, "001.json"), effect)
 		writeJSON(t, filepath.Join(receiptsDir, "002.json"), signCampaignDocument(t, policy, "campaign_signatures", privateKey))
 		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
 			t.Fatalf("post-hoc policy passed: %+v", result)
+		}
+	})
+
+	t.Run("cross-tenant authorization", func(t *testing.T) {
+		dir := t.TempDir()
+		privateKey, publicKeyHex := campaignTestKey()
+		_ = writePassingCoverageArtifacts(t, dir)
+		path := filepath.Join(dir, "02_PROOFGRAPH", "receipts", "001.json")
+		var policy map[string]any
+		data, err := os.ReadFile(path)
+		if err != nil || json.Unmarshal(data, &policy) != nil {
+			t.Fatalf("read policy receipt: %v", err)
+		}
+		policy["tenant_id"] = "tenant-b"
+		policy = signCampaignDocument(t, policy, "campaign_signatures", privateKey)
+		writeJSON(t, path, policy)
+		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+			t.Fatalf("cross-tenant policy passed: %+v", result)
+		}
+	})
+}
+
+func TestMalformedTapeAndMissingTenantFailClosed(t *testing.T) {
+	t.Run("malformed tape beside valid tape", func(t *testing.T) {
+		dir := t.TempDir()
+		tapesDir := filepath.Join(dir, "08_TAPES")
+		if err := os.MkdirAll(tapesDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		writeJSON(t, filepath.Join(tapesDir, "entry_001.json"), map[string]any{"value_hash": "sha256:value", "data_class": "internal"})
+		if err := os.WriteFile(filepath.Join(tapesDir, "entry_002.json"), []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if result := adv06TapeReplayTamper().Run(dir); result.Pass {
+			t.Fatalf("malformed tape passed beside valid tape: %+v", result)
+		}
+	})
+
+	t.Run("missing tenant", func(t *testing.T) {
+		dir := t.TempDir()
+		receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+		if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		writeJSON(t, filepath.Join(receiptsDir, "001.json"), map[string]any{"seq": 1, "action_type": "noop"})
+		if result := adv07TenantCrossleak().Run(dir); result.Pass {
+			t.Fatalf("receipt without tenant passed: %+v", result)
 		}
 	})
 }

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -2,6 +2,7 @@ package adversarial
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,9 +46,9 @@ func TestRunAllEmptyEvidenceFailsClosedAndWritesReport(t *testing.T) {
 
 func TestRunAllAcceptsCompletePositiveControls(t *testing.T) {
 	dir := t.TempDir()
-	writePassingCoverageArtifacts(t, dir)
+	publicKeyHex := writePassingCoverageArtifacts(t, dir)
 
-	result := RunAll(dir)
+	result := RunAllWithOptions(dir, VerificationOptions{CampaignPublicKeyHex: publicKeyHex})
 	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 || len(result.Suites) != 10 {
 		t.Fatalf("complete evidence result = %+v, want all suites passing", result)
 	}
@@ -201,6 +202,67 @@ func TestPanicEvidenceCannotBeShadowedByCanonicalRecord(t *testing.T) {
 	if result.Pass || !strings.Contains(result.TestResults[0].Reason, "receipts emitted after panic") {
 		t.Fatalf("shadowed panic result = %+v, want restrictive boundary failure", result)
 	}
+}
+
+func TestReceiptSequenceRejectsDuplicateDecreasingAndMissingValues(t *testing.T) {
+	for name, seqs := range map[string][]any{
+		"duplicate":       {1, 1},
+		"decreasing":      {2, 1},
+		"missing":         {1, nil},
+		"missing genesis": {2, 3},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+			if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			for index, seq := range seqs {
+				receipt := map[string]any{"action_type": "noop"}
+				if seq != nil {
+					receipt["seq"] = seq
+				}
+				writeJSON(t, filepath.Join(receiptsDir, fmt.Sprintf("%03d.json", index)), receipt)
+			}
+			if result := adv01ReceiptGapInjection().Run(dir); result.Pass || result.TestResults[0].Reason != "RECEIPT_GAP_DETECTED" {
+				t.Fatalf("ADV-01 accepted %s sequence: %+v", name, result)
+			}
+		})
+	}
+}
+
+func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
+	t.Run("tool manifest tamper", func(t *testing.T) {
+		dir := t.TempDir()
+		publicKeyHex := writePassingCoverageArtifacts(t, dir)
+		path := filepath.Join(dir, "99_EXT", "adversarial", "tools", "tool.json")
+		var manifest map[string]any
+		data, err := os.ReadFile(path)
+		if err != nil || json.Unmarshal(data, &manifest) != nil {
+			t.Fatalf("read tool manifest: %v", err)
+		}
+		manifest["name"] = "forged-tool"
+		writeJSON(t, path, manifest)
+		if result := adv08ToolManifestForge(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+			t.Fatalf("tampered tool manifest passed: %+v", result)
+		}
+	})
+
+	t.Run("post-hoc policy", func(t *testing.T) {
+		dir := t.TempDir()
+		privateKey, publicKeyHex := campaignTestKey()
+		receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+		if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		effect := map[string]any{"receipt_id": "effect", "receipt_hash": "effect", "seq": 1, "action_type": "effect_attempt", "decision_id": "decision-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"genesis"}}
+		policy := map[string]any{"receipt_id": "policy", "receipt_hash": "policy", "seq": 2, "action_type": "policy_decision", "status": "APPLIED", "decision_id": "decision-1", "envelope_id": "envelope-1", "envelope_hash": "sha256:envelope", "parent_receipt_hashes": []string{"effect"}}
+		writeJSON(t, filepath.Join(receiptsDir, "001.json"), effect)
+		writeJSON(t, filepath.Join(receiptsDir, "002.json"), signCampaignDocument(t, policy, "campaign_signatures", privateKey))
+		if result := adv02PolicyBypass(VerificationOptions{CampaignPublicKeyHex: publicKeyHex}).Run(dir); result.Pass {
+			t.Fatalf("post-hoc policy passed: %+v", result)
+		}
+	})
 }
 
 func writeJSON(t *testing.T, path string, value any) {

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -340,8 +340,8 @@ func TestBudgetBoundaryUsesExplicitScope(t *testing.T) {
 	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	exhaustedPath := filepath.Join(receiptsDir, "001.json")
-	decrementPath := filepath.Join(receiptsDir, "002.json")
+	exhaustedPath := filepath.Join(receiptsDir, "999.json")
+	decrementPath := filepath.Join(receiptsDir, "001.json")
 	writeJSON(t, exhaustedPath, map[string]any{"seq": 1, "action_type": "budget_exhausted", "budget_id": "budget-a"})
 	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "budget_id": "budget-b"})
 

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -403,6 +403,10 @@ func TestBudgetBoundaryUsesExplicitScope(t *testing.T) {
 	if result := adv04BudgetOverdraft().Run(dir); result.Pass || result.TestResults[0].Reason != "BUDGET_OVERDRAFT" {
 		t.Fatalf("same-budget overdraft was accepted: %+v", result)
 	}
+	writeJSON(t, decrementPath, map[string]any{"seq": 1, "action_type": "budget_decrement", "budget_snapshot_ref": "budget-a"})
+	if result := adv04BudgetOverdraft().Run(dir); result.Pass || result.TestResults[0].Reason != "BUDGET_OVERDRAFT" {
+		t.Fatalf("same-sequence budget boundary was accepted: %+v", result)
+	}
 
 	writeJSON(t, exhaustedPath, map[string]any{"seq": 1, "action_type": "budget_exhausted", "budget_id": "budget-a"})
 	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "decision_id": "budget-a"})
@@ -425,6 +429,49 @@ func TestReceiptSequenceIgnoresFilenameOrder(t *testing.T) {
 	writeJSON(t, filepath.Join(receiptsDir, "001.json"), map[string]any{"seq": 2})
 	if result := adv01ReceiptGapInjection().Run(dir); !result.Pass {
 		t.Fatalf("contiguous receipts were rejected because filenames were reordered: %+v", result)
+	}
+}
+
+func TestDAGRejectsDanglingAndSelfParents(t *testing.T) {
+	dir := t.TempDir()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	parentPath := filepath.Join(receiptsDir, "001.json")
+	childPath := filepath.Join(receiptsDir, "002.json")
+	writeJSON(t, parentPath, map[string]any{"receipt_id": "parent-id", "receipt_hash": "parent-hash", "seq": 1, "parent_receipt_hashes": []string{"genesis"}})
+	writeJSON(t, childPath, map[string]any{"receipt_id": "child", "receipt_hash": "child", "seq": 2, "parent_receipt_hashes": []string{"missing"}})
+	receipts := []map[string]interface{}{loadReceipt(parentPath), loadReceipt(childPath)}
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("dangling parent passed ADV-03: %+v", result)
+	}
+	if coverage := proofGraphParentCoverage(receipts); coverage.Covered {
+		t.Fatalf("dangling parent satisfied ADV-03 coverage: %+v", coverage)
+	}
+
+	writeJSON(t, childPath, map[string]any{"receipt_id": "child", "receipt_hash": "child", "seq": 2, "parent_receipt_hashes": []string{"child"}})
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("self parent passed ADV-03: %+v", result)
+	}
+
+	writeJSON(t, childPath, map[string]any{"receipt_id": "child", "receipt_hash": "child", "seq": 2, "parent_receipt_hashes": []string{"parent-id"}})
+	receipts[1] = loadReceipt(childPath)
+	if result := adv03DAGFork().Run(dir); !result.Pass {
+		t.Fatalf("resolved parent edge failed ADV-03: %+v", result)
+	}
+	if coverage := proofGraphParentCoverage(receipts); !coverage.Covered {
+		t.Fatalf("resolved parent edge did not satisfy ADV-03 coverage: %+v", coverage)
+	}
+
+	writeJSON(t, parentPath, map[string]any{"receipt_id": "parent-id", "receipt_hash": "parent-hash", "seq": 1, "parent_receipt_hashes": []string{"child"}})
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("cyclic parent graph passed ADV-03: %+v", result)
+	}
+	writeJSON(t, parentPath, map[string]any{"receipt_id": "parent-id", "receipt_hash": "parent-hash", "seq": 1, "parent_receipt_hashes": []string{"genesis"}})
+	writeJSON(t, filepath.Join(receiptsDir, "003.json"), map[string]any{"receipt_id": "sibling", "receipt_hash": "sibling", "seq": 3, "parent_receipt_hashes": []string{"parent-hash"}})
+	if result := adv03DAGFork().Run(dir); result.Pass {
+		t.Fatalf("same parent referenced through id and hash aliases passed ADV-03: %+v", result)
 	}
 }
 

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -1,6 +1,8 @@
 package adversarial
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -68,6 +70,7 @@ func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 	writeJSON(t, filepath.Join(receiptsDir, "001_budget_exhausted.json"), map[string]any{
 		"seq":         1,
 		"action_type": "budget_exhausted",
+		"budget_id":   "budget-1",
 		"tenant_id":   "tenant-a",
 	})
 	writeJSON(t, filepath.Join(receiptsDir, "003_effect_without_policy.json"), map[string]any{
@@ -81,6 +84,7 @@ func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 	writeJSON(t, filepath.Join(receiptsDir, "004_budget_decrement.json"), map[string]any{
 		"seq":                   4,
 		"action_type":           "budget_decrement",
+		"budget_id":             "budget-1",
 		"tenant_id":             "tenant-a",
 		"parent_receipt_hashes": []string{"parent-fork"},
 	})
@@ -281,6 +285,22 @@ func TestCryptographicSuitesRejectForgeryAndPostHocAuthorization(t *testing.T) {
 			t.Fatalf("cross-tenant policy passed: %+v", result)
 		}
 	})
+
+	t.Run("tape value tamper", func(t *testing.T) {
+		dir := t.TempDir()
+		_ = writePassingCoverageArtifacts(t, dir)
+		path := filepath.Join(dir, "08_TAPES", "entry_001.json")
+		var entry map[string]any
+		data, err := os.ReadFile(path)
+		if err != nil || json.Unmarshal(data, &entry) != nil {
+			t.Fatalf("read tape entry: %v", err)
+		}
+		entry["value"] = "Zm9yZ2Vk"
+		writeJSON(t, path, entry)
+		if result := adv06TapeReplayTamper().Run(dir); result.Pass {
+			t.Fatalf("tampered tape passed: %+v", result)
+		}
+	})
 }
 
 func TestMalformedTapeAndMissingTenantFailClosed(t *testing.T) {
@@ -290,7 +310,9 @@ func TestMalformedTapeAndMissingTenantFailClosed(t *testing.T) {
 		if err := os.MkdirAll(tapesDir, 0o750); err != nil {
 			t.Fatal(err)
 		}
-		writeJSON(t, filepath.Join(tapesDir, "entry_001.json"), map[string]any{"value_hash": "sha256:value", "data_class": "internal"})
+		value := []byte("valid")
+		digest := sha256.Sum256(value)
+		writeJSON(t, filepath.Join(tapesDir, "entry_001.json"), map[string]any{"value": value, "value_hash": hex.EncodeToString(digest[:]), "data_class": "internal"})
 		if err := os.WriteFile(filepath.Join(tapesDir, "entry_002.json"), []byte("{"), 0o600); err != nil {
 			t.Fatal(err)
 		}
@@ -310,6 +332,31 @@ func TestMalformedTapeAndMissingTenantFailClosed(t *testing.T) {
 			t.Fatalf("receipt without tenant passed: %+v", result)
 		}
 	})
+}
+
+func TestBudgetBoundaryUsesExplicitScope(t *testing.T) {
+	dir := t.TempDir()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	exhaustedPath := filepath.Join(receiptsDir, "001.json")
+	decrementPath := filepath.Join(receiptsDir, "002.json")
+	writeJSON(t, exhaustedPath, map[string]any{"seq": 1, "action_type": "budget_exhausted", "budget_id": "budget-a"})
+	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "budget_id": "budget-b"})
+
+	if result := adv04BudgetOverdraft().Run(dir); !result.Pass {
+		t.Fatalf("unrelated budget decrement was treated as overdraft: %+v", result)
+	}
+	coverage := budgetBoundaryCoverage([]map[string]interface{}{loadReceipt(exhaustedPath), loadReceipt(decrementPath)})
+	if coverage.Covered {
+		t.Fatalf("unrelated budgets satisfied ADV-04 coverage: %+v", coverage)
+	}
+
+	writeJSON(t, decrementPath, map[string]any{"seq": 2, "action_type": "budget_decrement", "budget_id": "budget-a"})
+	if result := adv04BudgetOverdraft().Run(dir); result.Pass || result.TestResults[0].Reason != "BUDGET_OVERDRAFT" {
+		t.Fatalf("same-budget overdraft was accepted: %+v", result)
+	}
 }
 
 func writeJSON(t *testing.T, path string, value any) {

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 )
 
-func TestRunAllEmptyEvidencePassesAndWritesReport(t *testing.T) {
+func TestRunAllEmptyEvidenceFailsClosedAndWritesReport(t *testing.T) {
 	dir := t.TempDir()
 
 	result := RunAll(dir)
-	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 || len(result.Suites) != 10 {
-		t.Fatalf("empty evidence result = %+v, want all suites passing", result)
+	if result.Pass || result.PassedSuites != 0 || result.FailedSuites != 10 || len(result.Suites) != 10 {
+		t.Fatalf("empty evidence result = %+v, want all suites rejected for missing positive controls", result)
 	}
 	if result.EvidenceDir != dir {
 		t.Fatalf("evidence dir = %q, want %q", result.EvidenceDir, dir)
@@ -30,8 +30,8 @@ func TestRunAllEmptyEvidencePassesAndWritesReport(t *testing.T) {
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		t.Fatalf("decode report: %v", err)
 	}
-	if !decoded.Pass || decoded.PassedSuites != 10 {
-		t.Fatalf("decoded report = %+v, want passing aggregate", decoded)
+	if decoded.Pass || decoded.FailedSuites != 10 {
+		t.Fatalf("decoded report = %+v, want fail-closed aggregate", decoded)
 	}
 
 	filePath := filepath.Join(t.TempDir(), "not-a-directory")
@@ -43,11 +43,21 @@ func TestRunAllEmptyEvidencePassesAndWritesReport(t *testing.T) {
 	}
 }
 
+func TestRunAllAcceptsCompletePositiveControls(t *testing.T) {
+	dir := t.TempDir()
+	writePassingCoverageArtifacts(t, dir)
+
+	result := RunAll(dir)
+	if !result.Pass || result.PassedSuites != 10 || result.FailedSuites != 0 || len(result.Suites) != 10 {
+		t.Fatalf("complete evidence result = %+v, want all suites passing", result)
+	}
+}
+
 func TestRunAllDetectsAdversarialEvidenceFailures(t *testing.T) {
 	dir := t.TempDir()
 	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
 	tapesDir := filepath.Join(dir, "08_TAPES")
-	toolsDir := filepath.Join(dir, "10_TOOLS")
+	toolsDir := filepath.Join(dir, "99_EXT", "adversarial", "tools")
 	for _, path := range []string{receiptsDir, tapesDir, toolsDir} {
 		if err := os.MkdirAll(path, 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", path, err)
@@ -171,6 +181,25 @@ func TestIndividualSuitePassingBranches(t *testing.T) {
 	}
 	if result := adv09ReceiptEmissionPanicHijack().Run(dir); result.Pass || result.TestResults[0].Reason != "panic record unreadable" {
 		t.Fatalf("ADV-09 unreadable panic result = %+v, want fail", result)
+	}
+}
+
+func TestPanicEvidenceCannotBeShadowedByCanonicalRecord(t *testing.T) {
+	dir := t.TempDir()
+	receiptsDir := filepath.Join(dir, "02_PROOFGRAPH", "receipts")
+	if err := os.MkdirAll(filepath.Join(dir, "06_LOGS"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(receiptsDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(dir, "06_LOGS", "receipt_emission_panic.json"), map[string]any{"last_good_seq": 99})
+	writeJSON(t, filepath.Join(dir, "panic.json"), map[string]any{"last_good_seq": 1})
+	writeJSON(t, filepath.Join(receiptsDir, "002.json"), map[string]any{"seq": 2})
+
+	result := adv09ReceiptEmissionPanicHijack().Run(dir)
+	if result.Pass || !strings.Contains(result.TestResults[0].Reason, "receipts emitted after panic") {
+		t.Fatalf("shadowed panic result = %+v, want restrictive boundary failure", result)
 	}
 }
 

--- a/core/pkg/conform/adversarial/runner_suites_coverage_test.go
+++ b/core/pkg/conform/adversarial/runner_suites_coverage_test.go
@@ -190,6 +190,10 @@ func TestAdversarialSuiteHelpers(t *testing.T) {
 	if got := loadReceipt(filepath.Join(dir, "missing.json")); got != nil {
 		t.Fatalf("loadReceipt missing file = %#v, want nil", got)
 	}
+	receipts := loadReceipts(files)
+	if len(receipts) != len(files) || receipts[0]["action_type"] != "policy_decision" || receipts[1]["action_type"] != "approval_action" || receipts[2] != nil {
+		t.Fatalf("loadReceipts = %#v, want one aligned entry per file", receipts)
+	}
 	if seqs := loadSequenceNumbers(files); len(seqs) != 2 || seqs[0] != 10 || seqs[1] != 11 {
 		t.Fatalf("loadSequenceNumbers = %#v, want [10 11]", seqs)
 	}

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 )
 
 // SuiteResult captures the outcome of an adversarial test suite.
@@ -421,9 +422,13 @@ func adv08ToolManifestForge(opts VerificationOptions) *Suite {
 			result := &SuiteResult{SuiteID: "ADV-08", Name: "Tool Manifest Forgery", Pass: true}
 
 			files := toolManifestFiles(evidenceDir)
+			legacyFiles, _ := filepath.Glob(filepath.Join(evidenceDir, "10_TOOLS", "*.json"))
 
 			t := TestResult{TestID: "ADV-08-T1", Name: "Tool manifests verify under the campaign trust root"}
-			unsigned := 0
+			unsigned := len(legacyFiles)
+			for _, f := range legacyFiles {
+				t.Evidence += fmt.Sprintf("undeclared legacy tool manifest: %s; ", filepath.Base(f))
+			}
 			for _, f := range files {
 				data, err := os.ReadFile(f)
 				var manifest map[string]interface{}
@@ -814,7 +819,8 @@ func verifyCampaignSignatures(document map[string]interface{}, field, domain, tr
 
 func validTapeEntry(entry map[string]interface{}) bool {
 	valueHash, ok := entry["value_hash"].(string)
-	if !ok || !hasNonEmptyString(entry, "data_class") {
+	dataClass, classOK := entry["data_class"].(string)
+	if !ok || !classOK || !validTapeDataClass(dataClass) {
 		return false
 	}
 	encodedValue, present := entry["value"].(string)
@@ -827,6 +833,15 @@ func validTapeEntry(entry map[string]interface{}) bool {
 	}
 	digest := sha256.Sum256(value)
 	return strings.EqualFold(strings.TrimPrefix(valueHash, "sha256:"), hex.EncodeToString(digest[:]))
+}
+
+func validTapeDataClass(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case contracts.DataClassPublic, contracts.DataClassInternal, contracts.DataClassConfidential, contracts.DataClassRestricted:
+		return true
+	default:
+		return false
+	}
 }
 
 func isHighFinality(effectClass, actionType string) bool {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -1,5 +1,7 @@
 // Package adversarial implements the 10 mandatory adversarial test suites
 // per §8.1 of the HELM Conformance Standard.
+// quantum_posture: this slice validates classical Ed25519 signature shape
+// only; cryptographic verification and post-quantum assurance are not claimed.
 //
 // Each suite verifies that the system correctly handles a specific
 // adversarial scenario by checking EvidencePack artifacts for expected
@@ -349,13 +351,11 @@ func adv08ToolManifestForge() *Suite {
 			t := TestResult{TestID: "ADV-08-T1", Name: "Tool manifests have signatures field"}
 			unsigned := 0
 			for _, f := range files {
-				data, _ := os.ReadFile(f)
+				data, err := os.ReadFile(f)
 				var manifest map[string]interface{}
-				if json.Unmarshal(data, &manifest) == nil {
-					if manifest["signatures"] == nil {
-						unsigned++
-						t.Evidence += fmt.Sprintf("unsigned: %s; ", filepath.Base(f))
-					}
+				if err != nil || json.Unmarshal(data, &manifest) != nil || !hasStructuredSignatures(manifest) {
+					unsigned++
+					t.Evidence += fmt.Sprintf("invalid or unsigned: %s; ", filepath.Base(f))
 				}
 			}
 			if unsigned > 0 {
@@ -383,8 +383,8 @@ func adv09ReceiptEmissionPanicHijack() *Suite {
 
 			t := TestResult{TestID: "ADV-09-T1", Name: "No receipts after panic record"}
 
-			panicFile := panicEvidencePath(evidenceDir)
-			if _, err := os.Stat(panicFile); err != nil {
+			panicFiles := panicEvidenceFiles(evidenceDir)
+			if len(panicFiles) == 0 {
 				t.Pass = true
 				t.Reason = "no panic record (normal operation)"
 				result.TestResults = append(result.TestResults, t)
@@ -393,17 +393,31 @@ func adv09ReceiptEmissionPanicHijack() *Suite {
 			}
 
 			// If panic exists, check that no receipts were emitted after it
-			panicData, _ := os.ReadFile(panicFile)
-			var panicRec map[string]interface{}
-			if json.Unmarshal(panicData, &panicRec) != nil {
-				t.Pass = false
-				t.Reason = "panic record unreadable"
-				result.TestResults = append(result.TestResults, t)
-				result.Pass = false
-				return result
+			var lastGoodSeq float64
+			haveBoundary := false
+			for _, panicFile := range panicFiles {
+				panicData, err := os.ReadFile(panicFile)
+				var panicRec map[string]interface{}
+				if err != nil || json.Unmarshal(panicData, &panicRec) != nil {
+					t.Pass = false
+					t.Reason = "panic record unreadable"
+					result.TestResults = append(result.TestResults, t)
+					result.Pass = false
+					return result
+				}
+				boundary, ok := panicRec["last_good_seq"].(float64)
+				if !ok {
+					t.Pass = false
+					t.Reason = "panic record missing last_good_seq"
+					result.TestResults = append(result.TestResults, t)
+					result.Pass = false
+					return result
+				}
+				if !haveBoundary || boundary < lastGoodSeq {
+					lastGoodSeq = boundary
+					haveBoundary = true
+				}
 			}
-
-			lastGoodSeq, _ := panicRec["last_good_seq"].(float64)
 
 			receiptsDir := filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts")
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
@@ -475,20 +489,47 @@ func adv10HighFinalityUnsigned() *Suite {
 // --- Helpers ---
 
 func toolManifestFiles(evidenceDir string) []string {
-	// Canonical packs carry adversarial-only tool fixtures as a declared
-	// extension. The legacy 10_TOOLS location remains readable for historical
-	// detector fixtures but is rejected by strict EvidencePack verification.
+	// Strict EvidencePack verification recognizes adversarial-only tool
+	// fixtures exclusively through this declared extension.
 	canonical, _ := filepath.Glob(filepath.Join(evidenceDir, "99_EXT", "adversarial", "tools", "*.json"))
-	legacy, _ := filepath.Glob(filepath.Join(evidenceDir, "10_TOOLS", "*.json"))
-	return append(canonical, legacy...)
+	return canonical
 }
 
-func panicEvidencePath(evidenceDir string) string {
+func panicEvidenceFiles(evidenceDir string) []string {
 	canonical := filepath.Join(evidenceDir, "06_LOGS", "receipt_emission_panic.json")
+	legacy := filepath.Join(evidenceDir, "panic.json")
+	files := make([]string, 0, 2)
 	if _, err := os.Stat(canonical); err == nil {
-		return canonical
+		files = append(files, canonical)
 	}
-	return filepath.Join(evidenceDir, "panic.json")
+	if _, err := os.Stat(legacy); err == nil {
+		files = append(files, legacy)
+	}
+	return files
+}
+
+func hasStructuredSignatures(manifest map[string]interface{}) bool {
+	signatures, ok := manifest["signatures"].([]interface{})
+	if !ok || len(signatures) == 0 {
+		return false
+	}
+	for _, raw := range signatures {
+		signature, ok := raw.(map[string]interface{})
+		if !ok || signature["algorithm"] != "ed25519" {
+			return false
+		}
+		keyID, _ := signature["key_id"].(string)
+		value, _ := signature["signature"].(string)
+		if strings.TrimSpace(keyID) == "" || len(value) != 128 {
+			return false
+		}
+		for _, char := range value {
+			if !strings.ContainsRune("0123456789abcdefABCDEF", char) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func loadReceipt(path string) map[string]interface{} {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -53,6 +53,8 @@ type Suite struct {
 // EvidencePack. A signature embedded in the pack can never establish trust.
 type VerificationOptions struct {
 	CampaignPublicKeyHex string
+	CampaignID           string
+	RunID                string
 }
 
 const (
@@ -209,7 +211,7 @@ func adv03DAGFork() *Suite {
 							continue
 						}
 						parentTarget, exists := referenceIndex[ps]
-						if !exists || child == "" || parentTarget == child {
+						if !exists || parentTarget == "" || child == "" || parentTarget == child {
 							invalidParents++
 							t.Evidence += fmt.Sprintf("dangling or self parent %s in %s; ", ps, filepath.Base(files[index]))
 							continue
@@ -463,7 +465,7 @@ func adv08ToolManifestForge(opts VerificationOptions) *Suite {
 			for _, f := range files {
 				data, err := os.ReadFile(f)
 				var manifest map[string]interface{}
-				if err != nil || json.Unmarshal(data, &manifest) != nil || !verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, opts.CampaignPublicKeyHex) {
+				if err != nil || json.Unmarshal(data, &manifest) != nil || !campaignBindingMatches(manifest, opts) || !verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, opts.CampaignPublicKeyHex) {
 					unsigned++
 					t.Evidence += fmt.Sprintf("invalid or unsigned: %s; ", filepath.Base(f))
 				}
@@ -532,14 +534,22 @@ func adv09ReceiptEmissionPanicHijack() *Suite {
 			receiptsDir := filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts")
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
 			postPanic := 0
+			invalidSequence := 0
 			for _, f := range files {
 				receipt := loadReceipt(f)
-				seq, _ := receipt["seq"].(float64)
+				seq, ok := receiptSequence(receipt)
+				if !ok {
+					invalidSequence++
+					continue
+				}
 				if seq > lastGoodSeq {
 					postPanic++
 				}
 			}
-			if postPanic > 0 {
+			if invalidSequence > 0 {
+				t.Pass = false
+				t.Reason = fmt.Sprintf("%d receipts have invalid sequence after panic boundary", invalidSequence)
+			} else if postPanic > 0 {
 				t.Pass = false
 				t.Reason = fmt.Sprintf("%d receipts emitted after panic", postPanic)
 			} else {
@@ -691,14 +701,14 @@ func hasBoundAuthorizationReceipt(files []string, effect map[string]interface{},
 
 func hasBoundAuthorization(receipts []map[string]interface{}, effect map[string]interface{}, actionType string, opts VerificationOptions) bool {
 	effectSeq, ok := receiptSequence(effect)
-	if !ok || !hasNonEmptyString(effect, "decision_id") || !hasNonEmptyString(effect, "tenant_id") || !hasNonEmptyString(effect, "envelope_id") || !hasNonEmptyString(effect, "envelope_hash") {
+	if !ok || !campaignBindingMatches(effect, opts) || !hasNonEmptyString(effect, "decision_id") || !hasNonEmptyString(effect, "tenant_id") || !hasNonEmptyString(effect, "envelope_id") || !hasNonEmptyString(effect, "envelope_hash") {
 		return false
 	}
 	for _, receipt := range receipts {
 		if receipt["action_type"] != actionType || receipt["decision_id"] != effect["decision_id"] || receipt["tenant_id"] != effect["tenant_id"] || receipt["envelope_id"] != effect["envelope_id"] || receipt["envelope_hash"] != effect["envelope_hash"] {
 			continue
 		}
-		if !authorizationReceiptAccepted(receipt, actionType) {
+		if !campaignBindingMatches(receipt, opts) || !authorizationReceiptAccepted(receipt, actionType) {
 			continue
 		}
 		seq, sequenced := receiptSequence(receipt)
@@ -710,6 +720,15 @@ func hasBoundAuthorization(receipts []map[string]interface{}, effect map[string]
 		}
 	}
 	return false
+}
+
+func campaignBindingMatches(document map[string]interface{}, opts VerificationOptions) bool {
+	campaignID := strings.TrimSpace(opts.CampaignID)
+	runID := strings.TrimSpace(opts.RunID)
+	if campaignID == "" || runID == "" {
+		return false
+	}
+	return document["campaign_id"] == campaignID && document["run_id"] == runID
 }
 
 func authorizationReceiptAccepted(receipt map[string]interface{}, actionType string) bool {
@@ -755,20 +774,22 @@ func receiptIsAncestor(receipts []map[string]interface{}, descendant, ancestor m
 	if ancestorID == "" {
 		return false
 	}
-	index := make(map[string]map[string]interface{}, len(receipts)*2)
+	referenceIndex := receiptReferenceIndex(receipts)
+	receiptsByIdentity := make(map[string]map[string]interface{}, len(receipts))
 	for _, receipt := range receipts {
-		if id, _ := receipt["receipt_id"].(string); id != "" {
-			index[id] = receipt
-		}
-		if hash, _ := receipt["receipt_hash"].(string); hash != "" {
-			index[hash] = receipt
+		if identity := receiptIdentity(receipt); identity != "" {
+			receiptsByIdentity[identity] = receipt
 		}
 	}
 	queue := receiptParentRefs(descendant)
 	seen := map[string]bool{}
 	for len(queue) > 0 {
-		parent := queue[0]
+		parentReference := queue[0]
 		queue = queue[1:]
+		parent, exists := referenceIndex[parentReference]
+		if !exists || parent == "" {
+			continue
+		}
 		if parent == ancestorID {
 			return true
 		}
@@ -776,7 +797,7 @@ func receiptIsAncestor(receipts []map[string]interface{}, descendant, ancestor m
 			continue
 		}
 		seen[parent] = true
-		if receipt := index[parent]; receipt != nil {
+		if receipt := receiptsByIdentity[parent]; receipt != nil {
 			queue = append(queue, receiptParentRefs(receipt)...)
 		}
 	}
@@ -793,14 +814,38 @@ func receiptIdentity(receipt map[string]interface{}) string {
 
 func receiptReferenceIndex(receipts []map[string]interface{}) map[string]string {
 	index := make(map[string]string, len(receipts)*2)
-	for _, receipt := range receipts {
+	owners := make(map[string]int, len(receipts)*2)
+	targetOwners := make(map[string]int, len(receipts))
+	collidedTargets := make(map[string]bool)
+	for receiptIndex, receipt := range receipts {
+		target := receiptIdentity(receipt)
+		if target == "" {
+			continue
+		}
+		if owner, exists := targetOwners[target]; exists && owner != receiptIndex {
+			collidedTargets[target] = true
+		} else {
+			targetOwners[target] = receiptIndex
+		}
+	}
+	for receiptIndex, receipt := range receipts {
 		target := receiptIdentity(receipt)
 		if target == "" {
 			continue
 		}
 		for _, key := range []string{"receipt_id", "receipt_hash"} {
 			if value, _ := receipt[key].(string); strings.TrimSpace(value) != "" {
-				index[strings.TrimSpace(value)] = target
+				reference := strings.TrimSpace(value)
+				if collidedTargets[target] {
+					index[reference] = ""
+					continue
+				}
+				if owner, exists := owners[reference]; exists && owner != receiptIndex {
+					index[reference] = ""
+					continue
+				}
+				owners[reference] = receiptIndex
+				index[reference] = target
 			}
 		}
 	}

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -804,8 +804,7 @@ func verifyCampaignSignatures(document map[string]interface{}, field, domain, tr
 	if err != nil {
 		return false
 	}
-	signedMessage := make([]byte, 0, len(domain)+1+len(canonical))
-	signedMessage = append(signedMessage, domain...)
+	signedMessage := []byte(domain)
 	signedMessage = append(signedMessage, 0)
 	signedMessage = append(signedMessage, canonical...)
 	wantKeyID, err := CampaignKeyID(trustedPublicKeyHex)

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -58,6 +58,11 @@ type VerificationOptions struct {
 	VerifiedEvidenceIndexHash  string
 	VerifiedEvidenceMerkleRoot string
 	VerifiedEvidenceEntryCount int
+	// AllowVerifiedConformanceSignature authorizes omission of the detached
+	// conformance signature from the detector workspace only after the caller
+	// has verified it against an external trusted key. It never establishes
+	// campaign trust and is never consumed by adversarial detectors.
+	AllowVerifiedConformanceSignature bool
 }
 
 const (

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -180,16 +180,42 @@ func adv03DAGFork() *Suite {
 			receiptsDir := filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts")
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
 
-			t := TestResult{TestID: "ADV-03-T1", Name: "No duplicate parent references (no forks)"}
-			parentCount := make(map[string]int)
+			t := TestResult{TestID: "ADV-03-T1", Name: "No duplicate, dangling, or self parent references"}
+			receipts := make([]map[string]interface{}, 0, len(files))
 			for _, f := range files {
-				receipt := loadReceipt(f)
+				receipts = append(receipts, loadReceipt(f))
+			}
+			referenceIndex := receiptReferenceIndex(receipts)
+			parentCount := make(map[string]int)
+			graph := make(map[string][]string, len(receipts))
+			invalidParents := 0
+			for index, receipt := range receipts {
+				child := receiptIdentity(receipt)
+				if child == "" {
+					invalidParents++
+					t.Evidence += fmt.Sprintf("missing receipt identity in %s; ", filepath.Base(files[index]))
+				}
 				parents, ok := receipt["parent_receipt_hashes"].([]interface{})
 				if ok {
 					for _, p := range parents {
-						if ps, ok := p.(string); ok && ps != "genesis" {
-							parentCount[ps]++
+						ps, valid := p.(string)
+						ps = strings.TrimSpace(ps)
+						if !valid || ps == "" {
+							invalidParents++
+							t.Evidence += fmt.Sprintf("invalid parent in %s; ", filepath.Base(files[index]))
+							continue
 						}
+						if ps == "genesis" {
+							continue
+						}
+						parentTarget, exists := referenceIndex[ps]
+						if !exists || child == "" || parentTarget == child {
+							invalidParents++
+							t.Evidence += fmt.Sprintf("dangling or self parent %s in %s; ", ps, filepath.Base(files[index]))
+							continue
+						}
+						parentCount[parentTarget]++
+						graph[child] = append(graph[child], parentTarget)
 					}
 				}
 			}
@@ -207,9 +233,14 @@ func adv03DAGFork() *Suite {
 					t.Evidence += fmt.Sprintf("parent %s claimed by %d children; ", parent, count)
 				}
 			}
-			if forks > 0 {
+			cycles := 0
+			if receiptGraphHasCycle(graph) {
+				cycles = 1
+				t.Evidence += "receipt parent graph contains a cycle; "
+			}
+			if forks > 0 || invalidParents > 0 || cycles > 0 {
 				t.Pass = false
-				t.Reason = fmt.Sprintf("%d DAG forks detected", forks)
+				t.Reason = fmt.Sprintf("%d DAG forks detected; %d invalid parent references; %d DAG cycles detected", forks, invalidParents, cycles)
 			} else {
 				t.Pass = true
 				t.Reason = "no DAG forks"
@@ -267,7 +298,7 @@ func adv04BudgetOverdraft() *Suite {
 			}
 			for _, decrement := range decrements {
 				for _, boundary := range exhaustedAt[decrement.scope] {
-					if decrement.seq > boundary {
+					if decrement.seq >= boundary {
 						overdraft = true
 						t.Evidence += fmt.Sprintf("budget_decrement seq %.0f after exhaustion seq %.0f for %s: %s; ", decrement.seq, boundary, decrement.scope, decrement.file)
 					}
@@ -760,6 +791,49 @@ func receiptIdentity(receipt map[string]interface{}) string {
 	return value
 }
 
+func receiptReferenceIndex(receipts []map[string]interface{}) map[string]string {
+	index := make(map[string]string, len(receipts)*2)
+	for _, receipt := range receipts {
+		target := receiptIdentity(receipt)
+		if target == "" {
+			continue
+		}
+		for _, key := range []string{"receipt_id", "receipt_hash"} {
+			if value, _ := receipt[key].(string); strings.TrimSpace(value) != "" {
+				index[strings.TrimSpace(value)] = target
+			}
+		}
+	}
+	return index
+}
+
+func receiptGraphHasCycle(graph map[string][]string) bool {
+	state := make(map[string]uint8, len(graph))
+	var visit func(string) bool
+	visit = func(node string) bool {
+		switch state[node] {
+		case 1:
+			return true
+		case 2:
+			return false
+		}
+		state[node] = 1
+		for _, parent := range graph[node] {
+			if visit(parent) {
+				return true
+			}
+		}
+		state[node] = 2
+		return false
+	}
+	for node := range graph {
+		if visit(node) {
+			return true
+		}
+	}
+	return false
+}
+
 func receiptParentRefs(receipt map[string]interface{}) []string {
 	raw, _ := receipt["parent_receipt_hashes"].([]interface{})
 	out := make([]string, 0, len(raw))
@@ -817,7 +891,7 @@ func verifyCampaignSignatures(document map[string]interface{}, field, domain, tr
 			return false
 		}
 		signatureHex, _ := signature["signature"].(string)
-		signatureBytes, err := hex.DecodeString(strings.TrimPrefix(strings.TrimSpace(signatureHex), "hex:"))
+		signatureBytes, err := hex.DecodeString(strings.TrimSpace(signatureHex))
 		if err != nil || len(signatureBytes) != ed25519.SignatureSize || !ed25519.Verify(ed25519.PublicKey(publicKey), signedMessage, signatureBytes) {
 			return false
 		}

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -11,6 +11,7 @@ package adversarial
 import (
 	"crypto/ed25519"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -220,17 +221,21 @@ func adv04BudgetOverdraft() *Suite {
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
 
 			t := TestResult{TestID: "ADV-04-T1", Name: "No budget_decrement after budget_exhausted"}
-			exhausted := false
+			exhausted := make(map[string]bool)
 			overdraft := false
 			for _, f := range files {
 				receipt := loadReceipt(f)
 				action, _ := receipt["action_type"].(string)
-				if action == "budget_exhausted" {
-					exhausted = true
+				scope := budgetScope(receipt)
+				if scope == "" {
+					continue
 				}
-				if exhausted && action == "budget_decrement" {
+				if exhausted[scope] && action == "budget_decrement" {
 					overdraft = true
-					t.Evidence = fmt.Sprintf("budget_decrement after exhaustion: %s", filepath.Base(f))
+					t.Evidence = fmt.Sprintf("budget_decrement after exhaustion for %s: %s", scope, filepath.Base(f))
+				}
+				if action == "budget_exhausted" {
+					exhausted[scope] = true
 				}
 			}
 			if overdraft {
@@ -304,16 +309,9 @@ func adv06TapeReplayTamper() *Suite {
 			for _, f := range files {
 				data, err := os.ReadFile(f)
 				var entry map[string]interface{}
-				if err != nil || json.Unmarshal(data, &entry) != nil {
+				if err != nil || json.Unmarshal(data, &entry) != nil || !validTapeEntry(entry) {
 					missing++
 					t.Evidence += fmt.Sprintf("invalid: %s; ", filepath.Base(f))
-					continue
-				}
-				if entry["value_hash"] == nil || entry["value_hash"] == "" {
-					missing++
-				}
-				if entry["data_class"] == nil || entry["data_class"] == "" {
-					missing++
 				}
 			}
 			if missing > 0 {
@@ -591,6 +589,15 @@ func isEffectAction(action string) bool {
 	return action == "effect_attempt" || action == "tool_call" || action == "connector_call"
 }
 
+func budgetScope(receipt map[string]interface{}) string {
+	for _, key := range []string{"budget_id", "budget_snapshot_ref", "decision_id"} {
+		if value, _ := receipt[key].(string); strings.TrimSpace(value) != "" {
+			return key + ":" + strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
 func hasBoundAuthorizationReceipt(files []string, effect map[string]interface{}, actionType string, opts VerificationOptions) bool {
 	receipts := make([]map[string]interface{}, 0, len(files))
 	for _, path := range files {
@@ -750,6 +757,23 @@ func verifyCampaignSignatures(document map[string]interface{}, field, trustedPub
 		}
 	}
 	return true
+}
+
+func validTapeEntry(entry map[string]interface{}) bool {
+	valueHash, ok := entry["value_hash"].(string)
+	if !ok || !hasNonEmptyString(entry, "data_class") {
+		return false
+	}
+	encodedValue, present := entry["value"].(string)
+	if !present {
+		return false
+	}
+	value, err := base64.StdEncoding.DecodeString(encodedValue)
+	if err != nil {
+		return false
+	}
+	digest := sha256.Sum256(value)
+	return strings.EqualFold(strings.TrimPrefix(valueHash, "sha256:"), hex.EncodeToString(digest[:]))
 }
 
 func isHighFinality(effectClass, actionType string) bool {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -54,6 +54,11 @@ type VerificationOptions struct {
 	CampaignPublicKeyHex string
 }
 
+const (
+	campaignReceiptSignatureDomain      = "helm.bounty.receipt-signature/v1"
+	campaignToolManifestSignatureDomain = "helm.bounty.tool-manifest-signature/v1"
+)
+
 // CampaignKeyID validates an Ed25519 campaign root and returns its stable ID.
 func CampaignKeyID(publicKeyHex string) (string, error) {
 	publicKey, err := hex.DecodeString(strings.TrimSpace(publicKeyHex))
@@ -422,7 +427,7 @@ func adv08ToolManifestForge(opts VerificationOptions) *Suite {
 			for _, f := range files {
 				data, err := os.ReadFile(f)
 				var manifest map[string]interface{}
-				if err != nil || json.Unmarshal(data, &manifest) != nil || !verifyCampaignSignatures(manifest, "signatures", opts.CampaignPublicKeyHex) {
+				if err != nil || json.Unmarshal(data, &manifest) != nil || !verifyCampaignSignatures(manifest, "signatures", campaignToolManifestSignatureDomain, opts.CampaignPublicKeyHex) {
 					unsigned++
 					t.Evidence += fmt.Sprintf("invalid or unsigned: %s; ", filepath.Base(f))
 				}
@@ -595,6 +600,7 @@ func loadSequenceNumbers(files []string) []uint64 {
 			seqs = append(seqs, uint64(seq))
 		}
 	}
+	sort.Slice(seqs, func(i, j int) bool { return seqs[i] < seqs[j] })
 	return seqs
 }
 
@@ -627,10 +633,12 @@ func isEffectAction(action string) bool {
 }
 
 func budgetScope(receipt map[string]interface{}) string {
-	for _, key := range []string{"budget_id", "budget_snapshot_ref", "decision_id"} {
-		if value, _ := receipt[key].(string); strings.TrimSpace(value) != "" {
-			return key + ":" + strings.TrimSpace(value)
-		}
+	// Proof receipts bind budget effects to the canonical budget snapshot.
+	// Alternate identifiers are deliberately not accepted: allowing different
+	// fallback fields on exhaustion and decrement receipts splits one logical
+	// budget into unrelated scopes and hides a post-exhaustion decrement.
+	if value, _ := receipt["budget_snapshot_ref"].(string); strings.TrimSpace(value) != "" {
+		return "budget_snapshot_ref:" + strings.TrimSpace(value)
 	}
 	return ""
 }
@@ -661,7 +669,7 @@ func hasBoundAuthorization(receipts []map[string]interface{}, effect map[string]
 		if !sequenced || seq >= effectSeq || !receiptIsAncestor(receipts, effect, receipt) {
 			continue
 		}
-		if verifyCampaignSignatures(receipt, "campaign_signatures", opts.CampaignPublicKeyHex) {
+		if verifyCampaignSignatures(receipt, "campaign_signatures", campaignReceiptSignatureDomain, opts.CampaignPublicKeyHex) {
 			return true
 		}
 	}
@@ -760,7 +768,10 @@ func hasNonEmptyString(value map[string]interface{}, key string) bool {
 	return ok && strings.TrimSpace(raw) != ""
 }
 
-func verifyCampaignSignatures(document map[string]interface{}, field, trustedPublicKeyHex string) bool {
+func verifyCampaignSignatures(document map[string]interface{}, field, domain, trustedPublicKeyHex string) bool {
+	if strings.TrimSpace(domain) == "" {
+		return false
+	}
 	publicKey, err := hex.DecodeString(strings.TrimSpace(trustedPublicKeyHex))
 	if err != nil || len(publicKey) != ed25519.PublicKeySize {
 		return false
@@ -779,6 +790,10 @@ func verifyCampaignSignatures(document map[string]interface{}, field, trustedPub
 	if err != nil {
 		return false
 	}
+	signedMessage := make([]byte, 0, len(domain)+1+len(canonical))
+	signedMessage = append(signedMessage, domain...)
+	signedMessage = append(signedMessage, 0)
+	signedMessage = append(signedMessage, canonical...)
 	wantKeyID, err := CampaignKeyID(trustedPublicKeyHex)
 	if err != nil {
 		return false
@@ -790,7 +805,7 @@ func verifyCampaignSignatures(document map[string]interface{}, field, trustedPub
 		}
 		signatureHex, _ := signature["signature"].(string)
 		signatureBytes, err := hex.DecodeString(strings.TrimPrefix(strings.TrimSpace(signatureHex), "hex:"))
-		if err != nil || len(signatureBytes) != ed25519.SignatureSize || !ed25519.Verify(ed25519.PublicKey(publicKey), canonical, signatureBytes) {
+		if err != nil || len(signatureBytes) != ed25519.SignatureSize || !ed25519.Verify(ed25519.PublicKey(publicKey), signedMessage, signatureBytes) {
 			return false
 		}
 	}

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -344,8 +344,7 @@ func adv08ToolManifestForge() *Suite {
 		Run: func(evidenceDir string) *SuiteResult {
 			result := &SuiteResult{SuiteID: "ADV-08", Name: "Tool Manifest Forgery", Pass: true}
 
-			manifestDir := filepath.Join(evidenceDir, "10_TOOLS")
-			files, _ := filepath.Glob(filepath.Join(manifestDir, "*.json"))
+			files := toolManifestFiles(evidenceDir)
 
 			t := TestResult{TestID: "ADV-08-T1", Name: "Tool manifests have signatures field"}
 			unsigned := 0
@@ -384,7 +383,7 @@ func adv09ReceiptEmissionPanicHijack() *Suite {
 
 			t := TestResult{TestID: "ADV-09-T1", Name: "No receipts after panic record"}
 
-			panicFile := filepath.Join(evidenceDir, "panic.json")
+			panicFile := panicEvidencePath(evidenceDir)
 			if _, err := os.Stat(panicFile); err != nil {
 				t.Pass = true
 				t.Reason = "no panic record (normal operation)"
@@ -474,6 +473,23 @@ func adv10HighFinalityUnsigned() *Suite {
 }
 
 // --- Helpers ---
+
+func toolManifestFiles(evidenceDir string) []string {
+	// Canonical packs carry adversarial-only tool fixtures as a declared
+	// extension. The legacy 10_TOOLS location remains readable for historical
+	// detector fixtures but is rejected by strict EvidencePack verification.
+	canonical, _ := filepath.Glob(filepath.Join(evidenceDir, "99_EXT", "adversarial", "tools", "*.json"))
+	legacy, _ := filepath.Glob(filepath.Join(evidenceDir, "10_TOOLS", "*.json"))
+	return append(canonical, legacy...)
+}
+
+func panicEvidencePath(evidenceDir string) string {
+	canonical := filepath.Join(evidenceDir, "06_LOGS", "receipt_emission_panic.json")
+	if _, err := os.Stat(canonical); err == nil {
+		return canonical
+	}
+	return filepath.Join(evidenceDir, "panic.json")
+}
 
 func loadReceipt(path string) map[string]interface{} {
 	data, err := os.ReadFile(path)

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
@@ -188,7 +189,13 @@ func adv03DAGFork() *Suite {
 			}
 
 			forks := 0
-			for parent, count := range parentCount {
+			parents := make([]string, 0, len(parentCount))
+			for parent := range parentCount {
+				parents = append(parents, parent)
+			}
+			sort.Strings(parents)
+			for _, parent := range parents {
+				count := parentCount[parent]
 				if count > 1 {
 					forks++
 					t.Evidence += fmt.Sprintf("parent %s claimed by %d children; ", parent, count)
@@ -221,24 +228,49 @@ func adv04BudgetOverdraft() *Suite {
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
 
 			t := TestResult{TestID: "ADV-04-T1", Name: "No budget_decrement after budget_exhausted"}
-			exhausted := make(map[string]bool)
 			overdraft := false
+			invalidBoundary := false
+			exhaustedAt := make(map[string][]float64)
+			var decrements []struct {
+				scope string
+				seq   float64
+				file  string
+			}
 			for _, f := range files {
 				receipt := loadReceipt(f)
 				action, _ := receipt["action_type"].(string)
-				scope := budgetScope(receipt)
-				if scope == "" {
+				if action != "budget_exhausted" && action != "budget_decrement" {
 					continue
 				}
-				if exhausted[scope] && action == "budget_decrement" {
-					overdraft = true
-					t.Evidence = fmt.Sprintf("budget_decrement after exhaustion for %s: %s", scope, filepath.Base(f))
+				scope := budgetScope(receipt)
+				seq, ok := receiptSequence(receipt)
+				if scope == "" || !ok {
+					invalidBoundary = true
+					t.Evidence += fmt.Sprintf("unscoped or unsequenced budget receipt: %s; ", filepath.Base(f))
+					continue
 				}
 				if action == "budget_exhausted" {
-					exhausted[scope] = true
+					exhaustedAt[scope] = append(exhaustedAt[scope], seq)
+				} else {
+					decrements = append(decrements, struct {
+						scope string
+						seq   float64
+						file  string
+					}{scope: scope, seq: seq, file: filepath.Base(f)})
 				}
 			}
-			if overdraft {
+			for _, decrement := range decrements {
+				for _, boundary := range exhaustedAt[decrement.scope] {
+					if decrement.seq > boundary {
+						overdraft = true
+						t.Evidence += fmt.Sprintf("budget_decrement seq %.0f after exhaustion seq %.0f for %s: %s; ", decrement.seq, boundary, decrement.scope, decrement.file)
+					}
+				}
+			}
+			if invalidBoundary {
+				t.Pass = false
+				t.Reason = "budget boundary contains an unscoped or unsequenced receipt"
+			} else if overdraft {
 				t.Pass = false
 				t.Reason = "BUDGET_OVERDRAFT"
 			} else {
@@ -357,7 +389,12 @@ func adv07TenantCrossleak() *Suite {
 				t.Reason = fmt.Sprintf("%d receipts missing tenant_id", missingTenant)
 			} else if len(tenants) > 1 {
 				t.Pass = false
-				t.Reason = fmt.Sprintf("multiple tenants in single run: %v", tenants)
+				tenantIDs := make([]string, 0, len(tenants))
+				for tenantID := range tenants {
+					tenantIDs = append(tenantIDs, tenantID)
+				}
+				sort.Strings(tenantIDs)
+				t.Reason = fmt.Sprintf("multiple tenants in single run: %s", strings.Join(tenantIDs, ","))
 			} else {
 				t.Pass = true
 				t.Reason = "tenant isolation maintained"
@@ -437,7 +474,7 @@ func adv09ReceiptEmissionPanicHijack() *Suite {
 					result.Pass = false
 					return result
 				}
-				boundary, ok := panicRec["last_good_seq"].(float64)
+				boundary, ok := receiptSequence(map[string]interface{}{"seq": panicRec["last_good_seq"]})
 				if !ok {
 					t.Pass = false
 					t.Reason = "panic record missing last_good_seq"
@@ -714,7 +751,8 @@ func receiptParentRefs(receipt map[string]interface{}) []string {
 
 func receiptSequence(receipt map[string]interface{}) (float64, bool) {
 	seq, ok := receipt["seq"].(float64)
-	return seq, ok && seq >= 0 && seq <= math.MaxUint64 && math.Trunc(seq) == seq
+	const maxExactJSONInteger = 1<<53 - 1
+	return seq, ok && seq >= 0 && seq <= maxExactJSONInteger && math.Trunc(seq) == seq
 }
 
 func hasNonEmptyString(value map[string]interface{}, key string) bool {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -302,15 +302,18 @@ func adv06TapeReplayTamper() *Suite {
 			files, _ := filepath.Glob(filepath.Join(tapesDir, "entry_*.json"))
 			missing := 0
 			for _, f := range files {
-				data, _ := os.ReadFile(f)
+				data, err := os.ReadFile(f)
 				var entry map[string]interface{}
-				if json.Unmarshal(data, &entry) == nil {
-					if entry["value_hash"] == nil || entry["value_hash"] == "" {
-						missing++
-					}
-					if entry["data_class"] == nil || entry["data_class"] == "" {
-						missing++
-					}
+				if err != nil || json.Unmarshal(data, &entry) != nil {
+					missing++
+					t.Evidence += fmt.Sprintf("invalid: %s; ", filepath.Base(f))
+					continue
+				}
+				if entry["value_hash"] == nil || entry["value_hash"] == "" {
+					missing++
+				}
+				if entry["data_class"] == nil || entry["data_class"] == "" {
+					missing++
 				}
 			}
 			if missing > 0 {
@@ -341,14 +344,20 @@ func adv07TenantCrossleak() *Suite {
 
 			t := TestResult{TestID: "ADV-07-T1", Name: "Single tenant_id across all receipts in run"}
 			tenants := make(map[string]int)
+			missingTenant := 0
 			for _, f := range files {
 				receipt := loadReceipt(f)
 				tid, _ := receipt["tenant_id"].(string)
-				if tid != "" {
-					tenants[tid]++
+				if strings.TrimSpace(tid) == "" {
+					missingTenant++
+					continue
 				}
+				tenants[tid]++
 			}
-			if len(tenants) > 1 {
+			if missingTenant > 0 {
+				t.Pass = false
+				t.Reason = fmt.Sprintf("%d receipts missing tenant_id", missingTenant)
+			} else if len(tenants) > 1 {
 				t.Pass = false
 				t.Reason = fmt.Sprintf("multiple tenants in single run: %v", tenants)
 			} else {
@@ -594,11 +603,11 @@ func hasBoundAuthorizationReceipt(files []string, effect map[string]interface{},
 
 func hasBoundAuthorization(receipts []map[string]interface{}, effect map[string]interface{}, actionType string, opts VerificationOptions) bool {
 	effectSeq, ok := receiptSequence(effect)
-	if !ok || !hasNonEmptyString(effect, "decision_id") || !hasNonEmptyString(effect, "envelope_id") || !hasNonEmptyString(effect, "envelope_hash") {
+	if !ok || !hasNonEmptyString(effect, "decision_id") || !hasNonEmptyString(effect, "tenant_id") || !hasNonEmptyString(effect, "envelope_id") || !hasNonEmptyString(effect, "envelope_hash") {
 		return false
 	}
 	for _, receipt := range receipts {
-		if receipt["action_type"] != actionType || receipt["decision_id"] != effect["decision_id"] || receipt["envelope_id"] != effect["envelope_id"] || receipt["envelope_hash"] != effect["envelope_hash"] {
+		if receipt["action_type"] != actionType || receipt["decision_id"] != effect["decision_id"] || receipt["tenant_id"] != effect["tenant_id"] || receipt["envelope_id"] != effect["envelope_id"] || receipt["envelope_hash"] != effect["envelope_hash"] {
 			continue
 		}
 		if !authorizationReceiptAccepted(receipt, actionType) {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -188,11 +188,18 @@ func adv03DAGFork() *Suite {
 				receipts = append(receipts, loadReceipt(f))
 			}
 			referenceIndex := receiptReferenceIndex(receipts)
+			receiptsByIdentity := make(map[string]map[string]interface{}, len(receipts))
+			for _, receipt := range receipts {
+				if identity := receiptIdentity(receipt); identity != "" {
+					receiptsByIdentity[identity] = receipt
+				}
+			}
 			parentCount := make(map[string]int)
 			graph := make(map[string][]string, len(receipts))
 			invalidParents := 0
 			for index, receipt := range receipts {
 				child := receiptIdentity(receipt)
+				childSeq, childSequenced := receiptSequence(receipt)
 				if child == "" {
 					invalidParents++
 					t.Evidence += fmt.Sprintf("missing receipt identity in %s; ", filepath.Base(files[index]))
@@ -211,9 +218,11 @@ func adv03DAGFork() *Suite {
 							continue
 						}
 						parentTarget, exists := referenceIndex[ps]
-						if !exists || parentTarget == "" || child == "" || parentTarget == child {
+						parentReceipt := receiptsByIdentity[parentTarget]
+						parentSeq, parentSequenced := receiptSequence(parentReceipt)
+						if !exists || parentTarget == "" || child == "" || parentTarget == child || !childSequenced || !parentSequenced || parentSeq >= childSeq {
 							invalidParents++
-							t.Evidence += fmt.Sprintf("dangling or self parent %s in %s; ", ps, filepath.Base(files[index]))
+							t.Evidence += fmt.Sprintf("dangling, self, or non-causal parent %s in %s; ", ps, filepath.Base(files[index]))
 							continue
 						}
 						parentCount[parentTarget]++
@@ -853,30 +862,36 @@ func receiptReferenceIndex(receipts []map[string]interface{}) map[string]string 
 }
 
 func receiptGraphHasCycle(graph map[string][]string) bool {
-	state := make(map[string]uint8, len(graph))
-	var visit func(string) bool
-	visit = func(node string) bool {
-		switch state[node] {
-		case 1:
-			return true
-		case 2:
-			return false
+	indegree := make(map[string]int, len(graph))
+	for node, parents := range graph {
+		if _, exists := indegree[node]; !exists {
+			indegree[node] = 0
 		}
-		state[node] = 1
+		for _, parent := range parents {
+			if _, exists := indegree[parent]; !exists {
+				indegree[parent] = 0
+			}
+			indegree[parent]++
+		}
+	}
+	queue := make([]string, 0, len(indegree))
+	for node, degree := range indegree {
+		if degree == 0 {
+			queue = append(queue, node)
+		}
+	}
+	processed := 0
+	for cursor := 0; cursor < len(queue); cursor++ {
+		node := queue[cursor]
+		processed++
 		for _, parent := range graph[node] {
-			if visit(parent) {
-				return true
+			indegree[parent]--
+			if indegree[parent] == 0 {
+				queue = append(queue, parent)
 			}
 		}
-		state[node] = 2
-		return false
 	}
-	for node := range graph {
-		if visit(node) {
-			return true
-		}
-	}
-	return false
+	return processed != len(indegree)
 }
 
 func receiptParentRefs(receipt map[string]interface{}) []string {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -187,80 +187,181 @@ func adv03DAGFork() *Suite {
 			for _, f := range files {
 				receipts = append(receipts, loadReceipt(f))
 			}
-			referenceIndex := receiptReferenceIndex(receipts)
-			receiptsByIdentity := make(map[string]map[string]interface{}, len(receipts))
-			for _, receipt := range receipts {
-				if identity := receiptIdentity(receipt); identity != "" {
-					receiptsByIdentity[identity] = receipt
-				}
-			}
-			parentCount := make(map[string]int)
-			graph := make(map[string][]string, len(receipts))
-			invalidParents := 0
-			for index, receipt := range receipts {
-				child := receiptIdentity(receipt)
-				childSeq, childSequenced := receiptSequence(receipt)
-				if child == "" {
-					invalidParents++
-					t.Evidence += fmt.Sprintf("missing receipt identity in %s; ", filepath.Base(files[index]))
-				}
-				parents, ok := receipt["parent_receipt_hashes"].([]interface{})
-				if ok {
-					for _, p := range parents {
-						ps, valid := p.(string)
-						ps = strings.TrimSpace(ps)
-						if !valid || ps == "" {
-							invalidParents++
-							t.Evidence += fmt.Sprintf("invalid parent in %s; ", filepath.Base(files[index]))
-							continue
-						}
-						if ps == "genesis" {
-							continue
-						}
-						parentTarget, exists := referenceIndex[ps]
-						parentReceipt := receiptsByIdentity[parentTarget]
-						parentSeq, parentSequenced := receiptSequence(parentReceipt)
-						if !exists || parentTarget == "" || child == "" || parentTarget == child || !childSequenced || !parentSequenced || parentSeq >= childSeq {
-							invalidParents++
-							t.Evidence += fmt.Sprintf("dangling, self, or non-causal parent %s in %s; ", ps, filepath.Base(files[index]))
-							continue
-						}
-						parentCount[parentTarget]++
-						graph[child] = append(graph[child], parentTarget)
-					}
-				}
-			}
-
-			forks := 0
-			parents := make([]string, 0, len(parentCount))
-			for parent := range parentCount {
-				parents = append(parents, parent)
-			}
-			sort.Strings(parents)
-			for _, parent := range parents {
-				count := parentCount[parent]
-				if count > 1 {
-					forks++
-					t.Evidence += fmt.Sprintf("parent %s claimed by %d children; ", parent, count)
-				}
-			}
-			cycles := 0
-			if receiptGraphHasCycle(graph) {
-				cycles = 1
-				t.Evidence += "receipt parent graph contains a cycle; "
-			}
-			if forks > 0 || invalidParents > 0 || cycles > 0 {
+			analysis := analyzeReceiptProofGraph(receipts, files)
+			t.Evidence = analysis.evidence
+			if analysis.forks > 0 || analysis.invalidParents > 0 || analysis.genesisClaims != 1 || analysis.cycles > 0 {
 				t.Pass = false
-				t.Reason = fmt.Sprintf("%d DAG forks detected; %d invalid parent references; %d DAG cycles detected", forks, invalidParents, cycles)
+				t.Reason = fmt.Sprintf(
+					"%d DAG forks detected; %d invalid parent references; %d genesis roots detected; %d DAG cycles detected",
+					analysis.forks,
+					analysis.invalidParents,
+					analysis.genesisClaims,
+					analysis.cycles,
+				)
 			} else {
 				t.Pass = true
-				t.Reason = "no DAG forks"
+				t.Reason = "single-root connected proof graph with no DAG forks"
 			}
 			result.TestResults = append(result.TestResults, t)
 			result.Pass = t.Pass
 			return result
 		},
 	}
+}
+
+type receiptProofGraphAnalysis struct {
+	causalEdges    int
+	forks          int
+	invalidParents int
+	genesisClaims  int
+	cycles         int
+	evidence       string
+}
+
+// analyzeReceiptProofGraph validates the whole proof graph, not just the
+// existence of one good edge. A valid pack has exactly one genesis claim on
+// sequence 1, and every later receipt has at least one resolvable, strictly
+// earlier parent. Those invariants make disconnected components impossible.
+func analyzeReceiptProofGraph(receipts []map[string]interface{}, files []string) receiptProofGraphAnalysis {
+	analysis := receiptProofGraphAnalysis{}
+	if len(receipts) == 0 {
+		analysis.invalidParents++
+		analysis.evidence = "proof graph has no receipts; "
+		return analysis
+	}
+
+	referenceIndex := receiptReferenceIndex(receipts)
+	receiptsByIdentity := make(map[string]map[string]interface{}, len(receipts))
+	for _, receipt := range receipts {
+		if identity := receiptIdentity(receipt); identity != "" {
+			receiptsByIdentity[identity] = receipt
+		}
+	}
+
+	// Reject ambiguous aliases even when no edge happens to reference them.
+	// Otherwise a later verifier could resolve the same receipt_id differently.
+	ambiguousReferences := make(map[string]bool)
+	for index, receipt := range receipts {
+		for _, key := range []string{"receipt_id", "receipt_hash"} {
+			reference, _ := receipt[key].(string)
+			reference = strings.TrimSpace(reference)
+			if reference == "" || referenceIndex[reference] != "" || ambiguousReferences[reference] {
+				continue
+			}
+			ambiguousReferences[reference] = true
+			analysis.invalidParents++
+			analysis.evidence += fmt.Sprintf("ambiguous receipt reference %s in %s; ", reference, receiptFileLabel(files, index))
+		}
+	}
+
+	parentCount := make(map[string]int)
+	graph := make(map[string][]string, len(receipts))
+	for index, receipt := range receipts {
+		fileLabel := receiptFileLabel(files, index)
+		child := receiptIdentity(receipt)
+		childSeq, childSequenced := receiptSequence(receipt)
+		if child == "" {
+			analysis.invalidParents++
+			analysis.evidence += fmt.Sprintf("missing receipt identity in %s; ", fileLabel)
+		}
+		if !childSequenced {
+			analysis.invalidParents++
+			analysis.evidence += fmt.Sprintf("invalid receipt sequence in %s; ", fileLabel)
+		}
+
+		parents, ok := receipt["parent_receipt_hashes"].([]interface{})
+		if !ok || len(parents) == 0 {
+			analysis.invalidParents++
+			analysis.evidence += fmt.Sprintf("missing or empty parent_receipt_hashes in %s; ", fileLabel)
+			continue
+		}
+
+		genesisParents := 0
+		validNonGenesisParents := 0
+		seenParentTargets := make(map[string]bool, len(parents))
+		for _, parentValue := range parents {
+			parentReference, valid := parentValue.(string)
+			parentReference = strings.TrimSpace(parentReference)
+			if !valid || parentReference == "" {
+				analysis.invalidParents++
+				analysis.evidence += fmt.Sprintf("invalid parent in %s; ", fileLabel)
+				continue
+			}
+			if parentReference == "genesis" {
+				analysis.genesisClaims++
+				genesisParents++
+				if seenParentTargets[parentReference] {
+					analysis.invalidParents++
+					analysis.evidence += fmt.Sprintf("duplicate genesis parent in %s; ", fileLabel)
+					continue
+				}
+				seenParentTargets[parentReference] = true
+				continue
+			}
+
+			parentTarget, exists := referenceIndex[parentReference]
+			parentReceipt := receiptsByIdentity[parentTarget]
+			parentSeq, parentSequenced := receiptSequence(parentReceipt)
+			if !exists || parentTarget == "" || child == "" || parentTarget == child || !childSequenced || !parentSequenced || parentSeq >= childSeq {
+				analysis.invalidParents++
+				analysis.evidence += fmt.Sprintf("dangling, self, or non-causal parent %s in %s; ", parentReference, fileLabel)
+				continue
+			}
+			if seenParentTargets[parentTarget] {
+				analysis.invalidParents++
+				analysis.evidence += fmt.Sprintf("duplicate parent target %s in %s; ", parentTarget, fileLabel)
+				continue
+			}
+			seenParentTargets[parentTarget] = true
+			validNonGenesisParents++
+			analysis.causalEdges++
+			parentCount[parentTarget]++
+			graph[child] = append(graph[child], parentTarget)
+		}
+
+		if !childSequenced {
+			continue
+		}
+		if childSeq == 1 {
+			if genesisParents != 1 || validNonGenesisParents != 0 || len(parents) != 1 {
+				analysis.invalidParents++
+				analysis.evidence += fmt.Sprintf("sequence 1 must have exactly one genesis parent in %s; ", fileLabel)
+			}
+			continue
+		}
+		if genesisParents != 0 || validNonGenesisParents == 0 {
+			analysis.invalidParents++
+			analysis.evidence += fmt.Sprintf("non-root receipt lacks a valid earlier parent in %s; ", fileLabel)
+		}
+	}
+
+	parents := make([]string, 0, len(parentCount))
+	for parent := range parentCount {
+		parents = append(parents, parent)
+	}
+	sort.Strings(parents)
+	for _, parent := range parents {
+		count := parentCount[parent]
+		if count > 1 {
+			analysis.forks++
+			analysis.evidence += fmt.Sprintf("parent %s claimed by %d children; ", parent, count)
+		}
+	}
+	if analysis.genesisClaims != 1 {
+		analysis.evidence += fmt.Sprintf("proof graph contains %d genesis claims; ", analysis.genesisClaims)
+	}
+	if receiptGraphHasCycle(graph) {
+		analysis.cycles = 1
+		analysis.evidence += "receipt parent graph contains a cycle; "
+	}
+	return analysis
+}
+
+func receiptFileLabel(files []string, index int) string {
+	if index >= 0 && index < len(files) && files[index] != "" {
+		return filepath.Base(files[index])
+	}
+	return fmt.Sprintf("receipt[%d]", index)
 }
 
 // ADV-04: Budget Overdraft

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -52,9 +52,12 @@ type Suite struct {
 // VerificationOptions supplies trust roots from outside the candidate
 // EvidencePack. A signature embedded in the pack can never establish trust.
 type VerificationOptions struct {
-	CampaignPublicKeyHex string
-	CampaignID           string
-	RunID                string
+	CampaignPublicKeyHex       string
+	CampaignID                 string
+	RunID                      string
+	VerifiedEvidenceIndexHash  string
+	VerifiedEvidenceMerkleRoot string
+	VerifiedEvidenceEntryCount int
 }
 
 const (

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -687,27 +687,36 @@ func authorizationReceiptAccepted(receipt map[string]interface{}, actionType str
 		return false
 	}
 	status = strings.ToUpper(strings.TrimSpace(status))
-	accepted := false
+	directlyAccepted := false
+	requiresVerdict := false
 	switch actionType {
 	case "policy_decision":
-		accepted = status == "APPLIED" || status == "ALLOW" || status == "ALLOWED"
+		directlyAccepted = status == "ALLOW" || status == "ALLOWED"
+		requiresVerdict = status == "APPLIED"
 	case "approval_action":
-		accepted = status == "APPLIED" || status == "APPROVED" || status == "ALLOW" || status == "ALLOWED"
+		directlyAccepted = status == "APPROVED" || status == "ALLOW" || status == "ALLOWED"
+		requiresVerdict = status == "APPLIED"
 	}
-	if !accepted {
+	if !directlyAccepted && !requiresVerdict {
 		return false
 	}
-	if verdict, exists := receipt["verdict"]; exists {
-		value, valid := verdict.(string)
-		if !valid {
-			return false
-		}
-		value = strings.ToUpper(strings.TrimSpace(value))
-		if value != "ALLOW" && value != "ALLOWED" && value != "APPROVE" && value != "APPROVED" {
-			return false
-		}
+	verdict, exists := receipt["verdict"]
+	if !exists {
+		return directlyAccepted
 	}
-	return true
+	value, valid := verdict.(string)
+	if !valid {
+		return false
+	}
+	value = strings.ToUpper(strings.TrimSpace(value))
+	switch actionType {
+	case "policy_decision":
+		return value == "ALLOW" || value == "ALLOWED"
+	case "approval_action":
+		return value == "ALLOW" || value == "ALLOWED" || value == "APPROVE" || value == "APPROVED"
+	default:
+		return false
+	}
 }
 
 func receiptIsAncestor(receipts []map[string]interface{}, descendant, ancestor map[string]interface{}) bool {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -1,7 +1,7 @@
 // Package adversarial implements the 10 mandatory adversarial test suites
 // per §8.1 of the HELM Conformance Standard.
-// quantum_posture: this slice validates classical Ed25519 signature shape
-// only; cryptographic verification and post-quantum assurance are not claimed.
+// quantum_posture: campaign authorization and tool manifests use classical
+// Ed25519 verification; no post-quantum assurance is claimed.
 //
 // Each suite verifies that the system correctly handles a specific
 // adversarial scenario by checking EvidencePack artifacts for expected
@@ -9,11 +9,17 @@
 package adversarial
 
 import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 )
 
 // SuiteResult captures the outcome of an adversarial test suite.
@@ -40,19 +46,40 @@ type Suite struct {
 	Run  func(evidenceDir string) *SuiteResult
 }
 
+// VerificationOptions supplies trust roots from outside the candidate
+// EvidencePack. A signature embedded in the pack can never establish trust.
+type VerificationOptions struct {
+	CampaignPublicKeyHex string
+}
+
+// CampaignKeyID validates an Ed25519 campaign root and returns its stable ID.
+func CampaignKeyID(publicKeyHex string) (string, error) {
+	publicKey, err := hex.DecodeString(strings.TrimSpace(publicKeyHex))
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return "", fmt.Errorf("campaign public key must be a %d-byte Ed25519 key encoded as hex", ed25519.PublicKeySize)
+	}
+	digest := sha256.Sum256(publicKey)
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
+}
+
 // AllSuites returns the 10 mandatory adversarial test suites per §8.1.
 func AllSuites() []*Suite {
+	return AllSuitesWithOptions(VerificationOptions{})
+}
+
+// AllSuitesWithOptions binds suites to an external campaign trust root.
+func AllSuitesWithOptions(opts VerificationOptions) []*Suite {
 	return []*Suite{
 		adv01ReceiptGapInjection(),
-		adv02PolicyBypass(),
+		adv02PolicyBypass(opts),
 		adv03DAGFork(),
 		adv04BudgetOverdraft(),
 		adv05EnvelopeEscape(),
 		adv06TapeReplayTamper(),
 		adv07TenantCrossleak(),
-		adv08ToolManifestForge(),
+		adv08ToolManifestForge(opts),
 		adv09ReceiptEmissionPanicHijack(),
-		adv10HighFinalityUnsigned(),
+		adv10HighFinalityUnsigned(opts),
 	}
 }
 
@@ -69,26 +96,24 @@ func adv01ReceiptGapInjection() *Suite {
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
 
 			t := TestResult{TestID: "ADV-01-T1", Name: "Monotonic sequence with gap detection"}
-			if len(files) < 2 {
-				t.Pass = true
-				t.Reason = "insufficient receipts for gap test"
-			} else {
-				// Check that sequences are contiguous
-				seqs := loadSequenceNumbers(files)
-				gap := false
-				for i := 1; i < len(seqs); i++ {
-					if seqs[i]-seqs[i-1] > 1 {
-						gap = true
-						t.Evidence = fmt.Sprintf("gap between seq %d and %d", seqs[i-1], seqs[i])
-					}
-				}
-				if gap {
+			seqs := loadSequenceNumbers(files)
+			t.Pass = len(seqs) == len(files)
+			if !t.Pass {
+				t.Evidence = "one or more receipts have a missing or invalid seq"
+			} else if len(seqs) > 0 && seqs[0] != 1 {
+				t.Pass = false
+				t.Evidence = fmt.Sprintf("receipt sequence starts at %d instead of genesis sequence 1", seqs[0])
+			}
+			for i := 1; t.Pass && i < len(seqs); i++ {
+				if seqs[i] <= seqs[i-1] || seqs[i]-seqs[i-1] != 1 {
 					t.Pass = false
-					t.Reason = "RECEIPT_GAP_DETECTED"
-				} else {
-					t.Pass = true
-					t.Reason = "no gaps in receipt sequence"
+					t.Evidence = fmt.Sprintf("non-contiguous sequence between seq %d and %d", seqs[i-1], seqs[i])
 				}
+			}
+			if t.Pass {
+				t.Reason = "no gaps in receipt sequence"
+			} else {
+				t.Reason = "RECEIPT_GAP_DETECTED"
 			}
 			result.TestResults = append(result.TestResults, t)
 			result.Pass = t.Pass
@@ -99,7 +124,7 @@ func adv01ReceiptGapInjection() *Suite {
 
 // ADV-02: Policy Bypass
 // Verifies that all actions have a corresponding policy decision receipt.
-func adv02PolicyBypass() *Suite {
+func adv02PolicyBypass(opts VerificationOptions) *Suite {
 	return &Suite{
 		ID:   "ADV-02",
 		Name: "Policy Bypass Detection",
@@ -109,14 +134,14 @@ func adv02PolicyBypass() *Suite {
 			receiptsDir := filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts")
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
 
-			t := TestResult{TestID: "ADV-02-T1", Name: "All effect_attempt has preceding policy_decision"}
+			t := TestResult{TestID: "ADV-02-T1", Name: "All effect actions have preceding policy_decision"}
 			effectsWithoutPolicy := 0
 			for _, f := range files {
 				receipt := loadReceipt(f)
-				if receipt["action_type"] == "effect_attempt" {
-					// Check that a policy_decision exists for this decision_id
+				action, _ := receipt["action_type"].(string)
+				if isEffectAction(action) {
 					decisionID, _ := receipt["decision_id"].(string)
-					if decisionID == "" || !hasPolicyReceiptForDecision(files, decisionID) {
+					if decisionID == "" || !hasBoundAuthorizationReceipt(files, receipt, "policy_decision", opts) {
 						effectsWithoutPolicy++
 					}
 				}
@@ -339,7 +364,7 @@ func adv07TenantCrossleak() *Suite {
 
 // ADV-08: Tool Manifest Forge
 // Verifies tool manifests have valid signatures and required fields.
-func adv08ToolManifestForge() *Suite {
+func adv08ToolManifestForge(opts VerificationOptions) *Suite {
 	return &Suite{
 		ID:   "ADV-08",
 		Name: "Tool Manifest Forgery",
@@ -348,22 +373,22 @@ func adv08ToolManifestForge() *Suite {
 
 			files := toolManifestFiles(evidenceDir)
 
-			t := TestResult{TestID: "ADV-08-T1", Name: "Tool manifests have signatures field"}
+			t := TestResult{TestID: "ADV-08-T1", Name: "Tool manifests verify under the campaign trust root"}
 			unsigned := 0
 			for _, f := range files {
 				data, err := os.ReadFile(f)
 				var manifest map[string]interface{}
-				if err != nil || json.Unmarshal(data, &manifest) != nil || !hasStructuredSignatures(manifest) {
+				if err != nil || json.Unmarshal(data, &manifest) != nil || !verifyCampaignSignatures(manifest, "signatures", opts.CampaignPublicKeyHex) {
 					unsigned++
 					t.Evidence += fmt.Sprintf("invalid or unsigned: %s; ", filepath.Base(f))
 				}
 			}
 			if unsigned > 0 {
 				t.Pass = false
-				t.Reason = fmt.Sprintf("%d tool manifests without signatures", unsigned)
+				t.Reason = fmt.Sprintf("%d tool manifests invalid or without signatures", unsigned)
 			} else {
 				t.Pass = true
-				t.Reason = "all tool manifests signed"
+				t.Reason = "all tool manifests cryptographically verified"
 			}
 			result.TestResults = append(result.TestResults, t)
 			result.Pass = t.Pass
@@ -445,7 +470,7 @@ func adv09ReceiptEmissionPanicHijack() *Suite {
 
 // ADV-10: High-Finality Unsigned Action
 // Verifies that high-finality actions (delete, deploy, financial) have HITL approval receipts.
-func adv10HighFinalityUnsigned() *Suite {
+func adv10HighFinalityUnsigned(opts VerificationOptions) *Suite {
 	return &Suite{
 		ID:   "ADV-10",
 		Name: "High-Finality Unsigned Action",
@@ -466,7 +491,7 @@ func adv10HighFinalityUnsigned() *Suite {
 				// High-finality: E4 (irreversible) or E5 (catastrophic)
 				if isHighFinality(effectClass, action) {
 					decisionID, _ := receipt["decision_id"].(string)
-					if decisionID == "" || !hasApprovalForDecision(files, decisionID) {
+					if decisionID == "" || !hasBoundAuthorizationReceipt(files, receipt, "approval_action", opts) {
 						unsigned++
 						t.Evidence += fmt.Sprintf("unapproved high-finality: %s (class=%s); ", filepath.Base(f), effectClass)
 					}
@@ -508,30 +533,6 @@ func panicEvidenceFiles(evidenceDir string) []string {
 	return files
 }
 
-func hasStructuredSignatures(manifest map[string]interface{}) bool {
-	signatures, ok := manifest["signatures"].([]interface{})
-	if !ok || len(signatures) == 0 {
-		return false
-	}
-	for _, raw := range signatures {
-		signature, ok := raw.(map[string]interface{})
-		if !ok || signature["algorithm"] != "ed25519" {
-			return false
-		}
-		keyID, _ := signature["key_id"].(string)
-		value, _ := signature["signature"].(string)
-		if strings.TrimSpace(keyID) == "" || len(value) != 128 {
-			return false
-		}
-		for _, char := range value {
-			if !strings.ContainsRune("0123456789abcdefABCDEF", char) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 func loadReceipt(path string) map[string]interface{} {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -546,7 +547,7 @@ func loadSequenceNumbers(files []string) []uint64 {
 	var seqs []uint64
 	for _, f := range files {
 		receipt := loadReceipt(f)
-		if seq, ok := receipt["seq"].(float64); ok {
+		if seq, ok := receiptSequence(receipt); ok {
 			seqs = append(seqs, uint64(seq))
 		}
 	}
@@ -575,6 +576,171 @@ func hasApprovalForDecision(files []string, decisionID string) bool {
 		}
 	}
 	return false
+}
+
+func isEffectAction(action string) bool {
+	return action == "effect_attempt" || action == "tool_call" || action == "connector_call"
+}
+
+func hasBoundAuthorizationReceipt(files []string, effect map[string]interface{}, actionType string, opts VerificationOptions) bool {
+	receipts := make([]map[string]interface{}, 0, len(files))
+	for _, path := range files {
+		if receipt := loadReceipt(path); receipt != nil {
+			receipts = append(receipts, receipt)
+		}
+	}
+	return hasBoundAuthorization(receipts, effect, actionType, opts)
+}
+
+func hasBoundAuthorization(receipts []map[string]interface{}, effect map[string]interface{}, actionType string, opts VerificationOptions) bool {
+	effectSeq, ok := receiptSequence(effect)
+	if !ok || !hasNonEmptyString(effect, "decision_id") || !hasNonEmptyString(effect, "envelope_id") || !hasNonEmptyString(effect, "envelope_hash") {
+		return false
+	}
+	for _, receipt := range receipts {
+		if receipt["action_type"] != actionType || receipt["decision_id"] != effect["decision_id"] || receipt["envelope_id"] != effect["envelope_id"] || receipt["envelope_hash"] != effect["envelope_hash"] {
+			continue
+		}
+		if !authorizationReceiptAccepted(receipt, actionType) {
+			continue
+		}
+		seq, sequenced := receiptSequence(receipt)
+		if !sequenced || seq >= effectSeq || !receiptIsAncestor(receipts, effect, receipt) {
+			continue
+		}
+		if verifyCampaignSignatures(receipt, "campaign_signatures", opts.CampaignPublicKeyHex) {
+			return true
+		}
+	}
+	return false
+}
+
+func authorizationReceiptAccepted(receipt map[string]interface{}, actionType string) bool {
+	status, ok := receipt["status"].(string)
+	if !ok {
+		return false
+	}
+	status = strings.ToUpper(strings.TrimSpace(status))
+	accepted := false
+	switch actionType {
+	case "policy_decision":
+		accepted = status == "APPLIED" || status == "ALLOW" || status == "ALLOWED"
+	case "approval_action":
+		accepted = status == "APPLIED" || status == "APPROVED" || status == "ALLOW" || status == "ALLOWED"
+	}
+	if !accepted {
+		return false
+	}
+	if verdict, exists := receipt["verdict"]; exists {
+		value, valid := verdict.(string)
+		if !valid {
+			return false
+		}
+		value = strings.ToUpper(strings.TrimSpace(value))
+		if value != "ALLOW" && value != "ALLOWED" && value != "APPROVE" && value != "APPROVED" {
+			return false
+		}
+	}
+	return true
+}
+
+func receiptIsAncestor(receipts []map[string]interface{}, descendant, ancestor map[string]interface{}) bool {
+	ancestorID := receiptIdentity(ancestor)
+	if ancestorID == "" {
+		return false
+	}
+	index := make(map[string]map[string]interface{}, len(receipts)*2)
+	for _, receipt := range receipts {
+		if id, _ := receipt["receipt_id"].(string); id != "" {
+			index[id] = receipt
+		}
+		if hash, _ := receipt["receipt_hash"].(string); hash != "" {
+			index[hash] = receipt
+		}
+	}
+	queue := receiptParentRefs(descendant)
+	seen := map[string]bool{}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		if parent == ancestorID {
+			return true
+		}
+		if seen[parent] {
+			continue
+		}
+		seen[parent] = true
+		if receipt := index[parent]; receipt != nil {
+			queue = append(queue, receiptParentRefs(receipt)...)
+		}
+	}
+	return false
+}
+
+func receiptIdentity(receipt map[string]interface{}) string {
+	if value, _ := receipt["receipt_hash"].(string); value != "" {
+		return value
+	}
+	value, _ := receipt["receipt_id"].(string)
+	return value
+}
+
+func receiptParentRefs(receipt map[string]interface{}) []string {
+	raw, _ := receipt["parent_receipt_hashes"].([]interface{})
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if value, _ := item.(string); value != "" && value != "genesis" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func receiptSequence(receipt map[string]interface{}) (float64, bool) {
+	seq, ok := receipt["seq"].(float64)
+	return seq, ok && seq >= 0 && seq <= math.MaxUint64 && math.Trunc(seq) == seq
+}
+
+func hasNonEmptyString(value map[string]interface{}, key string) bool {
+	raw, ok := value[key].(string)
+	return ok && strings.TrimSpace(raw) != ""
+}
+
+func verifyCampaignSignatures(document map[string]interface{}, field, trustedPublicKeyHex string) bool {
+	publicKey, err := hex.DecodeString(strings.TrimSpace(trustedPublicKeyHex))
+	if err != nil || len(publicKey) != ed25519.PublicKeySize {
+		return false
+	}
+	rawSignatures, ok := document[field].([]interface{})
+	if !ok || len(rawSignatures) == 0 {
+		return false
+	}
+	payload := make(map[string]interface{}, len(document)-1)
+	for key, value := range document {
+		if key != field {
+			payload[key] = value
+		}
+	}
+	canonical, err := canonicalize.JCS(payload)
+	if err != nil {
+		return false
+	}
+	wantKeyID, err := CampaignKeyID(trustedPublicKeyHex)
+	if err != nil {
+		return false
+	}
+	for _, raw := range rawSignatures {
+		signature, ok := raw.(map[string]interface{})
+		if !ok || signature["algorithm"] != "ed25519" || signature["key_id"] != wantKeyID {
+			return false
+		}
+		signatureHex, _ := signature["signature"].(string)
+		signatureBytes, err := hex.DecodeString(strings.TrimPrefix(strings.TrimSpace(signatureHex), "hex:"))
+		if err != nil || len(signatureBytes) != ed25519.SignatureSize || !ed25519.Verify(ed25519.PublicKey(publicKey), canonical, signatureBytes) {
+			return false
+		}
+	}
+	return true
 }
 
 func isHighFinality(effectClass, actionType string) bool {

--- a/core/pkg/conform/adversarial/suites.go
+++ b/core/pkg/conform/adversarial/suites.go
@@ -151,15 +151,15 @@ func adv02PolicyBypass(opts VerificationOptions) *Suite {
 
 			receiptsDir := filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts")
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
+			receipts := loadReceipts(files)
 
 			t := TestResult{TestID: "ADV-02-T1", Name: "All effect actions have preceding policy_decision"}
 			effectsWithoutPolicy := 0
-			for _, f := range files {
-				receipt := loadReceipt(f)
+			for _, receipt := range receipts {
 				action, _ := receipt["action_type"].(string)
 				if isEffectAction(action) {
 					decisionID, _ := receipt["decision_id"].(string)
-					if decisionID == "" || !hasBoundAuthorizationReceipt(files, receipt, "policy_decision", opts) {
+					if decisionID == "" || !hasBoundAuthorization(receipts, receipt, "policy_decision", opts) {
 						effectsWithoutPolicy++
 					}
 				}
@@ -692,21 +692,21 @@ func adv10HighFinalityUnsigned(opts VerificationOptions) *Suite {
 
 			receiptsDir := filepath.Join(evidenceDir, "02_PROOFGRAPH", "receipts")
 			files, _ := filepath.Glob(filepath.Join(receiptsDir, "*.json"))
+			receipts := loadReceipts(files)
 
 			t := TestResult{TestID: "ADV-10-T1", Name: "High-finality effects require approval_action receipt"}
 
 			unsigned := 0
-			for _, f := range files {
-				receipt := loadReceipt(f)
+			for i, receipt := range receipts {
 				action, _ := receipt["action_type"].(string)
 				effectClass, _ := receipt["effect_class"].(string)
 
 				// High-finality: E4 (irreversible) or E5 (catastrophic)
 				if isHighFinality(effectClass, action) {
 					decisionID, _ := receipt["decision_id"].(string)
-					if decisionID == "" || !hasBoundAuthorizationReceipt(files, receipt, "approval_action", opts) {
+					if decisionID == "" || !hasBoundAuthorization(receipts, receipt, "approval_action", opts) {
 						unsigned++
-						t.Evidence += fmt.Sprintf("unapproved high-finality: %s (class=%s); ", filepath.Base(f), effectClass)
+						t.Evidence += fmt.Sprintf("unapproved high-finality: %s (class=%s); ", filepath.Base(files[i]), effectClass)
 					}
 				}
 			}
@@ -754,6 +754,14 @@ func loadReceipt(path string) map[string]interface{} {
 	var receipt map[string]interface{}
 	json.Unmarshal(data, &receipt) //nolint:errcheck
 	return receipt
+}
+
+func loadReceipts(files []string) []map[string]interface{} {
+	receipts := make([]map[string]interface{}, len(files))
+	for i, file := range files {
+		receipts[i] = loadReceipt(file)
+	}
+	return receipts
 }
 
 func loadSequenceNumbers(files []string) []uint64 {
@@ -805,16 +813,6 @@ func budgetScope(receipt map[string]interface{}) string {
 		return "budget_snapshot_ref:" + strings.TrimSpace(value)
 	}
 	return ""
-}
-
-func hasBoundAuthorizationReceipt(files []string, effect map[string]interface{}, actionType string, opts VerificationOptions) bool {
-	receipts := make([]map[string]interface{}, 0, len(files))
-	for _, path := range files {
-		if receipt := loadReceipt(path); receipt != nil {
-			receipts = append(receipts, receipt)
-		}
-	}
-	return hasBoundAuthorization(receipts, effect, actionType, opts)
 }
 
 func hasBoundAuthorization(receipts []map[string]interface{}, effect map[string]interface{}, actionType string, opts VerificationOptions) bool {

--- a/core/pkg/evidence/seal.go
+++ b/core/pkg/evidence/seal.go
@@ -492,6 +492,15 @@ func ComputeEvidencePackIndexRoots(packDir string) (EvidencePackIndexRoots, erro
 	return inventory.Roots, err
 }
 
+// VerifyEvidencePackIndexRoots verifies every indexed file, rejects unindexed
+// files, and returns the roots of the verified inventory. Callers that use the
+// result as an authorization boundary must compare it with roots obtained from
+// a separately trusted seal or canonical verification result.
+func VerifyEvidencePackIndexRoots(packDir string) (EvidencePackIndexRoots, error) {
+	inventory, err := computeEvidencePackInventory(packDir, true)
+	return inventory.Roots, err
+}
+
 func computeEvidencePackInventory(packDir string, verifyFiles bool, allowVerifiedConformanceSignature ...bool) (evidencePackInventory, error) {
 	indexPath := filepath.Join(packDir, "00_INDEX.json")
 	indexData, err := os.ReadFile(indexPath)

--- a/core/pkg/evidence/seal.go
+++ b/core/pkg/evidence/seal.go
@@ -503,6 +503,9 @@ func VerifyEvidencePackIndexRoots(packDir string) (EvidencePackIndexRoots, error
 
 func computeEvidencePackInventory(packDir string, verifyFiles bool, allowVerifiedConformanceSignature ...bool) (evidencePackInventory, error) {
 	indexPath := filepath.Join(packDir, "00_INDEX.json")
+	if err := rejectEvidencePackSymlinks(packDir, "00_INDEX.json"); err != nil {
+		return evidencePackInventory{}, fmt.Errorf("read 00_INDEX.json: %w", err)
+	}
 	indexData, err := os.ReadFile(indexPath)
 	if err != nil {
 		return evidencePackInventory{}, fmt.Errorf("read 00_INDEX.json: %w", err)
@@ -622,6 +625,9 @@ func verifyEvidencePackIndexedFiles(packDir string, entries []indexRootEntry) er
 
 func verifyEvidencePackIndexedFile(packDir string, entry indexRootEntry) error {
 	clean := filepath.Clean(entry.Path)
+	if err := rejectEvidencePackSymlinks(packDir, clean); err != nil {
+		return fmt.Errorf("inspect indexed file %s: %w", entry.Path, err)
+	}
 	actual, err := HashFile(filepath.Join(packDir, clean))
 	if err != nil {
 		return fmt.Errorf("hash indexed file %s: %w", entry.Path, err)
@@ -629,6 +635,21 @@ func verifyEvidencePackIndexedFile(packDir string, entry indexRootEntry) error {
 	expected := strings.TrimPrefix(strings.TrimSpace(entry.SHA256), "sha256:")
 	if !strings.EqualFold(strings.TrimPrefix(actual, "sha256:"), expected) {
 		return fmt.Errorf("indexed file hash mismatch for %s: index=sha256:%s current=%s", entry.Path, expected, actual)
+	}
+	return nil
+}
+
+func rejectEvidencePackSymlinks(packDir, rel string) error {
+	path := packDir
+	for _, component := range strings.Split(filepath.Clean(rel), string(filepath.Separator)) {
+		path = filepath.Join(path, component)
+		info, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("evidence pack path is a symlink: %s", filepath.ToSlash(rel))
+		}
 	}
 	return nil
 }

--- a/core/pkg/evidence/seal_edge_coverage_test.go
+++ b/core/pkg/evidence/seal_edge_coverage_test.go
@@ -52,6 +52,44 @@ func TestEvidencePackSealIndexRootEdgeCases(t *testing.T) {
 	}
 }
 
+func TestVerifyEvidencePackIndexRootsChecksTheCompleteInventory(t *testing.T) {
+	dir := t.TempDir()
+	artifactPath := filepath.Join(dir, "01_SCORE.json")
+	if err := os.WriteFile(artifactPath, []byte(`{"score":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeSealTestIndex(t, dir, []string{"01_SCORE.json"})
+
+	computed, err := ComputeEvidencePackIndexRoots(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := VerifyEvidencePackIndexRoots(dir)
+	if err != nil {
+		t.Fatalf("verify indexed inventory: %v", err)
+	}
+	if verified != computed {
+		t.Fatalf("verified roots=%+v, computed roots=%+v", verified, computed)
+	}
+
+	if err := os.WriteFile(artifactPath, []byte(`{"score":2}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyEvidencePackIndexRoots(dir); err == nil || !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("tampered indexed file error=%v, want hash mismatch", err)
+	}
+
+	if err := os.WriteFile(artifactPath, []byte(`{"score":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "unindexed.json"), []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := VerifyEvidencePackIndexRoots(dir); err == nil || !strings.Contains(err.Error(), "unindexed evidence pack file") {
+		t.Fatalf("unindexed file error=%v, want fail-closed rejection", err)
+	}
+}
+
 func TestFileDevEvidenceSignerParseEdges(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := FileDevEvidenceKeyPath(dir)

--- a/core/pkg/evidence/seal_edge_coverage_test.go
+++ b/core/pkg/evidence/seal_edge_coverage_test.go
@@ -1,5 +1,8 @@
 package evidence
 
+// quantum_posture: these fixtures use SHA-256 and classical Ed25519 only to
+// exercise existing EvidencePack integrity behavior; no PQ assurance is made.
+
 import (
 	"context"
 	"crypto/ed25519"

--- a/core/pkg/evidence/seal_edge_coverage_test.go
+++ b/core/pkg/evidence/seal_edge_coverage_test.go
@@ -93,6 +93,55 @@ func TestVerifyEvidencePackIndexRootsChecksTheCompleteInventory(t *testing.T) {
 	}
 }
 
+func TestVerifyEvidencePackIndexRootsRejectsSymlinkPaths(t *testing.T) {
+	t.Run("indexed file", func(t *testing.T) {
+		dir := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "outside.json")
+		if err := os.WriteFile(outside, []byte(`{"score":1}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(dir, "01_SCORE.json")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		writeSealTestIndex(t, dir, []string{"01_SCORE.json"})
+
+		if _, err := VerifyEvidencePackIndexRoots(dir); err == nil || !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("indexed symlink error=%v, want symlink rejection", err)
+		}
+	})
+
+	t.Run("indexed directory", func(t *testing.T) {
+		dir := t.TempDir()
+		outside := t.TempDir()
+		if err := os.WriteFile(filepath.Join(outside, "01_SCORE.json"), []byte(`{"score":1}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(dir, "nested")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		writeSealTestIndex(t, dir, []string{"nested/01_SCORE.json"})
+
+		if _, err := VerifyEvidencePackIndexRoots(dir); err == nil || !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("indexed directory symlink error=%v, want symlink rejection", err)
+		}
+	})
+
+	t.Run("index file", func(t *testing.T) {
+		dir := t.TempDir()
+		outside := filepath.Join(t.TempDir(), "index.json")
+		if err := os.WriteFile(outside, []byte(`{"entries":[]}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(dir, "00_INDEX.json")); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+
+		if _, err := VerifyEvidencePackIndexRoots(dir); err == nil || !strings.Contains(err.Error(), "symlink") {
+			t.Fatalf("index symlink error=%v, want symlink rejection", err)
+		}
+	})
+}
+
 func TestFileDevEvidenceSignerParseEdges(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := FileDevEvidenceKeyPath(dir)


### PR DESCRIPTION
## Outcome

Adds source-owned differential coverage proof for all ten mandatory Kernel adversarial suites. Each check now requires:

- the expected detector test to pass on the unchanged positive control;
- a versioned deterministic negative mutation;
- that exact detector test ID to reject the mutant;
- byte-for-byte restoration before the next suite.

All coverage and aggregate execution runs inside one symlink-safe snapshot bounded to 4096 entries and 32 MiB. Before any detector runs, the snapshot verifies every indexed file, rejects unindexed files, and must exactly match externally supplied canonical verification roots: index hash, Merkle root, and entry count. Snapshot creation also hashes bytes during copy, then reopens and re-hashes the same inode with post-copy size and metadata checks, rejecting torn same-size rewrites.

Baseline suite results are reused, so the implementation performs one bounded pack copy and one baseline plus one mutant execution per suite. Oversized, changing, symlinked, non-regular, unindexed, hash-mismatched, or stale-root input fails closed before detector reads. A failed byte-for-byte mutation restore poisons the workspace and blocks later mutation probes.

This closes vacuous coverage, full-pack copy amplification, torn-read, and canonical-verifier versus detector split-view paths. Expected EvidencePack roots are operator-controlled inputs; they are never derived from the candidate by the adversarial runner. A separately verified detached conformance signature may be explicitly omitted from the detector workspace because no detector consumes it; every other unindexed file remains fail-closed.

This remains the first independently reviewable HELM-206 production slice. Later source-owned slices add the strict CLI, campaign/run-bound signed report verification, release identity, clean-room runner orchestration, and deployment. No merge authority or production activation is changed here.

## Validation

- go test ./...
- go test -race ./pkg/evidence ./pkg/conform/adversarial
- go vet ./pkg/evidence ./pkg/conform/adversarial
- make quantum-crypto-inventory
- make docs-truth
- git diff --check

Exact head validated locally: ead1cdf1d4dfea78b3fac0861e378bceb1fc76b8

Linear: HELM-206
Program: HELM-205

---

Replacement note (2026-07-18): this PR is superseded by a replacement branch/PR created from the same signed local commit set plus a local signed merge of current main, to avoid the unsigned GitHub update-branch merge commit without force-pushing this branch.

Supersedes: #583
Replacement exact head: a55feec6c7d93dcdc05b50c8761db28ede59ef81
