### PR TITLE
HELM-303: bind governance fields into the receipt/decision signatures (preimage V5 / decision V2)

### DIFF
--- a/core/pkg/contracts/decision.go
+++ b/core/pkg/contracts/decision.go
@@ -60,6 +60,12 @@ type DecisionRecord struct {
 	RequirementSetHash string    `json:"requirement_set_hash,omitempty"`
 	Signature          string    `json:"signature"`
 	SignatureType      string    `json:"signature_type"`
+	// SignatureVersion names the signing-preimage revision (HELM-303). Empty =
+	// legacy (free-text Reason in the preimage, ReasonCode absent).
+	// DecisionRecordSignatureV2 signs the machine-readable ReasonCode instead
+	// of prose: the field every downstream consumer keys on is the one the
+	// signature attests.
+	SignatureVersion   string    `json:"signature_version,omitempty"`
 	Timestamp          time.Time `json:"timestamp"`
 
 	// Intervention Metadata (Temporal Guardian)
@@ -133,6 +139,10 @@ const VerdictPending = "PENDING"
 // AuthorizedExecutionIntentSignatureV2 binds the full authority window and
 // portable effect semantics. Unversioned legacy intents are never executable.
 const AuthorizedExecutionIntentSignatureV2 = "authorized_execution_intent.v2"
+
+// DecisionRecordSignatureV2 marks the HELM-303 decision preimage: ReasonCode
+// replaces free-text Reason in the signed payload.
+const DecisionRecordSignatureV2 = "decision_record.v2"
 
 // AuthorizedExecutionIntent represents a derived, signed intent to execute a specific effect.
 // It decouples the "Permission" (Decision) from "Action" (Execution). (Sequence 8)

--- a/core/pkg/contracts/receipt.go
+++ b/core/pkg/contracts/receipt.go
@@ -34,6 +34,14 @@ type Receipt struct {
 	LamportClock uint64 `json:"lamport_clock"`       // Monotonic logical clock per session
 	ArgsHash     string `json:"args_hash,omitempty"` // SHA-256 of JCS-canonicalized tool args bound at the PEP boundary
 
+	// SignatureVersion names the signing-preimage revision this receipt's
+	// Signature was computed over (HELM-303). Empty = the legacy V4 preimage
+	// (receipt_id, decision_id, effect_id, status, output_hash, prev_hash,
+	// lamport, args_hash). ReceiptSignatureV5 additionally binds verdict,
+	// reason_code, policy_hash and session_id, so the governance meaning of a
+	// receipt can no longer be rewritten without invalidating its signature.
+	SignatureVersion string `json:"signature_version,omitempty"`
+
 	// Receipt-as-First-Class Artifact Extensions
 	ReplayScript     *ReplayScriptRef   `json:"replay_script,omitempty"`     // Link to deterministic replay script
 	Provenance       *ReceiptProvenance `json:"provenance,omitempty"`        // Chain of custody
@@ -148,3 +156,12 @@ type WitnessSignature struct {
 	WitnessID string `json:"witness_id"`
 	Signature string `json:"signature"`
 }
+
+// ReceiptSignatureV5 marks the HELM-303 signing preimage: the legacy V4
+// fields plus verdict, reason_code, policy_hash and session_id. The
+// emergency/safe_dep tail stays deliberately outside the receipt preimage —
+// emergency authority is already signature-bound via the V2
+// AuthorizedExecutionIntent preimage, and double-binding it here would force
+// a receipt re-sign on every intent-side evolution. Revisit in V6 only with
+// a concrete threat that the intent binding does not already cover.
+const ReceiptSignatureV5 = "receipt.v5"

--- a/core/pkg/crypto/canonical.go
+++ b/core/pkg/crypto/canonical.go
@@ -153,3 +153,76 @@ type authorizedExecutionIntentSigningEnvelope struct {
 func CanonicalizeReceipt(receiptID, decisionID, effectID, status, outputHash, prevHash string, lamportClock uint64, argsHash string) string {
 	return fmt.Sprintf("%s%s%s%s%s%s%s%s%s%s%s%s%d%s%s", receiptID, SigSeparator, decisionID, SigSeparator, effectID, SigSeparator, status, SigSeparator, outputHash, SigSeparator, prevHash, SigSeparator, lamportClock, SigSeparator, argsHash)
 }
+
+// --- HELM-303: V5 receipt / V2 decision signing preimages -----------------
+
+// CanonicalizeReceiptV5 extends the V4 preimage with the receipt's
+// governance-meaning fields: verdict, reason_code, policy_hash, session_id.
+// With V4, those fields could be rewritten on a persisted receipt without
+// invalidating its signature (the chain made it tamper-evident only once a
+// successor existed; the chain tip was signature-silent). Field order is
+// fixed and versioned; never reorder within a version.
+func CanonicalizeReceiptV5(r *contracts.Receipt) string {
+	v4 := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	return fmt.Sprintf("%s%s%s%s%s%s%s%s%s%s%s", v4,
+		SigSeparator, contracts.ReceiptSignatureV5,
+		SigSeparator, r.Verdict,
+		SigSeparator, r.ReasonCode,
+		SigSeparator, r.PolicyHash,
+		SigSeparator, r.SessionID)
+}
+
+// ReceiptSigningPayload stamps the receipt with the current preimage version
+// and returns the payload to sign. All signers must use this instead of
+// calling a Canonicalize* function directly, so a new preimage revision is a
+// one-line change here rather than an eight-site hunt.
+func ReceiptSigningPayload(r *contracts.Receipt) string {
+	r.SignatureVersion = contracts.ReceiptSignatureV5
+	return CanonicalizeReceiptV5(r)
+}
+
+// ReceiptVerifyPayload reconstructs the signed payload according to the
+// receipt's declared preimage version. Empty = legacy V4 (receipts signed
+// before HELM-303 stay verifiable under the preimage they were signed over);
+// unknown versions are rejected rather than guessed.
+func ReceiptVerifyPayload(r *contracts.Receipt) (string, error) {
+	switch r.SignatureVersion {
+	case "":
+		return CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash), nil
+	case contracts.ReceiptSignatureV5:
+		return CanonicalizeReceiptV5(r), nil
+	default:
+		return "", fmt.Errorf("unsupported receipt signature version %q", r.SignatureVersion)
+	}
+}
+
+// CanonicalizeDecisionV2 signs the machine-readable ReasonCode in place of
+// free-text Reason: the exported, keyed-on field is the attested one, and
+// prose (which the telemetry contract prohibits from export) leaves the
+// preimage entirely.
+func CanonicalizeDecisionV2(id, verdict, reasonCode, phenotypeHash, policyContentHash, effectDigest string) string {
+	return fmt.Sprintf("%s%s%s%s%s%s%s%s%s%s%s%s%s",
+		contracts.DecisionRecordSignatureV2, SigSeparator,
+		id, SigSeparator, verdict, SigSeparator, reasonCode, SigSeparator,
+		phenotypeHash, SigSeparator, policyContentHash, SigSeparator, effectDigest)
+}
+
+// DecisionSigningPayload stamps the record with the current preimage version
+// and returns the payload to sign.
+func DecisionSigningPayload(d *contracts.DecisionRecord) string {
+	d.SignatureVersion = contracts.DecisionRecordSignatureV2
+	return CanonicalizeDecisionV2(d.ID, d.Verdict, d.ReasonCode, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+}
+
+// DecisionVerifyPayload reconstructs the signed payload per the record's
+// declared preimage version; empty = legacy (free-text Reason).
+func DecisionVerifyPayload(d *contracts.DecisionRecord) (string, error) {
+	switch d.SignatureVersion {
+	case "":
+		return CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest), nil
+	case contracts.DecisionRecordSignatureV2:
+		return CanonicalizeDecisionV2(d.ID, d.Verdict, d.ReasonCode, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest), nil
+	default:
+		return "", fmt.Errorf("unsupported decision signature version %q", d.SignatureVersion)
+	}
+}

--- a/core/pkg/crypto/canonical_hardening_test.go
+++ b/core/pkg/crypto/canonical_hardening_test.go
@@ -46,7 +46,11 @@ func TestCanonicalizeDecision_FullBinding(t *testing.T) {
 	}{
 		{"ID", func(d *contracts.DecisionRecord) { d.ID = "dec-TAMPERED" }},
 		{"Verdict", func(d *contracts.DecisionRecord) { d.Verdict = "FAIL" }},
-		{"Reason", func(d *contracts.DecisionRecord) { d.Reason = "Tampered reason" }},
+		// HELM-303 preimage V2: the attested reason field is the
+		// machine-readable ReasonCode; free-text Reason left the preimage
+		// deliberately (prose is prohibited from export and must not carry
+		// the signed claim). See TestCanonicalizeDecisionV2_ReasonNotBound.
+		{"ReasonCode", func(d *contracts.DecisionRecord) { d.ReasonCode = "TAMPERED_CODE" }},
 		{"PhenotypeHash", func(d *contracts.DecisionRecord) { d.PhenotypeHash = "sha256:deadbeef" }},
 		{"PolicyContentHash", func(d *contracts.DecisionRecord) { d.PolicyContentHash = "sha256:YYYY" }},
 		{"EffectDigest", func(d *contracts.DecisionRecord) { d.EffectDigest = "sha256:ZZZZ" }},
@@ -90,5 +94,28 @@ func TestCanonicalizeDecision_EmptyFields(t *testing.T) {
 	ok, err := signer.VerifyDecision(d)
 	if err != nil || !ok {
 		t.Fatalf("signature should verify with empty optional fields: ok=%v err=%v", ok, err)
+	}
+}
+
+
+// TestCanonicalizeDecisionV2_ReasonNotBound pins the HELM-303 semantics
+// change explicitly: mutating free-text Reason on a V2-signed record does NOT
+// invalidate the signature — ReasonCode is the attested claim.
+func TestCanonicalizeDecisionV2_ReasonNotBound(t *testing.T) {
+	signer, err := NewEd25519Signer("drift7-v2-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := &contracts.DecisionRecord{ID: "dec-v2", Verdict: "DENY", Reason: "human words", ReasonCode: "POLICY_DENY"}
+	if err := signer.SignDecision(d); err != nil {
+		t.Fatal(err)
+	}
+	if d.SignatureVersion != contracts.DecisionRecordSignatureV2 {
+		t.Fatalf("expected V2 signature version, got %q", d.SignatureVersion)
+	}
+	d.Reason = "different human words"
+	ok, err := signer.VerifyDecision(d)
+	if err != nil || !ok {
+		t.Fatalf("Reason mutation must not invalidate a V2 signature (ok=%v err=%v)", ok, err)
 	}
 }

--- a/core/pkg/crypto/hybrid_signer.go
+++ b/core/pkg/crypto/hybrid_signer.go
@@ -101,7 +101,7 @@ func (h *HybridSigner) PublicKeyBytes() []byte {
 // The composite signature is stored in d.Signature and the SignatureType is
 // set to "Hybrid-Ed25519-MLDSA65:<keyID>".
 func (h *HybridSigner) SignDecision(d *contracts.DecisionRecord) error {
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload := DecisionSigningPayload(d)
 	sig, err := h.Sign([]byte(payload))
 	if err != nil {
 		return err
@@ -127,7 +127,7 @@ func (h *HybridSigner) SignIntent(i *contracts.AuthorizedExecutionIntent) error 
 
 // SignReceipt signs a Receipt using both Ed25519 and ML-DSA-65.
 func (h *HybridSigner) SignReceipt(r *contracts.Receipt) error {
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload := ReceiptSigningPayload(r)
 	sig, err := h.Sign([]byte(payload))
 	if err != nil {
 		return err

--- a/core/pkg/crypto/hybrid_signer_test.go
+++ b/core/pkg/crypto/hybrid_signer_test.go
@@ -151,7 +151,8 @@ func TestHybridSigner_SignDecision(t *testing.T) {
 	assert.Equal(t, expectedSigType, d.SignatureType)
 
 	// Verify the composite signature
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload, err := DecisionVerifyPayload(d)
+	require.NoError(t, err)
 	valid, err := signer.Verify([]byte(payload), d.Signature)
 	require.NoError(t, err)
 	assert.True(t, valid, "hybrid decision signature should verify")
@@ -227,14 +228,16 @@ func TestHybridSigner_SignReceiptRoundTrip(t *testing.T) {
 	assert.Equal(t, signer.MLDSASigner().PublicKey(), receipt.PublicKeySet[SigPrefixMLDSA65])
 
 	// Verify round-trip
-	payload := CanonicalizeReceipt(receipt.ReceiptID, receipt.DecisionID, receipt.EffectID, receipt.Status, receipt.OutputHash, receipt.PrevHash, receipt.LamportClock, receipt.ArgsHash)
+	payload, err := ReceiptVerifyPayload(receipt)
+	require.NoError(t, err)
 	valid, err := signer.Verify([]byte(payload), receipt.Signature)
 	require.NoError(t, err)
 	assert.True(t, valid, "receipt hybrid signature should verify")
 
 	// Tamper the status
 	receipt.Status = "FAILED"
-	payloadTampered := CanonicalizeReceipt(receipt.ReceiptID, receipt.DecisionID, receipt.EffectID, receipt.Status, receipt.OutputHash, receipt.PrevHash, receipt.LamportClock, receipt.ArgsHash)
+	payloadTampered, err := ReceiptVerifyPayload(receipt)
+	require.NoError(t, err)
 	valid, err = signer.Verify([]byte(payloadTampered), receipt.Signature)
 	require.NoError(t, err)
 	assert.False(t, valid, "should fail for tampered receipt")

--- a/core/pkg/crypto/hybrid_verifier.go
+++ b/core/pkg/crypto/hybrid_verifier.go
@@ -62,7 +62,10 @@ func (v *HybridVerifier) Verify(message []byte, signature []byte) bool {
 
 // VerifyDecision verifies a hybrid-signed DecisionRecord.
 func (v *HybridVerifier) VerifyDecision(d *contracts.DecisionRecord) (bool, error) {
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload, perr := DecisionVerifyPayload(d)
+	if perr != nil {
+		return false, perr
+	}
 	return v.verifyEnvelope([]byte(payload), d.Signature)
 }
 
@@ -78,7 +81,10 @@ func (v *HybridVerifier) VerifyIntent(i *contracts.AuthorizedExecutionIntent) (b
 // VerifyReceipt verifies a hybrid-signed Receipt over the canonical receipt
 // preimage (same preimage as the classical profile).
 func (v *HybridVerifier) VerifyReceipt(r *contracts.Receipt) (bool, error) {
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload, perr := ReceiptVerifyPayload(r)
+	if perr != nil {
+		return false, perr
+	}
 	return v.verifyEnvelope([]byte(payload), r.Signature)
 }
 
@@ -171,7 +177,10 @@ func VerifyReceiptProfile(edPubHex, mldsaPubHex string, r *contracts.Receipt) (p
 	default:
 		return profile, false, fmt.Errorf("unsupported receipt signature algorithm %q", r.SignatureAlgorithm)
 	}
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload, perr := ReceiptVerifyPayload(r)
+	if perr != nil {
+		return profile, false, perr
+	}
 
 	switch profile {
 	case ReceiptProfileHybrid:

--- a/core/pkg/crypto/mldsa_signer.go
+++ b/core/pkg/crypto/mldsa_signer.go
@@ -79,7 +79,7 @@ func (s *MLDSASigner) Verify(message []byte, signature []byte) bool {
 
 // SignDecision signs a DecisionRecord using ML-DSA-65.
 func (s *MLDSASigner) SignDecision(d *contracts.DecisionRecord) error {
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload := DecisionSigningPayload(d)
 	sig, err := s.Sign([]byte(payload))
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func (s *MLDSASigner) SignIntent(i *contracts.AuthorizedExecutionIntent) error {
 
 // SignReceipt signs a Receipt using ML-DSA-65.
 func (s *MLDSASigner) SignReceipt(r *contracts.Receipt) error {
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload := ReceiptSigningPayload(r)
 	sig, err := s.Sign([]byte(payload))
 	if err != nil {
 		return err
@@ -123,7 +123,10 @@ func (s *MLDSASigner) VerifyDecision(d *contracts.DecisionRecord) (bool, error) 
 	if d.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload, perr := DecisionVerifyPayload(d)
+	if perr != nil {
+		return false, perr
+	}
 	sig, err := hex.DecodeString(d.Signature)
 	if err != nil {
 		return false, fmt.Errorf("invalid signature hex: %w", err)
@@ -152,7 +155,10 @@ func (s *MLDSASigner) VerifyReceipt(r *contracts.Receipt) (bool, error) {
 	if r.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload, perr := ReceiptVerifyPayload(r)
+	if perr != nil {
+		return false, perr
+	}
 	sig, err := hex.DecodeString(r.Signature)
 	if err != nil {
 		return false, fmt.Errorf("invalid signature hex: %w", err)

--- a/core/pkg/crypto/mldsa_signer_test.go
+++ b/core/pkg/crypto/mldsa_signer_test.go
@@ -108,11 +108,18 @@ func TestMLDSASigner_SignDecision(t *testing.T) {
 		t.Error("VerifyDecision returned false for valid decision")
 	}
 
-	// Tampered decision must fail
+	// HELM-303 (preimage V2): the machine-readable ReasonCode is attested;
+	// free-text Reason deliberately is NOT (prose is prohibited from export
+	// and must not be the signed claim).
 	d.Reason = "I changed this"
+	valid, err = signer.VerifyDecision(d)
+	if err != nil || !valid {
+		t.Error("Reason is not part of the V2 preimage; mutating it must not invalidate")
+	}
+	d.ReasonCode = "TAMPERED_CODE"
 	valid, _ = signer.VerifyDecision(d)
 	if valid {
-		t.Error("VerifyDecision accepted tampered decision")
+		t.Error("Tampered ReasonCode accepted")
 	}
 }
 

--- a/core/pkg/crypto/mldsa_verifier.go
+++ b/core/pkg/crypto/mldsa_verifier.go
@@ -38,7 +38,10 @@ func (v *MLDSAVerifier) VerifyDecision(d *contracts.DecisionRecord) (bool, error
 	if d.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload, perr := DecisionVerifyPayload(d)
+	if perr != nil {
+		return false, perr
+	}
 	sig, err := hex.DecodeString(d.Signature)
 	if err != nil {
 		return false, fmt.Errorf("invalid signature hex: %w", err)
@@ -67,7 +70,10 @@ func (v *MLDSAVerifier) VerifyReceipt(r *contracts.Receipt) (bool, error) {
 	if r.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload, perr := ReceiptVerifyPayload(r)
+	if perr != nil {
+		return false, perr
+	}
 	sig, err := hex.DecodeString(r.Signature)
 	if err != nil {
 		return false, fmt.Errorf("invalid signature hex: %w", err)

--- a/core/pkg/crypto/receipt_v5_test.go
+++ b/core/pkg/crypto/receipt_v5_test.go
@@ -1,0 +1,116 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func v5TestReceipt() *contracts.Receipt {
+	return &contracts.Receipt{
+		ReceiptID:  "rcpt-1",
+		DecisionID: "dec-1",
+		EffectID:   "eff-1",
+		Status:     "EXECUTED",
+		OutputHash: "sha256:out",
+		PrevHash:   "sha256:prev",
+		LamportClock: 7,
+		ArgsHash:   "sha256:args",
+		Verdict:    "ALLOW",
+		ReasonCode: "POLICY_ALLOW",
+		PolicyHash: "sha256:policy",
+		SessionID:  "sess-1",
+	}
+}
+
+// The HELM-303 headline: governance-meaning fields can no longer be rewritten
+// on a persisted receipt without invalidating its signature — including on the
+// chain tip, with no successor receipt.
+func TestReceiptV5_GovernanceFieldsAreSignatureBound(t *testing.T) {
+	signer, err := NewEd25519Signer("v5-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := NewEd25519Verifier(signer.PublicKeyBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tampers := map[string]func(r *contracts.Receipt){
+		"Verdict":    func(r *contracts.Receipt) { r.Verdict = "DENY" },
+		"ReasonCode": func(r *contracts.Receipt) { r.ReasonCode = "TAMPERED" },
+		"PolicyHash": func(r *contracts.Receipt) { r.PolicyHash = "sha256:evil" },
+		"SessionID":  func(r *contracts.Receipt) { r.SessionID = "sess-evil" },
+	}
+	for name, tamper := range tampers {
+		t.Run(name, func(t *testing.T) {
+			r := v5TestReceipt()
+			if err := signer.SignReceipt(r); err != nil {
+				t.Fatal(err)
+			}
+			if r.SignatureVersion != contracts.ReceiptSignatureV5 {
+				t.Fatalf("signer must stamp V5, got %q", r.SignatureVersion)
+			}
+			if ok, err := verifier.VerifyReceipt(r); err != nil || !ok {
+				t.Fatalf("untampered V5 receipt must verify (ok=%v err=%v)", ok, err)
+			}
+			tamper(r)
+			if ok, _ := verifier.VerifyReceipt(r); ok {
+				t.Fatalf("tampered %s verified — field not bound", name)
+			}
+		})
+	}
+}
+
+// Receipts signed before HELM-303 (no signature_version) keep verifying under
+// the legacy V4 preimage: dual-verify, no re-signing of history.
+func TestReceiptLegacyV4StillVerifies(t *testing.T) {
+	signer, err := NewEd25519Signer("legacy-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := NewEd25519Verifier(signer.PublicKeyBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := v5TestReceipt()
+	// Sign the way a pre-HELM-303 kernel did: legacy preimage, no version.
+	legacyPayload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	sig, err := signer.Sign([]byte(legacyPayload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Signature = sig
+	r.SignatureVersion = ""
+
+	if ok, err := verifier.VerifyReceipt(r); err != nil || !ok {
+		t.Fatalf("legacy receipt must keep verifying (ok=%v err=%v)", ok, err)
+	}
+	// And the documented legacy hole stays visible: verdict mutation on a
+	// legacy receipt does NOT break its signature (it breaks the chain hash
+	// instead) — that asymmetry is exactly what V5 closes.
+	r.Verdict = "DENY"
+	if ok, _ := verifier.VerifyReceipt(r); !ok {
+		t.Fatal("legacy preimage does not bind Verdict; verification should still pass")
+	}
+}
+
+func TestReceiptUnknownVersionRejected(t *testing.T) {
+	signer, err := NewEd25519Signer("unk-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := NewEd25519Verifier(signer.PublicKeyBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := v5TestReceipt()
+	if err := signer.SignReceipt(r); err != nil {
+		t.Fatal(err)
+	}
+	r.SignatureVersion = "receipt.v99"
+	if ok, err := verifier.VerifyReceipt(r); err == nil || ok {
+		t.Fatalf("unknown preimage version must be rejected (ok=%v err=%v)", ok, err)
+	}
+}

--- a/core/pkg/crypto/signer.go
+++ b/core/pkg/crypto/signer.go
@@ -117,7 +117,7 @@ func (s *Ed25519Signer) Verify(message []byte, signature []byte) bool {
 // SignDecision signs a DecisionRecord
 func (s *Ed25519Signer) SignDecision(d *contracts.DecisionRecord) error {
 	// Canonicalize for signing
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload := DecisionSigningPayload(d)
 	sig, err := s.Sign([]byte(payload))
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func (s *Ed25519Signer) SignIntent(i *contracts.AuthorizedExecutionIntent) error
 // SignReceipt signs a Receipt
 func (s *Ed25519Signer) SignReceipt(r *contracts.Receipt) error {
 	// Canonicalize: ID:DecisionID:EffectID:Status:OutputHash
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload := ReceiptSigningPayload(r)
 	sig, err := s.Sign([]byte(payload))
 	if err != nil {
 		return err
@@ -161,7 +161,10 @@ func (s *Ed25519Signer) VerifyDecision(d *contracts.DecisionRecord) (bool, error
 	if d.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload, perr := DecisionVerifyPayload(d)
+	if perr != nil {
+		return false, perr
+	}
 	return Verify(s.PublicKey(), d.Signature, []byte(payload))
 }
 
@@ -180,7 +183,10 @@ func (s *Ed25519Signer) VerifyReceipt(r *contracts.Receipt) (bool, error) {
 	if r.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload, perr := ReceiptVerifyPayload(r)
+	if perr != nil {
+		return false, perr
+	}
 	return Verify(s.PublicKey(), r.Signature, []byte(payload))
 }
 

--- a/core/pkg/crypto/signer_test.go
+++ b/core/pkg/crypto/signer_test.go
@@ -35,10 +35,17 @@ func TestSigner_Integrity(t *testing.T) {
 		t.Error("Valid decision rejected")
 	}
 
-	// 3. Verify Tampered
+	// HELM-303 (preimage V2): the machine-readable ReasonCode is attested;
+	// free-text Reason deliberately is NOT (prose is prohibited from export
+	// and must not be the signed claim).
 	decision.Reason = "I changed this"
+	valid, err = signer.VerifyDecision(decision)
+	if err != nil || !valid {
+		t.Error("Reason is not part of the V2 preimage; mutating it must not invalidate")
+	}
+	decision.ReasonCode = "TAMPERED_CODE"
 	valid, _ = signer.VerifyDecision(decision)
 	if valid {
-		t.Error("Tampered decision accepted")
+		t.Error("Tampered ReasonCode accepted")
 	}
 }

--- a/core/pkg/crypto/verifier.go
+++ b/core/pkg/crypto/verifier.go
@@ -58,7 +58,10 @@ func (v *Ed25519Verifier) VerifyDecision(d *contracts.DecisionRecord) (bool, err
 	if d.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeDecision(d.ID, d.Verdict, d.Reason, d.PhenotypeHash, d.PolicyContentHash, d.EffectDigest)
+	payload, perr := DecisionVerifyPayload(d)
+	if perr != nil {
+		return false, perr
+	}
 	sig, err := hex.DecodeString(d.Signature)
 	if err != nil {
 		return false, err
@@ -85,7 +88,10 @@ func (v *Ed25519Verifier) VerifyReceipt(r *contracts.Receipt) (bool, error) {
 	if r.Signature == "" {
 		return false, fmt.Errorf("missing signature")
 	}
-	payload := CanonicalizeReceipt(r.ReceiptID, r.DecisionID, r.EffectID, r.Status, r.OutputHash, r.PrevHash, r.LamportClock, r.ArgsHash)
+	payload, perr := ReceiptVerifyPayload(r)
+	if perr != nil {
+		return false, perr
+	}
 	sig, err := hex.DecodeString(r.Signature)
 	if err != nil {
 		return false, err

--- a/core/pkg/verifier/verifier.go
+++ b/core/pkg/verifier/verifier.go
@@ -498,7 +498,11 @@ func verifyEd25519CanonicalReceipt(document map[string]any, sig, keyHex string) 
 		lamport = *v
 	}
 	// Mirrors crypto.CanonicalizeReceipt — receipt_id:decision_id:effect_id:
-	// status:output_hash:prev_hash:lamport_clock:args_hash.
+	// status:output_hash:prev_hash:lamport_clock:args_hash — and, when the
+	// document declares signature_version "receipt.v5" (HELM-303), the V5
+	// tail: :receipt.v5:verdict:reason_code:policy_hash:session_id
+	// (crypto.CanonicalizeReceiptV5). Unknown versions fail verification
+	// rather than fall back to a preimage the signer never produced.
 	payload := fmt.Sprintf("%s:%s:%s:%s:%s:%s:%d:%s",
 		firstString(document, "receipt_id"),
 		firstString(document, "decision_id"),
@@ -509,6 +513,19 @@ func verifyEd25519CanonicalReceipt(document map[string]any, sig, keyHex string) 
 		lamport,
 		firstString(document, "args_hash"),
 	)
+	switch sigVersion := firstString(document, "signature_version"); sigVersion {
+	case "":
+		// legacy V4 — payload as built
+	case "receipt.v5":
+		payload = fmt.Sprintf("%s:%s:%s:%s:%s:%s", payload, sigVersion,
+			firstString(document, "verdict"),
+			firstString(document, "reason_code"),
+			firstString(document, "policy_hash"),
+			firstString(document, "session_id"),
+		)
+	default:
+		return false
+	}
 	return ed25519.Verify(ed25519.PublicKey(pubBytes), []byte(payload), sigBytes)
 }
 


### PR DESCRIPTION
## The defect (from the HELM-290 telemetry audit)

**A persisted receipt's `verdict`, `reason_code`, `policy_hash`, `session_id` could be rewritten without invalidating its signature.** The V4 preimage binds exactly 8 fields; the chain catches mutation only once a successor exists — **the chain tip was signature-silent**. And `SignDecision` had the attestation inverted: free-text `Reason` (prohibited from export) was signed while machine-readable `ReasonCode` (what every consumer keys on) was not.

## The fix

| | before | after |
|---|---|---|
| Receipt preimage | 8 fields (V4) | **V5**: + `verdict`, `reason_code`, `policy_hash`, `session_id` |
| Decision preimage | free-text `Reason` signed, `ReasonCode` not | **V2**: `ReasonCode` signed, prose out |
| Versioning | none — verifiers hardcoded the shape | `SignatureVersion` on both types; empty = legacy, unknown = **rejected** |
| History | — | **dual-verify** — old receipts/decisions verify unchanged, no re-signing |

Mechanics: single choke points (`ReceiptSigningPayload`/`ReceiptVerifyPayload` + decision pair) replace 8 duplicated preimage constructions across ed25519/hybrid/ML-DSA; the offline verifier's mirrored preimage honors `signature_version` too.

**Deliberate exclusion, documented at the constant:** the emergency/`safe_dep` tail stays outside V5 — emergency authority is already signature-bound via the V2 `AuthorizedExecutionIntent` preimage; double-binding would couple receipt re-signing to intent evolution. Revisit only with a threat the intent binding doesn't cover.

## ⚠️ Semantics changes needing eyes (Ivan)

1. **DRIFT-7 hardening matrix edited**: tamper-row `Reason` → `ReasonCode`, plus a new test pinning that `Reason` is *deliberately not bound* in V2. This inverts a previously-tested invariant — intentionally.
2. New signatures are V5/V2 from the moment this deploys; mixed-version stores are expected and handled.

## Tests

Per-field tamper matrix on V5 (each governance field invalidates), legacy dual-verify incl. an explicit test of the documented legacy hole, unknown-version rejection, `Reason`-not-bound pin. **Full `core` suite green** — all existing fixtures pass via the legacy path, as designed.

Closes the `risk:release-blocker` on HELM-303; unblocks HELM-290's "cryptographically backed event" language for V5-signed traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)