### PR TITLE
fix(verifier): bind receipt-class dispatch to signed fields (HELM-183)

### DIFF
--- a/core/pkg/verifier/verifier.go
+++ b/core/pkg/verifier/verifier.go
@@ -390,19 +390,65 @@ func verifyEmbeddedDocumentSignature(document map[string]any, sig string, opts V
 	case "managed_agent_execution_receipt.v1":
 		return verifyManagedAgentEd25519Signature(document, sig, opts.ManagedAgentReceiptPublicKeyHex, firstString(document, "receipt_hash"))
 	default:
-		if firstString(document, "type") == "mcp_policy_decision" {
-			return verifyMCPPolicyDecisionReceiptSignature(document, sig, opts)
+		// MCP proof receipts bind their class to the signed EffectID prefix
+		// (covered by the receipt signature). The unsigned Type field survives
+		// only as a fallback for already-published dev-local packs that
+		// predate signed class binding; a Type that contradicts the signed
+		// class is a crafted receipt and fails closed.
+		const (
+			mcpPolicyDecisionClass = "mcp_policy_decision"
+			mcpGovernedEffectClass = "mcp_governed_effect_execution"
+		)
+		effectID := firstString(document, "effect_id")
+		class := ""
+		switch {
+		case strings.HasPrefix(effectID, mcpPolicyDecisionClass+"/"):
+			class = mcpPolicyDecisionClass
+		case strings.HasPrefix(effectID, mcpGovernedEffectClass+"/"):
+			class = mcpGovernedEffectClass
 		}
-		return false
+		if receiptType := firstString(document, "type"); receiptType != "" {
+			if class == "" {
+				class = receiptType
+			} else if receiptType != class {
+				return false
+			}
+		}
+		switch class {
+		case mcpPolicyDecisionClass:
+			return verifyMCPPolicyDecisionReceiptSignature(document, sig, opts)
+		case mcpGovernedEffectClass:
+			return verifyMCPGovernedEffectReceiptSignature(document, sig, opts)
+		default:
+			return false
+		}
 	}
 }
 
+// verifyMCPGovernedEffectReceiptSignature verifies the SafeExecutor receipt
+// emitted by the local positive MCP proof. Like the policy-decision receipt,
+// its disclosed key is trusted only inside a dev-local pack whose seal has
+// already passed. Production profiles require out-of-band trust roots.
+func verifyMCPGovernedEffectReceiptSignature(document map[string]any, sig string, opts VerifyOptions) bool {
+	profile := opts.Profile
+	if profile == "" {
+		profile = evidencepkg.EvidenceTrustProfileDevLocal
+	}
+	if profile != evidencepkg.EvidenceTrustProfileDevLocal || firstString(document, "signature_algorithm") != "ed25519" {
+		return false
+	}
+	keySet, _ := document["public_key_set"].(map[string]any)
+	if keySet == nil {
+		return false
+	}
+	return verifyEd25519CanonicalReceipt(document, sig, firstString(keySet, "ed25519"))
+}
+
 // verifyMCPPolicyDecisionReceiptSignature verifies kernel-issued MCP proof
-// receipts (`mcp proof` quarantine scenarios). The signing key is disclosed in
-// receipt metadata and is integrity-anchored by the pack seal, so
-// disclosure-based trust is accepted only under the dev-local profile — the
-// same trust decision the seal check already makes for dev-local packs. Every
-// other profile requires out-of-band trust roots and fails closed here.
+// receipts (`mcp proof` quarantine scenarios). New receipts use the signer-
+// populated public_key_set; metadata disclosure remains as a legacy fallback.
+// Both disclosure forms are integrity-anchored by the pack seal and trusted
+// only under dev-local. Every other profile requires an out-of-band root.
 func verifyMCPPolicyDecisionReceiptSignature(document map[string]any, sig string, opts VerifyOptions) bool {
 	profile := opts.Profile
 	if profile == "" {
@@ -410,6 +456,13 @@ func verifyMCPPolicyDecisionReceiptSignature(document map[string]any, sig string
 	}
 	if profile != evidencepkg.EvidenceTrustProfileDevLocal {
 		return false
+	}
+	if firstString(document, "signature_algorithm") == "ed25519" {
+		if keySet, ok := document["public_key_set"].(map[string]any); ok {
+			if keyHex := strings.TrimSpace(firstString(keySet, "ed25519")); keyHex != "" {
+				return verifyEd25519CanonicalReceipt(document, sig, keyHex)
+			}
+		}
 	}
 	meta, _ := document["metadata"].(map[string]any)
 	if meta == nil {
@@ -428,7 +481,11 @@ func verifyMCPPolicyDecisionReceiptSignature(document map[string]any, sig string
 			return false
 		}
 	}
-	pubBytes, err := hex.DecodeString(keyHex)
+	return verifyEd25519CanonicalReceipt(document, sig, keyHex)
+}
+
+func verifyEd25519CanonicalReceipt(document map[string]any, sig, keyHex string) bool {
+	pubBytes, err := hex.DecodeString(strings.TrimSpace(keyHex))
 	if err != nil || len(pubBytes) != ed25519.PublicKeySize {
 		return false
 	}
@@ -795,8 +852,10 @@ func checkLamportMonotonicity(bundlePath string) CheckResult {
 }
 
 func checkPolicyDecisionHashes(bundlePath string) CheckResult {
-	// Verify that decision records exist and contain decision hashes.
-	// Check receipts for decision_hash fields.
+	// Verify that decision records expose a signed policy binding. Legacy
+	// receipts use decision_hash. Current MCP proof receipts use the signed
+	// EffectID, OutputHash (complete authorization evaluation), and ArgsHash
+	// (raw authorization inputs), avoiding an unsigned compatibility field.
 	receiptsDir := receiptPath(bundlePath)
 	if !dirExists(receiptsDir) {
 		// Already caught by lamport check, but note here too
@@ -808,8 +867,11 @@ func checkPolicyDecisionHashes(bundlePath string) CheckResult {
 		return CheckResult{Name: "policy_decision_hashes", Pass: false, Reason: "no receipt files to verify decision hashes"}
 	}
 
-	// Structural check: parse each receipt and verify decision_hash field exists
-	verified := 0
+	// Structural check: parse each receipt and verify either the legacy field or
+	// the current signed MCP policy-receipt binding exists.
+	legacyVerified := 0
+	mcpPolicyTotal := 0
+	mcpPolicyVerified := 0
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
@@ -823,16 +885,32 @@ func checkPolicyDecisionHashes(bundlePath string) CheckResult {
 		if err := json.Unmarshal(data, &receipt); err != nil {
 			continue
 		}
-		if _, ok := receipt["decision_hash"]; ok {
-			verified++
+		if strings.HasPrefix(firstString(receipt, "effect_id"), "mcp_policy_decision/") {
+			mcpPolicyTotal++
+			if firstString(receipt, "output_hash") != "" &&
+				firstString(receipt, "args_hash") != "" &&
+				firstString(receipt, "signature") != "" {
+				mcpPolicyVerified++
+			}
+			continue
+		}
+		if firstString(receipt, "decision_hash") != "" {
+			legacyVerified++
 		}
 	}
 
-	if verified == 0 {
-		return CheckResult{Name: "policy_decision_hashes", Pass: false, Reason: "no receipts contain decision_hash field"}
+	if mcpPolicyTotal > 0 {
+		if mcpPolicyTotal != mcpPolicyVerified {
+			return CheckResult{Name: "policy_decision_hashes", Pass: false, Reason: fmt.Sprintf("%d/%d MCP policy receipts lack signed authorization bindings", mcpPolicyTotal-mcpPolicyVerified, mcpPolicyTotal)}
+		}
+		return CheckResult{Name: "policy_decision_hashes", Pass: true, Detail: fmt.Sprintf("%d MCP policy receipts with signed authorization bindings", mcpPolicyVerified)}
 	}
 
-	return CheckResult{Name: "policy_decision_hashes", Pass: true, Detail: fmt.Sprintf("%d receipts with decision hashes", verified)}
+	if legacyVerified == 0 {
+		return CheckResult{Name: "policy_decision_hashes", Pass: false, Reason: "no receipts contain a policy decision binding"}
+	}
+
+	return CheckResult{Name: "policy_decision_hashes", Pass: true, Detail: fmt.Sprintf("%d receipts with legacy decision hashes", legacyVerified)}
 }
 
 func checkReplayDeterminism(bundlePath string) CheckResult {

--- a/core/pkg/verifier/verifier_test.go
+++ b/core/pkg/verifier/verifier_test.go
@@ -418,6 +418,216 @@ func TestVerifyBundleMCPPolicyDecisionReceiptTrust(t *testing.T) {
 	})
 }
 
+func TestVerifyBundleMCPGovernedEffectReceiptTrust(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyHex := hex.EncodeToString(pub)
+	// Mirrors crypto.CanonicalizeReceipt field order.
+	sign := func(effectID string) string {
+		payload := "exec-001:dec-001:" + effectID + ":APPLIED:sha256:out::1:sha256:args"
+		return hex.EncodeToString(ed25519.Sign(priv, []byte(payload)))
+	}
+	receipt := func(effectID, sig, pubKeyHex string) map[string]any {
+		keySet := map[string]any{}
+		if pubKeyHex != "" {
+			keySet["ed25519"] = pubKeyHex
+		}
+		return map[string]any{
+			"receipt_id":          "exec-001",
+			"decision_id":         "dec-001",
+			"effect_id":           effectID,
+			"status":              "APPLIED",
+			"output_hash":         "sha256:out",
+			"prev_hash":           "",
+			"lamport_clock":       1,
+			"args_hash":           "sha256:args",
+			"signature":           sig,
+			"signature_algorithm": "ed25519",
+			"public_key_set":      keySet,
+		}
+	}
+	const signedEffectID = "mcp_governed_effect_execution/proof.local_write"
+
+	t.Run("signed effect_id class dispatches without unsigned type", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"), receipt(signedEffectID, sign(signedEffectID), keyHex))
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundle(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, check := range report.Checks {
+			if check.Name == "embedded_signature_trust" && !check.Pass {
+				t.Fatalf("dev-local governed-effect receipt signature should verify: %+v", check)
+			}
+		}
+	})
+
+	t.Run("legacy type dispatch still verifies", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		const legacyEffectID = "mcp.effect/proof.local_write"
+		doc := receipt(legacyEffectID, sign(legacyEffectID), keyHex)
+		doc["type"] = "mcp_governed_effect_execution"
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"), doc)
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundle(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, check := range report.Checks {
+			if check.Name == "embedded_signature_trust" && !check.Pass {
+				t.Fatalf("legacy governed-effect receipt signature should verify: %+v", check)
+			}
+		}
+	})
+
+	t.Run("tampered signature fails closed", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		forged := hex.EncodeToString(ed25519.Sign(priv, []byte("exec-001:dec-001:"+signedEffectID+":APPLIED:sha256:out::1:sha256:args-tampered")))
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"), receipt(signedEffectID, forged, keyHex))
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundle(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEmbeddedSignatureTrustFails(t, report)
+	})
+
+	t.Run("missing key disclosure fails closed", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"), receipt(signedEffectID, sign(signedEffectID), ""))
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundle(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEmbeddedSignatureTrustFails(t, report)
+	})
+
+	t.Run("non-dev-local profile refuses disclosure trust", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"), receipt(signedEffectID, sign(signedEffectID), keyHex))
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundleWithOptions(dir, VerifyOptions{Profile: evidencepkg.EvidenceTrustProfileTeam})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEmbeddedSignatureTrustFails(t, report)
+	})
+}
+
+func TestVerifyBundleReceiptClassBindingMismatch(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyHex := hex.EncodeToString(pub)
+	receipt := func(effectID, receiptType string) map[string]any {
+		// Valid signature over the canonical payload: the receipt would verify
+		// under either class path if dispatch trusted the unsigned type.
+		payload := "exec-001:dec-001:" + effectID + ":APPLIED:sha256:out::1:sha256:args"
+		return map[string]any{
+			"type":                receiptType,
+			"receipt_id":          "exec-001",
+			"decision_id":         "dec-001",
+			"effect_id":           effectID,
+			"status":              "APPLIED",
+			"output_hash":         "sha256:out",
+			"prev_hash":           "",
+			"lamport_clock":       1,
+			"args_hash":           "sha256:args",
+			"signature":           hex.EncodeToString(ed25519.Sign(priv, []byte(payload))),
+			"signature_algorithm": "ed25519",
+			"public_key_set":      map[string]any{"ed25519": keyHex},
+		}
+	}
+
+	t.Run("unsigned type contradicting signed policy class is rejected", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"),
+			receipt("mcp_policy_decision/proof.read", "mcp_governed_effect_execution"))
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundle(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEmbeddedSignatureTrustFails(t, report)
+	})
+
+	t.Run("unsigned type contradicting signed effect class is rejected", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"),
+			receipt("mcp_governed_effect_execution/proof.local_write", "mcp_policy_decision"))
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundle(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEmbeddedSignatureTrustFails(t, report)
+	})
+
+	t.Run("signed policy class with key set verifies without unsigned type", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		doc := receipt("mcp_policy_decision/proof.read", "")
+		delete(doc, "type")
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"), doc)
+		sealVerifierFixture(t, dir, "test-session-001")
+		report, err := VerifyBundle(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, check := range report.Checks {
+			if check.Name == "embedded_signature_trust" && !check.Pass {
+				t.Fatalf("signed-class policy receipt should verify: %+v", check)
+			}
+		}
+	})
+}
+
+func TestCheckPolicyDecisionHashesSignedBinding(t *testing.T) {
+	writePolicyReceipt := func(t *testing.T, dir string, doc map[string]any) {
+		t.Helper()
+		writeJSON(t, filepath.Join(dir, "receipts", "receipt-001.json"), doc)
+	}
+
+	t.Run("signed binding passes", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		writePolicyReceipt(t, dir, map[string]any{
+			"receipt_id":    "rcpt-001",
+			"decision_id":   "dec-001",
+			"effect_id":     "mcp_policy_decision/proof.read",
+			"status":        "DENY",
+			"output_hash":   "sha256:out",
+			"args_hash":     "sha256:args",
+			"signature":     "abc123",
+			"lamport_clock": 1,
+		})
+		result := checkPolicyDecisionHashes(dir)
+		if !result.Pass {
+			t.Fatalf("MCP policy receipt with signed binding should pass: %+v", result)
+		}
+	})
+
+	t.Run("missing binding fields fail closed", func(t *testing.T) {
+		dir := createValidBundleFixture(t)
+		writePolicyReceipt(t, dir, map[string]any{
+			"receipt_id":    "rcpt-001",
+			"decision_id":   "dec-001",
+			"effect_id":     "mcp_policy_decision/proof.read",
+			"status":        "DENY",
+			"output_hash":   "sha256:out",
+			"signature":     "abc123",
+			"lamport_clock": 1,
+		})
+		result := checkPolicyDecisionHashes(dir)
+		if result.Pass {
+			t.Fatalf("MCP policy receipt without args_hash must fail: %+v", result)
+		}
+	})
+}
+
 func TestVerifyBundleWitnessSignatureTrust(t *testing.T) {
 	pub, priv, err := ed25519.GenerateKey(nil)
 	if err != nil {

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,5 +1,5 @@
 # HELM Protected Manifest
-# Generated: 2026-07-20T00:59:10Z
+# Generated: 2026-07-20T20:48:59Z
 # Source: current protected working tree; per-entry hashes are authoritative
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
@@ -447,9 +447,9 @@ f2229d08f1b6ad50f51e976305814161e9269884bf563c18fb57bb7416285d10  core/pkg/verif
 bfbe8e2d25ff38dc49eb34028cfede4e449bdc63e3b810f1b19913a11b72442b  core/pkg/verifier/externalreceipt/externalreceipt.go
 fdb3835dc6315a0730a961d458a0c1e4f9f5d79059f33b8908718f075718e12f  core/pkg/verifier/externalreceipt/externalreceipt_test.go
 e70d160b80a81e70a4d1019d9903135d25f813bbe5803b1da8582e727e8c819c  core/pkg/verifier/host_evidence_test.go
-c72cf3a4275a7529e23812ddc487ba759648f9a33248ed76b1453dae709849be  core/pkg/verifier/verifier.go
+0a90747696d5caaa95af478b94bd088b0d96f5ed383bf014a1c9cc4f4d80006f  core/pkg/verifier/verifier.go
 6826dbc4685bd55768db73e1d39e7195ac05571d2452337aa10c87704027f153  core/pkg/verifier/verifier_behavior_coverage_test.go
-c066a6086e521c514cfdc2e36a0cab0a99b259499332046b54506630d0ccb2d8  core/pkg/verifier/verifier_test.go
+2c4a15b6ae93de4e280db50a58e9e59e3ac6dfb80e891a345dad03e646cca1de  core/pkg/verifier/verifier_test.go
 f5332ef5eaa72e342066a9d3dad0f822415efeece0312fd97c9cb23674b2c647  core/pkg/connectors/sandbox/README.md
 54d138f657e16bc1df4cf260a562f3e0ad239f6c145129565799700401c6f78d  core/pkg/connectors/sandbox/branchfs.go
 3a43db565ecb1e9d80be41747dfcf8d591f131ef7ef2979b9066f77309ed7656  core/pkg/connectors/sandbox/bridge.go


### PR DESCRIPTION
## Summary

Closes a receipt-class confusion weakness in the evidence verifier: `verifyEmbeddedDocumentSignature` selected the MCP-proof verification path from the receipt's **unsigned** `type` field (`verifier.go` default case). A crafted dev-local proof pack could set `type` to steer which verification logic ran against a signed receipt.

**Fix:** derive the receipt class from the **signed** `effect_id` prefix (`mcp_policy_decision/…` or `mcp_governed_effect_execution/…`, both covered by the receipt signature). The unsigned `type` survives only as a legacy fallback for already-published dev-local packs; **a `type` that contradicts the signed class fails closed** (`return false`), and an unknown class fails closed (`default: return false`).

Also:
- adds `verifyMCPGovernedEffectReceiptSignature` (the positive governed-effect proof receipt), dev-local + ed25519 only, signer-populated `public_key_set`
- `checkPolicyDecisionHashes` now accepts the **signed** EffectID + OutputHash + ArgsHash binding instead of the unsigned `decision_hash` compatibility field (legacy still accepted)

## Provenance & scope

Extracted from the larger `codex/helm-183-kernel-proof` branch (a demo feature entangled with this hardening) during the 2026-07-20 estate sweep, rebased onto current main, and reduced to the **minimal verifier surface** — the demo (`mcp_proof_cmd.go` etc.) is deliberately excluded. Scope is **dev-local proof-pack verification**; production profiles still require out-of-band trust roots and fail closed here, unchanged.

## Tests

- `TestVerifyBundleReceiptClassBindingMismatch/unsigned_type_contradicting_signed_policy_class_is_rejected` — the fix
- `signed_effect_id_class_dispatches_without_unsigned_type` — new receipts verify with no `type` at all
- `legacy_type_dispatch_still_verifies` — backward compat
- `tampered_signature_fails_closed`

## Validation

- `go build ./...`, `go vet ./pkg/verifier/...`, `go test ./pkg/verifier/... ./pkg/crypto/...` — PASS
- gofmt clean; quantum-inventory pass; boundary manifest regenerated (1047 files)

Kernel-critical (`core/pkg/verifier`) — requesting kernel-guardian review before merge.
