### PR TITLE
feat(mcp): wire serve policy into the standalone MCP runtime (T11)

### DIFF
--- a/core/cmd/helm-ai-kernel/mcp_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_cmd.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/prg"
 )
 
 // runMCPCmd implements `helm-ai-kernel mcp` — MCP server distribution and management.
@@ -117,19 +118,33 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 	cmd.SetOutput(stderr)
 
 	var (
-		transport string
-		port      int
-		authMode  string
-		dataDir   string
+		transport  string
+		port       int
+		authMode   string
+		dataDir    string
+		policyPath string
 	)
 
 	cmd.StringVar(&transport, "transport", "stdio", "Transport: stdio, http")
 	cmd.IntVar(&port, "port", 9100, "Port for HTTP transport")
 	cmd.StringVar(&authMode, "auth", "none", "Auth mode: none, static-header, oauth")
 	cmd.StringVar(&dataDir, "data-dir", "data", "Data directory for local MCP signing state")
+	cmd.StringVar(&policyPath, "policy", "", "Path to a serve policy file; without it, execution is fail-closed (deny-all)")
 
 	if err := cmd.Parse(args); err != nil {
 		return 2
+	}
+
+	// A serve policy compiles to the Guardian rule graph. Absent --policy the
+	// graph stays empty, which denies every execution (fail-closed default).
+	var policyGraph *prg.Graph
+	if policyPath != "" {
+		runtimePolicy, err := loadServePolicyRuntime(policyPath)
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: load serve policy %q: %v\n", policyPath, err)
+			return 2
+		}
+		policyGraph = runtimePolicy.Graph
 	}
 
 	switch transport {
@@ -138,13 +153,13 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "Error: stdio transport only supports --auth none")
 			return 2
 		}
-		if err := serveLocalMCPStdioWithDataDir(os.Stdin, stdout, dataDir); err != nil {
+		if err := serveLocalMCPStdioWithDataDirAndPolicy(os.Stdin, stdout, dataDir, policyGraph); err != nil {
 			fmt.Fprintf(stderr, "Error: MCP stdio server failed: %v\n", err)
 			return 2
 		}
 		return 0
 	case "http":
-		server, err := newLocalMCPHTTPServerWithDataDir(port, authMode, dataDir)
+		server, err := newLocalMCPHTTPServerWithDataDirAndPolicy(port, authMode, dataDir, policyGraph)
 		if err != nil {
 			fmt.Fprintf(stderr, "Error: %v\n", err)
 			return 2

--- a/core/cmd/helm-ai-kernel/mcp_cmd.go
+++ b/core/cmd/helm-ai-kernel/mcp_cmd.go
@@ -145,6 +145,15 @@ func runMCPServe(args []string, stdout, stderr io.Writer) int {
 			return 2
 		}
 		policyGraph = runtimePolicy.Graph
+		// Report the compiled allow-set so a mis-authored policy that authorizes
+		// nothing is visible, not a silent deny-all. Logged to stderr so it is
+		// safe on the stdio transport, where stdout carries the MCP protocol.
+		authorized := len(runtimePolicy.AllowMap())
+		if authorized == 0 {
+			fmt.Fprintf(stderr, "Warning: serve policy %q authorizes 0 actions; every execution will be denied\n", policyPath)
+		} else {
+			fmt.Fprintf(stderr, "Serve policy %q authorizes %d action(s)\n", policyPath, authorized)
+		}
 	}
 
 	switch transport {

--- a/core/cmd/helm-ai-kernel/mcp_runtime.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime.go
@@ -46,24 +46,37 @@ func newLocalMCPRuntime() (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
 }
 
 func newLocalMCPRuntimeWithDataDir(dataDir string) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
+	return newLocalMCPRuntimeWithDataDirAndPolicy(dataDir, nil)
+}
+
+func newLocalMCPRuntimeWithDataDirAndPolicy(dataDir string, policyGraph *prg.Graph) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
 	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
 	if err != nil {
 		return nil, nil, err
 	}
-	return newLocalMCPRuntimeWithSigner(signer)
+	return newLocalMCPRuntimeWithSignerAndPolicy(signer, policyGraph)
 }
 
 func newLocalMCPRuntimeWithSigner(signer helmcrypto.Signer) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
+	return newLocalMCPRuntimeWithSignerAndPolicy(signer, nil)
+}
+
+// newLocalMCPRuntimeWithSignerAndPolicy builds the local MCP runtime whose
+// Guardian enforces policyGraph. A nil policyGraph keeps the historical
+// fail-closed default: the catalog stays discoverable but every execution is
+// denied, because an empty graph carries no allow rule. Pass a compiled graph
+// (see `mcp serve --policy`) to authorize the actions it declares.
+func newLocalMCPRuntimeWithSignerAndPolicy(signer helmcrypto.Signer, policyGraph *prg.Graph) (*mcppkg.ToolCatalog, mcppkg.ToolExecutor, error) {
 	if signer == nil {
 		return nil, nil, fmt.Errorf("mcp signer is required")
+	}
+	if policyGraph == nil {
+		policyGraph = prg.NewGraph()
 	}
 	catalog := mcppkg.NewInMemoryCatalog()
 	catalog.RegisterCommonTools()
 	catalog.RegisterGovernanceTools()
-	// The local MCP catalog is discoverable by default, but execution must not
-	// inherit an implicit allow policy. Until serve policy wiring is plumbed into
-	// this gateway, an empty graph keeps MCP execution fail-closed.
-	guard := guardian.NewGuardian(signer, prg.NewGraph(), nil)
+	guard := guardian.NewGuardian(signer, policyGraph, nil)
 	firewall := mcppkg.NewGovernanceFirewall(guard, catalog)
 
 	return catalog, mcppkg.ToolExecutor(firewall.WrapToolHandler(runLocalMCPTool)), nil
@@ -207,7 +220,11 @@ func serveLocalMCPStdio(stdin io.Reader, stdout io.Writer) error {
 }
 
 func serveLocalMCPStdioWithDataDir(stdin io.Reader, stdout io.Writer, dataDir string) error {
-	catalog, executor, err := newLocalMCPRuntimeWithDataDir(dataDir)
+	return serveLocalMCPStdioWithDataDirAndPolicy(stdin, stdout, dataDir, nil)
+}
+
+func serveLocalMCPStdioWithDataDirAndPolicy(stdin io.Reader, stdout io.Writer, dataDir string, policyGraph *prg.Graph) error {
+	catalog, executor, err := newLocalMCPRuntimeWithDataDirAndPolicy(dataDir, policyGraph)
 	if err != nil {
 		return err
 	}
@@ -413,13 +430,17 @@ func newLocalMCPHTTPServer(port int, authMode string) (*http.Server, error) {
 }
 
 func newLocalMCPHTTPServerWithDataDir(port int, authMode, dataDir string) (*http.Server, error) {
+	return newLocalMCPHTTPServerWithDataDirAndPolicy(port, authMode, dataDir, nil)
+}
+
+func newLocalMCPHTTPServerWithDataDirAndPolicy(port int, authMode, dataDir string, policyGraph *prg.Graph) (*http.Server, error) {
 	// SEC: Default to localhost to prevent accidental network exposure.
 	mcpBind := "127.0.0.1"
 	if envBind := os.Getenv("HELM_BIND_ADDR"); envBind != "" {
 		mcpBind = envBind
 	}
 	baseURL := fmt.Sprintf("http://%s:%d", mcpBind, port)
-	catalog, executor, err := newLocalMCPRuntimeWithDataDir(dataDir)
+	catalog, executor, err := newLocalMCPRuntimeWithDataDirAndPolicy(dataDir, policyGraph)
 	if err != nil {
 		return nil, err
 	}

--- a/core/cmd/helm-ai-kernel/mcp_runtime_failclosed_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime_failclosed_test.go
@@ -8,7 +8,48 @@ import (
 	"testing"
 
 	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/prg"
 )
+
+// A compiled serve policy authorizes execution: with a graph that carries an
+// EXECUTE_TOOL rule (what the governance firewall evaluates), the same file_read
+// that fails closed under the empty-graph default now succeeds. This is the
+// behavior `mcp serve --policy` wires in.
+func TestLocalMCPRuntimeAuthorizesExecutionWithPolicyGraph(t *testing.T) {
+	dir := chdirTempDir(t)
+	target := filepath.Join(dir, "allowed.txt")
+	if err := os.WriteFile(target, []byte("authorized-content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := prg.NewGraph()
+	// The guardian keys the policy lookup on the tool action (the firewall
+	// passes ToolName as the decision Resource), so a serve policy authorizes
+	// specific tools by name. An empty requirement set is vacuously satisfied,
+	// so this rule allows file_read while every other tool stays fail-closed.
+	if err := graph.AddRule("file_read", prg.RequirementSet{ID: "serve-policy:file_read", Logic: prg.AND}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, executor, err := newLocalMCPRuntimeWithDataDirAndPolicy(dir, graph)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := executor(context.Background(), mcppkg.ToolExecutionRequest{
+		ToolName:  "file_read",
+		SessionID: "mcp-test",
+		Arguments: map[string]any{"path": target},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.IsError {
+		t.Fatalf("expected policy-authorized execution to succeed, got error: %q", resp.Content)
+	}
+	if !strings.Contains(resp.Content, "authorized-content") {
+		t.Fatalf("expected authorized file content, got %q", resp.Content)
+	}
+}
 
 func TestLocalMCPRuntimeFailsClosedWithoutPolicyGraph(t *testing.T) {
 	dir := chdirTempDir(t)


### PR DESCRIPTION
## Summary

Wires a real policy into the standalone `helm-ai-kernel mcp serve` path (T11 / MCP-serve policy gap).

Before: `newLocalMCPRuntimeWithSigner` hardcoded an empty `prg.NewGraph()`, so the standalone MCP server denied **every** execution (fail-closed) with **no mechanism** to authorize anything. The serve-policy compiler (`loadServePolicyRuntime` → `compileServePolicyGraph`) already existed but was never plumbed into the stdio/http runtime.

After: `mcp serve --policy <path>` compiles the policy to the Guardian rule graph, authorizing exactly the tool actions the policy declares. The firewall passes `ToolName` as the decision `Resource`, which keys the policy lookup — so a policy allows specific tools by name; everything undeclared stays denied.

## Fail-closed preserved

Threaded via **additive `...AndPolicy` constructor variants**. Every existing function (`newLocalMCPRuntimeWithSigner`, `...WithDataDir`, `serveLocalMCPStdioWithDataDir`, `newLocalMCPHTTPServerWithDataDir`) becomes a thin `nil`-defaulting wrapper, and `nil` → `prg.NewGraph()`. So the empty-graph deny-all default is unchanged for all current callers and tests — no behavior change without `--policy`.

## Tests

- `TestLocalMCPRuntimeAuthorizesExecutionWithPolicyGraph` (new): a graph with a `file_read` allow rule permits that read
- `TestLocalMCPRuntimeFailsClosedWithoutPolicyGraph` (preserved): empty graph denies

## Validation

- `go build ./...`, `go vet ./cmd/helm-ai-kernel/`, full `cmd/helm-ai-kernel` package tests, quantum-inventory — all pass; gofmt clean; not a protected path.

Kernel-adjacent (Guardian construction) — kernel-guardian review requested.
