### PR TITLE
fix(helm-chart): default seccompProfile RuntimeDefault for PodSecurity restricted

### DIFF
--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -93,12 +93,12 @@
     "podSecurityContext": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Pod-level securityContext. Defaults run the kernel as non-root (UID/GID 65534, nobody) with fsGroup so the data volume is writable."
+      "description": "Pod-level securityContext. Defaults run the kernel as non-root (UID/GID 65534, nobody) with fsGroup so the data volume is writable, and set seccompProfile RuntimeDefault so pods are admitted under PodSecurity \"restricted\"."
     },
     "securityContext": {
       "type": "object",
       "additionalProperties": true,
-      "description": "Container-level securityContext. Defaults drop ALL Linux capabilities, disable privilege escalation, and mount the root filesystem read-only; helm.dataDir is the only writable path."
+      "description": "Container-level securityContext. Defaults drop ALL Linux capabilities, disable privilege escalation, mount the root filesystem read-only (helm.dataDir is the only writable path), and set seccompProfile RuntimeDefault so pods are admitted under PodSecurity \"restricted\"."
     },
     "service": {
       "type": "object",

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -31,6 +31,8 @@ podSecurityContext:
   runAsUser: 65534
   runAsGroup: 65534
   fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -38,6 +40,8 @@ securityContext:
   capabilities:
     drop:
       - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Summary

Namespaces enforcing PodSecurity `restricted` reject the chart's pods with `must set securityContext.seccompProfile.type to "RuntimeDefault"` because neither default sets a seccomp profile. Verified live 2026-07-21 deploying chart 0.7.3 into a restricted namespace on k3s: the deploy fails as shipped and succeeds with both values `--set` to `RuntimeDefault`.

This bakes `seccompProfile: {type: RuntimeDefault}` into both `podSecurityContext` and the container `securityContext` defaults:

- pod-level satisfies restricted admission for the Pod;
- container-level keeps the kernel container — and the optional `config-reloader` sidecar, which reuses `.Values.securityContext` — compliant even when `podSecurityContext` is overridden.

`values.schema.json` descriptions for both objects are updated so the enumerated defaults stay truthful (the schema already allows the key via `additionalProperties: true`; no schema shape change).

Claim boundary: this is chart deployment hardening only — it applies the standard Kubernetes runtime default seccomp profile to chart-managed pods and makes no kernel seccomp-enforcement claim (`docs/CLAIM_BOUNDARIES.md`).

Launchpad app templates: this was flagged here as a residual follow-up when the PR was authored. #626 has since landed on `main` and sets `RuntimeDefault` across `templates/launchpad-apps/` and `templates/tests/launchpad-connectivity.yaml`, so no residual gap remains.

Linear: HELM issue to be filed (Linear MCP was unavailable in the authoring session; issue text is prepared). Add the `HELM-*` id here once filed so Git automation links it.

## Validation

```bash
helm lint deploy/helm-chart                     # helm v3.21.0 (CI-pinned version), clean
helm template t deploy/helm-chart               # RuntimeDefault rendered at pod + container level
helm template t deploy/helm-chart \
  --set helm.policy.reloadHints.configReloaderSidecar.enabled=true   # 3× RuntimeDefault incl. sidecar
make verify-fixtures                             # green
make version-drift                               # all surfaces OK at 0.7.3
make quality-pr                                  # impact-scoped: applicable checks passed, rest skipped
```

In-cluster chart smoke (`templates/tests/`) is not locally runnable; the path-triggered `helm-integration` workflow covers it on this PR.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes (`values.schema.json` descriptions).
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md` (n/a — launchpad templates untouched here; their seccomp defaults landed separately in #626).
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path (n/a).
- [x] Release version surfaces are lockstep (`make version-drift` OK; chart `version`/`appVersion` untouched — release commits own bumps).
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md` (n/a — additive hardening of rendered defaults, not breaking).
- [x] Advisory quality warnings are acknowledged or tracked when relevant (none raised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

