### PR TITLE
fix(helm-chart): add seccompProfile RuntimeDefault to launchpad app pods

### DIFF
--- a/deploy/helm-chart/templates/launchpad-apps/_helpers.tpl
+++ b/deploy/helm-chart/templates/launchpad-apps/_helpers.tpl
@@ -106,6 +106,8 @@ Usage: {{ include "helm-ai-kernel.launchpadApp.egressSidecar" (dict "sidecar" .V
     capabilities:
       drop:
         - ALL
+    seccompProfile:
+      type: RuntimeDefault
   env:
     - name: HELM_EGRESS_LISTEN
       value: {{ printf ":%d" (int $s.port) | quote }}
@@ -160,6 +162,10 @@ Usage: {{ include "helm-ai-kernel.launchpadApp.egressInit" (dict "sidecar" .Valu
       add:
         - NET_ADMIN
         - NET_RAW
+    # RuntimeDefault does not break the iptables install: runc's default seccomp
+    # profile admits the netfilter syscalls once CAP_NET_ADMIN is granted.
+    seccompProfile:
+      type: RuntimeDefault
   command:
     - /bin/sh
     - -c

--- a/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/hermes-job.yaml
@@ -42,6 +42,8 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
         fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         {{- include "helm-ai-kernel.launchpadApp.egressInit" (dict "sidecar" $cfg.egressSidecar) | nindent 8 }}
       containers:
@@ -123,6 +125,8 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
         fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       # Init container order matters: the egress-init installs the iptables
       # REDIRECT and runs to completion FIRST, then the egress proxy starts as a
       # restartPolicy:Always sidecar (Pod completion is driven solely by the main

--- a/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
@@ -36,6 +36,8 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
         fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
         # Egress enforcement: install the iptables REDIRECT before the workload
         # starts, so every outbound TCP is forced through the egress proxy sidecar.

--- a/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
+++ b/deploy/helm-chart/templates/tests/launchpad-connectivity.yaml
@@ -24,6 +24,8 @@ spec:
     runAsNonRoot: true
     runAsUser: 65534
     runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: connectivity
       image: {{ .Values.launchpadApps.test.image | quote }}


### PR DESCRIPTION
## Summary

Follow-up to #625, which set `seccompProfile: RuntimeDefault` on the chart-wide `podSecurityContext`/`securityContext` defaults. The opt-in launchpad app templates were out of that PR's scope and define their own pod/container securityContexts without a seccompProfile, so their pods still fail the PodSecurity "restricted" seccomp check when `launchpadApps.openclaw.enabled` or `launchpadApps.hermes.enabled` is set (all disabled by default).

This adds `seccompProfile: {type: RuntimeDefault}`:

- pod-level: openclaw Deployment, hermes Job mode, hermes Deployment mode, launchpad connectivity test Pod
- container-level: shared `launchpadApp.egressSidecar` and `launchpadApp.egressInit` helper blocks, so the partials stay self-carrying at any include site

Scope honesty: `egress-init` intentionally keeps `runAsUser: 0` + `NET_ADMIN`/`NET_RAW` — that is what makes the transparent iptables REDIRECT (and the "every egress leaves a receipt" guarantee) real. Launchpad pods therefore still do not pass full "restricted" admission after this change; it closes the seccomp violation class and aligns the launchpad templates with the #625 posture. No runtime behavior change expected: runc's default seccomp profile admits the netfilter syscalls once `CAP_NET_ADMIN` is granted.

Independent of #625 (zero file overlap: #625 touches `values.yaml`/`values.schema.json`; this touches only the launchpad templates). The two merge in either order.

## Validation

Real Kubernetes Helm v3.21.0 (the CI pin from `.github/workflows/helm-integration.yml`, darwin-arm64 tarball from get.helm.sh, sha256 verified against the published checksum):

```bash
helm lint deploy/helm-chart
# → 1 chart(s) linted, 0 chart(s) failed (icon INFO pre-existing)

helm template t deploy/helm-chart \
  --set launchpadApps.openclaw.enabled=true --set launchpadApps.hermes.enabled=true
# → 7× seccompProfile / 7× type: RuntimeDefault
#   (openclaw pod + its egress-init + egress-proxy; hermes Job pod + its
#    egress-init + egress-proxy sidecar-init; connectivity test pod)

helm template t deploy/helm-chart \
  --set launchpadApps.openclaw.enabled=true --set launchpadApps.hermes.enabled=true \
  --set launchpadApps.hermes.mode=deployment
# → 7× seccompProfile / 7× type: RuntimeDefault (hermes Deployment-mode pod covered)

helm template t deploy/helm-chart   # defaults, no launchpad apps
# → 0× seccompProfile; render byte-identical to origin/main except the
#   auto-generated dev signing-key line (templates/secret.yaml:27 renders
#   `randAlphaNum 64 | sha256sum` fresh on every render — inherent template
#   nondeterminism, not from this change). Main kernel Deployment unchanged.
```

`make quality-pr` not applicable: the diff is 14 added YAML lines in chart templates, no Go/SDK/contract surface. The `Helm Integration — Launchpad k8s smoke` workflow triggers on `deploy/helm-chart/**` and runs the minikube baseline + negative launchpad smoke on this PR, which boots openclaw+hermes pods (egress-init iptables install included) under the new seccomp settings.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes. — N/A: launchpad securityContexts are template-hardcoded, not values-driven; no schema or docs surface changes (#625 owns the `values.schema.json` description updates for the chart-wide defaults).
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. — Reviewed: no registry entry, policy, artifact digest, MCP manifest, or launch-runtime change; images remain digest-pinned; this only strengthens the chart-managed co-deployment sandbox posture. No F2/attack-matrix or public-claim changes.
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path. — N/A.
- [x] Release version surfaces are lockstep (`make version-drift`) when touching `VERSION`, release workflows, chart metadata, SDK manifests, OpenAPI, or publishing docs. — N/A: no version surface touched (Chart.yaml untouched).
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`. — N/A: no interface change.
- [x] Advisory quality warnings are acknowledged or tracked when relevant. — None raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
