### PR TITLE
fix(docs): use site-absolute links in air-gap guide

### DIFF
--- a/docs/guides/air-gap-appliance.md
+++ b/docs/guides/air-gap-appliance.md
@@ -56,7 +56,7 @@ export OPENAI_BASE_URL=http://127.0.0.1:9090/v1
 Every tool call is checked against policy and allowed, denied, or escalated;
 each decision writes a hash-chained receipt. The Local Inference Gateway can
 additionally pin the engine by model hash, so a receipt records *which* model
-answered. See [Use The OpenAI-Compatible Proxy](use-openai-compatible-proxy).
+answered. See [Use The OpenAI-Compatible Proxy](/guides/use-openai-compatible-proxy).
 
 ## Make the egress policy the host firewall source
 
@@ -87,7 +87,7 @@ helm-ai-kernel verify evidence-pack.tar
 and the JCS canonical form) before any network step; the `--online` ledger
 check is opt-in and off by default. Replay from genesis works without a route
 to the internet. For the full export-and-check walkthrough see
-[Export And Verify EvidencePacks](export-verify-evidencepacks).
+[Export And Verify EvidencePacks](/guides/export-verify-evidencepacks).
 
 ## Run it as a system service
 


### PR DESCRIPTION
## What

Converts the two extensionless relative links in `docs/guides/air-gap-appliance.md` to site-absolute form, matching the convention used by `docs/guides/implementation-partner.md`:

- line 59: `(use-openai-compatible-proxy)` → `(/guides/use-openai-compatible-proxy)`
- line 90: `(export-verify-evidencepacks)` → `(/guides/export-verify-evidencepacks)`

## Why

The current Docs Truth runner pin (`dev-orchestration@014aa7eb`) does not lint relative links, but the runner on dev-orchestration `main` does: once this guide's estate-ledger row lands (Mindburn-Labs/docs#136), the stricter runner reports `broken_relative_link` for both lines because the extensionless targets do not exist as files. Site-absolute paths are what the published docs host serves (e.g. `helm.docs.mindburn.org/guides/...`) and are exempt from the file-existence check, so this keeps the estate green across the next runner pin bump.

## Validation

Local runs against a CI-shaped workspace ({this branch, docs@fix/docs-truth-kernel-ledger-backfill, .github@main}):

| Runner | ledger rows only | ledger rows + this fix |
| --- | --- | --- |
| pinned `014aa7eb` (CI today) | PASS | PASS |
| dev-orchestration `main` (next pin) | FAIL: 2× `broken_relative_link` (lines 59/90) | **PASS, 0 failures** |

## Note on this PR's checks

The `docs-truth / docs-truth` check on this PR stays red with 8 estate-wide `missing_ledger_row` failures until Mindburn-Labs/docs#136 merges (every open kernel PR currently inherits that state); re-run the check after that merge and it goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
