### PR TITLE
docs(guides): add .md suffix to air-gap-appliance relative links

### DIFF
--- a/docs/guides/air-gap-appliance.md
+++ b/docs/guides/air-gap-appliance.md
@@ -56,7 +56,7 @@ export OPENAI_BASE_URL=http://127.0.0.1:9090/v1
 Every tool call is checked against policy and allowed, denied, or escalated;
 each decision writes a hash-chained receipt. The Local Inference Gateway can
 additionally pin the engine by model hash, so a receipt records *which* model
-answered. See [Use The OpenAI-Compatible Proxy](use-openai-compatible-proxy).
+answered. See [Use The OpenAI-Compatible Proxy](use-openai-compatible-proxy.md).
 
 ## Make the egress policy the host firewall source
 
@@ -87,7 +87,7 @@ helm-ai-kernel verify evidence-pack.tar
 and the JCS canonical form) before any network step; the `--online` ledger
 check is opt-in and off by default. Replay from genesis works without a route
 to the internet. For the full export-and-check walkthrough see
-[Export And Verify EvidencePacks](export-verify-evidencepacks).
+[Export And Verify EvidencePacks](export-verify-evidencepacks.md).
 
 ## Run it as a system service
 


### PR DESCRIPTION
## What

Appends `.md` to the two relative markdown links in `docs/guides/air-gap-appliance.md`:

| Line | Before | After |
| --- | --- | --- |
| 59 | `](use-openai-compatible-proxy)` | `](use-openai-compatible-proxy.md)` |
| 90 | `](export-verify-evidencepacks)` | `](export-verify-evidencepacks.md)` |

Both targets exist as `docs/guides/use-openai-compatible-proxy.md` and `docs/guides/export-verify-evidencepacks.md`.

## Why

The file was added by #623 (b72e01ee). Both links fail the org docs-truth gate's `broken_relative_link` check, which resolves relative markdown targets against the filesystem (`docs-truth-org.rb:397-433`). The failure only surfaced after the file was registered in the org markdown-estate ledger (Mindburn-Labs/docs#135) — content checks only run for files that have a ledger row.

This matches the repo-wide convention of relative links **with** the `.md` extension, including `docs/PROOF_LOOP.md:64`, which links the same target as `[Export and verify EvidencePacks](guides/export-verify-evidencepacks.md)`.

## Published docs site: verified

The guide is a public surface (`slug: guides/air-gap-appliance`) in `docs/public-docs.manifest.json`, so I checked `app-helm-docs` before opening this. The `.md` suffix does not break the published page — **it fixes it**.

Both link paths in `app-helm-docs` rewrite relative hrefs to a GitHub blob URL rather than treating them as internal routes:

- `rewriteSourceLinks` — `scripts/generate-docs-assets.mjs:180-199` (prebuild)
- `resolveHref` — `lib/docs.ts:860-866` (render)

Each resolves the href against the source doc's directory and emits `https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/<resolved>`. Running that exact logic over both forms:

```
BEFORE  .../blob/main/docs/guides/use-openai-compatible-proxy      target exists: false   -> 404
AFTER   .../blob/main/docs/guides/use-openai-compatible-proxy.md   target exists: true    -> resolves
```

So the extension is required for the published link to resolve.

### Why not site-absolute links

#629 proposed `/guides/...` instead. Not viable: `docs/guides/use-openai-compatible-proxy.md` is not a published surface (no manifest entry — the proxy doc publishes from `docs/INTEGRATIONS/openai_baseurl.md` at `integrations/openai-compatible-proxy`), so `/guides/use-openai-compatible-proxy` 404s on the site. And `relative_markdown_target?` (`docs-truth-org.rb:435-440`) skips any target starting with `/`, so the gate could never catch it. #629 is closed; details there.

## Verification

**The fix is confirmed by CI:** the `docs-truth` report artifact on this PR contains **zero `broken_relative_link` failures**. Before the change the gate reported exactly two, both in this file:

```
broken_relative_link | docs/guides/air-gap-appliance.md | line 59 points to missing relative target use-openai-compatible-proxy
broken_relative_link | docs/guides/air-gap-appliance.md | line 90 points to missing relative target export-verify-evidencepacks
```

## Remaining CI failures are not from this change

`docs-truth`, `openai / gpt-5.6-sol`, and `HELM Autonomous Release Permit` are red. The now-closed #629 — a *different* edit to the same two lines — failed with the identical three, which rules out the diff as the cause.

**`docs-truth` (3 failures, was 11).** All are ledger/tooling issues outside this repo:

- 8 × `duplicate_ledger_row` — **already fixed** by Mindburn-Labs/docs#138 (#134 and #136 landed the same backfill independently).
- 3 × `ledger_path_not_tracked` — `deploy/appliance/README.md`, `docs/deployment/boundary-enforcement-profile.md`, `docs/design/sealed-boundary-appliance-profile.md`. These ledger rows carry the `pre-merge docs-truth contract for Mindburn-Labs/helm-ai-kernel#624` note that the gate is supposed to tolerate — but **CI runs a gate build that predates that feature**. `docs-truth.yml` pins `Mindburn-Labs/.github@1382586657`, which pins `dev-orchestration@014aa7eb`; that revision contains zero occurrences of `PRE_MERGE_CONTRACT`, which was added later in dev-orchestration#16 (`54c6d75`). Verified by running both script revisions over identical inputs: `014aa7eb` → these exact 3 failures, `54c6d75` → PASS.

  **These 3 resolve on their own when #624 merges** — it adds exactly those three files, so they become tracked and the rows stop being orphans regardless of gate version. Bumping the pin instead is *not* recommended as a quick fix: measured across the workspace it would clear these 3 and 49 in `docs_for_team`, but surface **38 new `banned_stale_string` failures in `helm-ai-enterprise`** (obsolete "website/docs" and Console ownership wording) that need real editorial work first.

**`openai / gpt-5.6-sol`** fails in "Run isolated read-only model review" (re-run twice, same result) — a provider-side/reviewer issue. **`HELM Autonomous Release Permit`** then fails at "Reduce distinct-provider reviews" because the 2-of-2 distinct-provider quorum only has the anthropic review. The permit failure is a symptom of the reviewer failure, not independent.

Note for reviewers: do not treat a local `docs-truth-org.rb` run as authoritative. A local checkout runs dev-orchestration `main`, while CI runs the older pinned revision — they disagree on exactly these 3 rows. Trust the CI artifact.

Docs-only change; no source or behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)