### PR TITLE
ci(docs-truth): adopt derived ledger rows (HELM-41)

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -13,6 +13,6 @@ on:
 jobs:
   docs-truth:
     name: docs-truth
-    uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@1382586657b369c9c81947b42f04525e3922b0f9
+    uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@3ce0af631a00853274a42a016977083ff06b619f
     secrets:
       MINDBURN_ORG_READ_TOKEN: ${{ secrets.PLATFORM_DESIGN_SYSTEM_REPO_READ_TOKEN }}


### PR DESCRIPTION
Bumps this repo's `Docs Truth` pin to [Mindburn-Labs/.github#56](https://github.com/Mindburn-Labs/.github/pull/56), which points the shared runner at [dev-orchestration#18](https://github.com/Mindburn-Labs/dev-orchestration/pull/18) — HELM-41.

## What changes for this repo

- Adding tracked markdown no longer needs a paired PR to `Mindburn-Labs/docs`. `missing_ledger_row` is gone as a failure class; a file with no ledger row is classified from the repo (`owner`, `public_surface` from manifest visibility, `source_refs` from the anchors the repo carries) and reported as a `derived_ledger_row` warning.
- A ledger row whose file does not exist is now a warning, not a failure, so the estate no longer goes red in either direction of the two-repo handshake.
- Content checks are unchanged — banned strings, stale repo references, relative links, public-claim source refs, `truth_gate`, archive rules all still fail the build.
- Also picks up per-repo `docs-truth.yaml` ignores (HELM-59) and pre-merge contracts.

## Why now

On 2026-07-21 seven merged kernel PRs left eight files unregistered, which turned `helm-ai-kernel` main and every open PR red (HELM-314); the recovery then collided with a second session writing the same rows. HELM-41 recorded the same pattern costing 34 hours in `docs_for_team` in July. Derivation removes the chore, so the incentive to skip it disappears.

## Validation

Measured across the whole estate before rollout — 47 active repos, real checkouts, CI workspace shape: failures drop from 96 (oldest pin in use) / 85 (previous shared runner) to **38**, and all 38 are a genuine stale-wording defect in `helm-ai-enterprise`, which bumps last. This repo is clean under the new runner. Runner selftests: 14/14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
