### PR TITLE
ci(docs-truth): grant the caller pull-requests: write

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -2,10 +2,6 @@ name: Docs Truth
 
 permissions:
   contents: read
-  # Lets the reusable's orphan-ledger step upsert a PR comment. A called
-  # workflow cannot elevate GITHUB_TOKEN beyond the caller's grant, so this
-  # must be declared here or the run fails at startup.
-  pull-requests: write
 
 on:
   pull_request:
@@ -17,6 +13,12 @@ on:
 jobs:
   docs-truth:
     name: docs-truth
+    # Scoped to this job, not the workflow: only the reusable's orphan-ledger
+    # step needs it, and a called workflow cannot elevate GITHUB_TOKEN beyond
+    # the caller's grant — without it the run fails at startup.
+    permissions:
+      contents: read
+      pull-requests: write
     uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@3ce0af631a00853274a42a016977083ff06b619f
     secrets:
       MINDBURN_ORG_READ_TOKEN: ${{ secrets.PLATFORM_DESIGN_SYSTEM_REPO_READ_TOKEN }}

--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -2,6 +2,10 @@ name: Docs Truth
 
 permissions:
   contents: read
+  # Lets the reusable's orphan-ledger step upsert a PR comment. A called
+  # workflow cannot elevate GITHUB_TOKEN beyond the caller's grant, so this
+  # must be declared here or the run fails at startup.
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Fixes a `startup_failure` on `main` that I introduced in #630.

## What broke

#630 bumped the pin to `Mindburn-Labs/.github@3ce0af63`, where the reusable workflow declares `pull-requests: write` for its orphan-ledger comment step. A called workflow cannot elevate `GITHUB_TOKEN` beyond the caller's grant, so a caller declaring only `contents: read` fails **before any job starts** — run [29815268938](https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/29815268938), `startup_failure`, no jobs, no report.

Five of the six repos rolled onto this pin (`docs`, `docs_for_team`, `gitops-platform`, `homebrew-tap`, `mindburn-infra`) already declared the permission — `helm-ai-kernel` was the only caller that did not, which is why `docs`'s run passed and this one never started. I checked the reusable workflow's runner behaviour before rollout but not its `permissions` block against each caller. That is the gap; this restores the gate.

## Change

Adds `pull-requests: write` to this workflow's `permissions`, matching the other callers and the note in the reusable workflow itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
