### PR TITLE
test(docs-truth): HELM-41 acceptance probe — markdown with no ledger row

### DIFF
--- a/docs/helm-41-orphan-proof.md
+++ b/docs/helm-41-orphan-proof.md
@@ -1,0 +1,3 @@
+# HELM-41 acceptance probe
+
+Temporary file with no ledger row in Mindburn-Labs/docs. If Docs Truth passes on this PR, derivation works and the two-repo handshake is gone. Deleted immediately after.


### PR DESCRIPTION
Throwaway PR proving the HELM-41 acceptance criterion: a new tracked markdown file with **no row** in `Mindburn-Labs/docs/audit/markdown-estate-ledger.csv` must pass `Docs Truth`. Under the previous runner this failed with `missing_ledger_row` and reddened main plus every open PR here — exactly the HELM-314 outage this morning. Not for merge; closing and deleting the branch as soon as the check reports.