### PR TITLE
ci(docs-truth): adopt the derived-ledger-rows runner (HELM-41)

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -13,6 +13,6 @@ on:
 jobs:
   docs-truth:
     name: docs-truth
-    uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@1382586657b369c9c81947b42f04525e3922b0f9
+    uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@3ce0af631a00853274a42a016977083ff06b619f
     secrets:
       MINDBURN_ORG_READ_TOKEN: ${{ secrets.PLATFORM_DESIGN_SYSTEM_REPO_READ_TOKEN }}


### PR DESCRIPTION
## Что

Поднимает пин общего обработчика docs-truth с `13825866` на `3ce0af63` — тот же, что уже принят в [Mindburn-Labs/docs#147](https://github.com/Mindburn-Labs/docs/pull/147) и стоит по умолчанию в `.github`.

## Зачем

Под новым обработчиком отслеживаемая разметка без записи в реестре **классифицируется из самого репозитория**, а не валит проверку: `missing_ledger_row` становится предупреждением `derived_ledger_row`, `ledger_path_not_tracked` понижается туда же — потому что о том, какие файлы существуют, авторитетно судит репозиторий, а не реестр.

Проверки содержимого не изменились и по-прежнему выполняются, теперь и по выведенным записям.

## Что это меняет на практике

Добавление markdown-файла в этот репозиторий больше не требует парного запроса в `Mindburn-Labs/docs` и больше не красит основную ветку вместе со всеми открытыми запросами, пока эта пара не сведена.

Именно это и произошло с #623: файлы `docs/guides/air-gap-appliance.md` и `examples/governed_local_inference/README.md` были добавлены здесь, а общеорганизационная проверка краснела до тех пор, пока в соседнем репозитории не появились записи.

## Проверка

Локальный прогон обхода по этому репозиторию: **0 отказов до и после**. Смена пина ничего не ломает — она снимает целый класс будущих ложных срабатываний.
