### PR TITLE
ci(docs-truth): вернуть штатный ключ MINDBURN_ORG_READ_TOKEN

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -21,4 +21,4 @@ jobs:
       pull-requests: write
     uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@3ce0af631a00853274a42a016977083ff06b619f
     secrets:
-      MINDBURN_ORG_READ_TOKEN: ${{ secrets.PLATFORM_DESIGN_SYSTEM_REPO_READ_TOKEN }}
+      MINDBURN_ORG_READ_TOKEN: ${{ secrets.MINDBURN_ORG_READ_TOKEN }}


### PR DESCRIPTION
Возврат с временной подмены на штатный ключ — он перевыпущен с доступом.

Доказательство уже есть: в [Mindburn-Labs/docs#153](https://github.com/Mindburn-Labs/docs/pull/153) тот же возврат дал зелёную проверку, и только после этого был влит.

**Здесь та же дисциплина: вливается только если прогон на этой ветке зелёный.** Вливание на предположении сегодня уже уронило основную ветку в docs и потребовало отката.