### PR TITLE
ci(docs-truth): вернуть штатный ключ MINDBURN_ORG_READ_TOKEN

### DIFF
--- a/.github/workflows/docs-truth.yml
+++ b/.github/workflows/docs-truth.yml
@@ -21,4 +21,4 @@ jobs:
       pull-requests: write
     uses: Mindburn-Labs/.github/.github/workflows/docs-truth-public.yml@3ce0af631a00853274a42a016977083ff06b619f
     secrets:
-      MINDBURN_ORG_READ_TOKEN: ${{ secrets.PLATFORM_DESIGN_SYSTEM_REPO_READ_TOKEN }}
+      MINDBURN_ORG_READ_TOKEN: ${{ secrets.MINDBURN_ORG_READ_TOKEN }}


### PR DESCRIPTION
Возврат с временной подмены на штатный ключ — он перевыпущен с доступом.

Доказательство: в [Mindburn-Labs/docs#153](https://github.com/Mindburn-Labs/docs/pull/153) тот же возврат дал зелёную проверку, и только тогда был влит. Здесь на предыдущей ветке проверка тоже была зелёной.

Заменяет #635, где я забыл обязательную подпись `Signed-off-by`.