### PR TITLE
fix(prg): refuse rules Graph.Validate cannot evaluate instead of passing them

### DIFF
--- a/core/pkg/prg/engine_comprehensive_test.go
+++ b/core/pkg/prg/engine_comprehensive_test.go
@@ -929,3 +929,75 @@ func TestCompiler_Compile_ContainsRule(t *testing.T) {
 		t.Fatal("compiled graph should contain rule with ID as key")
 	}
 }
+
+// Graph.Validate evaluates artifact presence only. Before this guard, a
+// requirement carrying a CEL Expression but no ArtifactType was assumed
+// satisfied, so Validate could return true *plus a rule hash* for a policy
+// whose expression was never evaluated — a fail-open verdict carrying evidence
+// of an evaluation that did not happen.
+func TestGraph_Validate_RefusesCELExpressionRequirement(t *testing.T) {
+	g := NewGraph()
+	_ = g.AddRule("act-cel", RequirementSet{
+		ID:    "rs-cel",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "r1", Expression: "intent.risk < 3"},
+		},
+	})
+
+	ok, hash, err := g.Validate("act-cel", nil)
+	if err == nil {
+		t.Fatal("expected Validate to refuse a CEL expression requirement")
+	}
+	if ok {
+		t.Fatal("fail-open: reported satisfied without evaluating the expression")
+	}
+	if hash != "" {
+		t.Fatalf("must not emit a rule hash for an unevaluated rule, got %q", hash)
+	}
+	if !strings.Contains(err.Error(), "EvaluateRequirementSet") {
+		t.Fatalf("error should name the canonical evaluator, got %q", err)
+	}
+}
+
+// The guard must see expressions nested in child sets, not just top-level ones.
+func TestGraph_Validate_RefusesNestedCELExpressionRequirement(t *testing.T) {
+	g := NewGraph()
+	_ = g.AddRule("act-nested", RequirementSet{
+		ID:    "rs-root",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "r1", ArtifactType: "evidence/alert"},
+		},
+		Children: []RequirementSet{{
+			ID:           "rs-child",
+			Logic:        AND,
+			Requirements: []Requirement{{ID: "r2", Expression: "state.approved == true"}},
+		}},
+	})
+
+	arts := []*pkg_artifact.ArtifactEnvelope{{Type: "evidence/alert"}}
+	ok, _, err := g.Validate("act-nested", arts)
+	if err == nil || ok {
+		t.Fatal("expected a nested CEL expression requirement to be refused")
+	}
+}
+
+// A requirement with neither an ArtifactType nor an Expression is malformed.
+// It must fail closed rather than count as satisfied.
+func TestGraph_Validate_MalformedRequirementFailsClosed(t *testing.T) {
+	g := NewGraph()
+	_ = g.AddRule("act-malformed", RequirementSet{
+		ID:           "rs-malformed",
+		Logic:        AND,
+		Requirements: []Requirement{{ID: "r1", Description: "no artifact type, no expression"}},
+	})
+
+	ok, _, err := g.Validate("act-malformed", nil)
+	if ok {
+		t.Fatal("fail-open: malformed requirement counted as satisfied")
+	}
+	if err == nil {
+		t.Fatal("expected an error for an unsatisfiable rule")
+	}
+}

--- a/core/pkg/prg/graph.go
+++ b/core/pkg/prg/graph.go
@@ -131,15 +131,44 @@ func (g *Graph) Validate(actionID string, artifacts []*pkg_artifact.ArtifactEnve
 		return false, "", fmt.Errorf("no policy defined for action %s", actionID)
 	}
 
+	// check evaluates artifact presence only. Returning true for a rule whose CEL
+	// expressions were never evaluated would hand the caller a satisfied verdict
+	// and a rule hash for a policy this evaluator did not actually apply. Refuse
+	// instead, and name the evaluator that can.
+	if hasExpressionRequirement(rule) {
+		return false, "", fmt.Errorf(
+			"action %s carries CEL expression requirements: Graph.Validate evaluates artifact presence only — use PolicyEngine.EvaluateRequirementSet",
+			actionID,
+		)
+	}
+
 	if check(rule, artifacts) {
 		return true, rule.Hash(), nil
 	}
 	return false, "", fmt.Errorf("missing requirement")
 }
 
+// hasExpressionRequirement reports whether rs or any descendant carries a CEL
+// Expression. Used by Validate to refuse rules it cannot faithfully evaluate.
+func hasExpressionRequirement(rs RequirementSet) bool {
+	for _, req := range rs.Requirements {
+		if req.Expression != "" {
+			return true
+		}
+	}
+	for _, child := range rs.Children {
+		if hasExpressionRequirement(child) {
+			return true
+		}
+	}
+	return false
+}
+
 // check is the legacy artifact-presence validator used by Graph.Validate.
-// It evaluates only ArtifactType requirements; CEL Expression requirements are
-// treated as satisfied here. The canonical evaluator that honours CEL is
+// It evaluates only ArtifactType requirements. Rules carrying CEL Expressions
+// are rejected by Validate before reaching here, so anything this function sees
+// must be checkable; a requirement it cannot check is malformed and fails
+// closed. The canonical evaluator that honours CEL is
 // PolicyEngine.EvaluateRequirementSet — prefer it for policy decisions. This
 // function is retained for the artifact-only Graph.Validate API and kept in
 // operator-semantics sync with that path.
@@ -163,8 +192,10 @@ func check(rs RequirementSet, artifacts []*pkg_artifact.ArtifactEnvelope) bool {
 				}
 			}
 		} else {
-			// Expression or others ignored in this legacy check
-			has = true
+			// Neither an ArtifactType nor (per Validate's guard) an Expression:
+			// the requirement is malformed. Fail closed — this evaluator must
+			// never report a requirement it did not actually check as satisfied.
+			has = false
 		}
 		leafResults = append(leafResults, has)
 	}


### PR DESCRIPTION
## Problem

`check` in `core/pkg/prg/graph.go` evaluates **artifact presence only**. A requirement carrying a CEL `Expression` but no `ArtifactType` fell into this branch:

```go
} else {
    // Expression or others ignored in this legacy check
    has = true
}
```

So `Graph.Validate` could return `true` **and `rule.Hash()`** for a policy whose expression was never evaluated — a satisfied verdict carrying evidence of an evaluation that did not happen.

That is a fail-open path inside a component whose stated posture is fail-closed.

## Fix

`Validate` now refuses rules it cannot faithfully evaluate, and names the evaluator that can — which is what the function's own doc comment already directed callers toward:

> The canonical evaluator that honours CEL is `PolicyEngine.EvaluateRequirementSet` — prefer it for policy decisions.

The malformed case (neither `ArtifactType` nor `Expression`) now fails closed instead of counting as satisfied.

**Why refuse rather than silently return `false`:** a caller reaching this path has picked the wrong evaluator. An error says so; a `false` would look like a policy denial and send someone debugging the wrong thing.

## Blast radius

Effectively zero today. `Graph.Validate` has **no production callers** — only `pkg/prg/engine_comprehensive_test.go` — and the guardian decision path uses `PolicyEngine.EvaluateRequirementSet` (`guardian.go:477`). This closes an exported foot-gun *before* something calls it.

## Tests

Three new cases, six existing ones unchanged:

```
--- PASS: TestGraph_Validate_RefusesCELExpressionRequirement
--- PASS: TestGraph_Validate_RefusesNestedCELExpressionRequirement   (child sets, not just top level)
--- PASS: TestGraph_Validate_MalformedRequirementFailsClosed
```

The first asserts the full fail-open signature: not satisfied, **and** no rule hash emitted.

## Boundary

`core/pkg/prg` has **0 entries** in `tools/boundary/protected.manifest` (guardian has 41), so no manifest regeneration and no `[KERNEL-SYNC]` follow-up is required. Confirmed rather than assumed:

```
make verify-boundary → Results: 1051 current, 0 stale, 0 errors → OSS boundary check passed. ✓
GOWORK=off go vet ./pkg/prg/  → clean
GOWORK=off go test ./pkg/prg/ → ok
```

## Provenance

Found by a full 318-issue audit of the HELM AI board against source-owned evidence. **This path is named in no existing Linear issue** — it surfaced while surveying the HELM-56 remainder. It needs an issue filed; Linear writes are currently held pending an MCP re-auth.

A sibling fail-open found in the same survey — `guardian.go:468` discarding the `toMap` error, so CEL evaluates against an empty `input.effect` — is **not** in this PR: it sits in the protected guardian package and is batched with the HELM-52/56 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)