### PR TITLE
fix(guardian): enforce tainted-egress denial by default, reserve the override key (HELM-52)

### DIFF
--- a/core/pkg/guardian/guardian.go
+++ b/core/pkg/guardian/guardian.go
@@ -252,6 +252,14 @@ func NewGuardian(signer crypto.Signer, ruleGraph *prg.Graph, reg *pkg_artifact.R
 		slog.Warn("[guardian] no authority clock injected; falling back to wall clock (KERNEL_TCB §3) — inject WithClock in production")
 		g.clock = wallClock{}
 	}
+
+	if !taintEgressEnforcementEnabled() {
+		// Logged once here rather than per-decision: the check sits on the hot
+		// path, but a disabled security boundary must never be silent. This
+		// state contradicts TaintSafeEgress in proofs/GuardianPipeline.tla.
+		slog.Warn("[guardian] tainted-egress enforcement DISABLED by HELM_TAINT_TRACKING; TAINTED_DATA_EGRESS_DENY will not fire (contradicts proofs/GuardianPipeline.tla TaintSafeEgress)")
+	}
+
 	g.boundaryChain = []BoundaryInterceptor{
 		g.zeroidInterceptor,
 		NewTemporalInterceptor(g),
@@ -1143,9 +1151,22 @@ func stringContextValue(ctx map[string]any, keys ...string) (string, bool) {
 	return "", false
 }
 
-func taintTrackingEnabled() bool {
+// taintEgressEnforcementEnabled reports whether the built-in tainted-egress deny
+// is active. Taint *labelling* always runs; this gates only enforcement.
+//
+// Enforcement defaults to ON. proofs/GuardianPipeline.tla:52-53 states
+// TaintSafeEgress unconditionally, it is listed in Safety and enforced as an
+// INVARIANT in guardian.cfg, and it is model-checked on every PR. A default of
+// off left the implementation weaker than its own proof: with the variable
+// unset, the && at the call site short-circuited and TAINTED_DATA_EGRESS_DENY
+// never evaluated.
+//
+// Only an explicit "0" or "false" disables it — an unset or unparseable value
+// enforces, so a typo cannot silently open the boundary. Disabling is intended
+// for incident response and is logged once at construction.
+func taintEgressEnforcementEnabled() bool {
 	v := strings.TrimSpace(os.Getenv("HELM_TAINT_TRACKING"))
-	return v == "1" || strings.EqualFold(v, "true")
+	return !(v == "0" || strings.EqualFold(v, "false"))
 }
 
 func taintedEgressDenied(ctx map[string]interface{}, labels []string) bool {
@@ -1156,7 +1177,7 @@ func taintedEgressDenied(ctx map[string]interface{}, labels []string) bool {
 	// context was bound by a trusted transport/adapter boundary, never from
 	// caller-supplied arguments (otherwise any agent can self-approve
 	// PII/credential/secret egress).
-	if approved, ok := ctx["allow_tainted_egress"].(bool); ok && approved && trustedSecurityContext(ctx) {
+	if approved, ok := ctx[ContextAllowTaintedEgress].(bool); ok && approved && trustedSecurityContext(ctx) {
 		return false
 	}
 	destination, _ := ctx["destination"].(string)

--- a/core/pkg/guardian/interceptor.go
+++ b/core/pkg/guardian/interceptor.go
@@ -24,13 +24,17 @@ const (
 	ContextSourceChannel   = "source_channel"
 	ContextTrustLevel      = "trust_level"
 	ContextDestination     = "destination"
+	// ContextAllowTaintedEgress overrides the tainted-egress deny. It is a
+	// security decision and must be bound by the transport, never passed as a
+	// caller argument — see IsReservedSecurityContextKey.
+	ContextAllowTaintedEgress = "allow_tainted_egress"
 )
 
 // IsReservedSecurityContextKey identifies context keys whose values must be
 // bound by a trusted transport or adapter boundary, never by caller arguments.
 func IsReservedSecurityContextKey(key string) bool {
 	switch strings.TrimSpace(key) {
-	case ContextSecurityTrusted, ContextCredentialHash, ContextSessionID, ContextSourceChannel, ContextTrustLevel, ContextDestination:
+	case ContextSecurityTrusted, ContextCredentialHash, ContextSessionID, ContextSourceChannel, ContextTrustLevel, ContextDestination, ContextAllowTaintedEgress:
 		return true
 	default:
 		return false
@@ -712,7 +716,7 @@ func (t *TaintEgressInterceptor) Evaluate(ctx context.Context, evalCtx *Evaluati
 		evalCtx.Request.Context["taint"] = taintLabels
 		evalCtx.Tainted = true
 	}
-	if taintTrackingEnabled() && taintedEgressDenied(evalCtx.Request.Context, taintLabels) {
+	if taintEgressEnforcementEnabled() && taintedEgressDenied(evalCtx.Request.Context, taintLabels) {
 		now := t.g.clock.Now()
 		decision := &contracts.DecisionRecord{
 			ID:         newDecisionID(),

--- a/core/pkg/guardian/interceptor_test.go
+++ b/core/pkg/guardian/interceptor_test.go
@@ -158,3 +158,111 @@ func TestTaintInterceptorEgressBlock(t *testing.T) {
 		assert.Equal(t, string(contracts.ReasonTaintedEgressDeny), dec.ReasonCode)
 	})
 }
+
+// Tainted-egress enforcement defaults to ON.
+//
+// Previously HELM_TAINT_TRACKING had to be set to "1"/"true" to enforce, so with
+// it unset the `&&` at the call site short-circuited and TAINTED_DATA_EGRESS_DENY
+// never evaluated. That left the implementation weaker than its own proof:
+// proofs/GuardianPipeline.tla:52-53 asserts TaintSafeEgress unconditionally, it
+// is enforced as an INVARIANT in guardian.cfg, and it is model-checked on every
+// PR. These cases pin the code to the proof.
+func TestTaintEgressEnforcementDefault(t *testing.T) {
+	taintedRequest := func() DecisionRequest {
+		return DecisionRequest{
+			Principal: "untrusted-agent",
+			Action:    "EXECUTE_TOOL",
+			Resource:  "http.post",
+			Context: map[string]interface{}{
+				"destination": "https://external.egress.com/upload",
+				"taint":       []string{contracts.TaintCredential},
+			},
+		}
+	}
+
+	t.Run("unset enforces", func(t *testing.T) {
+		t.Setenv("HELM_TAINT_TRACKING", "")
+		g := newMinimalGuardian()
+
+		dec, err := g.EvaluateDecision(context.Background(), taintedRequest())
+		assert.NoError(t, err)
+		assert.Equal(t, string(contracts.VerdictDeny), dec.Verdict,
+			"unset must enforce: an unconfigured kernel had no tainted-egress boundary")
+		assert.Equal(t, string(contracts.ReasonTaintedEgressDeny), dec.ReasonCode)
+	})
+
+	t.Run("unparseable value enforces", func(t *testing.T) {
+		// A typo must not silently open a security boundary.
+		t.Setenv("HELM_TAINT_TRACKING", "yes")
+		g := newMinimalGuardian()
+
+		dec, err := g.EvaluateDecision(context.Background(), taintedRequest())
+		assert.NoError(t, err)
+		assert.Equal(t, string(contracts.VerdictDeny), dec.Verdict,
+			"only an explicit 0/false may disable enforcement")
+		assert.Equal(t, string(contracts.ReasonTaintedEgressDeny), dec.ReasonCode)
+	})
+
+	t.Run("explicit opt-out disables", func(t *testing.T) {
+		// Retained for incident response; logged once at construction.
+		t.Setenv("HELM_TAINT_TRACKING", "0")
+		g := newMinimalGuardian()
+
+		dec, err := g.EvaluateDecision(context.Background(), taintedRequest())
+		assert.NoError(t, err)
+		// Equal, not NotEqual: NotEqual would pass for any other reason code,
+		// including unrelated breakage. Skipped gate falls through to PRG.
+		assert.Equal(t, string(contracts.ReasonNoPolicy), dec.ReasonCode,
+			"explicit opt-out must skip the deny and fall through to PRG")
+	})
+
+	t.Run("false also disables", func(t *testing.T) {
+		t.Setenv("HELM_TAINT_TRACKING", "FALSE")
+		g := newMinimalGuardian()
+
+		dec, err := g.EvaluateDecision(context.Background(), taintedRequest())
+		assert.NoError(t, err)
+		assert.Equal(t, string(contracts.ReasonNoPolicy), dec.ReasonCode)
+	})
+}
+
+// allow_tainted_egress is a security decision and must be bound by the transport,
+// never accepted as a caller argument. fee619c9 required a trusted context before
+// honouring the override but left the key out of IsReservedSecurityContextKey, so
+// any transport that copies non-reserved arguments into the decision context and
+// then marks it trusted -- pkg/mcp/server.go does this -- let a caller smuggle the
+// override in and self-approve its own tainted egress.
+func TestAllowTaintedEgressIsReservedSecurityContextKey(t *testing.T) {
+	if !IsReservedSecurityContextKey(ContextAllowTaintedEgress) {
+		t.Fatal("allow_tainted_egress must be transport-bound: a caller argument could otherwise self-approve tainted egress")
+	}
+	if taintedEgressDenied(map[string]interface{}{
+		ContextDestination: "https://external.example.com", ContextAllowTaintedEgress: true, ContextSecurityTrusted: true,
+	}, []string{contracts.TaintSecret}) {
+		t.Fatal("transport-bound override must still suppress the deny")
+	}
+	if !taintedEgressDenied(map[string]interface{}{
+		ContextDestination: "https://external.example.com", ContextAllowTaintedEgress: true,
+	}, []string{contracts.TaintSecret}) {
+		t.Fatal("untrusted override must not suppress the deny")
+	}
+}
+
+// Taint labelling is unconditional; the variable gates only the built-in deny.
+func TestTaintLabellingIsUnconditional(t *testing.T) {
+	t.Setenv("HELM_TAINT_TRACKING", "0")
+	evalCtx := &EvaluationContext{Request: DecisionRequest{
+		Principal: "agent", Action: "EXECUTE_TOOL", Resource: "http.post",
+		Context: map[string]interface{}{
+			ContextDestination: "https://external.egress.com/upload",
+			"taint":            []string{contracts.TaintPII},
+		},
+	}}
+	passThrough := func(context.Context, *EvaluationContext) (*contracts.DecisionRecord, error) {
+		return &contracts.DecisionRecord{Verdict: string(contracts.VerdictAllow)}, nil
+	}
+	_, err := NewTaintEgressInterceptor(newMinimalGuardian()).Evaluate(context.Background(), evalCtx, passThrough)
+	assert.NoError(t, err)
+	assert.True(t, evalCtx.Tainted, "taint labelling must run even with enforcement disabled")
+	assert.NotNil(t, evalCtx.Request.Context["taint"], "taint labels must reach the CEL input")
+}

--- a/docs/security/clawguard-taint-tracking.md
+++ b/docs/security/clawguard-taint-tracking.md
@@ -31,7 +31,7 @@ ClawGuard's core operational move is deterministic enforcement at every tool-cal
 | --- | --- |
 | Task/tool boundary rule set | PRG/CEL requirements evaluated by Guardian |
 | Taint on tool-returned or external content | `Effect.Taint` and `AuthorizedExecutionIntent.Taint` |
-| Deterministic tool-call interception | Feature-flagged Guardian tainted-egress gate |
+| Deterministic tool-call interception | Guardian tainted-egress gate (enforced by default) |
 | Auditable enforcement | signed `DecisionRecord`, intent taint binding, TLA invariant |
 
 ## Runtime Contract
@@ -45,7 +45,7 @@ Callers may attach taint labels through `DecisionRequest.Context`:
 }
 ```
 
-When `HELM_TAINT_TRACKING=1`, Guardian denies outbound egress carrying sensitive taint (`pii`, `credential`, or `secret`) unless the context explicitly contains:
+Guardian denies outbound egress carrying sensitive taint (`pii`, `credential`, or `secret`) unless the context explicitly contains:
 
 ```json
 {
@@ -53,7 +53,35 @@ When `HELM_TAINT_TRACKING=1`, Guardian denies outbound egress carrying sensitive
 }
 ```
 
+and that context was bound by a trusted transport boundary. `allow_tainted_egress`
+is a reserved security-context key (`IsReservedSecurityContextKey`), so a transport
+that forwards caller arguments — the MCP server, for example — rejects it at the
+boundary rather than copying it into the decision context. Without that, an agent
+could pass the flag as a tool argument and self-approve its own egress on any
+transport that marks its context trusted.
+
 The decision remains fail-closed: denial uses `TAINTED_DATA_EGRESS_DENY`, and issued execution intents copy normalized taint labels from the effect they authorize.
+
+### Enforcement default
+
+Enforcement is **on by default**. `proofs/GuardianPipeline.tla` states `TaintSafeEgress`
+unconditionally and model-checks it on every PR, so a non-enforcing default left the
+implementation weaker than its own proof.
+
+`HELM_TAINT_TRACKING` now acts as an **opt-out**, intended for incident response:
+
+| Value | Enforcement |
+| --- | --- |
+| unset, `1`, `true`, or anything unrecognized | **enforced** |
+| `0` or `false` | disabled |
+
+An unrecognized value enforces so a typo cannot silently open the boundary. When
+enforcement is disabled, Guardian logs a warning once at construction naming the
+proof invariant it contradicts — a disabled security boundary is never silent.
+
+Taint *labelling* is unconditional and unaffected by this variable: labels are always
+propagated into `DecisionRequest.Context["taint"]` and the CEL input, so PRG rules can
+act on taint even where the built-in deny is disabled.
 
 ## CEL Helper
 

--- a/tools/boundary/protected.manifest
+++ b/tools/boundary/protected.manifest
@@ -1,5 +1,5 @@
 # HELM Protected Manifest
-# Generated: 2026-07-21T10:10:00Z
+# Generated: 2026-07-21T12:46:00Z
 # Source: current protected working tree; per-entry hashes are authoritative
 # Format: SHA256  PATH
 # quantum_posture: boundary manifest only; it records crypto file hashes but is not a cryptographic control.
@@ -603,7 +603,7 @@ f3bae08d14fe098e6b6322c7eac60746ae5fd2277e348d82c3a9d3701becb05a  core/pkg/guard
 33b80ff2f4dc9eba8c135cb61ac232deb9be30e84fe63585e31f6ddfeadd19b1  core/pkg/guardian/decision_fuzz_test.go
 d4fa373206ebec6a2226322a2aea776c5d66a8f8c5b4f533c0e61c2e116deb3b  core/pkg/guardian/execution_intent_test.go
 d23c84456f34f27e6cb7fd113211028dbd88c34980fe81e3b74a307d701a4bfd  core/pkg/guardian/extended2_test.go
-ca357a16947145067179f4586df61e61b38d0d500cc498764598462c8c87efd9  core/pkg/guardian/guardian.go
+01f659e5748664caf9bdc83fc1af07cc60191477db13e8c558f76a957840e6e5  core/pkg/guardian/guardian.go
 9fc820cc5de13baf08dc3a37d97142e2ad3f506f82a06b38b92579e180d93d15  core/pkg/guardian/guardian_additional_coverage_test.go
 05d2907a744570e725955e9967f578b098389dee199fa7af7d54c2381f770a54  core/pkg/guardian/guardian_behavior_coverage_test.go
 2a5ca32bc0c383992332eea7cd839575ee7dd4b6266c2ed64c7bd8a2bfec044f  core/pkg/guardian/guardian_bench_test.go
@@ -617,8 +617,8 @@ d7ad656ec37a80da9538c9435229f2e06214ccdde857fdf81e86dbb18d4ad7d7  core/pkg/guard
 604a3143cb413e5f65278430f7f40c0c98c3eb123b7180d01c05e7b19906f678  core/pkg/guardian/guardian_stress_coverage_test.go
 ac6ed02511a836d82a9c31f650b93e4741f403c6f3fd150306762b12a5fc667d  core/pkg/guardian/guardian_test.go
 b8a92ba80717a401aed15e89883c609ca40e7281b74b2b781fd9b327e9360a9c  core/pkg/guardian/integration_test.go
-52fcdd33999d6b9aa8d29785589a58a38d73a918f0de452e9fe8c85cbaa7d38d  core/pkg/guardian/interceptor.go
-ff78b833c6f03eecbf994ddf44b2e41cc65346c3cd8bca55d0c1ed2bbfc4fe7d  core/pkg/guardian/interceptor_test.go
+c09172c6ce26a4417d3c7e48152e854ce7d821dc9ea0e35c01f10296a8efb942  core/pkg/guardian/interceptor.go
+365a76cf2d043aaab20841cb0452bc0eb8350850aa6ed47f7ee14ed80f87ce8a  core/pkg/guardian/interceptor_test.go
 c0118e244adcba44a228c918ffb6c2fddc5be3273b7383914fb81e5f933bdb54  core/pkg/guardian/intervention_test.go
 fa50013f154fd1a1ebe1dcc1448b22f0ef3650990cefef4e7693aed227130b52  core/pkg/guardian/otel.go
 27e480317e91ec0ca763f23b1cc5db4a6fa9bae0090a6f4b0d97954dd25fcdf3  core/pkg/guardian/otel_test.go


### PR DESCRIPTION
## Problem

`taintTrackingEnabled()` returned true only for an explicit `"1"`/`"true"`, so enforcement defaulted to **OFF**. Go's `&&` short-circuits at the call site, so with the variable unset `taintedEgressDenied` was never called and `TAINTED_DATA_EGRESS_DENY` never fired.

**An unconfigured kernel had no tainted-egress boundary at all** — while its own proof said otherwise. `proofs/GuardianPipeline.tla:52-53` states `TaintSafeEgress` with no flag or parameter, is listed in `Safety` (:172), enforced as an `INVARIANT` in `guardian.cfg:16`, and model-checked on every PR.

## Fix

| `HELM_TAINT_TRACKING` | Enforcement |
|---|---|
| unset, `1`, `true`, unrecognized | **enforced** |
| `0`, `false` | disabled |

An unrecognized value enforces so a typo cannot silently open a boundary. Disabling logs once at construction, naming the invariant it contradicts.

Renamed `taintTrackingEnabled` → `taintEgressEnforcementEnabled`: labelling is unconditional and unaffected; only the built-in deny was ever gated.

### The flip alone was not enough

Review found `allow_tainted_egress` was **absent from `IsReservedSecurityContextKey`**. Any transport that copies non-reserved caller arguments into the decision context and then marks it trusted — `pkg/mcp/server.go:87-94` does exactly this — let a caller pass the flag as a **tool argument** and self-approve its own tainted egress.

`fee619c9` closed the direct half by requiring a trusted context, but that marker means *"arrived via a transport"*, not *"this value was bound by the transport"*. Reserving the key makes such a transport reject it at the boundary.

**Without this, the doc change in this PR would have published a false security guarantee.**

## Scope of the proof claim

This **narrows** the code-vs-proof divergence; it does not close it. Three paths still ALLOW where the spec forbids — explicit opt-out, the transport-bound override (the spec models no override), and a request with no `destination` key. None are introduced here; each needs its own issue.

**No TLA+ change is required, and none should be made** — modelling the flag or the override would mean weakening `TaintSafeEgress`. Pipeline shape unchanged (6 gates).

## Tests

Four cases pin the default: unset enforces · unrecognized enforces · `"0"` disables · `"FALSE"` disables. The disabling cases assert `Equal(ReasonNoPolicy)` rather than `NotEqual`, which would have passed for any unrelated breakage. Plus reserved-key coverage (override still honoured when transport-bound, still ignored when not) and a case pinning that labelling runs with enforcement disabled.

## Gates

`make lint` · race on guardian/mcp/firewall/effects · `make verify-boundary` **1051 current, 0 stale, 0 errors** with the manifest regenerated in-commit.

## Two corrections to my own earlier claims, both caught in review

- **The bench figure was wrong.** "p99 26µs" was `ed25519_sign_only`, not the overhead benchmark. Actual overhead p99 ≈ **129µs** on this branch vs **122µs** on main — no regression here, but overhead p99 has exceeded the 75µs operating bar since June on both. Separate pre-existing issue.
- **`TestEvidencePackSingleSource` does not fail on pristine main.** I reported it as a pre-existing main-branch failure. It isn't — the local failure was a stray `.claude/worktrees/` copy of `evidence.go` that the test's `skipDirs` doesn't exclude. Test fragility, not a defect.

Rebased onto **v0.7.4** (`a079cdfc`), which shipped mid-review. The manifest conflict was resolved by regenerating, never by merging hashes.

Follow-ups filed by the review, not in scope here: snapshot the env at construction (it's read per-decision, so enforcement can change mid-process without appearing in the receipt); `destination`-key evasion; `TestEvidencePackSingleSource` walking `.claude`.

Refs: HELM-52, HELM-48

🤖 Generated with [Claude Code](https://claude.com/claude-code)