### PR TITLE
ci: run the race gate and enforce reason-code reachability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,8 @@ jobs:
         run: make lint
       - name: ProofGraph signature write guard
         run: bash scripts/ci/check_proofgraph_signature_writes.sh
+      - name: Reason-code reachability
+        run: python3 scripts/ci/check_reason_code_reachability.py
       - name: Build
         run: make build
       - name: Test
@@ -172,6 +174,22 @@ jobs:
         run: make crucible
       - name: Benchmark report
         run: make bench-report
+
+  # Runs the `go-race` gate from scripts/ci/quality-gates.json. That gate is
+  # registered only in the `merge` profile, and no workflow invokes
+  # `make quality-merge` — so the race detector never ran in CI. Kept as its own
+  # job so it runs concurrently with `kernel` instead of serializing behind it.
+  kernel-race:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: "1.25.12"
+          cache-dependency-path: "**/go.sum"
+      - name: Core race tests
+        run: make test-race
 
   python-sdk:
     runs-on: ubuntu-latest

--- a/scripts/ci/check_reason_code_reachability.py
+++ b/scripts/ci/check_reason_code_reachability.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Require every declared ReasonCode to be reachable.
+
+A reason code that is declared and enumerated but never emitted is an
+unenforceable contract: it reads as coverage in review and produces nothing at
+runtime. ERR_ASSUMPTION_STALE is the canonical example — declared, given a
+conformance vector, never returned by any code path.
+
+A code passes if non-test code can emit it, or if it is recorded in
+reason-codes-known-unreachable.txt with an owner and a tracking issue. The
+allowlist is also checked in reverse: an entry whose code has since become
+reachable fails, so the list burns down instead of rotting.
+
+Matching is deliberately qualified. Two packages shadow these names and must
+not count as emissions:
+  - core/pkg/conform/reason_codes.go reuses the Go identifiers
+  - core/pkg/connectors/ton/acton/errors.go reuses the wire values
+So an emission is `contracts.<Ident>` anywhere, or a bare `<Ident>` inside
+core/pkg/contracts/ only. Lines assigning ExpectedReasonCode are conformance
+expectations — assertions about required behavior, not emissions — and are
+excluded.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+VERDICT = ROOT / "core" / "pkg" / "contracts" / "verdict.go"
+CONTRACTS_DIR = ROOT / "core" / "pkg" / "contracts"
+SEARCH_ROOT = ROOT / "core"
+ALLOWLIST = pathlib.Path(__file__).resolve().parent / "reason-codes-known-unreachable.txt"
+
+DECL_RE = re.compile(r'^\s+(Reason[A-Za-z0-9_]+)\s+ReasonCode\s*=\s*"([^"]+)"', re.M)
+EXPECTATION_RE = re.compile(r"ExpectedReasonCode\s*:")
+
+SKIP_PARTS = {".git", "node_modules", "vendor", "worktrees", "testdata"}
+
+
+def go_sources() -> list[pathlib.Path]:
+    out = []
+    for path in SEARCH_ROOT.rglob("*.go"):
+        if path.name.endswith("_test.go"):
+            continue
+        if path == VERDICT:
+            continue
+        # Relative to SEARCH_ROOT — an absolute-path check would match the
+        # checkout's own location (e.g. running from .claude/worktrees/...)
+        # and silently skip every file.
+        if SKIP_PARTS & set(path.relative_to(SEARCH_ROOT).parts):
+            continue
+        out.append(path)
+    return out
+
+
+def main() -> int:
+    source = VERDICT.read_text(encoding="utf-8")
+    declared = {ident: wire for ident, wire in DECL_RE.findall(source)}
+    if not declared:
+        print(f"error: no ReasonCode declarations parsed from {VERDICT}", file=sys.stderr)
+        return 2
+
+    emitted: set[str] = set()
+    for path in go_sources():
+        in_contracts_pkg = CONTRACTS_DIR in path.parents
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for line in text.splitlines():
+            if EXPECTATION_RE.search(line):
+                continue
+            for ident in declared:
+                if ident in emitted:
+                    continue
+                if f"contracts.{ident}" in line:
+                    emitted.add(ident)
+                elif in_contracts_pkg and re.search(rf"\b{ident}\b", line):
+                    emitted.add(ident)
+
+    allowed: set[str] = set()
+    if ALLOWLIST.exists():
+        for raw in ALLOWLIST.read_text(encoding="utf-8").splitlines():
+            line = raw.split("#", 1)[0].strip()
+            if line:
+                allowed.add(line.split()[0])
+
+    unreachable = sorted(set(declared) - emitted - allowed)
+    stale = sorted(allowed & emitted)
+    unknown = sorted(allowed - set(declared))
+
+    if unreachable:
+        print("Declared ReasonCodes that no non-test code can emit:")
+        for ident in unreachable:
+            print(f"  {ident:<45} {declared[ident]}")
+        print(
+            f"\nEmit each from the path that should produce it, or add it to\n"
+            f"{ALLOWLIST.relative_to(ROOT)} with an owner and a tracking issue."
+        )
+
+    if stale:
+        print("\nAllowlisted ReasonCodes that are now emitted — remove these entries:")
+        for ident in stale:
+            print(f"  {ident:<45} {declared[ident]}")
+
+    if unknown:
+        print("\nAllowlist entries that are not declared ReasonCodes:")
+        for ident in unknown:
+            print(f"  {ident}")
+
+    if unreachable or stale or unknown:
+        return 1
+
+    print(f"reason-code reachability: {len(declared)} declared, {len(emitted)} emitted, {len(allowed)} allowlisted")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/reason-codes-known-unreachable.txt
+++ b/scripts/ci/reason-codes-known-unreachable.txt
@@ -1,0 +1,80 @@
+# Declared ReasonCodes that no non-test code can emit.
+#
+# Enforced by scripts/ci/check_reason_code_reachability.py. An entry here is a
+# recorded, reviewed gap — not a dismissal. The gate also fails when a listed
+# code becomes reachable, so this list burns down rather than rotting.
+#
+# Seeded 2026-07-21 from docs/ai/helm-verifiable-execution-research-review.md.
+# 48 of 96 declared codes were unreachable at seed time. Format: identifier
+# first; the rest of the line is free text.
+
+# ── TON / Acton (24) — duplicated registry, NOT unimplemented ──────────────
+# core/pkg/connectors/ton/acton/errors.go declares its own ReasonCode type with
+# these same 24 wire values, and the connector emits those. The contracts copies
+# are the unreachable half of a two-registry split. Remedy is to collapse the
+# duplication onto one registry, not to add emit sites here.
+ReasonTONActonArgvRejected                   ERR_TON_ACTON_ARGV_REJECTED
+ReasonTONActonGenericMainnetScriptDenied     ERR_TON_ACTON_GENERIC_MAINNET_SCRIPT_DENIED
+ReasonTONActonRawShellForbidden              ERR_TON_ACTON_RAW_SHELL_FORBIDDEN
+ReasonTONActonUnknownCommand                 ERR_TON_ACTON_UNKNOWN_COMMAND
+ReasonTONActonUnsupportedVersion             ERR_TON_ACTON_UNSUPPORTED_VERSION
+ReasonTONApprovalCeremonyRequired            ERR_TON_APPROVAL_CEREMONY_REQUIRED
+ReasonTONCoverageThresholdFailed             ERR_TON_COVERAGE_THRESHOLD_FAILED
+ReasonTONExpectedEffectMismatch              ERR_TON_EXPECTED_EFFECT_MISMATCH
+ReasonTONLibraryMainnetRequiresApproval      ERR_TON_LIBRARY_MAINNET_REQUIRES_APPROVAL
+ReasonTONLibrarySpendCeilingExceeded         ERR_TON_LIBRARY_SPEND_CEILING_EXCEEDED
+ReasonTONMainnetRequiresApproval             ERR_TON_MAINNET_REQUIRES_APPROVAL
+ReasonTONMutationThresholdFailed             ERR_TON_MUTATION_THRESHOLD_FAILED
+ReasonTONNetworkGrantRequired                ERR_TON_NETWORK_GRANT_REQUIRED
+ReasonTONPlaintextMnemonicForbidden          ERR_TON_PLAINTEXT_MNEMONIC_FORBIDDEN
+ReasonTONSandboxGrantRequired                ERR_TON_SANDBOX_GRANT_REQUIRED
+ReasonTONScriptManifestHashMismatch          ERR_TON_SCRIPT_MANIFEST_HASH_MISMATCH
+ReasonTONScriptManifestRequired              ERR_TON_SCRIPT_MANIFEST_REQUIRED
+ReasonTONSourceVerificationRequired          ERR_TON_SOURCE_VERIFICATION_REQUIRED
+ReasonTONSpendCeilingExceeded                ERR_TON_SPEND_CEILING_EXCEEDED
+ReasonTONTolkCompilerMismatch                ERR_TON_TOLK_COMPILER_MISMATCH
+ReasonTONTolkCompilerUnpinned                ERR_TON_TOLK_COMPILER_UNPINNED
+ReasonTONVerifyBytecodeMismatch              ERR_TON_VERIFY_BYTECODE_MISMATCH
+ReasonTONVerifyDryRunRequired                ERR_TON_VERIFY_DRY_RUN_REQUIRED
+ReasonTONWalletRefRequired                   ERR_TON_WALLET_REF_REQUIRED
+
+# ── Harness Engineering v1.4 (9 of the 10-code block) — specified, unbuilt ──
+# Declared with conformance vectors in core/pkg/conformance/negative_vectors.go
+# and never emitted. ReasonAssumptionStale is the State Witness gate; it is
+# scheduled work, see docs/ai/helm-enforcement-integrity-remediation-plan.md.
+# NOTE: ReasonPlanTransactionConflict is NOT listed here because it IS emitted --
+# at core/pkg/runtimeadapters/mcp/bridge.go:371, for nonce replay rather than a
+# plan-transaction conflict. Reachability cannot catch a miscoded emission.
+ReasonAssumptionStale                        ERR_ASSUMPTION_STALE
+ReasonGUIPostconditionUnverified             ERR_GUI_POSTCONDITION_UNVERIFIED
+ReasonGreenTestScopeMissing                  ERR_GREEN_TEST_SCOPE_MISSING
+ReasonGroundedActionRefRequired              ERR_GROUNDED_ACTION_REF_REQUIRED
+ReasonHarnessChangeContractInvalid           ERR_HARNESS_CHANGE_CONTRACT_INVALID
+ReasonHarnessMutationRequiresApproval        ERR_HARNESS_MUTATION_REQUIRES_APPROVAL
+ReasonHarnessTraceRequired                   ERR_HARNESS_TRACE_REQUIRED
+ReasonPlanTransactionRequired                ERR_PLAN_TRANSACTION_REQUIRED
+ReasonVerificationScopeRequired              ERR_VERIFICATION_SCOPE_REQUIRED
+
+# ── Tainted-flow (2) — shadowed by core/pkg/conform/reason_codes.go ─────────
+# The conform package declares untyped string constants with identical Go
+# identifiers. Only conform.* is referenced; contracts.* is unreachable.
+ReasonTaintedEscalate                        TAINTED_HIGH_RISK_ESCALATE
+ReasonTaintedInvokeDeny                      TAINTED_PRIVILEGED_INVOKE_DENY
+
+# ── Policy / host-evidence (3) ──────────────────────────────────────────────
+ReasonPolicyDeniedHostObservedEgress         ERR_POLICY_DENIED_BUT_HOST_OBSERVED_EGRESS
+ReasonPolicyHashMismatch                     POLICY_HASH_MISMATCH
+ReasonPolicySigInvalid                       POLICY_SIGNATURE_INVALID
+
+# ── Remaining (10) ──────────────────────────────────────────────────────────
+ReasonComputeGasExhausted                    ERR_COMPUTE_GAS_EXHAUSTED
+ReasonComputeTimeExhausted                   ERR_COMPUTE_TIME_EXHAUSTED
+ReasonConnectorContractDrift                 ERR_CONNECTOR_CONTRACT_DRIFT
+ReasonContinuityStale                        ERR_CONTINUITY_STALE
+ReasonDevFallbackPresent                     ERR_DEV_FALLBACK_PRESENT
+ReasonEmergencyCapsuleInvalid                ERR_EMERGENCY_CAPSULE_INVALID
+ReasonHardwareQuorumUnbound                  ERR_HARDWARE_QUORUM_UNBOUND
+ReasonHostProcessUnbound                     ERR_HOST_PROCESS_UNBOUND
+ReasonJurisdiction                           JURISDICTION_VIOLATION
+ReasonTenantIsolation                        TENANT_ISOLATION
+


### PR DESCRIPTION
Two enforcement paths that existed and never ran. From the enforcement-integrity audit in `docs/ai/helm-verifiable-execution-research-review.md`.

## `go-race` was registered but unreachable

`go-race` is defined in `scripts/ci/quality-gates.json` with the correct command, 30-min timeout, and `core/**` path filter. It is assigned to exactly one profile — `merge` — and **no workflow invokes `make quality-merge`**:

| Profile | Workflow | Has `go-race` |
|---|---|---|
| `pr` | ci.yml:74 | no |
| `nightly` | nightly-quality.yml:44 | no |
| `release` | release.yml:84 | no |
| `merge` | **none** | **yes** |

So the race detector has never run in CI. Added as its own `kernel-race` job rather than a step on `kernel`, so it runs concurrently rather than serializing ~30 min onto the critical path.

**Verified:** `make test-race` passes clean on `main` today — 0 data races, 0 failures — so this lands green rather than red.

## Reason-code reachability (new)

48 of 96 declared `ReasonCode` constants are never emitted by non-test code. A code that is declared, enumerated, and given a conformance vector but never returned reads as coverage in review and produces nothing at runtime. `ERR_ASSUMPTION_STALE` is the canonical case: declared at `verdict.go:138`, documented in `reason-codes-v1.json:579`, vectored at `negative_vectors.go:188`, zero emit sites.

The gate requires each declared code to be emitted or recorded in `reason-codes-known-unreachable.txt`. It **also fails when an allowlisted code becomes reachable**, so the list burns down instead of rotting.

Matching is deliberately qualified — two packages shadow these names and must not count as emissions:
- `core/pkg/conform/reason_codes.go` reuses the Go identifiers
- `core/pkg/connectors/ton/acton/errors.go` reuses the wire values

An emission is `contracts.<Ident>` anywhere, or a bare `<Ident>` inside `core/pkg/contracts/` only. `ExpectedReasonCode:` lines are conformance expectations, not emissions.

### The allowlist records *why*, per group

The 24 `ReasonTON*` entries are **a duplicated registry, not unimplemented work** — `acton/errors.go` declares the same 24 wire values on its own type and the connector emits those. Remedy is collapsing the duplication, not adding emit sites.

Note `ReasonPlanTransactionConflict` is deliberately *not* allowlisted: it is emitted, at `bridge.go:371` — for nonce replay rather than a plan-transaction conflict. Reachability cannot catch a miscoded emission; that is tracked separately.

## Verification

- `make lint` — clean
- `make test-race` — clean (0 races)
- Gate green: `96 declared, 48 emitted, 48 allowlisted`
- Canary tested all three modes: new unreachable code fails; allowlisting it passes; a stale allowlist entry fails. `verdict.go` restored, no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)