### PR TITLE
feat(guardian): report the gate roster so nil-skipped gates are observable

### DIFF
--- a/core/pkg/guardian/roster.go
+++ b/core/pkg/guardian/roster.go
@@ -1,0 +1,115 @@
+package guardian
+
+import (
+	"sort"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+// GateID names a Guardian dependency that gates authorization.
+//
+// Every gate is injected through a GuardianOption and every use site is written
+// `if g.<field> != nil`, so an uninjected gate is silently skipped rather than
+// refused. The roster below makes that composition observable: which gates a
+// Guardian will actually run is otherwise only discoverable by reading each
+// call site.
+//
+// proofs/GuardianPipeline.tla asserts AllowRequiresUnanimity over every gate
+// and has no state for an absent one, so a nil gate is a refinement gap
+// against a spec TLC checks on each PR. Reporting the roster is the first step
+// toward closing it; binding the roster hash into the decision record and
+// refusing to construct with an unset gate follow.
+type GateID string
+
+const (
+	GateAgentKillSwitch GateID = "agent_kill_switch"
+	GateAudit           GateID = "audit"
+	GateBehavioralTrust GateID = "behavioral_trust"
+	GateBudget          GateID = "budget"
+	GateCompliance      GateID = "compliance"
+	GateContext         GateID = "context"
+	GateDelegation      GateID = "delegation"
+	GateEgress          GateID = "egress"
+	GateFreeze          GateID = "freeze"
+	GateIsolation       GateID = "isolation"
+	GatePDP             GateID = "pdp"
+	GatePolicySnapshots GateID = "policy_snapshots"
+	GatePrivilege       GateID = "privilege"
+	GateSafeDeprecation GateID = "safe_deprecation"
+	GateScopedStop      GateID = "scoped_stop"
+	GateSessionRisk     GateID = "session_risk"
+	GateTemporal        GateID = "temporal"
+	GateThreat          GateID = "threat"
+	GateWarmLease       GateID = "warm_lease"
+)
+
+// GateRoster records which gates a Guardian will run and which it will skip.
+//
+// Both slices are sorted so the roster canonicalizes deterministically.
+type GateRoster struct {
+	Active   []GateID `json:"active"`
+	Inactive []GateID `json:"inactive"`
+}
+
+// Hash returns the JCS/SHA-256 digest of the roster in wire form. It is the
+// value intended to be bound into a decision record, so evidence states which
+// gates produced a verdict instead of leaving that to code review.
+func (r GateRoster) Hash() (string, error) {
+	digest, err := canonicalize.CanonicalHash(r)
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + digest, nil
+}
+
+// GateRoster reports the gates injected into g. A gate is Active when its
+// dependency is non-nil — exactly the condition each call site tests before
+// running it.
+func (g *Guardian) GateRoster() GateRoster {
+	injected := map[GateID]bool{
+		GateAgentKillSwitch: g.agentKillSwitch != nil,
+		GateAudit:           g.auditLog != nil,
+		GateBehavioralTrust: g.behavioralScorer != nil,
+		GateBudget:          g.tracker != nil,
+		GateCompliance:      g.complianceChecker != nil,
+		GateContext:         g.contextGuard != nil,
+		GateDelegation:      g.delegationStore != nil,
+		GateEgress:          g.egressChecker != nil,
+		GateFreeze:          g.freezeCtrl != nil,
+		GateIsolation:       g.isolationChecker != nil,
+		GatePDP:             g.pdp != nil,
+		GatePolicySnapshots: g.snapshotStore != nil,
+		GatePrivilege:       g.privilegeResolver != nil,
+		GateSafeDeprecation: g.safeDepController != nil,
+		GateScopedStop:      g.scopedStopReader != nil,
+		GateSessionRisk:     g.sessionRiskMemory != nil,
+		GateTemporal:        g.temporal != nil,
+		GateThreat:          g.threatScanner != nil,
+		GateWarmLease:       g.warmLeaseMgr != nil,
+	}
+
+	roster := GateRoster{Active: []GateID{}, Inactive: []GateID{}}
+	for id, present := range injected {
+		if present {
+			roster.Active = append(roster.Active, id)
+		} else {
+			roster.Inactive = append(roster.Inactive, id)
+		}
+	}
+	sort.Slice(roster.Active, func(i, j int) bool { return roster.Active[i] < roster.Active[j] })
+	sort.Slice(roster.Inactive, func(i, j int) bool { return roster.Inactive[i] < roster.Inactive[j] })
+	return roster
+}
+
+// AllGateIDs returns every declared gate, sorted.
+func AllGateIDs() []GateID {
+	ids := []GateID{
+		GateAgentKillSwitch, GateAudit, GateBehavioralTrust, GateBudget,
+		GateCompliance, GateContext, GateDelegation, GateEgress, GateFreeze,
+		GateIsolation, GatePDP, GatePolicySnapshots, GatePrivilege,
+		GateSafeDeprecation, GateScopedStop, GateSessionRisk, GateTemporal,
+		GateThreat, GateWarmLease,
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}

--- a/core/pkg/guardian/roster_test.go
+++ b/core/pkg/guardian/roster_test.go
@@ -1,0 +1,132 @@
+package guardian
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/kernel"
+)
+
+// gateFieldByID maps each declared gate to the Guardian field its call sites
+// nil-check. It lives in the test so production code carries no reflection.
+var gateFieldByID = map[GateID]string{
+	GateAgentKillSwitch: "agentKillSwitch",
+	GateAudit:           "auditLog",
+	GateBehavioralTrust: "behavioralScorer",
+	GateBudget:          "tracker",
+	GateCompliance:      "complianceChecker",
+	GateContext:         "contextGuard",
+	GateDelegation:      "delegationStore",
+	GateEgress:          "egressChecker",
+	GateFreeze:          "freezeCtrl",
+	GateIsolation:       "isolationChecker",
+	GatePDP:             "pdp",
+	GatePolicySnapshots: "snapshotStore",
+	GatePrivilege:       "privilegeResolver",
+	GateSafeDeprecation: "safeDepController",
+	GateScopedStop:      "scopedStopReader",
+	GateSessionRisk:     "sessionRiskMemory",
+	GateTemporal:        "temporal",
+	GateThreat:          "threatScanner",
+	GateWarmLease:       "warmLeaseMgr",
+}
+
+// nonGateFields are Guardian fields that are not injectable gates: core
+// collaborators the Guardian cannot run without, or derived state. They are
+// listed explicitly so that adding a field forces a deliberate choice between
+// "this is a gate" and "this is not".
+var nonGateFields = map[string]bool{
+	"signer":            true,
+	"prg":               true,
+	"pe":                true,
+	"registry":          true,
+	"clock":             true,
+	"envFprint":         true,
+	"snapshotScope":     true,
+	"otel":              true,
+	"zeroidInterceptor": true,
+	"boundaryChain":     true,
+}
+
+// A new nil-gated dependency added to Guardian without a GateID would be
+// invisible to the roster — and an invisible gate is how fourteen of them came
+// to be unset in every production path. This fails until it is classified.
+func TestGateRosterCoversEveryGuardianGateField(t *testing.T) {
+	mapped := make(map[string]GateID, len(gateFieldByID))
+	for id, field := range gateFieldByID {
+		if prev, dup := mapped[field]; dup {
+			t.Fatalf("field %q mapped by both %q and %q", field, prev, id)
+		}
+		mapped[field] = id
+	}
+
+	structType := reflect.TypeOf(Guardian{})
+	for i := 0; i < structType.NumField(); i++ {
+		name := structType.Field(i).Name
+		if nonGateFields[name] {
+			continue
+		}
+		if _, ok := mapped[name]; !ok {
+			t.Errorf("Guardian field %q has no GateID and is not listed in nonGateFields; "+
+				"classify it so the roster stays complete", name)
+		}
+	}
+
+	for field := range mapped {
+		if _, ok := structType.FieldByName(field); !ok {
+			t.Errorf("gateFieldByID references %q, which is not a Guardian field", field)
+		}
+	}
+
+	if len(AllGateIDs()) != len(gateFieldByID) {
+		t.Fatalf("AllGateIDs has %d entries, gateFieldByID has %d", len(AllGateIDs()), len(gateFieldByID))
+	}
+}
+
+// Pins the audit baseline: constructed with no options, every gate is skipped.
+// Production call sites pass at most three options, so this is close to what
+// actually ships. If a gate becomes injected by default, this test should be
+// updated deliberately rather than by accident.
+func TestGateRosterReportsEveryGateInactiveWithoutOptions(t *testing.T) {
+	g := NewGuardian(nil, nil, nil)
+
+	roster := g.GateRoster()
+	if len(roster.Active) != 0 {
+		t.Errorf("Active = %v, want none for an option-less Guardian", roster.Active)
+	}
+	if len(roster.Inactive) != len(AllGateIDs()) {
+		t.Errorf("Inactive has %d gates, want all %d", len(roster.Inactive), len(AllGateIDs()))
+	}
+}
+
+// The roster is only useful as evidence if it hashes deterministically.
+func TestGateRosterHashIsDeterministicAndDistinguishesComposition(t *testing.T) {
+	bare := NewGuardian(nil, nil, nil)
+	bareHash, err := bare.GateRoster().Hash()
+	if err != nil {
+		t.Fatalf("hashing bare roster: %v", err)
+	}
+	repeatHash, err := NewGuardian(nil, nil, nil).GateRoster().Hash()
+	if err != nil {
+		t.Fatalf("hashing repeat roster: %v", err)
+	}
+	if bareHash != repeatHash {
+		t.Fatalf("roster hash is not deterministic: %q vs %q", bareHash, repeatHash)
+	}
+
+	withFreeze := NewGuardian(nil, nil, nil, WithFreezeController(kernel.NewFreezeController()))
+	freezeRoster := withFreeze.GateRoster()
+	freezeHash, err := freezeRoster.Hash()
+	if err != nil {
+		t.Fatalf("hashing freeze roster: %v", err)
+	}
+	if freezeHash == bareHash {
+		t.Fatal("roster hash did not change when a gate was injected")
+	}
+	for _, id := range freezeRoster.Active {
+		if id == GateFreeze {
+			return
+		}
+	}
+	t.Fatalf("Active = %v, want it to contain %q", freezeRoster.Active, GateFreeze)
+}


### PR DESCRIPTION
First slice of the enforcement-integrity remediation (HELM-320). **No behavior change** — this makes the guardian's composition observable and test-enforced, so the fail-closed work can land on a foundation that can't silently regress.

## The problem

`Guardian` has **19 dependencies that gate authorization**. Every one is injected by a `GuardianOption`, and every one is used behind `if g.<field> != nil` — so an uninjected gate is *skipped*, not refused. Which gates a given Guardian will actually run is discoverable only by reading each call site.

Across the five production `NewGuardian` call sites, **14 are nil everywhere**:

| Documented gate | Field | Nil-check |
|---|---|---|
| Freeze | `freezeCtrl` | `interceptor.go:192` |
| Context | `contextGuard` | `interceptor.go:251` |
| Identity | `isolationChecker` | `interceptor.go:351` |
| Egress | `egressChecker` | `interceptor.go:681` |
| Threat | `threatScanner` | `interceptor.go:371` |
| Delegation | `delegationStore` | `interceptor.go:428` |
| Budget | `tracker` | `guardian.go:426,498` |
| Compliance | `complianceChecker` | `guardian.go:1036` |

Policy evaluation (PRG/CEL/PDP) and the scoped-stop fence do run. Defense-in-depth does not.

`proofs/GuardianPipeline.tla` already forbids this — `AllowRequiresUnanimity` quantifies over every gate and `gateState` has no value for an absent one. **A nil gate is a refinement gap against a spec TLC checks on every PR**, not a design choice.

## What this adds

- `GateRoster()` reports `Active` / `Inactive` from the same nil condition each call site tests.
- `Hash()` canonicalizes the roster (JCS + SHA-256, wire-prefixed) so it can later be bound into a decision record — at which point **evidence states which gates produced a verdict**, instead of that being a code-review question.

## The test that earns its keep

`TestGateRosterCoversEveryGuardianGateField` reflects over `Guardian`'s fields and fails when one is neither mapped to a `GateID` nor listed as a non-gate collaborator. An unclassified nil-gated dependency is exactly how fourteen gates came to be unset without anyone noticing, so adding one now forces a deliberate choice.

**Verified by canary:** temporarily adding a `canaryGate` field fails the test with

```
Guardian field "canaryGate" has no GateID and is not listed in nonGateFields;
classify it so the roster stays complete
```

and passes once removed. `guardian.go` restored with no diff.

## Deliberately not in this PR

No signature change, and no gate is newly enforced. Refusing to construct with an unset gate requires a **posture decision per gate**, and several fail closed when enabled unconfigured — notably egress, where `firewall/egress.go:16,58,65` makes an empty allowlist deny-all, so switching it on unconfigured is a total outage. That is likely *why* these are nil.

So the enforcement step lands separately, behind counterfactual evidence: wire each gate in shadow mode using the existing contract-level `EnforcementModeShadow` / signed `CounterfactualReceipt` primitives, collect what each *would* have denied, then promote one at a time with config. See `docs/ai/helm-enforcement-integrity-remediation-plan.md` (Mindburn-Labs/docs#156).

## Verification

- `go build ./pkg/guardian/` — clean
- `go test ./pkg/guardian/` — ok
- `go test -race ./pkg/guardian/` — ok
- `make lint` — exit 0
- 3 new tests pass; canary confirms the completeness guard fails correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)