### PR TITLE
fix(workstation): fail closed signer setup

### DIFF
--- a/core/cmd/helm-ai-kernel/hook_cmd.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd.go
@@ -20,9 +20,10 @@ var (
 )
 
 type hookOptions struct {
-	Client  string
-	DataDir string
-	JSON    bool
+	Client          string
+	DataDir         string
+	SigningSeedFile string
+	JSON            bool
 }
 
 type preToolPayload struct {
@@ -85,6 +86,7 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 	fs.SetOutput(stderr)
 	fs.StringVar(&opts.Client, "client", "", "Client name: claude-code or codex")
 	fs.StringVar(&opts.DataDir, "data-dir", opts.DataDir, "Directory for HELM local state")
+	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
 	fs.BoolVar(&opts.JSON, "json", false, "Reserved for structured diagnostics")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -143,7 +145,7 @@ func writeHookDeny(stdout io.Writer, reason string) error {
 }
 
 func printHookUsage(w io.Writer) {
-	fmt.Fprintln(w, "Usage: helm-ai-kernel hook pre-tool --client <claude-code|codex> [--data-dir DIR]")
+	fmt.Fprintln(w, "Usage: helm-ai-kernel hook pre-tool --client <claude-code|codex> [--data-dir DIR] [--signing-seed-file PATH]")
 }
 
 func decodePreToolPayload(stdin io.Reader) (preToolPayload, error) {
@@ -238,9 +240,9 @@ func buildHookDecisionReceipt(opts hookOptions, payload preToolPayload, classifi
 			"tool":   payload.ToolName,
 		},
 	}
-	seed, err := ensureLocalWorkstationSigningSeed(opts.DataDir)
+	seed, err := resolveWorkstationSigningSeed(opts.DataDir, "", opts.SigningSeedFile)
 	if err != nil {
-		return nil, fmt.Errorf("load local workstation signing key: %w", err)
+		return nil, fmt.Errorf("load workstation signing key: %w", err)
 	}
 	return workstation.Decide(profile, req, workstation.DecisionOptions{SigningSeed: seed})
 }

--- a/core/cmd/helm-ai-kernel/hook_cmd.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd.go
@@ -1,3 +1,7 @@
+// quantum_posture: hook decision receipts are signed with the classical
+// Ed25519 workstation seed resolved via workstation_signing.go; no
+// post-quantum or hybrid primitives are used in this file.
+
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/hook_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd_test.go
@@ -134,6 +134,37 @@ func TestHookPreToolFailsClosedWhenLocalSigningKeyIsInsecure(t *testing.T) {
 	}
 }
 
+func TestHookPreToolProductionRequiresExplicitSigningSeedFile(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "true")
+	tmp := t.TempDir()
+	payload := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /srv/production"}}`
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "local receipt signer is unavailable") {
+		t.Fatalf("production hook without signer = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(tmp, workstationSigningKeyDirectory)); !os.IsNotExist(err) {
+		t.Fatalf("production hook created local signing key state: %v", err)
+	}
+
+	seedFile := filepath.Join(t.TempDir(), "hook.seed")
+	if err := os.WriteFile(seedFile, []byte(strings.Repeat("2", 64)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp, "--signing-seed-file", seedFile}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("production hook with explicit signer = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if receipts := globReceipts(t, tmp); len(receipts) != 1 {
+		t.Fatalf("explicit production signer receipts = %v, want one", receipts)
+	}
+	if _, err := os.Stat(workstationSigningSeedPath(tmp)); !os.IsNotExist(err) {
+		t.Fatalf("production hook created fallback seed: %v", err)
+	}
+}
+
 func TestHookPreToolFailsClosedWhenReceiptCannotPersist(t *testing.T) {
 	tmp := t.TempDir()
 	if _, err := ensureLocalWorkstationSigningSeed(tmp); err != nil {

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -728,6 +728,29 @@ func upsertHookConfig(path, matcher, command, allowedRoot string) error {
 	hooks := objectValue(root, "hooks")
 	pre := arrayValue(hooks, "PreToolUse")
 	if hookCommandPresent(pre, command) {
+		// Same hook identity: rewrite the stored command in place so a
+		// re-install with a new --signing-seed-file updates the config
+		// instead of silently keeping the old seed path.
+		key := hookCommandKey(command)
+		for _, item := range pre {
+			obj, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			hookItems, ok := obj["hooks"].([]any)
+			if !ok {
+				continue
+			}
+			for _, h := range hookItems {
+				hookObj, ok := h.(map[string]any)
+				if !ok {
+					continue
+				}
+				if hookCommandKey(hookCommandFromAny(h)) == key {
+					hookObj["command"] = command
+				}
+			}
+		}
 		return writeJSONObject(path, root, allowedRoot)
 	}
 	entry := map[string]any{
@@ -833,8 +856,11 @@ func arrayValue(root map[string]any, key string) []any {
 }
 
 // signingSeedFileArgPattern matches the optional --signing-seed-file segment
-// of an installed hook command, with its shell-quoted or bare argument.
-var signingSeedFileArgPattern = regexp.MustCompile(` --signing-seed-file (?:'[^']*'|\S+)`)
+// of an installed hook command, with its shell-quoted or bare argument. The
+// argument alternation mirrors shellQuote output: a sequence of
+// single-quoted chunks, escaped quotes (the '\” idiom), and bare
+// non-space characters.
+var signingSeedFileArgPattern = regexp.MustCompile(` --signing-seed-file (?:'[^']*'|\\'|[^\s'])+`)
 
 // hookCommandKey reduces an installed hook command to its identity: the
 // signing-seed-file argument is a deployment detail, so `setup status` and

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -32,16 +32,17 @@ var (
 )
 
 type setupOptions struct {
-	Target       string
-	Operation    string
-	Scope        string
-	Workspace    string
-	WorkspaceSet bool
-	Yes          bool
-	DryRun       bool
-	JSON         bool
-	NoQuickstart bool
-	DataDir      string
+	Target          string
+	Operation       string
+	Scope           string
+	Workspace       string
+	WorkspaceSet    bool
+	Yes             bool
+	DryRun          bool
+	JSON            bool
+	NoQuickstart    bool
+	DataDir         string
+	SigningSeedFile string
 }
 
 type setupSummary struct {
@@ -152,7 +153,7 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup: create data dir: %v\n", err)
 		return 1
 	}
-	if _, err := ensureLocalWorkstationSigningSeed(opts.DataDir); err != nil {
+	if _, err := resolveWorkstationSigningSeed(opts.DataDir, "", opts.SigningSeedFile); err != nil {
 		fmt.Fprintf(stderr, "setup: provision local receipt signing key: %v\n", err)
 		return 1
 	}
@@ -297,6 +298,7 @@ func parseSetupInstallArgs(args []string, stderr io.Writer) (setupOptions, int) 
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
 	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Install without starting the blocking Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
+	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
 	if err := fs.Parse(args[1:]); err != nil {
 		return opts, 2
 	}
@@ -323,6 +325,7 @@ func parseSetupInspectArgs(name string, args []string, stderr io.Writer, include
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
 	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Report a headless setup without a Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
+	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
 	if includeYes {
 		fs.BoolVar(&opts.Yes, "yes", false, "Remove without prompting")
 	}
@@ -487,12 +490,17 @@ func setupUninstallCommand(opts setupOptions) string {
 	if opts.Scope == "project" {
 		workspace = " --workspace " + shellQuote(opts.Workspace)
 	}
+	signingSeedFile := ""
+	if strings.TrimSpace(opts.SigningSeedFile) != "" {
+		signingSeedFile = " --signing-seed-file " + shellQuote(opts.SigningSeedFile)
+	}
 	return fmt.Sprintf(
-		"helm-ai-kernel setup remove %s --scope %s%s --yes --data-dir %s",
+		"helm-ai-kernel setup remove %s --scope %s%s --yes --data-dir %s%s",
 		opts.Target,
 		opts.Scope,
 		workspace,
 		shellQuote(opts.DataDir),
+		signingSeedFile,
 	)
 }
 
@@ -688,7 +696,11 @@ func setupHookMatcher(target string) string {
 }
 
 func setupHookCommand(opts setupOptions, bin string) string {
-	return shellQuote(bin) + " hook pre-tool --client " + opts.Target + " --data-dir " + shellQuote(opts.DataDir)
+	command := shellQuote(bin) + " hook pre-tool --client " + opts.Target + " --data-dir " + shellQuote(opts.DataDir)
+	if strings.TrimSpace(opts.SigningSeedFile) != "" {
+		command += " --signing-seed-file " + shellQuote(opts.SigningSeedFile)
+	}
+	return command
 }
 
 func upsertHookConfig(path, matcher, command, allowedRoot string) error {

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -374,6 +375,14 @@ func normalizeSetupOptions(opts setupOptions, stderr io.Writer) (setupOptions, i
 	}
 	if abs, err := filepath.Abs(opts.DataDir); err == nil {
 		opts.DataDir = abs
+	}
+	// The seed-file path gets baked into the installed hook command, which
+	// later runs from an arbitrary working directory — a relative path would
+	// resolve against that directory and fail the signer.
+	if strings.TrimSpace(opts.SigningSeedFile) != "" {
+		if abs, err := filepath.Abs(opts.SigningSeedFile); err == nil {
+			opts.SigningSeedFile = abs
+		}
 	}
 	if opts.Workspace == "" {
 		workspace, err := os.Getwd()
@@ -759,7 +768,7 @@ func removeHookConfig(path, command, allowedRoot string) error {
 		}
 		keptHooks := make([]any, 0, len(hookItems))
 		for _, h := range hookItems {
-			if hookCommandFromAny(h) != command {
+			if hookCommandKey(hookCommandFromAny(h)) != hookCommandKey(command) {
 				keptHooks = append(keptHooks, h)
 			}
 		}
@@ -818,7 +827,20 @@ func arrayValue(root map[string]any, key string) []any {
 	return []any{}
 }
 
+// signingSeedFileArgPattern matches the optional --signing-seed-file segment
+// of an installed hook command, with its shell-quoted or bare argument.
+var signingSeedFileArgPattern = regexp.MustCompile(` --signing-seed-file (?:'[^']*'|\S+)`)
+
+// hookCommandKey reduces an installed hook command to its identity: the
+// signing-seed-file argument is a deployment detail, so `setup status` and
+// `setup remove` must match the hook whether or not (and with whichever path
+// form) the flag was passed on their own invocation.
+func hookCommandKey(command string) string {
+	return signingSeedFileArgPattern.ReplaceAllString(command, "")
+}
+
 func hookCommandPresent(pre []any, command string) bool {
+	key := hookCommandKey(command)
 	for _, item := range pre {
 		obj, ok := item.(map[string]any)
 		if !ok {
@@ -829,7 +851,7 @@ func hookCommandPresent(pre []any, command string) bool {
 			continue
 		}
 		for _, h := range hooks {
-			if hookCommandFromAny(h) == command {
+			if hookCommandKey(hookCommandFromAny(h)) == key {
 				return true
 			}
 		}

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -1,3 +1,8 @@
+// quantum_posture: setup provisions and propagates the path to the classical
+// Ed25519 workstation signing seed (resolution and key handling live in
+// workstation_signing.go); crypto/rand is used only for install identifiers.
+// No post-quantum or hybrid primitives are used in this file.
+
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -1436,3 +1436,40 @@ func TestHookCommandKeyIgnoresSigningSeedFileArgument(t *testing.T) {
 		t.Fatal("hook installed with seed-file flag not matched by flagless lookup")
 	}
 }
+
+func TestHookCommandKeyHandlesEscapedQuotesInSeedPath(t *testing.T) {
+	base := "'/usr/local/bin/helm-ai-kernel' hook pre-tool --client claude-code --data-dir '/home/op/.helm'"
+	trickyPath := "/tmp/o'brien/seed.hex"
+	withSeed := base + " --signing-seed-file " + shellQuote(trickyPath)
+
+	if got := hookCommandKey(withSeed); got != base {
+		t.Fatalf("escaped-quote seed path not fully stripped:\n got %q\nwant %q", got, base)
+	}
+}
+
+func TestUpsertHookConfigUpdatesSeedFileOnReinstall(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "settings.json")
+	base := "'/usr/local/bin/helm-ai-kernel' hook pre-tool --client claude-code --data-dir '/home/op/.helm'"
+	oldCmd := base + " --signing-seed-file '/keys/old.hex'"
+	newCmd := base + " --signing-seed-file '/keys/new.hex'"
+
+	if err := upsertHookConfig(path, "*", oldCmd, tmp); err != nil {
+		t.Fatalf("initial install: %v", err)
+	}
+	if err := upsertHookConfig(path, "*", newCmd, tmp); err != nil {
+		t.Fatalf("reinstall with rotated seed: %v", err)
+	}
+
+	root, err := readJSONObject(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(root)
+	if !strings.Contains(string(raw), "/keys/new.hex") {
+		t.Fatalf("reinstall did not update stored seed path: %s", raw)
+	}
+	if strings.Contains(string(raw), "/keys/old.hex") {
+		t.Fatalf("stale seed path survived reinstall: %s", raw)
+	}
+}

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -1402,3 +1402,37 @@ func markCodexProjectTrusted(t *testing.T, home, workspace string) {
 		t.Fatal(err)
 	}
 }
+
+func TestSetupNormalizesRelativeSigningSeedFile(t *testing.T) {
+	var stderr bytes.Buffer
+	opts, code := parseSetupInstallArgs([]string{"claude-code", "--yes", "--data-dir", t.TempDir(), "--signing-seed-file", "rel/seed.hex"}, &stderr)
+	if code != 0 {
+		t.Fatalf("parse exit = %d stderr=%s", code, stderr.String())
+	}
+	if !filepath.IsAbs(opts.SigningSeedFile) {
+		t.Fatalf("SigningSeedFile = %q, want absolute (relative paths bake a cwd-dependent hook command)", opts.SigningSeedFile)
+	}
+}
+
+func TestHookCommandKeyIgnoresSigningSeedFileArgument(t *testing.T) {
+	base := "'/usr/local/bin/helm-ai-kernel' hook pre-tool --client claude-code --data-dir '/home/op/.helm'"
+	withSeed := base + " --signing-seed-file '/home/op/keys/seed.hex'"
+	withBareSeed := base + " --signing-seed-file /home/op/keys/seed.hex"
+
+	if hookCommandKey(withSeed) != hookCommandKey(base) {
+		t.Fatalf("quoted seed-file arg changes hook identity:\n%q\n%q", hookCommandKey(withSeed), hookCommandKey(base))
+	}
+	if hookCommandKey(withBareSeed) != hookCommandKey(base) {
+		t.Fatalf("bare seed-file arg changes hook identity")
+	}
+	if hookCommandKey(base) != base {
+		t.Fatalf("command without the flag must be unchanged, got %q", hookCommandKey(base))
+	}
+
+	// status/remove parity: a hook installed WITH the flag is found by a
+	// lookup command built WITHOUT it.
+	pre := []any{map[string]any{"hooks": []any{map[string]any{"command": withSeed}}}}
+	if !hookCommandPresent(pre, base) {
+		t.Fatal("hook installed with seed-file flag not matched by flagless lookup")
+	}
+}

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -34,6 +34,21 @@ func TestSetupNoArgsPrintsChooser(t *testing.T) {
 	}
 }
 
+func TestSetupHookCommandIncludesExplicitSigningSeedFile(t *testing.T) {
+	opts := setupOptions{
+		Target:          "codex",
+		DataDir:         "/tmp/helm-data",
+		SigningSeedFile: "/private/approved/workstation.seed",
+	}
+	command := setupHookCommand(opts, "/usr/local/bin/helm-ai-kernel")
+	if !strings.Contains(command, "--signing-seed-file '/private/approved/workstation.seed'") {
+		t.Fatalf("hook command did not preserve explicit signer source: %s", command)
+	}
+	if removal := setupUninstallCommand(opts); !strings.Contains(removal, "--signing-seed-file '/private/approved/workstation.seed'") {
+		t.Fatalf("uninstall command did not preserve explicit signer source: %s", removal)
+	}
+}
+
 func TestSetupJSONSupportMatrix(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{"helm-ai-kernel", "setup", "--json"}, &stdout, &stderr)

--- a/core/cmd/helm-ai-kernel/workstation_signing.go
+++ b/core/cmd/helm-ai-kernel/workstation_signing.go
@@ -40,6 +40,9 @@ func resolveWorkstationSigningSeed(dataDir, seedHex, seedFile string) ([]byte, e
 }
 
 func ensureLocalWorkstationSigningSeed(dataDir string) ([]byte, error) {
+	if envBool("HELM_PRODUCTION") {
+		return nil, errors.New("production mode requires --signing-seed-file")
+	}
 	dataDir, err := normalizedWorkstationDataDir(dataDir)
 	if err != nil {
 		return nil, err

--- a/core/cmd/helm-ai-kernel/workstation_signing_test.go
+++ b/core/cmd/helm-ai-kernel/workstation_signing_test.go
@@ -54,6 +54,30 @@ func TestLocalWorkstationSigningKeyLifecycle(t *testing.T) {
 	}
 }
 
+func TestProductionWorkstationSigningRequiresExplicitSeedFile(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "true")
+	dataDir := filepath.Join(t.TempDir(), "helm")
+
+	if _, err := resolveWorkstationSigningSeed(dataDir, "", ""); err == nil || !strings.Contains(err.Error(), "requires --signing-seed-file") {
+		t.Fatalf("production missing signer error = %v, want explicit seed requirement", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, workstationSigningKeyDirectory)); !os.IsNotExist(err) {
+		t.Fatalf("production missing signer created local key state: %v", err)
+	}
+
+	seedFile := filepath.Join(t.TempDir(), "workstation.seed")
+	if err := os.WriteFile(seedFile, []byte(strings.Repeat("1", ed25519.SeedSize*2)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seed, err := resolveWorkstationSigningSeed(dataDir, "", seedFile)
+	if err != nil {
+		t.Fatalf("load explicit production signing seed: %v", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		t.Fatalf("explicit production seed length = %d, want %d", len(seed), ed25519.SeedSize)
+	}
+}
+
 func TestLocalWorkstationSigningKeyRejectsSymlinkAndMismatchedPublicKey(t *testing.T) {
 	dataDir := filepath.Join(t.TempDir(), "helm")
 	keyDir := filepath.Join(dataDir, workstationSigningKeyDirectory)


### PR DESCRIPTION
## Summary

- Require `--signing-seed-file` for hook and setup signer resolution in `HELM_PRODUCTION`.
- Keep secure local signer provisioning limited to local and development paths.
- Propagate the approved signer-file path into installed hook, status, and removal commands.
- Cover production missing-key denial and explicit-key hook signing with ephemeral test keys.

## Security context

The existing v0.7.3 hardening removes the source-derived receipt seed, separates signature integrity from signer trust, and permanently rejects the retired deterministic signer as a trust anchor. This PR closes the remaining production setup/hook path that could otherwise generate a local key when a signer was absent.

Receipt canonicalization and signature preimages are unchanged.

## Validation

- `go test ./core/pkg/workstation -count=1`
- `go test ./core/pkg/runtimeadapters/mcp -count=1`
- `go test ./core/cmd/helm-ai-kernel -count=1`
- `make test`
- `make lint`

## Required follow-up decisions

- Authoritative trust-store format and owner, including multi-key support.
- Production distribution mechanism for private signer and public trust anchor.
- Key rotation and migration plan; legacy receipts retain integrity verification but are intentionally untrusted.

Refs HELM-225