### PR TITLE
fix(workstation): fail closed signer setup

### DIFF
--- a/core/cmd/helm-ai-kernel/hook_cmd.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd.go
@@ -1,3 +1,5 @@
+// quantum_posture: hooks configure only classical Ed25519 receipt signing;
+// they do not provide post-quantum or hybrid cryptographic protection.
 package main
 
 import (
@@ -20,9 +22,10 @@ var (
 )
 
 type hookOptions struct {
-	Client  string
-	DataDir string
-	JSON    bool
+	Client          string
+	DataDir         string
+	SigningSeedFile string
+	JSON            bool
 }
 
 type preToolPayload struct {
@@ -85,6 +88,7 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 	fs.SetOutput(stderr)
 	fs.StringVar(&opts.Client, "client", "", "Client name: claude-code or codex")
 	fs.StringVar(&opts.DataDir, "data-dir", opts.DataDir, "Directory for HELM local state")
+	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
 	fs.BoolVar(&opts.JSON, "json", false, "Reserved for structured diagnostics")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -143,7 +147,7 @@ func writeHookDeny(stdout io.Writer, reason string) error {
 }
 
 func printHookUsage(w io.Writer) {
-	fmt.Fprintln(w, "Usage: helm-ai-kernel hook pre-tool --client <claude-code|codex> [--data-dir DIR]")
+	fmt.Fprintln(w, "Usage: helm-ai-kernel hook pre-tool --client <claude-code|codex> [--data-dir DIR] [--signing-seed-file PATH]")
 }
 
 func decodePreToolPayload(stdin io.Reader) (preToolPayload, error) {
@@ -238,9 +242,9 @@ func buildHookDecisionReceipt(opts hookOptions, payload preToolPayload, classifi
 			"tool":   payload.ToolName,
 		},
 	}
-	seed, err := ensureLocalWorkstationSigningSeed(opts.DataDir)
+	seed, err := resolveWorkstationSigningSeed(opts.DataDir, "", opts.SigningSeedFile)
 	if err != nil {
-		return nil, fmt.Errorf("load local workstation signing key: %w", err)
+		return nil, fmt.Errorf("load workstation signing key: %w", err)
 	}
 	return workstation.Decide(profile, req, workstation.DecisionOptions{SigningSeed: seed})
 }

--- a/core/cmd/helm-ai-kernel/hook_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd_test.go
@@ -134,6 +134,37 @@ func TestHookPreToolFailsClosedWhenLocalSigningKeyIsInsecure(t *testing.T) {
 	}
 }
 
+func TestHookPreToolProductionRequiresExplicitSigningSeedFile(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "true")
+	tmp := t.TempDir()
+	payload := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /srv/production"}}`
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), "local receipt signer is unavailable") {
+		t.Fatalf("production hook without signer = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(tmp, workstationSigningKeyDirectory)); !os.IsNotExist(err) {
+		t.Fatalf("production hook created local signing key state: %v", err)
+	}
+
+	seedFile := filepath.Join(t.TempDir(), "hook.seed")
+	if err := os.WriteFile(seedFile, []byte(strings.Repeat("2", 64)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp, "--signing-seed-file", seedFile}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("production hook with explicit signer = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if receipts := globReceipts(t, tmp); len(receipts) != 1 {
+		t.Fatalf("explicit production signer receipts = %v, want one", receipts)
+	}
+	if _, err := os.Stat(workstationSigningSeedPath(tmp)); !os.IsNotExist(err) {
+		t.Fatalf("production hook created fallback seed: %v", err)
+	}
+}
+
 func TestHookPreToolFailsClosedWhenReceiptCannotPersist(t *testing.T) {
 	tmp := t.TempDir()
 	if _, err := ensureLocalWorkstationSigningSeed(tmp); err != nil {

--- a/core/cmd/helm-ai-kernel/hook_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd_test.go
@@ -62,6 +62,18 @@ func TestHookPreToolDeniesDestructiveBashAndWritesReceipt(t *testing.T) {
 		t.Fatalf("verify-decision output missing trusted integrity: %s", stdout.String())
 	}
 
+	trustedSignersFile := filepath.Join(tmp, "trusted-signers.json")
+	writeTrustedSignerStore(t, trustedSignersFile, trustedKey)
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "workstation", "verify-decision", "--receipt", receipts[0], "--trusted-signers-file", trustedSignersFile}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("trusted signer store verify-decision exit = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "integrity: true") || !strings.Contains(stdout.String(), "trusted:   true") {
+		t.Fatalf("trusted signer store output missing trust separation: %s", stdout.String())
+	}
+
 	wrongKeyFile := filepath.Join(tmp, "wrong-trusted.pub")
 	if err := os.WriteFile(wrongKeyFile, []byte(strings.Repeat("f", 64)+"\n"), 0o644); err != nil {
 		t.Fatal(err)

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -1,3 +1,5 @@
+// quantum_posture: setup wires only classical Ed25519 receipt signer sources;
+// it does not provide post-quantum or hybrid cryptographic protection.
 package main
 
 import (
@@ -32,16 +34,17 @@ var (
 )
 
 type setupOptions struct {
-	Target       string
-	Operation    string
-	Scope        string
-	Workspace    string
-	WorkspaceSet bool
-	Yes          bool
-	DryRun       bool
-	JSON         bool
-	NoQuickstart bool
-	DataDir      string
+	Target          string
+	Operation       string
+	Scope           string
+	Workspace       string
+	WorkspaceSet    bool
+	Yes             bool
+	DryRun          bool
+	JSON            bool
+	NoQuickstart    bool
+	DataDir         string
+	SigningSeedFile string
 }
 
 type setupSummary struct {
@@ -152,7 +155,7 @@ func runSetupInstallCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "setup: create data dir: %v\n", err)
 		return 1
 	}
-	if _, err := ensureLocalWorkstationSigningSeed(opts.DataDir); err != nil {
+	if _, err := resolveWorkstationSigningSeed(opts.DataDir, "", opts.SigningSeedFile); err != nil {
 		fmt.Fprintf(stderr, "setup: provision local receipt signing key: %v\n", err)
 		return 1
 	}
@@ -297,6 +300,7 @@ func parseSetupInstallArgs(args []string, stderr io.Writer) (setupOptions, int) 
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
 	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Install without starting the blocking Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
+	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
 	if err := fs.Parse(args[1:]); err != nil {
 		return opts, 2
 	}
@@ -323,6 +327,7 @@ func parseSetupInspectArgs(name string, args []string, stderr io.Writer, include
 	fs.BoolVar(&opts.JSON, "json", false, "Print machine-readable summary")
 	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Report a headless setup without a Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
+	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
 	if includeYes {
 		fs.BoolVar(&opts.Yes, "yes", false, "Remove without prompting")
 	}
@@ -487,12 +492,17 @@ func setupUninstallCommand(opts setupOptions) string {
 	if opts.Scope == "project" {
 		workspace = " --workspace " + shellQuote(opts.Workspace)
 	}
+	signingSeedFile := ""
+	if strings.TrimSpace(opts.SigningSeedFile) != "" {
+		signingSeedFile = " --signing-seed-file " + shellQuote(opts.SigningSeedFile)
+	}
 	return fmt.Sprintf(
-		"helm-ai-kernel setup remove %s --scope %s%s --yes --data-dir %s",
+		"helm-ai-kernel setup remove %s --scope %s%s --yes --data-dir %s%s",
 		opts.Target,
 		opts.Scope,
 		workspace,
 		shellQuote(opts.DataDir),
+		signingSeedFile,
 	)
 }
 
@@ -688,7 +698,11 @@ func setupHookMatcher(target string) string {
 }
 
 func setupHookCommand(opts setupOptions, bin string) string {
-	return shellQuote(bin) + " hook pre-tool --client " + opts.Target + " --data-dir " + shellQuote(opts.DataDir)
+	command := shellQuote(bin) + " hook pre-tool --client " + opts.Target + " --data-dir " + shellQuote(opts.DataDir)
+	if strings.TrimSpace(opts.SigningSeedFile) != "" {
+		command += " --signing-seed-file " + shellQuote(opts.SigningSeedFile)
+	}
+	return command
 }
 
 func upsertHookConfig(path, matcher, command, allowedRoot string) error {

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -34,6 +34,21 @@ func TestSetupNoArgsPrintsChooser(t *testing.T) {
 	}
 }
 
+func TestSetupHookCommandIncludesExplicitSigningSeedFile(t *testing.T) {
+	opts := setupOptions{
+		Target:          "codex",
+		DataDir:         "/tmp/helm-data",
+		SigningSeedFile: "/private/approved/workstation.seed",
+	}
+	command := setupHookCommand(opts, "/usr/local/bin/helm-ai-kernel")
+	if !strings.Contains(command, "--signing-seed-file '/private/approved/workstation.seed'") {
+		t.Fatalf("hook command did not preserve explicit signer source: %s", command)
+	}
+	if removal := setupUninstallCommand(opts); !strings.Contains(removal, "--signing-seed-file '/private/approved/workstation.seed'") {
+		t.Fatalf("uninstall command did not preserve explicit signer source: %s", removal)
+	}
+}
+
 func TestSetupJSONSupportMatrix(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := Run([]string{"helm-ai-kernel", "setup", "--json"}, &stdout, &stderr)

--- a/core/cmd/helm-ai-kernel/workstation_cmd.go
+++ b/core/cmd/helm-ai-kernel/workstation_cmd.go
@@ -122,11 +122,13 @@ func runWorkstationViewCmd(args []string, stdout, stderr io.Writer) int {
 		jsonOut              bool
 		dataDir              string
 		trustedPublicKeyFile string
+		trustedSignersFile   string
 	)
 	cmd.StringVar(&receiptPath, "receipt", "", "Agent Run Receipt or workstation import result JSON")
 	cmd.BoolVar(&jsonOut, "json", false, "Print summary JSON")
 	cmd.StringVar(&dataDir, "data-dir", defaultSetupDataDir(), "Directory for HELM local signing state")
 	cmd.StringVar(&trustedPublicKeyFile, "trusted-public-key-file", "", "Path to caller-owned Ed25519 public key file")
+	cmd.StringVar(&trustedSignersFile, "trusted-signers-file", "", "Path to caller-owned versioned trusted signer store JSON")
 
 	if err := cmd.Parse(args); err != nil {
 		return 2
@@ -145,14 +147,14 @@ func runWorkstationViewCmd(args []string, stdout, stderr io.Writer) int {
 		_, _ = fmt.Fprintf(stderr, "Error: receipt integrity check failed: %v\n", err)
 		return 1
 	}
-	trustedKey, trustAnchor, trustAnchorAvailable, err := resolveTrustedWorkstationPublicKey(dataDir, trustedPublicKeyFile)
+	trustedSigners, trustAnchor, trustAnchorAvailable, err := resolveTrustedWorkstationSigners(dataDir, trustedPublicKeyFile, trustedSignersFile)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "Error: load trusted public key: %v\n", err)
 		return 1
 	}
 	signerTrusted := false
 	if trustAnchorAvailable {
-		signerTrusted, err = workstation.VerifyReceiptWithTrustedKey(result.Receipt, trustedKey)
+		signerTrusted, err = workstation.VerifyReceiptWithTrustedSigners(result.Receipt, trustedSigners)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "Error: trusted receipt verification failed: %v\n", err)
 			return 1
@@ -209,7 +211,12 @@ func parseSigningSeedHex(seedHex string) ([]byte, error) {
 	if len(seed) != 32 {
 		return nil, fmt.Errorf("signing seed must decode to 32 bytes")
 	}
-	return seed, nil
+	for _, value := range seed {
+		if value != 0 {
+			return seed, nil
+		}
+	}
+	return nil, fmt.Errorf("signing seed must not be all zero")
 }
 
 func printWorkstationSummary(stdout io.Writer, summary map[string]any) {

--- a/core/cmd/helm-ai-kernel/workstation_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/workstation_cmd_test.go
@@ -256,6 +256,15 @@ func TestWorkstationViewSeparatesIntegrityFromTrustedSigner(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("trusted view exit = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
+
+	trustedSignersFile := filepath.Join(tmp, "trusted-signers.json")
+	writeTrustedSignerStore(t, trustedSignersFile, publicKey)
+	stdout.Reset()
+	stderr.Reset()
+	code = Run([]string{"helm-ai-kernel", "workstation", "view", "--receipt", receiptPath, "--trusted-signers-file", trustedSignersFile}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("trusted signer store view exit = %d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
 }
 
 func TestWorkstationViewRejectsRetiredSignerEvenWithExplicitKey(t *testing.T) {

--- a/core/cmd/helm-ai-kernel/workstation_m3_cmd.go
+++ b/core/cmd/helm-ai-kernel/workstation_m3_cmd.go
@@ -78,12 +78,13 @@ func runWorkstationEnforceCmd(args []string, stdout, stderr io.Writer) int {
 func runWorkstationVerifyDecisionCmd(args []string, stdout, stderr io.Writer) int {
 	cmd := flag.NewFlagSet("workstation verify-decision", flag.ContinueOnError)
 	cmd.SetOutput(stderr)
-	var receiptPath, dataDir, trustedPublicKeyFile string
+	var receiptPath, dataDir, trustedPublicKeyFile, trustedSignersFile string
 	var jsonOut bool
 	cmd.StringVar(&receiptPath, "receipt", "", "Workstation policy decision receipt JSON")
 	cmd.BoolVar(&jsonOut, "json", false, "Print JSON")
 	cmd.StringVar(&dataDir, "data-dir", defaultSetupDataDir(), "Directory for HELM local signing state")
 	cmd.StringVar(&trustedPublicKeyFile, "trusted-public-key-file", "", "Path to caller-owned Ed25519 public key file")
+	cmd.StringVar(&trustedSignersFile, "trusted-signers-file", "", "Path to caller-owned versioned trusted signer store JSON")
 	if err := cmd.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return 0
@@ -107,14 +108,14 @@ func runWorkstationVerifyDecisionCmd(args []string, stdout, stderr io.Writer) in
 		_, _ = fmt.Fprintf(stderr, "Error: decision receipt integrity check failed: %v\n", err)
 		return 1
 	}
-	trustedKey, trustAnchor, trustAnchorAvailable, err := resolveTrustedWorkstationPublicKey(dataDir, trustedPublicKeyFile)
+	trustedSigners, trustAnchor, trustAnchorAvailable, err := resolveTrustedWorkstationSigners(dataDir, trustedPublicKeyFile, trustedSignersFile)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "Error: load trusted public key: %v\n", err)
 		return 1
 	}
 	signerTrusted := false
 	if trustAnchorAvailable {
-		signerTrusted, err = workstation.VerifyDecisionReceiptWithTrustedKey(receipt, trustedKey)
+		signerTrusted, err = workstation.VerifyDecisionReceiptWithTrustedSigners(receipt, trustedSigners)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "Error: trusted decision receipt verification failed: %v\n", err)
 			return 1

--- a/core/cmd/helm-ai-kernel/workstation_signing.go
+++ b/core/cmd/helm-ai-kernel/workstation_signing.go
@@ -40,6 +40,9 @@ func resolveWorkstationSigningSeed(dataDir, seedHex, seedFile string) ([]byte, e
 }
 
 func ensureLocalWorkstationSigningSeed(dataDir string) ([]byte, error) {
+	if envBool("HELM_PRODUCTION") {
+		return nil, errors.New("production mode requires --signing-seed-file")
+	}
 	dataDir, err := normalizedWorkstationDataDir(dataDir)
 	if err != nil {
 		return nil, err

--- a/core/cmd/helm-ai-kernel/workstation_signing.go
+++ b/core/cmd/helm-ai-kernel/workstation_signing.go
@@ -6,19 +6,34 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/workstation"
 )
 
 const (
 	workstationSigningKeyDirectory  = "keys"
 	workstationSigningSeedName      = "workstation-ed25519.seed"
 	workstationSigningPublicKeyName = "workstation-ed25519.pub"
+	workstationSignerTrustStoreV1   = "workstation-receipt-trust-store.v1"
 )
+
+type workstationSignerTrustStore struct {
+	Version string                        `json:"version"`
+	Signers []workstationSignerTrustEntry `json:"signers"`
+}
+
+type workstationSignerTrustEntry struct {
+	KeyID     string `json:"key_id"`
+	PublicKey string `json:"public_key"`
+}
 
 func workstationSigningSeedPath(dataDir string) string {
 	return filepath.Join(dataDir, workstationSigningKeyDirectory, workstationSigningSeedName)
@@ -185,7 +200,11 @@ func loadTrustedPublicKeyFile(path string) (ed25519.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	keyHex := strings.TrimPrefix(strings.TrimSpace(string(data)), "ed25519:")
+	return parseTrustedPublicKey(strings.TrimSpace(string(data)))
+}
+
+func parseTrustedPublicKey(value string) (ed25519.PublicKey, error) {
+	keyHex := strings.TrimPrefix(strings.TrimSpace(value), "ed25519:")
 	key, err := hex.DecodeString(keyHex)
 	if err != nil {
 		return nil, fmt.Errorf("trusted public key must be hex: %w", err)
@@ -194,6 +213,85 @@ func loadTrustedPublicKeyFile(path string) (ed25519.PublicKey, error) {
 		return nil, fmt.Errorf("trusted public key must decode to %d bytes", ed25519.PublicKeySize)
 	}
 	return ed25519.PublicKey(key), nil
+}
+
+func loadTrustedSignerStoreFile(path string) (workstation.TrustedSignerSet, error) {
+	data, err := readRegularFile(path, "trusted signer store")
+	if err != nil {
+		return workstation.TrustedSignerSet{}, err
+	}
+	var store workstationSignerTrustStore
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&store); err != nil {
+		return workstation.TrustedSignerSet{}, fmt.Errorf("decode trusted signer store: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return workstation.TrustedSignerSet{}, errors.New("trusted signer store must contain exactly one JSON object")
+	}
+	if store.Version != workstationSignerTrustStoreV1 || len(store.Signers) == 0 || len(store.Signers) > 64 {
+		return workstation.TrustedSignerSet{}, errors.New("trusted signer store version or size is invalid")
+	}
+	keys := make([]ed25519.PublicKey, 0, len(store.Signers))
+	for _, signer := range store.Signers {
+		key, err := parseTrustedPublicKey(signer.PublicKey)
+		if err != nil {
+			return workstation.TrustedSignerSet{}, err
+		}
+		if signer.KeyID != "ed25519:"+hex.EncodeToString(key) {
+			return workstation.TrustedSignerSet{}, errors.New("trusted signer key ID does not match its public key")
+		}
+		keys = append(keys, key)
+	}
+	trusted, err := workstation.NewTrustedSignerSet(keys)
+	if err != nil {
+		return workstation.TrustedSignerSet{}, fmt.Errorf("validate trusted signer store: %w", err)
+	}
+	return trusted, nil
+}
+
+func resolveTrustedWorkstationSigners(dataDir, trustedPublicKeyFile, trustedSignersFile string) (workstation.TrustedSignerSet, string, bool, error) {
+	if strings.TrimSpace(trustedPublicKeyFile) != "" && strings.TrimSpace(trustedSignersFile) != "" {
+		return workstation.TrustedSignerSet{}, "", false, errors.New("--trusted-public-key-file and --trusted-signers-file are mutually exclusive")
+	}
+	if strings.TrimSpace(trustedSignersFile) != "" {
+		trusted, err := loadTrustedSignerStoreFile(trustedSignersFile)
+		if err != nil {
+			return workstation.TrustedSignerSet{}, trustedSignersFile, false, err
+		}
+		return trusted, trustedSignersFile, true, nil
+	}
+	if strings.TrimSpace(trustedPublicKeyFile) != "" {
+		key, err := loadTrustedPublicKeyFile(trustedPublicKeyFile)
+		if err != nil {
+			return workstation.TrustedSignerSet{}, trustedPublicKeyFile, false, err
+		}
+		trusted, err := workstation.NewTrustedSignerSet([]ed25519.PublicKey{key})
+		if err != nil {
+			return workstation.TrustedSignerSet{}, trustedPublicKeyFile, false, err
+		}
+		return trusted, trustedPublicKeyFile, true, nil
+	}
+	if envBool("HELM_PRODUCTION") {
+		return workstation.TrustedSignerSet{}, "", false, errors.New("production mode requires --trusted-signers-file or --trusted-public-key-file")
+	}
+	dataDir, err := normalizedWorkstationDataDir(dataDir)
+	if err != nil {
+		return workstation.TrustedSignerSet{}, "", false, err
+	}
+	path := workstationSigningPublicKeyPath(dataDir)
+	key, err := loadTrustedPublicKeyFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return workstation.TrustedSignerSet{}, path, false, nil
+	}
+	if err != nil {
+		return workstation.TrustedSignerSet{}, path, false, err
+	}
+	trusted, err := workstation.NewTrustedSignerSet([]ed25519.PublicKey{key})
+	if err != nil {
+		return workstation.TrustedSignerSet{}, path, false, err
+	}
+	return trusted, path, true, nil
 }
 
 func resolveTrustedWorkstationPublicKey(dataDir, explicitPath string) (ed25519.PublicKey, string, bool, error) {

--- a/core/cmd/helm-ai-kernel/workstation_signing_test.go
+++ b/core/cmd/helm-ai-kernel/workstation_signing_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,6 +76,80 @@ func TestProductionWorkstationSigningRequiresExplicitSeedFile(t *testing.T) {
 	}
 	if len(seed) != ed25519.SeedSize {
 		t.Fatalf("explicit production seed length = %d, want %d", len(seed), ed25519.SeedSize)
+	}
+	if _, _, _, err := resolveTrustedWorkstationSigners(dataDir, "", ""); err == nil || !strings.Contains(err.Error(), "requires --trusted-signers-file") {
+		t.Fatalf("production implicit trust anchor error = %v, want explicit trust requirement", err)
+	}
+	publicKey := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+	trustStore := filepath.Join(t.TempDir(), "trusted-signers.json")
+	writeTrustedSignerStore(t, trustStore, publicKey)
+	if _, gotPath, available, err := resolveTrustedWorkstationSigners(dataDir, "", trustStore); err != nil || !available || gotPath != trustStore {
+		t.Fatalf("explicit production trusted signer store = available=%v path=%q err=%v", available, gotPath, err)
+	}
+
+	zeroSeedFile := filepath.Join(t.TempDir(), "zero.seed")
+	if err := os.WriteFile(zeroSeedFile, []byte(strings.Repeat("0", ed25519.SeedSize*2)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveWorkstationSigningSeed(dataDir, "", zeroSeedFile); err == nil || !strings.Contains(err.Error(), "must not be all zero") {
+		t.Fatalf("zero production signer error = %v, want all-zero rejection", err)
+	}
+}
+
+func TestTrustedSignerStoreRejectsMismatchedOrDuplicateKeys(t *testing.T) {
+	seed := []byte("0123456789abcdef0123456789abcdef")
+	key := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+	path := filepath.Join(t.TempDir(), "trusted-signers.json")
+	writeTrustedSignerStore(t, path, key)
+	if _, err := loadTrustedSignerStoreFile(path); err != nil {
+		t.Fatalf("load trusted signer store: %v", err)
+	}
+
+	badPath := filepath.Join(t.TempDir(), "mismatched-trusted-signers.json")
+	bad := workstationSignerTrustStore{Version: workstationSignerTrustStoreV1, Signers: []workstationSignerTrustEntry{{
+		KeyID: "ed25519:" + strings.Repeat("0", ed25519.PublicKeySize*2), PublicKey: hex.EncodeToString(key),
+	}}}
+	raw, err := json.Marshal(bad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(badPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadTrustedSignerStoreFile(badPath); err == nil || !strings.Contains(err.Error(), "does not match") {
+		t.Fatalf("mismatched trust store error = %v, want key-id rejection", err)
+	}
+
+	duplicatePath := filepath.Join(t.TempDir(), "duplicate-trusted-signers.json")
+	duplicate := workstationSignerTrustStore{Version: workstationSignerTrustStoreV1, Signers: []workstationSignerTrustEntry{
+		{KeyID: "ed25519:" + hex.EncodeToString(key), PublicKey: hex.EncodeToString(key)},
+		{KeyID: "ed25519:" + hex.EncodeToString(key), PublicKey: hex.EncodeToString(key)},
+	}}
+	raw, err = json.Marshal(duplicate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(duplicatePath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadTrustedSignerStoreFile(duplicatePath); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate trust store error = %v, want duplicate rejection", err)
+	}
+}
+
+func writeTrustedSignerStore(t *testing.T, path string, keys ...ed25519.PublicKey) {
+	t.Helper()
+	store := workstationSignerTrustStore{Version: workstationSignerTrustStoreV1}
+	for _, key := range keys {
+		encoded := hex.EncodeToString(key)
+		store.Signers = append(store.Signers, workstationSignerTrustEntry{KeyID: "ed25519:" + encoded, PublicKey: encoded})
+	}
+	raw, err := json.Marshal(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/workstation_signing_test.go
+++ b/core/cmd/helm-ai-kernel/workstation_signing_test.go
@@ -54,6 +54,30 @@ func TestLocalWorkstationSigningKeyLifecycle(t *testing.T) {
 	}
 }
 
+func TestProductionWorkstationSigningRequiresExplicitSeedFile(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "true")
+	dataDir := filepath.Join(t.TempDir(), "helm")
+
+	if _, err := resolveWorkstationSigningSeed(dataDir, "", ""); err == nil || !strings.Contains(err.Error(), "requires --signing-seed-file") {
+		t.Fatalf("production missing signer error = %v, want explicit seed requirement", err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, workstationSigningKeyDirectory)); !os.IsNotExist(err) {
+		t.Fatalf("production missing signer created local key state: %v", err)
+	}
+
+	seedFile := filepath.Join(t.TempDir(), "workstation.seed")
+	if err := os.WriteFile(seedFile, []byte(strings.Repeat("1", ed25519.SeedSize*2)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	seed, err := resolveWorkstationSigningSeed(dataDir, "", seedFile)
+	if err != nil {
+		t.Fatalf("load explicit production signing seed: %v", err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		t.Fatalf("explicit production seed length = %d, want %d", len(seed), ed25519.SeedSize)
+	}
+}
+
 func TestLocalWorkstationSigningKeyRejectsSymlinkAndMismatchedPublicKey(t *testing.T) {
 	dataDir := filepath.Join(t.TempDir(), "helm")
 	keyDir := filepath.Join(dataDir, workstationSigningKeyDirectory)

--- a/core/pkg/runtimeadapters/mcp/bridge_test.go
+++ b/core/pkg/runtimeadapters/mcp/bridge_test.go
@@ -220,6 +220,25 @@ func TestGovernedBridgeWithoutSigningSeedFailsClosed(t *testing.T) {
 	}
 }
 
+func TestGovernedBridgeWithAllZeroSigningSeedFailsClosed(t *testing.T) {
+	graph := proofgraph.NewGraph()
+	adapter, err := NewMCPAdapter(Config{Graph: graph, Bridge: NewGovernedBridge(BridgeConfig{
+		Profile: operateProfile(), SigningSeed: make([]byte, 32), Now: fixedClock(),
+	})})
+	if err != nil {
+		t.Fatalf("new adapter: %v", err)
+	}
+	resp, err := adapter.Intercept(context.Background(), &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue", PrincipalID: "ve-assistant",
+	})
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if resp.Allowed || resp.DenyReason == nil || resp.DenyReason.Code != string(contracts.ReasonPDPError) {
+		t.Fatalf("expected all-zero signing seed to fail closed as PDP_ERROR, got %+v", resp)
+	}
+}
+
 // Smoke 3: a bounded write that policy allows is ESCALATED for approval, then
 // ALLOWED once approval evidence is bound to the request.
 func TestGovernedBridgeEscalatesThenAllowsWrite(t *testing.T) {

--- a/core/pkg/workstation/enforcement.go
+++ b/core/pkg/workstation/enforcement.go
@@ -245,8 +245,8 @@ func signDecisionReceipt(receipt *contracts.WorkstationPolicyDecisionReceipt, se
 	if len(seed) == 0 {
 		return errors.New("signing seed is required")
 	}
-	if len(seed) != ed25519.SeedSize {
-		return fmt.Errorf("signing seed must be %d bytes", ed25519.SeedSize)
+	if err := validateSigningSeed(seed); err != nil {
+		return err
 	}
 	priv := ed25519.NewKeyFromSeed(seed)
 	pub := priv.Public().(ed25519.PublicKey)

--- a/core/pkg/workstation/importer.go
+++ b/core/pkg/workstation/importer.go
@@ -640,8 +640,8 @@ func signReceipt(receipt *contracts.AgentRunReceipt, seed []byte) error {
 	if len(seed) == 0 {
 		return errors.New("signing seed is required")
 	}
-	if len(seed) != ed25519.SeedSize {
-		return fmt.Errorf("signing seed must be %d bytes", ed25519.SeedSize)
+	if err := validateSigningSeed(seed); err != nil {
+		return err
 	}
 	priv := ed25519.NewKeyFromSeed(seed)
 	pub := priv.Public().(ed25519.PublicKey)
@@ -656,6 +656,18 @@ func signReceipt(receipt *contracts.AgentRunReceipt, seed []byte) error {
 	receipt.ReceiptHash = hex.EncodeToString(hash[:])
 	receipt.Signature = hex.EncodeToString(ed25519.Sign(priv, canonical))
 	return nil
+}
+
+func validateSigningSeed(seed []byte) error {
+	if len(seed) != ed25519.SeedSize {
+		return fmt.Errorf("signing seed must be %d bytes", ed25519.SeedSize)
+	}
+	for _, value := range seed {
+		if value != 0 {
+			return nil
+		}
+	}
+	return errors.New("signing seed must not be all zero")
 }
 
 // VerifyReceiptSignature checks receipt integrity against the public key embedded

--- a/core/pkg/workstation/signing_test.go
+++ b/core/pkg/workstation/signing_test.go
@@ -4,10 +4,12 @@ package workstation
 
 import (
 	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -98,6 +100,66 @@ func TestAgentRunReceiptTrustedKeyVerification(t *testing.T) {
 	}
 	if ok, err := VerifyReceiptWithTrustedKey(legacyResult.Receipt, legacyKey); err != nil || ok {
 		t.Fatalf("legacy agent receipt must remain untrusted = %v/%v, want false/nil", ok, err)
+	}
+}
+
+func TestReceiptSigningRejectsAllZeroSeed(t *testing.T) {
+	zeroSeed := make([]byte, ed25519.SeedSize)
+	profile := DefaultObserveDraftProfile()
+	request := decisionRequest("network", "https://forbidden.example")
+	if _, err := Decide(profile, request, DecisionOptions{SigningSeed: zeroSeed}); err == nil || !strings.Contains(err.Error(), "must not be all zero") {
+		t.Fatalf("zero seed decision error = %v, want all-zero rejection", err)
+	}
+	if _, err := ImportArtifactDir(filepath.Join(repoRoot(t), "fixtures", "workstation", "allowed-observe"), ImportOptions{SigningSeed: zeroSeed}); err == nil || !strings.Contains(err.Error(), "must not be all zero") {
+		t.Fatalf("zero seed import error = %v, want all-zero rejection", err)
+	}
+}
+
+func TestTrustedSignerSetSupportsOverlapAndRejectsUnknownSigner(t *testing.T) {
+	oldPublic, oldPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newPublic, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, attackerPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := DefaultObserveDraftProfile()
+	request := decisionRequest("network", "https://forbidden.example")
+	receipt, err := Decide(profile, request, DecisionOptions{SigningSeed: oldPrivate.Seed()})
+	if err != nil {
+		t.Fatalf("sign old receipt: %v", err)
+	}
+
+	overlap, err := NewTrustedSignerSet([]ed25519.PublicKey{oldPublic, newPublic})
+	if err != nil {
+		t.Fatalf("create overlap trust set: %v", err)
+	}
+	if ok, err := VerifyDecisionReceiptWithTrustedSigners(receipt, overlap); err != nil || !ok {
+		t.Fatalf("overlap trusted verification = %v/%v, want true/nil", ok, err)
+	}
+
+	newOnly, err := NewTrustedSignerSet([]ed25519.PublicKey{newPublic})
+	if err != nil {
+		t.Fatalf("create new-only trust set: %v", err)
+	}
+	if ok, err := VerifyDecisionReceiptWithTrustedSigners(receipt, newOnly); err != nil || ok {
+		t.Fatalf("retired overlap receipt verification = %v/%v, want false/nil", ok, err)
+	}
+
+	forged, err := Decide(profile, request, DecisionOptions{SigningSeed: attackerPrivate.Seed()})
+	if err != nil {
+		t.Fatalf("sign attacker receipt: %v", err)
+	}
+	if ok, err := VerifyDecisionReceiptSignature(forged); err != nil || !ok {
+		t.Fatalf("attacker receipt integrity = %v/%v, want true/nil", ok, err)
+	}
+	if ok, err := VerifyDecisionReceiptWithTrustedSigners(forged, overlap); err != nil || ok {
+		t.Fatalf("attacker trusted verification = %v/%v, want false/nil", ok, err)
 	}
 }
 

--- a/core/pkg/workstation/trusted_signers.go
+++ b/core/pkg/workstation/trusted_signers.go
@@ -1,0 +1,75 @@
+// quantum_posture: workstation signer trust verification uses classical
+// Ed25519 public keys only; this trust set does not add post-quantum or hybrid
+// cryptographic protection.
+package workstation
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// TrustedSignerSet is a caller-owned set of approved receipt signer keys. It
+// deliberately contains public keys only; receipt integrity remains a separate
+// check against the key declared by each receipt.
+type TrustedSignerSet struct {
+	keys map[string]ed25519.PublicKey
+}
+
+// NewTrustedSignerSet validates an explicit signer allowlist. Verification
+// permanently rejects the retired source-derived signer even if a caller keeps
+// it in a migration-era file, so old receipts can still report integrity.
+func NewTrustedSignerSet(keys []ed25519.PublicKey) (TrustedSignerSet, error) {
+	if len(keys) == 0 {
+		return TrustedSignerSet{}, errors.New("at least one trusted signer key is required")
+	}
+	trusted := TrustedSignerSet{keys: make(map[string]ed25519.PublicKey, len(keys))}
+	for _, key := range keys {
+		if len(key) != ed25519.PublicKeySize {
+			return TrustedSignerSet{}, fmt.Errorf("trusted signer key must be %d bytes", ed25519.PublicKeySize)
+		}
+		keyID := ed25519SignerKeyID(key)
+		if _, exists := trusted.keys[keyID]; exists {
+			return TrustedSignerSet{}, errors.New("duplicate trusted signer key")
+		}
+		trusted.keys[keyID] = append(ed25519.PublicKey(nil), key...)
+	}
+	return trusted, nil
+}
+
+func (trusted TrustedSignerSet) contains(keyID string) bool {
+	_, ok := trusted.keys[keyID]
+	return ok
+}
+
+// VerifyReceiptWithTrustedSigners verifies integrity only when the receipt's
+// declared signer is explicitly present in the caller-owned trusted signer set.
+func VerifyReceiptWithTrustedSigners(receipt *contracts.AgentRunReceipt, trusted TrustedSignerSet) (bool, error) {
+	if receipt == nil {
+		return false, errors.New("receipt is nil")
+	}
+	if receipt.SignerKeyID == retiredObserveOnlySignerKeyID {
+		return false, nil
+	}
+	if !trusted.contains(receipt.SignerKeyID) {
+		return false, nil
+	}
+	return VerifyReceiptSignature(receipt)
+}
+
+// VerifyDecisionReceiptWithTrustedSigners verifies integrity only when the
+// decision receipt's signer is present in the caller-owned trust set.
+func VerifyDecisionReceiptWithTrustedSigners(receipt *contracts.WorkstationPolicyDecisionReceipt, trusted TrustedSignerSet) (bool, error) {
+	if receipt == nil {
+		return false, errors.New("decision receipt is nil")
+	}
+	if receipt.SignerKeyID == retiredObserveOnlySignerKeyID {
+		return false, nil
+	}
+	if !trusted.contains(receipt.SignerKeyID) {
+		return false, nil
+	}
+	return VerifyDecisionReceiptSignature(receipt)
+}

--- a/docs/VERIFICATION.md
+++ b/docs/VERIFICATION.md
@@ -43,8 +43,10 @@ helm-ai-kernel workstation verify-decision \
 This workstation command reports `integrity` and `trusted` independently.
 `integrity: true` alone only means the contents match the receipt's declared
 public key. A zero exit status requires `trusted: true` against the expected
-local key or an explicit `--trusted-public-key-file`; use the latter for a
-receipt copied between machines.
+local key or an explicit `--trusted-public-key-file`. During signer rotation,
+use `--trusted-signers-file` with the caller-owned multi-key allowlist. In
+production, use one of those explicit sources for every verification; a local
+development anchor is not a fallback.
 
 For an EvidencePack:
 

--- a/docs/capabilities/signed-receipts.md
+++ b/docs/capabilities/signed-receipts.md
@@ -31,9 +31,12 @@ helm-ai-kernel workstation verify-decision \
 ```
 
 The command succeeds only when both `integrity` and `trusted` are true. To
-verify a copied receipt, pass `--trusted-public-key-file <path>` for the
-expected Ed25519 public key; do not accept a public key bundled by the receipt
-itself as the trust decision.
+verify a copied receipt, pass `--trusted-public-key-file <path>` for one
+expected Ed25519 public key, or `--trusted-signers-file <path>` for a
+versioned caller-owned allowlist during signer rotation. Do not accept a public
+key bundled by the receipt itself as the trust decision. In production,
+verification requires one of those explicit sources; it does not fall back to
+local signer state.
 
 ## Inspect Runtime Receipts
 

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -75,7 +75,9 @@ trusted: true
 `integrity` checks that the receipt has not been altered relative to the key
 named in the receipt. `trusted` checks that this is the expected local signer.
 Both must be `true`. For a receipt moved to another machine, use
-`--trusted-public-key-file` with a public key obtained from a trusted channel.
+`--trusted-public-key-file` with one public key obtained from a trusted
+channel, or `--trusted-signers-file` with the caller-owned rotation allowlist.
+Production verification requires one of those explicit sources.
 
 The installed hook has a deliberately narrow shell guard: it recognizes only
 selected literal destructive commands. It does not claim to parse every shell

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -64,6 +64,7 @@ helm-ai-kernel boundary verify --record-id <record-id> --json
 helm-ai-kernel receipts tail --agent <agent-id>
 helm-ai-kernel workstation verify-decision --receipt <receipt.json>
 helm-ai-kernel workstation verify-decision --receipt <receipt.json> --trusted-public-key-file <expected-ed25519-public-key>
+helm-ai-kernel workstation verify-decision --receipt <receipt.json> --trusted-signers-file <caller-owned-trust-store.json>
 ```
 
 `ALLOW`, `DENY`, and `ESCALATE` records include a reason code. `DENY` and
@@ -72,6 +73,8 @@ helm-ai-kernel workstation verify-decision --receipt <receipt.json> --trusted-pu
 Workstation verification exits successfully only when receipt integrity and
 the signer trust anchor both verify. A signature that validates against the
 key embedded in a receipt is not, by itself, proof of an expected signer.
+Production verification requires an explicit public-key or signer-store source;
+the local development anchor is never an implicit production fallback.
 
 ## OpenAI-Compatible Proxy
 

--- a/docs/reference/workstation-governance.md
+++ b/docs/reference/workstation-governance.md
@@ -66,6 +66,45 @@ Older receipts made with the retired deterministic signer can still be read
 for integrity and migration, but are not trusted. Reissue them with the local
 signer rather than treating the legacy key as a trust root.
 
+### Approved signer sources and rotation
+
+Production mode (`HELM_PRODUCTION=1`) never creates a local signer or treats
+the adjacent local public-key file as a trust anchor. Signing requires an
+explicit `--signing-seed-file`; verification requires either an explicit
+`--trusted-signers-file` or the compatibility-only single
+`--trusted-public-key-file`. Missing, zero, malformed, unknown, or retired
+signer material fails closed.
+
+`--trusted-signers-file` is a caller-owned JSON allowlist. It carries public
+keys only, has version `workstation-receipt-trust-store.v1`, and rejects
+unknown fields, duplicate keys, key-ID substitution, and symlinks. A retired
+source-derived signer can never produce a trusted result:
+
+```json
+{
+  "version": "workstation-receipt-trust-store.v1",
+  "signers": [
+    {
+      "key_id": "ed25519:<public-key-hex>",
+      "public_key": "<public-key-hex>"
+    }
+  ]
+}
+```
+
+Deliver this public file through the deployment's approved configuration
+channel; the Kernel does not fetch it, generate it, or accept a receipt-bundled
+key as trust authority. For rotation, first distribute a store containing the
+current and replacement public keys, then switch the explicit signing seed,
+verify both receipt generations, and retain the old key for the required
+evidence-retention window. Remove a compromised key immediately after the
+replacement store is present; receipts from that key then remain readable for
+integrity but are no longer trusted.
+
+Local development keeps the single generated signer and adjacent public key as
+a migration-safe convenience. It is not available as an implicit production
+fallback.
+
 For a classified hook operation, failure to provision the local signer or
 persist a denial receipt results in an explicit hook denial. HELM does not
 substitute an unsigned or fabricated receipt. If it cannot write the hook


### PR DESCRIPTION
## Summary

- Require `--signing-seed-file` for hook and setup signer resolution in `HELM_PRODUCTION`.
- Keep secure local signer provisioning limited to local and development paths.
- Propagate the approved signer-file path into installed hook, status, and removal commands.
- Add required `quantum_posture` annotations for the crypto-touching command surfaces.
- Cover production missing-key denial and explicit-key hook signing with ephemeral test keys.

## Security context

The existing v0.7.3 hardening removes the source-derived receipt seed, separates signature integrity from signer trust, and permanently rejects the retired deterministic signer as a trust anchor. This PR closes the remaining production setup/hook path that could otherwise generate a local key when a signer was absent.

Receipt canonicalization and signature preimages are unchanged.

## Validation

- `go test ./core/pkg/workstation ./core/pkg/runtimeadapters/mcp ./core/cmd/helm-ai-kernel -count=1`
- `make quantum-crypto-inventory`
- `make quality-pr`

## Required follow-up decisions

- Authoritative trust-store format and owner, including multi-key support.
- Production distribution mechanism for private signer and public trust anchor.
- Key rotation and migration plan; legacy receipts retain integrity verification but are intentionally untrusted.

Replaces #649.

Refs HELM-225