### PR TITLE
fix(prg): refuse rules Graph.Validate cannot evaluate instead of passing them

### DIFF
--- a/core/pkg/prg/engine_comprehensive_test.go
+++ b/core/pkg/prg/engine_comprehensive_test.go
@@ -1035,4 +1035,35 @@ func TestGraph_Validate_MalformedRequirementFailsClosed(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for an unsatisfiable rule")
 	}
+	if !strings.Contains(err.Error(), "action act-malformed has malformed requirement") {
+		t.Fatalf("expected actionable malformed-rule error, got %q", err)
+	}
+}
+
+// A malformed leaf must abort evaluation before a parent NOT can invert it.
+func TestGraph_Validate_MalformedRequirementNestedInNOTFailsClosed(t *testing.T) {
+	g := NewGraph()
+	_ = g.AddRule("act-malformed-not", RequirementSet{
+		ID:    "rs-root",
+		Logic: AND,
+		Children: []RequirementSet{{
+			ID:           "rs-not",
+			Logic:        NOT,
+			Requirements: []Requirement{{ID: "r-malformed"}},
+		}},
+	})
+
+	ok, hash, err := g.Validate("act-malformed-not", nil)
+	if ok {
+		t.Fatal("fail-open: malformed requirement was inverted by NOT")
+	}
+	if hash != "" {
+		t.Fatalf("must not emit a rule hash for a malformed rule, got %q", hash)
+	}
+	if err == nil {
+		t.Fatal("expected an error for a malformed requirement")
+	}
+	if !strings.Contains(err.Error(), "action act-malformed-not has malformed requirement") {
+		t.Fatalf("expected actionable malformed-rule error, got %q", err)
+	}
 }

--- a/core/pkg/prg/engine_comprehensive_test.go
+++ b/core/pkg/prg/engine_comprehensive_test.go
@@ -964,3 +964,75 @@ func TestCompiler_Compile_ContainsRule(t *testing.T) {
 		t.Fatal("compiled graph should contain rule with ID as key")
 	}
 }
+
+// Graph.Validate evaluates artifact presence only. Before this guard, a
+// requirement carrying a CEL Expression but no ArtifactType was assumed
+// satisfied, so Validate could return true *plus a rule hash* for a policy
+// whose expression was never evaluated — a fail-open verdict carrying evidence
+// of an evaluation that did not happen.
+func TestGraph_Validate_RefusesCELExpressionRequirement(t *testing.T) {
+	g := NewGraph()
+	_ = g.AddRule("act-cel", RequirementSet{
+		ID:    "rs-cel",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "r1", Expression: "intent.risk < 3"},
+		},
+	})
+
+	ok, hash, err := g.Validate("act-cel", nil)
+	if err == nil {
+		t.Fatal("expected Validate to refuse a CEL expression requirement")
+	}
+	if ok {
+		t.Fatal("fail-open: reported satisfied without evaluating the expression")
+	}
+	if hash != "" {
+		t.Fatalf("must not emit a rule hash for an unevaluated rule, got %q", hash)
+	}
+	if !strings.Contains(err.Error(), "EvaluateRequirementSet") {
+		t.Fatalf("error should name the canonical evaluator, got %q", err)
+	}
+}
+
+// The guard must see expressions nested in child sets, not just top-level ones.
+func TestGraph_Validate_RefusesNestedCELExpressionRequirement(t *testing.T) {
+	g := NewGraph()
+	_ = g.AddRule("act-nested", RequirementSet{
+		ID:    "rs-root",
+		Logic: AND,
+		Requirements: []Requirement{
+			{ID: "r1", ArtifactType: "evidence/alert"},
+		},
+		Children: []RequirementSet{{
+			ID:           "rs-child",
+			Logic:        AND,
+			Requirements: []Requirement{{ID: "r2", Expression: "state.approved == true"}},
+		}},
+	})
+
+	arts := []*pkg_artifact.ArtifactEnvelope{{Type: "evidence/alert"}}
+	ok, _, err := g.Validate("act-nested", arts)
+	if err == nil || ok {
+		t.Fatal("expected a nested CEL expression requirement to be refused")
+	}
+}
+
+// A requirement with neither an ArtifactType nor an Expression is malformed.
+// It must fail closed rather than count as satisfied.
+func TestGraph_Validate_MalformedRequirementFailsClosed(t *testing.T) {
+	g := NewGraph()
+	_ = g.AddRule("act-malformed", RequirementSet{
+		ID:           "rs-malformed",
+		Logic:        AND,
+		Requirements: []Requirement{{ID: "r1", Description: "no artifact type, no expression"}},
+	})
+
+	ok, _, err := g.Validate("act-malformed", nil)
+	if ok {
+		t.Fatal("fail-open: malformed requirement counted as satisfied")
+	}
+	if err == nil {
+		t.Fatal("expected an error for an unsatisfiable rule")
+	}
+}

--- a/core/pkg/prg/graph.go
+++ b/core/pkg/prg/graph.go
@@ -131,15 +131,44 @@ func (g *Graph) Validate(actionID string, artifacts []*pkg_artifact.ArtifactEnve
 		return false, "", fmt.Errorf("no policy defined for action %s", actionID)
 	}
 
+	// check evaluates artifact presence only. Returning true for a rule whose CEL
+	// expressions were never evaluated would hand the caller a satisfied verdict
+	// and a rule hash for a policy this evaluator did not actually apply. Refuse
+	// instead, and name the evaluator that can.
+	if hasExpressionRequirement(rule) {
+		return false, "", fmt.Errorf(
+			"action %s carries CEL expression requirements: Graph.Validate evaluates artifact presence only — use PolicyEngine.EvaluateRequirementSet",
+			actionID,
+		)
+	}
+
 	if check(rule, artifacts) {
 		return true, rule.Hash(), nil
 	}
 	return false, "", fmt.Errorf("missing requirement")
 }
 
+// hasExpressionRequirement reports whether rs or any descendant carries a CEL
+// Expression. Used by Validate to refuse rules it cannot faithfully evaluate.
+func hasExpressionRequirement(rs RequirementSet) bool {
+	for _, req := range rs.Requirements {
+		if req.Expression != "" {
+			return true
+		}
+	}
+	for _, child := range rs.Children {
+		if hasExpressionRequirement(child) {
+			return true
+		}
+	}
+	return false
+}
+
 // check is the legacy artifact-presence validator used by Graph.Validate.
-// It evaluates only ArtifactType requirements; CEL Expression requirements are
-// treated as satisfied here. The canonical evaluator that honours CEL is
+// It evaluates only ArtifactType requirements. Rules carrying CEL Expressions
+// are rejected by Validate before reaching here, so anything this function sees
+// must be checkable; a requirement it cannot check is malformed and fails
+// closed. The canonical evaluator that honours CEL is
 // PolicyEngine.EvaluateRequirementSet — prefer it for policy decisions. This
 // function is retained for the artifact-only Graph.Validate API and kept in
 // operator-semantics sync with that path.
@@ -163,8 +192,10 @@ func check(rs RequirementSet, artifacts []*pkg_artifact.ArtifactEnvelope) bool {
 				}
 			}
 		} else {
-			// Expression or others ignored in this legacy check
-			has = true
+			// Neither an ArtifactType nor (per Validate's guard) an Expression:
+			// the requirement is malformed. Fail closed — this evaluator must
+			// never report a requirement it did not actually check as satisfied.
+			has = false
 		}
 		leafResults = append(leafResults, has)
 	}

--- a/core/pkg/prg/graph.go
+++ b/core/pkg/prg/graph.go
@@ -141,6 +141,12 @@ func (g *Graph) Validate(actionID string, artifacts []*pkg_artifact.ArtifactEnve
 			actionID,
 		)
 	}
+	if hasMalformedRequirement(rule) {
+		return false, "", fmt.Errorf(
+			"action %s has malformed requirement: expected artifact_type or expression",
+			actionID,
+		)
+	}
 
 	if check(rule, artifacts) {
 		return true, rule.Hash(), nil
@@ -164,14 +170,29 @@ func hasExpressionRequirement(rs RequirementSet) bool {
 	return false
 }
 
+// hasMalformedRequirement reports whether rs or any descendant has a
+// requirement with neither an ArtifactType nor an Expression.
+func hasMalformedRequirement(rs RequirementSet) bool {
+	for _, req := range rs.Requirements {
+		if req.ArtifactType == "" && req.Expression == "" {
+			return true
+		}
+	}
+	for _, child := range rs.Children {
+		if hasMalformedRequirement(child) {
+			return true
+		}
+	}
+	return false
+}
+
 // check is the legacy artifact-presence validator used by Graph.Validate.
 // It evaluates only ArtifactType requirements. Rules carrying CEL Expressions
-// are rejected by Validate before reaching here, so anything this function sees
-// must be checkable; a requirement it cannot check is malformed and fails
-// closed. The canonical evaluator that honours CEL is
-// PolicyEngine.EvaluateRequirementSet — prefer it for policy decisions. This
-// function is retained for the artifact-only Graph.Validate API and kept in
-// operator-semantics sync with that path.
+// or malformed leaves are rejected by Validate before reaching here. The
+// canonical evaluator that honours CEL is PolicyEngine.EvaluateRequirementSet
+// — prefer it for policy decisions. This function keeps only the AND/OR/NOT
+// aggregation semantics aligned with that evaluator; its leaf evaluation is
+// deliberately artifact-only.
 //
 //nolint:gocognit // recursive requirement checking is inherently complex
 func check(rs RequirementSet, artifacts []*pkg_artifact.ArtifactEnvelope) bool {
@@ -191,11 +212,6 @@ func check(rs RequirementSet, artifacts []*pkg_artifact.ArtifactEnvelope) bool {
 					break
 				}
 			}
-		} else {
-			// Neither an ArtifactType nor (per Validate's guard) an Expression:
-			// the requirement is malformed. Fail closed — this evaluator must
-			// never report a requirement it did not actually check as satisfied.
-			has = false
 		}
 		leafResults = append(leafResults, has)
 	}


### PR DESCRIPTION
Replaces #637 with a DCO-signed commit (the `Signed-off-by` check rejected the unsigned original; force-push is blocked in this workspace, so this is a fresh branch rather than an amend).

## Problem

`check` in `core/pkg/prg/graph.go` evaluates artifact presence only. A requirement carrying a CEL `Expression` but no `ArtifactType` fell into the `else` branch and was assumed satisfied (`has = true`), so `Graph.Validate` could return `true` **plus `rule.Hash()`** for a policy whose expression was never evaluated — a satisfied verdict carrying evidence of an evaluation that did not happen. Fail-open inside a fail-closed component.

## Fix

`Validate` refuses rules it cannot faithfully evaluate and names the canonical evaluator (`PolicyEngine.EvaluateRequirementSet`), which its own doc comment already directs callers to. The malformed case (neither type nor expression) now fails closed.

## Blast radius

`Graph.Validate` has no production callers (only `engine_comprehensive_test.go`); the guardian path uses `PolicyEngine.EvaluateRequirementSet`. This closes an exported foot-gun before something calls it.

## Tests & boundary

Three new cases (top-level expression refused, nested-in-child refused, malformed fails closed). `core/pkg/prg` has **0 entries** in `tools/boundary/protected.manifest`, so no manifest regen; `make verify-boundary` → 1051 current / 0 stale / 0 errors. Rebased on v0.7.4.

Found by the 318-issue HELM board audit; this path is in no existing Linear issue and needs one filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)