### PR TITLE
feat(hook): add --shell-mode=allowlist for default-deny shell classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ non-allowlisted HTTPS request. Prompt-only manipulation, model refusal, or an
 agent that never attempts the tool call needs model, app, and sandbox controls
 alongside HELM.
 
+Coverage differs by effect class. The v0.7 shell guard is a selected-effect
+guardrail: it recognizes a small set of literal destructive command forms and
+does not interpret shell expansion, aliases, `eval`, or wrappers. See
+[Workstation governance](docs/reference/workstation-governance.md) for the
+per-class boundary.
+
 ## One Example
 
 ```text
@@ -76,6 +82,7 @@ You get:  a signed receipt you can verify offline (integrity always;
 | Local AI-agent risk audit | [Agent Risk Scan](docs/reference/agent-risk-scan.md) |
 | CLI commands | [CLI reference](docs/reference/cli.md) |
 | Security model | [Execution security model](docs/EXECUTION_SECURITY_MODEL.md) |
+| Why not just an approval prompt | [Agent permission modes](docs/AGENT_PERMISSION_MODES.md) |
 | MCP tool quarantine | [MCP integration](docs/INTEGRATIONS/mcp.md) |
 | Client implementation handoff | [Implementation partner handoff](docs/guides/implementation-partner.md) |
 | Evidence verification | [Verification](docs/VERIFICATION.md) |
@@ -135,7 +142,7 @@ orchestrator, cloud control plane, or observability tool.
 
 | Category | Examples | What They Do | Where They Stop | HELM AI Kernel |
 | --- | --- | --- | --- | --- |
-| **Agent permission modes** | Claude Code Auto Mode | Let agents work faster with fewer prompts. | Permission automation is not execution governance. | **HELM makes every governed action produce a verdict and proof.** |
+| **Agent permission modes** | Claude Code Auto Mode | Let agents work faster with fewer prompts. | [Permission automation is not execution governance](docs/AGENT_PERMISSION_MODES.md). | **HELM makes every governed action produce a verdict and proof.** |
 | **Model-vendor agents** | OpenAI Agents, ChatGPT Agent, Claude agents | Provide agent runtimes, tools, guardrails, and HITL flows. | They are tied to their own agent stack and do not create neutral execution evidence. | **HELM is model-neutral: any agent can route actions through the same boundary.** |
 | **Coding agents** | GitHub Copilot, Devin, Cursor, Replit Agent | Write, edit, test, and ship code faster. | They optimize developer productivity, not cross-runtime authority. | **HELM governs what the agent is allowed to execute.** |
 | **Agent orchestration** | LangGraph, CrewAI, AutoGen, n8n | Decide what agents should do next. | Orchestration chooses attempts; it does not prove authorization. | **HELM decides whether the attempted action may happen.** |

--- a/core/cmd/helm-ai-kernel/hook_cmd.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -15,7 +16,22 @@ import (
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/shellscan"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/workstation"
+)
+
+// Shell classification modes.
+//
+// denylist is the 0.7.x behavior: a command is allowed unless it matches a
+// destructive substring. It is the default through 0.7.x so upgrades do not
+// break, and remains available afterwards as the escape hatch.
+//
+// allowlist inverts the posture to match how the same hook already treats
+// mcp__ tools — recognized read-only commands pass, everything else is routed
+// to the policy engine and denied.
+const (
+	shellModeDenylist  = "denylist"
+	shellModeAllowlist = "allowlist"
 )
 
 var (
@@ -28,6 +44,7 @@ type hookOptions struct {
 	DataDir         string
 	SigningSeedFile string
 	JSON            bool
+	ShellMode       string
 }
 
 type preToolPayload struct {
@@ -92,6 +109,7 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 	fs.StringVar(&opts.DataDir, "data-dir", opts.DataDir, "Directory for HELM local state")
 	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
 	fs.BoolVar(&opts.JSON, "json", false, "Reserved for structured diagnostics")
+	fs.StringVar(&opts.ShellMode, "shell-mode", shellModeDenylist, "Shell classification: denylist (default) or allowlist")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -101,6 +119,15 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 		return 2
 	}
 	opts.Client = client
+	switch mode := strings.ToLower(strings.TrimSpace(opts.ShellMode)); mode {
+	case shellModeDenylist, shellModeAllowlist:
+		opts.ShellMode = mode
+	default:
+		// Exit 2 blocks the tool call, so an unreadable configuration fails
+		// closed rather than silently reverting to the permissive mode.
+		fmt.Fprintf(stderr, "hook pre-tool: unknown --shell-mode %q (want %s or %s)\n", opts.ShellMode, shellModeDenylist, shellModeAllowlist)
+		return 2
+	}
 	if strings.TrimSpace(opts.DataDir) != "" {
 		if abs, err := filepath.Abs(opts.DataDir); err == nil {
 			opts.DataDir = abs
@@ -111,11 +138,20 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 		fmt.Fprintf(stderr, "hook pre-tool: %v\n", err)
 		return 2
 	}
-	classification := classifyPreToolPayload(payload)
+	// Loaded before classification because allowlist mode needs the profile's
+	// Observe.AllowedActions to decide whether to ask. A load failure denies —
+	// it is reported separately from a signer failure, which the single
+	// downstream error message used to misattribute.
+	profile, err := loadHookPolicyProfile(opts.DataDir)
+	if err != nil {
+		fmt.Fprintf(stderr, "hook pre-tool: %v\n", err)
+		return emitHookDenyOrFail(stdout, stderr, "HELM denied operation: workstation policy profile is unavailable")
+	}
+	classification := classifyPreToolPayload(payload, opts.ShellMode, profile)
 	if !classification.ShouldDecide {
 		return 0
 	}
-	receipt, err := buildHookDecisionReceipt(opts, payload, classification)
+	receipt, err := buildHookDecisionReceipt(opts, payload, classification, profile)
 	if err != nil {
 		fmt.Fprintf(stderr, "hook pre-tool: %v\n", err)
 		return emitHookDenyOrFail(stdout, stderr, "HELM denied operation: local receipt signer is unavailable")
@@ -171,21 +207,31 @@ func decodePreToolPayload(stdin io.Reader) (preToolPayload, error) {
 	return payload, nil
 }
 
-func classifyPreToolPayload(payload preToolPayload) hookClassification {
+// loadHookPolicyProfile reads the workstation profile from the data directory,
+// falling back to the built-in observe/draft default when no file is present.
+//
+// The default is already a usable allowlist — five read-only actions in Observe
+// and an empty Operate.Permissions that denies everything else — so allowlist
+// mode works before a user edits anything.
+func loadHookPolicyProfile(dataDir string) (contracts.WorkstationPolicyProfile, error) {
+	if strings.TrimSpace(dataDir) == "" {
+		return workstation.LoadPolicyProfileFile("")
+	}
+	path := filepath.Join(dataDir, "policy", "workstation.json")
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return workstation.LoadPolicyProfileFile("")
+		}
+		return contracts.WorkstationPolicyProfile{}, fmt.Errorf("stat policy profile %s: %w", path, err)
+	}
+	return workstation.LoadPolicyProfileFile(path)
+}
+
+func classifyPreToolPayload(payload preToolPayload, shellMode string, profile contracts.WorkstationPolicyProfile) hookClassification {
 	tool := strings.TrimSpace(payload.ToolName)
 	switch {
 	case strings.EqualFold(tool, "Bash"):
-		command := inputString(payload.ToolInput, "command", "cmd")
-		if isDestructiveShellCommand(command) {
-			return hookClassification{
-				ShouldDecide: true,
-				Class:        "shell-operate",
-				Target:       command,
-				Action:       "shell_operate",
-				ToolID:       "shell",
-				Reason:       "shell operation",
-			}
-		}
+		return classifyShellCommand(inputString(payload.ToolInput, "command", "cmd"), shellMode, profile)
 	case strings.HasPrefix(tool, "mcp__"):
 		if isHelmSelfMCPTool(tool) {
 			return hookClassification{}
@@ -220,14 +266,65 @@ func classifyPreToolPayload(payload preToolPayload) hookClassification {
 	return hookClassification{}
 }
 
-func buildHookDecisionReceipt(opts hookOptions, payload preToolPayload, classification hookClassification) (*contracts.WorkstationPolicyDecisionReceipt, error) {
+// classifyShellCommand decides whether a Bash call needs a policy decision.
+//
+// The two modes differ in fail direction, which is the whole point of the flag:
+// denylist asks only about commands it recognizes as destructive, so anything
+// unrecognized proceeds unrecorded; allowlist asks about everything it cannot
+// establish as permitted.
+func classifyShellCommand(command, shellMode string, profile contracts.WorkstationPolicyProfile) hookClassification {
+	operate := hookClassification{
+		ShouldDecide: true,
+		Class:        "shell-operate",
+		Target:       command,
+		Action:       "shell_operate",
+		ToolID:       "shell",
+		Reason:       "shell operation",
+	}
+
+	if !strings.EqualFold(shellMode, shellModeAllowlist) {
+		if isDestructiveShellCommand(command) {
+			return operate
+		}
+		return hookClassification{}
+	}
+
+	// Ordering is load-bearing. The metacharacter check runs before allowlist
+	// matching so that "git status && rm -rf /" is rejected on the chaining
+	// rather than accepted on its first two tokens. Because this runs first,
+	// ClassifyReadOnly only ever sees a single simple command.
+	if !shellscan.StaticallyAnalyzable(command) {
+		return hookClassification{
+			ShouldDecide: true,
+			Class:        "shell-unanalyzable",
+			Target:       command,
+			Action:       workstation.ActionShellUnanalyzable,
+			ToolID:       "shell",
+			Reason:       "shell command that cannot be statically analyzed",
+		}
+	}
+	if action, ok := shellscan.ClassifyReadOnly(command); ok && observeActionAllowed(profile, action) {
+		return hookClassification{}
+	}
+	return operate
+}
+
+// observeActionAllowed bridges shellscan's action IDs to the profile's
+// Observe.AllowedActions. Before this existed the field was populated by the
+// profile constructor and read by nothing.
+func observeActionAllowed(profile contracts.WorkstationPolicyProfile, action string) bool {
+	for _, allowed := range profile.Observe.AllowedActions {
+		if strings.EqualFold(strings.TrimSpace(allowed), action) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildHookDecisionReceipt(opts hookOptions, payload preToolPayload, classification hookClassification, profile contracts.WorkstationPolicyProfile) (*contracts.WorkstationPolicyDecisionReceipt, error) {
 	effectType, effectMode, defaultAction, defaultTool := workstation.EffectDefaults(classification.Class)
 	action := firstNonEmptyString(classification.Action, defaultAction)
 	toolID := firstNonEmptyString(classification.ToolID, payload.ToolName, defaultTool)
-	profile, err := workstation.LoadPolicyProfileFile("")
-	if err != nil {
-		return nil, err
-	}
 	req := contracts.WorkstationDecisionRequest{
 		RunID:        firstNonEmptyString(payload.SessionID, "hook-pre-tool"),
 		ActorID:      "agent.local",

--- a/core/cmd/helm-ai-kernel/setup_cmd.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd.go
@@ -49,6 +49,7 @@ type setupOptions struct {
 	NoQuickstart    bool
 	DataDir         string
 	SigningSeedFile string
+	ShellMode       string
 }
 
 type setupSummary struct {
@@ -224,7 +225,7 @@ func runSetupStatusCmd(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	summary.MCPInstalled = setupMCPInstalled(opts, summary.ClientConfigPath, summary.BinaryPath)
-	summary.HookInstalled = setupHookInstalled(opts, summary.HookConfigPath, summary.BinaryPath)
+	summary.HookInstalled = setupHookInstalled(summary.HookConfigPath)
 	if opts.Target == "codex" && opts.Scope == "project" && (summary.MCPInstalled || summary.HookInstalled) {
 		summary.CodexTrustPending = codexProjectTrustPending(opts.Workspace)
 	}
@@ -260,7 +261,7 @@ func runSetupRemoveCmd(args []string, stdout, stderr io.Writer) int {
 		return 2
 	}
 	if !opts.DryRun {
-		if err := removeSetupHook(opts, summary.BinaryPath); err != nil {
+		if err := removeSetupHook(opts); err != nil {
 			fmt.Fprintf(stderr, "setup remove: remove hook: %v\n", err)
 			return 1
 		}
@@ -305,6 +306,7 @@ func parseSetupInstallArgs(args []string, stderr io.Writer) (setupOptions, int) 
 	fs.BoolVar(&opts.NoQuickstart, "no-quickstart", false, "Install without starting the blocking Quickstart server")
 	fs.StringVar(&opts.DataDir, "data-dir", "", "Directory for HELM local state")
 	fs.StringVar(&opts.SigningSeedFile, "signing-seed-file", "", "Path to 0600 file containing a 32-byte Ed25519 seed as hex")
+	fs.StringVar(&opts.ShellMode, "shell-mode", "", "Shell classification baked into the hook: denylist (default) or allowlist")
 	if err := fs.Parse(args[1:]); err != nil {
 		return opts, 2
 	}
@@ -365,6 +367,14 @@ func normalizeSetupOptions(opts setupOptions, stderr io.Writer) (setupOptions, i
 	}
 	if opts.Scope == "user" && opts.WorkspaceSet {
 		fmt.Fprintln(stderr, "setup: --workspace is only valid with --scope project")
+		return opts, 2
+	}
+	// Empty means "bake no flag", which leaves the hook on its own default.
+	switch mode := strings.ToLower(strings.TrimSpace(opts.ShellMode)); mode {
+	case "", shellModeDenylist, shellModeAllowlist:
+		opts.ShellMode = mode
+	default:
+		fmt.Fprintf(stderr, "setup: --shell-mode must be %s or %s, got %q\n", shellModeDenylist, shellModeAllowlist, opts.ShellMode)
 		return opts, 2
 	}
 	if opts.DataDir == "" {
@@ -623,8 +633,8 @@ func installSetupHook(opts setupOptions, bin string) error {
 	return upsertHookConfig(setupHookConfigPath(opts), setupHookMatcher(opts.Target), setupHookCommand(opts, bin), setupPrivateFileRoot(opts))
 }
 
-func removeSetupHook(opts setupOptions, bin string) error {
-	return removeHookConfig(setupHookConfigPath(opts), setupHookCommand(opts, bin), setupPrivateFileRoot(opts))
+func removeSetupHook(opts setupOptions) error {
+	return removeHookConfig(setupHookConfigPath(opts), setupPrivateFileRoot(opts))
 }
 
 func setupMCPInstalled(opts setupOptions, path, bin string) bool {
@@ -649,7 +659,7 @@ func setupMCPInstalled(opts setupOptions, path, bin string) bool {
 	}
 }
 
-func setupHookInstalled(opts setupOptions, path, bin string) bool {
+func setupHookInstalled(path string) bool {
 	root, err := readJSONObject(path)
 	if err != nil {
 		return false
@@ -658,7 +668,13 @@ func setupHookInstalled(opts setupOptions, path, bin string) bool {
 	if !ok {
 		return false
 	}
-	return hookCommandPresent(arrayValue(hooks, "PreToolUse"), setupHookCommand(opts, bin))
+	found := false
+	forEachHookCommand(arrayValue(hooks, "PreToolUse"), func(_ map[string]any, command string) {
+		if isHelmHookCommand(command) {
+			found = true
+		}
+	})
+	return found
 }
 
 func setupQuickstartProfile(target string) string {
@@ -714,6 +730,13 @@ func setupHookCommand(opts setupOptions, bin string) string {
 	if strings.TrimSpace(opts.SigningSeedFile) != "" {
 		command += " --signing-seed-file " + shellQuote(opts.SigningSeedFile)
 	}
+	// Emitted only when the operator asks for it. Through 0.7.x the hook's own
+	// default is denylist, so a flagless command line keeps existing behavior;
+	// 0.8.0 flips that binary default, which is what carries the change to
+	// installs whose baked command was never rewritten.
+	if mode := strings.ToLower(strings.TrimSpace(opts.ShellMode)); mode != "" {
+		command += " --shell-mode=" + mode
+	}
 	return command
 }
 
@@ -729,8 +752,9 @@ func upsertHookConfig(path, matcher, command, allowedRoot string) error {
 	pre := arrayValue(hooks, "PreToolUse")
 	if hookCommandPresent(pre, command) {
 		// Same hook identity: rewrite the stored command in place so a
-		// re-install with a new --signing-seed-file updates the config
-		// instead of silently keeping the old seed path.
+		// re-install with changed deployment flags (a new --signing-seed-file
+		// or an added --shell-mode) updates the config instead of silently
+		// keeping the old command line.
 		key := hookCommandKey(command)
 		for _, item := range pre {
 			obj, ok := item.(map[string]any)
@@ -769,7 +793,7 @@ func upsertHookConfig(path, matcher, command, allowedRoot string) error {
 	return writeJSONObject(path, root, allowedRoot)
 }
 
-func removeHookConfig(path, command, allowedRoot string) error {
+func removeHookConfig(path, allowedRoot string) error {
 	if _, err := privateFileWritePath(path, allowedRoot); err != nil {
 		return err
 	}
@@ -796,7 +820,7 @@ func removeHookConfig(path, command, allowedRoot string) error {
 		}
 		keptHooks := make([]any, 0, len(hookItems))
 		for _, h := range hookItems {
-			if hookCommandKey(hookCommandFromAny(h)) != hookCommandKey(command) {
+			if !isHelmHookCommand(hookCommandFromAny(h)) {
 				keptHooks = append(keptHooks, h)
 			}
 		}
@@ -862,12 +886,17 @@ func arrayValue(root map[string]any, key string) []any {
 // non-space characters.
 var signingSeedFileArgPattern = regexp.MustCompile(` --signing-seed-file (?:'[^']*'|\\'|[^\s'])+`)
 
+// shellModeArgPattern matches the optional --shell-mode segment of an
+// installed hook command (baked as --shell-mode=<mode>).
+var shellModeArgPattern = regexp.MustCompile(` --shell-mode(?:=[^\s]+| [^\s]+)`)
+
 // hookCommandKey reduces an installed hook command to its identity: the
-// signing-seed-file argument is a deployment detail, so `setup status` and
-// `setup remove` must match the hook whether or not (and with whichever path
-// form) the flag was passed on their own invocation.
+// signing-seed-file and shell-mode arguments are deployment details, so
+// `setup status` and `setup remove` must match the hook whether or not (and
+// with whichever value) those flags were baked into its command line.
 func hookCommandKey(command string) string {
-	return signingSeedFileArgPattern.ReplaceAllString(command, "")
+	key := signingSeedFileArgPattern.ReplaceAllString(command, "")
+	return shellModeArgPattern.ReplaceAllString(key, "")
 }
 
 func hookCommandPresent(pre []any, command string) bool {
@@ -888,6 +917,40 @@ func hookCommandPresent(pre []any, command string) bool {
 		}
 	}
 	return false
+}
+
+// helmHookCommandMarker identifies a HELM PreToolUse hook independently of the
+// flags baked into its command line.
+//
+// Identity must not depend on the exact string: when a release adds a flag to
+// the baked command (0.8.0 emitting --shell-mode), exact matching would treat
+// the new command as a different hook — installing a second entry beside the
+// old one so both fire, and leaving the old one behind on uninstall.
+const helmHookCommandMarker = " hook pre-tool"
+
+func isHelmHookCommand(command string) bool {
+	return strings.Contains(command, helmHookCommandMarker)
+}
+
+func forEachHookCommand(pre []any, fn func(hook map[string]any, command string)) {
+	for _, item := range pre {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		hooks, ok := obj["hooks"].([]any)
+		if !ok {
+			continue
+		}
+		for _, h := range hooks {
+			hookObj, ok := h.(map[string]any)
+			if !ok {
+				continue
+			}
+			command, _ := hookObj["command"].(string)
+			fn(hookObj, command)
+		}
+	}
 }
 
 func hookCommandFromAny(v any) string {

--- a/core/cmd/helm-ai-kernel/setup_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/setup_cmd_test.go
@@ -789,7 +789,7 @@ func TestSetupClaudeProjectPreservesSymlinkedHookConfig(t *testing.T) {
 	assertSetupSymlinkTarget(t, link, target, 0o600, "hook pre-tool --client claude-code")
 	assertNoSetupTempFiles(t, filepath.Dir(link), targetDir)
 
-	if err := removeSetupHook(opts, bin); err != nil {
+	if err := removeSetupHook(opts); err != nil {
 		t.Fatalf("remove symlinked Claude hook: %v", err)
 	}
 	assertSetupSymlinkTarget(t, link, target, 0o600, "")
@@ -839,7 +839,7 @@ func TestSetupCodexProjectPreservesSymlinkedConfigFiles(t *testing.T) {
 	assertSetupSymlinkTarget(t, hookLink, hookTarget, 0o600, "hook pre-tool --client codex")
 	assertNoSetupTempFiles(t, filepath.Dir(configLink), targetDir)
 
-	if err := removeSetupHook(opts, bin); err != nil {
+	if err := removeSetupHook(opts); err != nil {
 		t.Fatalf("remove symlinked Codex hook config: %v", err)
 	}
 	if err := removeSetupMCP(opts); err != nil {
@@ -1001,7 +1001,7 @@ func TestSetupUserScopePreservesExternalHookSymlinks(t *testing.T) {
 				t.Fatalf("install user hook through external symlink: %v", err)
 			}
 			assertSetupSymlinkTarget(t, link, managed, 0o600, "hook pre-tool --client "+target)
-			if err := removeSetupHook(opts, bin); err != nil {
+			if err := removeSetupHook(opts); err != nil {
 				t.Fatalf("remove user hook through external symlink: %v", err)
 			}
 			assertSetupSymlinkTarget(t, link, managed, 0o600, "")

--- a/core/cmd/helm-ai-kernel/shell_mode_test.go
+++ b/core/cmd/helm-ai-kernel/shell_mode_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/workstation"
+)
+
+func runShellHook(t *testing.T, dataDir, mode, command string) (int, string, string) {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"tool_name":  "Bash",
+		"tool_input": map[string]any{"command": command},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := []string{"--client", "claude-code", "--data-dir", dataDir}
+	if mode != "" {
+		args = append(args, "--shell-mode", mode)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd(args, bytes.NewReader(payload), &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func soleReceiptReason(t *testing.T, dataDir string) string {
+	t.Helper()
+	receipts := globReceipts(t, dataDir)
+	if len(receipts) != 1 {
+		t.Fatalf("receipts = %v, want exactly one", receipts)
+	}
+	receipt, err := workstation.LoadDecisionReceipt(receipts[0])
+	if err != nil {
+		t.Fatalf("load receipt: %v", err)
+	}
+	if receipt.Verdict != contracts.WorkstationVerdictDeny {
+		t.Fatalf("receipt verdict = %s, want DENY", receipt.Verdict)
+	}
+	if ok, err := workstation.VerifyDecisionReceiptSignature(receipt); err != nil || !ok {
+		t.Fatalf("receipt signature ok=%v err=%v", ok, err)
+	}
+	return receipt.ReasonCode
+}
+
+func TestHookAllowlistModeAllowsAllowlistedReadOnly(t *testing.T) {
+	// Each of these maps to an action already present in the default profile's
+	// Observe.AllowedActions, so allowlist mode works before any user edits.
+	for _, command := range []string{"git status", "git diff HEAD~1", "ls -la", "go test ./...", "cat README.md"} {
+		t.Run(command, func(t *testing.T) {
+			tmp := t.TempDir()
+			restoreHookClock(t)
+			code, stdout, stderr := runShellHook(t, tmp, shellModeAllowlist, command)
+			if code != 0 {
+				t.Fatalf("hook exit = %d stderr = %s", code, stderr)
+			}
+			if stdout != "" {
+				t.Fatalf("allowlisted command emitted approval output: %s", stdout)
+			}
+			if receipts := globReceipts(t, tmp); len(receipts) != 0 {
+				t.Fatalf("allowlisted command wrote receipts: %v", receipts)
+			}
+		})
+	}
+}
+
+func TestHookAllowlistModeDeniesUnrecognizedCommand(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	// Not destructive by the 0.7.x denylist, and not recognized as read-only.
+	// Denylist mode lets this through silently; allowlist mode is the whole
+	// point of the change.
+	code, stdout, stderr := runShellHook(t, tmp, shellModeAllowlist, "npm publish --access public")
+	if code != 0 {
+		t.Fatalf("hook exit = %d stderr = %s", code, stderr)
+	}
+	if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+		t.Fatalf("unrecognized command should be denied, output = %s", stdout)
+	}
+	if reason := soleReceiptReason(t, tmp); reason != "OPERATE_PERMISSIONS_EMPTY" {
+		t.Fatalf("receipt reason = %s, want OPERATE_PERMISSIONS_EMPTY", reason)
+	}
+}
+
+func TestHookAllowlistModeDeniesEvasionCorpus(t *testing.T) {
+	// wantReason separates the two denial grounds: a command that cannot be
+	// analyzed at all, versus one that is analyzable but unauthorized. The
+	// distinction lives in the signed receipt, not just the console line.
+	cases := []struct {
+		name       string
+		command    string
+		wantReason string
+	}{
+		{"chained after allowlisted", "git status && rm -rf /", "SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE"},
+		{"command substitution", "$(echo rm) -rf /tmp/x", "SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE"},
+		{"base64 pipe to shell", "echo cm0gLXJmIC8= | base64 -d | sh", "SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE"},
+		{"redirect from allowlisted", "git show HEAD > /tmp/authorized_keys", "SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE"},
+		{"newline chaining", "git status\nrm -rf /", "SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE"},
+		{"whitespace padding", "rm  -rf /tmp/x", "OPERATE_PERMISSIONS_EMPTY"},
+		{"uppercase", "RM -RF /tmp/x", "OPERATE_PERMISSIONS_EMPTY"},
+		{"quote splitting", "r''m -rf /tmp/x", "OPERATE_PERMISSIONS_EMPTY"},
+		{"mutating git subcommand", "git push --force origin main", "OPERATE_PERMISSIONS_EMPTY"},
+		{"absolute path bypass", "/bin/rm -rf /tmp/x", "OPERATE_PERMISSIONS_EMPTY"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			restoreHookClock(t)
+			code, stdout, stderr := runShellHook(t, tmp, shellModeAllowlist, tc.command)
+			if code != 0 {
+				t.Fatalf("hook exit = %d stderr = %s", code, stderr)
+			}
+			if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+				t.Fatalf("%q must be denied in allowlist mode, output = %s", tc.command, stdout)
+			}
+			if reason := soleReceiptReason(t, tmp); reason != tc.wantReason {
+				t.Fatalf("%q receipt reason = %s, want %s", tc.command, reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestHookDenylistModeIsUnchanged(t *testing.T) {
+	t.Run("destructive still denied", func(t *testing.T) {
+		tmp := t.TempDir()
+		restoreHookClock(t)
+		code, stdout, stderr := runShellHook(t, tmp, shellModeDenylist, "rm -rf /tmp/helm-demo")
+		if code != 0 {
+			t.Fatalf("hook exit = %d stderr = %s", code, stderr)
+		}
+		if !strings.Contains(stdout, `"permissionDecision":"deny"`) {
+			t.Fatalf("destructive command should be denied, output = %s", stdout)
+		}
+	})
+
+	// This records the 0.7.x gap the flag preserves rather than fixes: in
+	// denylist mode an unrecognized mutation proceeds with no verdict, no
+	// receipt, and no record that HELM saw it. Allowlist mode is the fix; this
+	// asserts the default did not silently change under existing installs.
+	t.Run("unrecognized mutation still passes silently", func(t *testing.T) {
+		tmp := t.TempDir()
+		restoreHookClock(t)
+		code, stdout, stderr := runShellHook(t, tmp, shellModeDenylist, "npm publish --access public")
+		if code != 0 {
+			t.Fatalf("hook exit = %d stderr = %s", code, stderr)
+		}
+		if stdout != "" {
+			t.Fatalf("denylist mode changed behavior for an unrecognized command: %s", stdout)
+		}
+		if receipts := globReceipts(t, tmp); len(receipts) != 0 {
+			t.Fatalf("denylist mode wrote a receipt it did not write before: %v", receipts)
+		}
+	})
+}
+
+func TestHookDefaultShellModeIsDenylist(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	// No --shell-mode flag at all, which is what an 0.7.x baked command line
+	// looks like after an upgrade.
+	code, stdout, stderr := runShellHook(t, tmp, "", "npm publish --access public")
+	if code != 0 {
+		t.Fatalf("hook exit = %d stderr = %s", code, stderr)
+	}
+	if stdout != "" {
+		t.Fatalf("default mode must remain denylist through 0.7.x, got output: %s", stdout)
+	}
+}
+
+func TestHookRejectsUnknownShellMode(t *testing.T) {
+	code, stdout, stderr := runShellHook(t, t.TempDir(), "permissive", "ls -la")
+	if code != 2 {
+		t.Fatalf("unknown --shell-mode exit = %d, want blocking exit 2 (stdout=%s stderr=%s)", code, stdout, stderr)
+	}
+	if !strings.Contains(stderr, "unknown --shell-mode") {
+		t.Fatalf("stderr missing the mode error: %s", stderr)
+	}
+}
+
+func helmHookCommands(t *testing.T, path string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read hook config: %v", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("parse hook config: %v", err)
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	pre, _ := hooks["PreToolUse"].([]any)
+	var found []string
+	forEachHookCommand(pre, func(_ map[string]any, command string) {
+		if isHelmHookCommand(command) {
+			found = append(found, command)
+		}
+	})
+	return found
+}
+
+// TestSetupHookUpsertReplacesChangedCommandLine pins the dedup fix. Before it,
+// hook identity was the exact command string, so installing after a flag change
+// appended a second PreToolUse entry and left both hooks firing — and uninstall
+// then matched neither.
+func TestSetupHookUpsertReplacesChangedCommandLine(t *testing.T) {
+	tmp := t.TempDir()
+	workspace := filepath.Join(tmp, "workspace")
+	if err := os.MkdirAll(filepath.Join(workspace, ".claude"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	opts := setupOptions{Target: "claude-code", Scope: "project", Workspace: workspace, DataDir: filepath.Join(tmp, "helm")}
+	bin := filepath.Join(tmp, "helm-ai-kernel")
+	path := setupHookConfigPath(opts)
+
+	if err := installSetupHook(opts, bin); err != nil {
+		t.Fatalf("install flagless hook: %v", err)
+	}
+	if commands := helmHookCommands(t, path); len(commands) != 1 {
+		t.Fatalf("after first install, HELM hooks = %v, want exactly one", commands)
+	}
+
+	upgraded := opts
+	upgraded.ShellMode = shellModeAllowlist
+	if err := installSetupHook(upgraded, bin); err != nil {
+		t.Fatalf("install hook with changed command line: %v", err)
+	}
+	commands := helmHookCommands(t, path)
+	if len(commands) != 1 {
+		t.Fatalf("changed command line installed %d HELM hooks, want exactly one: %v", len(commands), commands)
+	}
+	if !strings.Contains(commands[0], "--shell-mode=allowlist") {
+		t.Fatalf("hook command was not rewritten: %s", commands[0])
+	}
+	if !setupHookInstalled(path) {
+		t.Fatal("setupHookInstalled must recognize a hook whose flags changed")
+	}
+
+	// Removal must also match on identity rather than the exact string, or the
+	// rewritten entry would be orphaned.
+	if err := removeSetupHook(upgraded); err != nil {
+		t.Fatalf("remove rewritten hook: %v", err)
+	}
+	if commands := helmHookCommands(t, path); len(commands) != 0 {
+		t.Fatalf("removal left HELM hooks behind: %v", commands)
+	}
+}

--- a/core/pkg/mcp/argscan.go
+++ b/core/pkg/mcp/argscan.go
@@ -27,6 +27,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/shellscan"
 )
 
 // ArgScanFinding represents a single suspicious pattern detected in a tool-call argument.
@@ -75,21 +77,24 @@ func WithArgScanClock(clock func() time.Time) ArgScanOption {
 func defaultArgPatterns() []argPattern {
 	return []argPattern{
 		{
+			// The three shell patterns are defined in core/pkg/shellscan and
+			// shared, so argument scanning and raw shell-command analysis cannot
+			// drift apart on what counts as a metacharacter.
 			Name:     "shell_metachar",
 			Severity: DocScanSeverityHigh,
-			Regex:    regexp.MustCompile("[;&|`]|\\$\\(|\\$\\{|\\x00|>\\||<\\("),
+			Regex:    shellscan.ShellMetachar,
 			Desc:     "Shell metacharacter (;&|` $() ${} NUL redirect process-substitution) in tool argument",
 		},
 		{
 			Name:     "command_substitution_backtick",
 			Severity: DocScanSeverityCritical,
-			Regex:    regexp.MustCompile("`[^`]*`"),
+			Regex:    shellscan.CommandSubstitutionBacktick,
 			Desc:     "Backtick command substitution in tool argument",
 		},
 		{
 			Name:     "shell_payload_common",
 			Severity: DocScanSeverityCritical,
-			Regex:    regexp.MustCompile(`(?i)(^|[\s;&|])(sh|bash|zsh|ksh|dash)\s+(-c\s+|<\()`),
+			Regex:    shellscan.ShellPayloadCommon,
 			Desc:     "Shell spawn with -c or process-substitution payload in tool argument",
 		},
 		{

--- a/core/pkg/shellscan/shellscan.go
+++ b/core/pkg/shellscan/shellscan.go
@@ -1,0 +1,185 @@
+// Package shellscan classifies raw shell command strings against the abstract
+// action IDs used by workstation policy profiles.
+//
+// It exists to close a bridge that did not exist. The PreToolUse hook receives
+// a raw command string, while contracts.WorkstationObservePolicy.AllowedActions
+// expresses permission as abstract IDs ("git.status", "shell.read"). With
+// nothing mapping one to the other, Bash calls were governed by a denylist of
+// twelve substrings — default-allow — while every other tool class in the same
+// hook was default-deny with an allowlist. This package supplies the map so
+// shell can adopt the same posture.
+//
+// Design invariants:
+//
+//   - Fail direction is DENY. An unrecognized command is simply not classified;
+//     the caller routes it to the policy engine, which denies when no operate
+//     permission is granted. A safe command that goes unrecognized is an
+//     annoyance. An unsafe command that gets recognized is a breach. Only the
+//     second failure mode matters, so the recognition list is deliberately
+//     narrow and grows by evidence.
+//
+//   - Static analyzability is decided BEFORE allowlist matching, and
+//     ClassifyReadOnly re-checks it rather than trusting callers. Prefix
+//     matching on argv is sound only for a command that cannot chain,
+//     substitute, or redirect — that ordering is what makes "git status &&
+//     rm -rf /" fail on the metacharacter rather than pass on its first two
+//     tokens. It also means this package needs no shell lexer, and the repo
+//     has none.
+//
+//   - Every allowlisted entry must be read-only for ALL argument values, since
+//     arguments beyond argv[0..1] are never inspected. "git branch" is absent
+//     precisely because "git branch -D" deletes.
+//
+//   - Deterministic, no I/O, safe for concurrent use.
+//
+// The regex set is shared with core/pkg/mcp's argument scanner, which imports
+// it from here so both surfaces agree on what counts as a shell metacharacter.
+package shellscan
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Shared injection patterns. core/pkg/mcp/argscan.go consumes these so a single
+// definition governs both MCP argument scanning and shell command analysis.
+var (
+	// ShellMetachar matches command chaining, expansion, substitution, NUL, and
+	// the pipe/process-substitution redirect forms.
+	ShellMetachar = regexp.MustCompile("[;&|`]|\\$\\(|\\$\\{|\\x00|>\\||<\\(")
+
+	// CommandSubstitutionBacktick matches backtick command substitution.
+	CommandSubstitutionBacktick = regexp.MustCompile("`[^`]*`")
+
+	// ShellPayloadCommon matches a nested shell spawn carrying a payload.
+	ShellPayloadCommon = regexp.MustCompile(`(?i)(^|[\s;&|])(sh|bash|zsh|ksh|dash)\s+(-c\s+|<\()`)
+)
+
+// Patterns that matter for raw command analysis but not for scanning JSON
+// arguments, so they are local rather than shared.
+//
+// shellRedirect is the one that would otherwise be missed: ShellMetachar covers
+// ">|" and "<(" but not a bare ">". Without this, "git show HEAD > ~/.ssh/
+// authorized_keys" survives the metacharacter gate and then matches "git show"
+// on the allowlist — turning a read-only entry into an arbitrary file write.
+var (
+	shellRedirect = regexp.MustCompile(`[<>]`)
+	shellControl  = regexp.MustCompile(`[\r\n\x00]`)
+)
+
+// Observe action IDs. These must stay identical to the strings used in
+// contracts.WorkstationObservePolicy.AllowedActions — see
+// workstation.DefaultObserveDraftProfile.
+const (
+	ActionGitStatus  = "git.status"
+	ActionGitDiff    = "git.diff"
+	ActionShellRead  = "shell.read"
+	ActionShellTest  = "shell.test"
+	ActionShellBuild = "shell.build"
+)
+
+// gitReadOnlySubcommands maps a git subcommand to its action ID. Membership
+// requires the subcommand to be read-only for every argument vector, because
+// arguments are not inspected.
+var gitReadOnlySubcommands = map[string]string{
+	"status": ActionGitStatus,
+	"diff":   ActionGitDiff,
+	"log":    ActionGitDiff,
+	"show":   ActionGitDiff,
+}
+
+// twoTokenCommands maps "argv0 argv1" to an action ID, for tools whose first
+// token alone says nothing about mutation ("go" could be "go build" or
+// "go clean").
+var twoTokenCommands = map[string]string{
+	"go test":     ActionShellTest,
+	"go vet":      ActionShellTest,
+	"go build":    ActionShellBuild,
+	"cargo test":  ActionShellTest,
+	"cargo build": ActionShellBuild,
+	"npm test":    ActionShellTest,
+	"make test":   ActionShellTest,
+	"make build":  ActionShellBuild,
+}
+
+// readOnlyCommands maps a bare command name to an action ID, for commands that
+// cannot mutate state regardless of arguments. "env" is deliberately absent —
+// "env FOO=bar rm -rf /" executes rm.
+var readOnlyCommands = map[string]string{
+	"ls":     ActionShellRead,
+	"pwd":    ActionShellRead,
+	"cat":    ActionShellRead,
+	"head":   ActionShellRead,
+	"tail":   ActionShellRead,
+	"wc":     ActionShellRead,
+	"stat":   ActionShellRead,
+	"file":   ActionShellRead,
+	"echo":   ActionShellRead,
+	"date":   ActionShellRead,
+	"whoami": ActionShellRead,
+	"uname":  ActionShellRead,
+	"grep":   ActionShellRead,
+	"rg":     ActionShellRead,
+	"pytest": ActionShellTest,
+}
+
+// StaticallyAnalyzable reports whether command is a single simple command:
+// no chaining, expansion, substitution, redirection, embedded newline, or
+// nested shell spawn.
+//
+// An empty command is not analyzable, so it denies rather than falling through
+// as a no-op.
+func StaticallyAnalyzable(command string) bool {
+	if strings.TrimSpace(command) == "" {
+		return false
+	}
+	for _, re := range []*regexp.Regexp{
+		ShellMetachar,
+		CommandSubstitutionBacktick,
+		ShellPayloadCommon,
+		shellRedirect,
+		shellControl,
+	} {
+		if re.MatchString(command) {
+			return false
+		}
+	}
+	return true
+}
+
+// ClassifyReadOnly maps command to an Observe action ID, reporting ok=false for
+// anything it does not explicitly recognize. A false result is not a verdict —
+// it means "this package cannot vouch for the command", and the caller must
+// route it to the policy engine.
+//
+// The returned ID is only permission to proceed once the caller has confirmed
+// it appears in the active profile's Observe.AllowedActions. Classification and
+// authorization stay separate: this decides what a command *is*, the profile
+// decides whether that is allowed.
+func ClassifyReadOnly(command string) (string, bool) {
+	// Re-checked rather than assumed. This makes the allowlist invariant hold
+	// for any input, including from a caller that forgets the ordering.
+	if !StaticallyAnalyzable(command) {
+		return "", false
+	}
+	fields := strings.Fields(strings.ToLower(command))
+	if len(fields) == 0 {
+		return "", false
+	}
+	// git is matched on its subcommand and never falls through to the bare-name
+	// table, so an unlisted subcommand cannot be rescued by a "git" entry.
+	if fields[0] == "git" {
+		if len(fields) < 2 {
+			return "", false
+		}
+		action, ok := gitReadOnlySubcommands[fields[1]]
+		return action, ok
+	}
+	if len(fields) >= 2 {
+		if action, ok := twoTokenCommands[fields[0]+" "+fields[1]]; ok {
+			return action, true
+		}
+	}
+	action, ok := readOnlyCommands[fields[0]]
+	return action, ok
+}

--- a/core/pkg/shellscan/shellscan_gap_test.go
+++ b/core/pkg/shellscan/shellscan_gap_test.go
@@ -1,0 +1,105 @@
+package shellscan
+
+import "testing"
+
+// This file pins what shellscan deliberately does NOT establish, following the
+// honest-gap precedent in core/pkg/threatscan/semantic_gap_test.go. A failure
+// here means the boundary moved — either a gap closed (update the file) or a
+// control regressed.
+
+// TestTransitiveEffectsAreNotBounded records that classification bounds the
+// SHAPE of a command, never the behavior of the program it starts. These
+// commands are classified read-only and are authorized only because an operator
+// put shell.test / shell.build in the profile's Observe.AllowedActions, which
+// is an explicit statement that running the repository's own build and test
+// code is acceptable. shellscan does not and cannot verify what that code does.
+//
+// The bound comes from elsewhere: the command still cannot chain, redirect, or
+// substitute, so its blast radius is whatever the repository's own tooling
+// already had.
+func TestTransitiveEffectsAreNotBounded(t *testing.T) {
+	cases := []struct {
+		command string
+		action  string
+		gap     string
+	}{
+		{"go test ./...", ActionShellTest, "test binaries execute arbitrary repository code"},
+		{"make test", ActionShellTest, "the Makefile target is arbitrary and not inspected"},
+		{"make build", ActionShellBuild, "same as make test"},
+		{"go build -o /tmp/attacker-chosen ./cmd/x", ActionShellBuild, "-o writes a binary to an argument-chosen path"},
+		{"pytest -q", ActionShellTest, "conftest.py executes at collection time"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			action, ok := ClassifyReadOnly(tc.command)
+			if !ok || action != tc.action {
+				t.Fatalf("expected %q to classify as %s (known gap: %s), got %q ok=%v", tc.command, tc.action, tc.gap, action, ok)
+			}
+			t.Logf("accepted gap: %s — %s", tc.command, tc.gap)
+		})
+	}
+}
+
+// TestArgumentsAreNotInspected records that once the executable position is
+// allowlisted, the remaining arguments are not examined. Found by
+// FuzzClassifyReadOnly, which minimized to "git stAtus rm -r".
+//
+// This is safe for the four allowlisted git subcommands specifically: status,
+// diff, log, and show treat unrecognized operands as pathspecs or revisions and
+// never execute them. It would NOT be safe for a subcommand that takes a command
+// operand, which is why the table is restricted to these four and why
+// membership requires read-only behavior for every argument vector.
+func TestArgumentsAreNotInspected(t *testing.T) {
+	action, ok := ClassifyReadOnly("git status rm -r")
+	if !ok || action != ActionGitStatus {
+		t.Fatalf("expected pathspec arguments to be ignored, got %q ok=%v", action, ok)
+	}
+	t.Log("accepted gap: arguments after an allowlisted git subcommand are not inspected")
+}
+
+// TestExternalDiffDriverResidual records the one way an allowlisted git command
+// can still invoke another program: diff, log, and show honor the diff.external
+// config key and the GIT_EXTERNAL_DIFF environment variable, neither of which
+// appears in argv.
+//
+// The argv-borne form is already blocked — "git -c diff.external=rm diff" puts
+// "-c" in the subcommand position, so it never matches the table. What remains
+// is ambient config the hook cannot see, which belongs to environment
+// provenance rather than command classification.
+func TestExternalDiffDriverResidual(t *testing.T) {
+	if _, ok := ClassifyReadOnly("git -c diff.external=rm diff"); ok {
+		t.Fatal("argv-borne external diff driver must not classify: -c occupies the subcommand position")
+	}
+	action, ok := ClassifyReadOnly("git diff HEAD~1")
+	if !ok || action != ActionGitDiff {
+		t.Fatalf("expected plain git diff to classify, got %q ok=%v", action, ok)
+	}
+	t.Log("accepted gap: ambient diff.external / GIT_EXTERNAL_DIFF is outside argv analysis")
+}
+
+// TestUndecidableCommandsRouteToDeny records the cases this package refuses to
+// reason about. None is classified, so each falls through to the policy engine
+// and is denied when no operate permission is granted. Denial is the correct
+// outcome, not a limitation to fix.
+func TestUndecidableCommandsRouteToDeny(t *testing.T) {
+	undecidable := []struct {
+		command string
+		why     string
+	}{
+		{"eval \"$X\"", "eval defers the real command to runtime"},
+		{"$EDITOR /etc/passwd", "argv[0] is itself a variable"},
+		{"xargs rm", "the operand comes from stdin, which is not visible here"},
+		{"find . -delete", "a mutating flag on a non-allowlisted binary"},
+		{"nice -n 10 rm -rf /tmp/x", "a wrapper binary hides the real command"},
+		{"sudo ls", "privilege elevation is never read-only"},
+	}
+
+	for _, tc := range undecidable {
+		t.Run(tc.command, func(t *testing.T) {
+			if action, ok := ClassifyReadOnly(tc.command); ok {
+				t.Fatalf("expected %q to remain unclassified (%s), got %s", tc.command, tc.why, action)
+			}
+		})
+	}
+}

--- a/core/pkg/shellscan/shellscan_test.go
+++ b/core/pkg/shellscan/shellscan_test.go
@@ -1,0 +1,235 @@
+package shellscan
+
+import (
+	"strings"
+	"testing"
+)
+
+// mutatingExecutables are binaries and git subcommands that must never appear
+// in the executable position of an allowlist table. This ties the new
+// default-deny path to the pre-0.7.5 denylist (isDestructiveShellCommand) so
+// allowlist mode cannot permit what denylist mode already refused.
+//
+// The check applies to table KEYS, not to whole commands: "git status rm -r"
+// passes only "rm" as a pathspec, which git never executes, so scanning the
+// full command string for these names produces false positives without adding
+// any safety.
+var mutatingExecutables = map[string]bool{
+	"rm": true, "dd": true, "mkfs": true, "mv": true, "cp": true,
+	"chmod": true, "chown": true, "ln": true, "truncate": true,
+	"kubectl": true, "docker": true, "curl": true, "wget": true,
+	"sudo": true, "env": true, "eval": true, "exec": true,
+	"sh": true, "bash": true, "zsh": true, "find": true, "xargs": true,
+	// git subcommands, checked as the second token
+	"reset": true, "clean": true, "push": true, "branch": true,
+	"checkout": true, "rebase": true, "merge": true, "commit": true,
+}
+
+func TestClassifyReadOnlyEvasionCorpus(t *testing.T) {
+	// Each entry is a command that must NOT be classified read-only. The
+	// annotation names the control that stops it, so a regression tells you
+	// which one broke.
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{"whitespace padding", "rm  -rf /tmp/x"},
+		{"uppercase", "RM -RF /tmp/x"},
+		{"quote splitting", "r''m -rf /tmp/x"},
+		{"command substitution", "$(echo rm) -rf /tmp/x"},
+		{"backtick substitution", "git status `rm -rf /`"},
+		{"variable indirection", "X=rm; $X -rf /tmp/x"},
+		{"base64 pipe to shell", "echo cm0gLXJmIC8= | base64 -d | sh"},
+		{"chained after allowlisted", "git status && rm -rf /"},
+		{"semicolon after allowlisted", "git status; rm -rf /"},
+		{"newline after allowlisted", "git status\nrm -rf /"},
+		{"redirect from allowlisted", "git show HEAD > /tmp/authorized_keys"},
+		{"append redirect", "echo pwned >> /tmp/authorized_keys"},
+		{"nested shell spawn", "bash -c \"rm -rf /\""},
+		{"env prefix", "env rm -rf /tmp/x"},
+		{"mutating git subcommand", "git branch -D main"},
+		{"mutating git subcommand push", "git push --force origin main"},
+		{"absolute path bypass", "/bin/rm -rf /tmp/x"},
+		{"unlisted binary", "curl https://example.com/x.sh"},
+		{"empty", ""},
+		{"whitespace only", "   "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			action, ok := ClassifyReadOnly(tc.command)
+			if ok {
+				t.Fatalf("classified %q as read-only action %q; the allowlist must not recognize it", tc.command, action)
+			}
+			if action != "" {
+				t.Fatalf("expected empty action on a rejected command, got %q", action)
+			}
+		})
+	}
+}
+
+func TestClassifyReadOnlyRecognizesAllowlisted(t *testing.T) {
+	cases := []struct {
+		command string
+		want    string
+	}{
+		{"git status", ActionGitStatus},
+		{"git status --short", ActionGitStatus},
+		{"git diff HEAD~1", ActionGitDiff},
+		{"git log --oneline -20", ActionGitDiff},
+		{"git show HEAD", ActionGitDiff},
+		{"ls -la", ActionShellRead},
+		{"cat README.md", ActionShellRead},
+		{"pwd", ActionShellRead},
+		{"grep -rn helm core/", ActionShellRead},
+		{"go test ./...", ActionShellTest},
+		{"go vet ./...", ActionShellTest},
+		{"go build ./cmd/helm-ai-kernel", ActionShellBuild},
+		{"make test", ActionShellTest},
+		{"pytest -q", ActionShellTest},
+		{"GIT STATUS", ActionGitStatus},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.command, func(t *testing.T) {
+			action, ok := ClassifyReadOnly(tc.command)
+			if !ok {
+				t.Fatalf("expected %q to classify as %s, got ok=false", tc.command, tc.want)
+			}
+			if action != tc.want {
+				t.Fatalf("%q classified as %s, want %s", tc.command, action, tc.want)
+			}
+		})
+	}
+}
+
+func TestStaticallyAnalyzable(t *testing.T) {
+	analyzable := []string{
+		"git status",
+		"ls -la /tmp",
+		"go test ./...",
+		"rm -rf /tmp/x", // analyzable, but not allowlisted — a different control
+	}
+	for _, cmd := range analyzable {
+		if !StaticallyAnalyzable(cmd) {
+			t.Fatalf("expected %q to be statically analyzable", cmd)
+		}
+	}
+
+	notAnalyzable := []string{
+		"", "   ",
+		"git status && ls",
+		"git status; ls",
+		"git status | wc -l",
+		"echo $(whoami)",
+		"echo ${HOME}",
+		"echo `whoami`",
+		"cat < /etc/passwd",
+		"echo x > /tmp/y",
+		"echo x >| /tmp/y",
+		"diff <(ls) <(ls)",
+		"sh -c 'ls'",
+		"ls\nrm -rf /",
+		"ls\x00rm",
+	}
+	for _, cmd := range notAnalyzable {
+		if StaticallyAnalyzable(cmd) {
+			t.Fatalf("expected %q to be rejected as not statically analyzable", cmd)
+		}
+	}
+}
+
+// FuzzClassifyReadOnly pins the allowlist invariant: no input may return
+// ok=true unless it is statically analyzable AND maps to a known action ID AND
+// contains no destructive needle. Fuzzing is meaningful here precisely because
+// this is an allowlist — the property holds over all inputs, which is not true
+// of a denylist.
+func FuzzClassifyReadOnly(f *testing.F) {
+	seeds := []string{
+		"git status",
+		"git status && rm -rf /",
+		"rm  -rf /",
+		"$(echo rm) -rf /",
+		"RM -RF /",
+		"r''m -rf /",
+		"X=rm; $X -rf /",
+		"echo cm0gLXJmIC8= | base64 -d | sh",
+		"git show HEAD > /tmp/keys",
+		"go build -o /tmp/out ./cmd/...",
+		"ls\x00rm -rf /",
+		"",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	known := map[string]bool{
+		ActionGitStatus:  true,
+		ActionGitDiff:    true,
+		ActionShellRead:  true,
+		ActionShellTest:  true,
+		ActionShellBuild: true,
+	}
+
+	f.Fuzz(func(t *testing.T, command string) {
+		action, ok := ClassifyReadOnly(command)
+		if !ok {
+			if action != "" {
+				t.Fatalf("ok=false must return an empty action, got %q for %q", action, command)
+			}
+			return
+		}
+		if !StaticallyAnalyzable(command) {
+			t.Fatalf("classified a non-analyzable command as %s: %q", action, command)
+		}
+		if !known[action] {
+			t.Fatalf("returned unknown action id %q for %q", action, command)
+		}
+		// The executable must have come from a table. This is what guarantees
+		// a classification can never originate anywhere but the allowlist.
+		fields := strings.Fields(strings.ToLower(command))
+		if len(fields) == 0 {
+			t.Fatalf("classified an empty command as %s", action)
+		}
+		var fromTable bool
+		if fields[0] == "git" {
+			if len(fields) >= 2 {
+				_, fromTable = gitReadOnlySubcommands[fields[1]]
+			}
+		} else {
+			if len(fields) >= 2 {
+				_, fromTable = twoTokenCommands[fields[0]+" "+fields[1]]
+			}
+			if !fromTable {
+				_, fromTable = readOnlyCommands[fields[0]]
+			}
+		}
+		if !fromTable {
+			t.Fatalf("classified %q as %s but its executable is in no allowlist table", command, action)
+		}
+	})
+}
+
+// TestAllowlistTablesHaveNoMutatingExecutable is the static counterpart to the
+// fuzz invariant: the fuzzer proves classification only ever comes from these
+// tables, and this proves the tables never name something that mutates. Adding
+// "rm" to readOnlyCommands fails here rather than silently shipping.
+func TestAllowlistTablesHaveNoMutatingExecutable(t *testing.T) {
+	for name := range readOnlyCommands {
+		if mutatingExecutables[name] {
+			t.Fatalf("readOnlyCommands names the mutating executable %q", name)
+		}
+	}
+	for pair := range twoTokenCommands {
+		for _, token := range strings.Fields(pair) {
+			if mutatingExecutables[token] {
+				t.Fatalf("twoTokenCommands entry %q names the mutating token %q", pair, token)
+			}
+		}
+	}
+	for sub := range gitReadOnlySubcommands {
+		if mutatingExecutables[sub] {
+			t.Fatalf("gitReadOnlySubcommands names the mutating subcommand %q", sub)
+		}
+	}
+}

--- a/core/pkg/shellscan/testdata/fuzz/FuzzClassifyReadOnly/91b3eb16b7649a57
+++ b/core/pkg/shellscan/testdata/fuzz/FuzzClassifyReadOnly/91b3eb16b7649a57
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("git stAtus rm -r")

--- a/core/pkg/workstation/enforcement.go
+++ b/core/pkg/workstation/enforcement.go
@@ -21,6 +21,12 @@ type DecisionOptions struct {
 	SigningSeed []byte
 }
 
+// ActionShellUnanalyzable marks a shell command the caller could not statically
+// analyze. It is an action value rather than a new effect type so existing
+// effect-type switches and receipt consumers keep working unchanged, while the
+// signed receipt still records why the command was refused.
+const ActionShellUnanalyzable = "shell_unanalyzable"
+
 func LoadPolicyProfileFile(path string) (contracts.WorkstationPolicyProfile, error) {
 	if strings.TrimSpace(path) == "" {
 		return DefaultObserveDraftProfile(), nil
@@ -164,6 +170,8 @@ func EffectDefaults(effectClass string) (effectType, effectMode, action, toolID 
 		return contracts.EffectTypeWorkstationPaymentInitiate, contracts.WorkstationEffectModeOperate, "payment_initiate", "payment.initiate"
 	case "shell-operate", "shell_operate":
 		return contracts.EffectTypeWorkstationShellCommand, contracts.WorkstationEffectModeOperate, "shell_operate", "shell"
+	case "shell-unanalyzable", "shell_unanalyzable":
+		return contracts.EffectTypeWorkstationShellCommand, contracts.WorkstationEffectModeOperate, ActionShellUnanalyzable, "shell"
 	case "file", "draft", "write":
 		return contracts.EffectTypeWorkstationFileWrite, contracts.WorkstationEffectModeDraft, "file_write", "workspace.write"
 	default:

--- a/core/pkg/workstation/importer.go
+++ b/core/pkg/workstation/importer.go
@@ -391,6 +391,12 @@ func EvaluateEvent(profile contracts.WorkstationPolicyProfile, event ToolEvent) 
 	if taintedOperateEvent(event) {
 		return contracts.WorkstationVerdictDeny, "TAINTED_CONTEXT_REQUIRES_DENY", "tainted context cannot authorize operate-class effects"
 	}
+	// A command that cannot be statically analyzed is denied on that ground
+	// specifically, so the signed receipt states the real reason rather than
+	// the generic OPERATE_PERMISSIONS_EMPTY it would otherwise fall through to.
+	if event.Action == ActionShellUnanalyzable {
+		return contracts.WorkstationVerdictDeny, "SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE", "shell command cannot be statically analyzed"
+	}
 	if event.EffectType == contracts.EffectTypeWorkstationFileWrite || event.EffectType == contracts.EffectTypeWorkstationFileDraft || event.Type == "file_write" || event.Type == "draft_edit" {
 		if !draftTargetAllowed(profile.Draft.WorkspaceRoots, event.Target) {
 			return contracts.WorkstationVerdictDeny, "DRAFT_TARGET_OUTSIDE_WORKSPACE_SCOPE", "draft target is outside the configured workspace scope"

--- a/docs/AGENT_PERMISSION_MODES.md
+++ b/docs/AGENT_PERMISSION_MODES.md
@@ -1,0 +1,93 @@
+---
+title: Agent Permission Modes
+last_reviewed: 2026-07-21
+---
+
+<!-- quantum_posture: this page documents classical Ed25519 receipt signing and does not claim post-quantum or hybrid cryptographic protection. -->
+
+# Agent Permission Modes
+
+Most agent runtimes ask before they act: a prompt appears, a human answers, the
+action proceeds. That is a real control. At one operator, one agent, one
+keyboard, it is often the only control needed.
+
+This page describes where that mechanism stops and what HELM adds. It compares
+mechanism classes, not named tools.
+
+| Property | Per-action permission prompt | HELM AI Kernel |
+| --- | --- | --- |
+| Enforcement site | inside the runtime being governed | a boundary the effect must cross |
+| Grant shape | standing permission, once answered | permit bound to connector, action, parameters, resource |
+| Reuse | persists until revoked | single-use, expiring, nonce-checked |
+| Artifact | none defined | signed receipt, verifiable offline |
+| Unattended runs | no answer available | verdict resolves without a human present |
+| Failure behavior | varies by runtime | unable to sign a receipt, deny |
+
+## What a Permission Prompt Governs
+
+A permission prompt gates what that runtime is about to do, at the moment it does
+it. Its scope is the runtime's own action set. Its authority is the operator
+sitting in front of it.
+
+Two consequences follow from the shape of the mechanism rather than from any
+implementation of it.
+
+**Answering is a grant, not a binding.** "Allow this action" tends to become
+"allow actions like this," and the allowance persists. The permitted set grows
+monotonically and is rarely reviewed downward.
+
+**Attention is the limiting resource.** A study of experienced developers
+overseeing coding agents found real-time monitoring is
+[rarely performed](https://arxiv.org/html/2606.05391), with oversight running on
+satisficing heuristics because the systems are "too fast, too complex, and too
+much for users." A randomized experiment (n=2,784) found people are
+[less likely to correct erroneous AI suggestions](https://www.nature.com/articles/s41598-026-34983-y)
+when correcting them requires extra effort. EU AI Act
+[Article 14](https://artificialintelligenceact.eu/article/14/) treats this as a
+design constraint: overseers must be able to counter automation bias, disregard
+or override output, and halt the system.
+
+A prompt asks a human for attention. It does not create the attention.
+
+## Where HELM Differs
+
+HELM decides from policy at a boundary the effect must cross, then writes a
+signed record of the decision.
+
+- **Bound permits, not standing grants.** An `EffectPermit` names one connector,
+  one action, one parameter set, one resource, with an expiry and a single-use
+  nonce. An identical re-dispatch is caught as a replay.
+- **An artifact a third party can check.** Each decision produces a signed
+  receipt. The offline verifier trusts only Ed25519, SHA-256, and JCS — not the
+  network, not an account, not the process that issued the receipt.
+- **A verdict without a human present.** Scheduled work, unattended runs, and
+  delegated sub-agents have nobody to prompt. Policy still resolves.
+- **A defined failure direction.** If a signed receipt cannot be produced, the
+  operation is denied rather than allowed.
+
+## HELM's Narrow Claim
+
+HELM governs effects that reach its boundary. It does not govern actions a
+runtime takes without routing them, and it is not a model-layer control against
+prompt manipulation.
+
+Coverage differs by effect class. See
+[Workstation governance](reference/workstation-governance.md) for the per-class
+boundary, including the deliberately narrow shell guard.
+
+The claim is not that HELM understands every action. It is that what HELM cannot
+establish as permitted does not pass.
+
+## Comparison Rules
+
+- Compare mechanism classes, not named tools or their current behavior.
+- Say "different scope" before saying "better".
+- A permission prompt is a real control; do not argue it is worthless.
+- Name the routed action and proof artifact for any HELM claim.
+- Do not imply HELM governs an action that never crossed the boundary.
+
+## Useful Reading
+
+- [Workstation governance](reference/workstation-governance.md)
+- [HELM Proof Loop](PROOF_LOOP.md)
+- [Verification](VERIFICATION.md)

--- a/docs/public-docs.manifest.json
+++ b/docs/public-docs.manifest.json
@@ -91,6 +91,15 @@
       "sensitivity": "public"
     },
     {
+      "slug": "agent-permission-modes",
+      "title": "Agent Permission Modes",
+      "section": "guide",
+      "source_path": "docs/AGENT_PERMISSION_MODES.md",
+      "docs_origin_hint": "helm.docs.mindburn.org/agent-permission-modes",
+      "access": "public",
+      "sensitivity": "public"
+    },
+    {
       "slug": "integrations/openai-compatible-proxy",
       "title": "OpenAI Proxy",
       "section": "integrations",

--- a/docs/quickstart/workstation-governance.md
+++ b/docs/quickstart/workstation-governance.md
@@ -77,9 +77,24 @@ named in the receipt. `trusted` checks that this is the expected local signer.
 Both must be `true`. For a receipt moved to another machine, use
 `--trusted-public-key-file` with a public key obtained from a trusted channel.
 
-The installed hook has a deliberately narrow shell guard: it recognizes only
-selected literal destructive commands. It does not claim to parse every shell
-expansion, wrapper, or destructive tool.
+By default the installed hook has a deliberately narrow shell guard: it
+recognizes only selected literal destructive commands. It does not claim to
+parse every shell expansion, wrapper, or destructive tool, and a command it does
+not recognize proceeds with no verdict and no receipt.
+
+To invert that default so unrecognized commands are denied rather than passed,
+install with `--shell-mode=allowlist`:
+
+```bash
+helm-ai-kernel setup claude-code --shell-mode=allowlist --yes
+```
+
+In allowlist mode a command passes only if it is statically analyzable — no
+chaining, substitution, redirection, or nested shell — and maps to an action ID
+listed in the active profile's `Observe.AllowedActions`. Everything else is
+denied with a signed receipt. See
+[Workstation Governance](../reference/workstation-governance.md) for the full
+model and its limits.
 
 ## Prove An Escalation
 

--- a/docs/reference/workstation-governance.md
+++ b/docs/reference/workstation-governance.md
@@ -90,10 +90,47 @@ helm-ai-kernel workstation enforce \
 
 `decide` emits a signed policy decision receipt. `enforce` emits the same receipt and exits with code `126` on `DENY`, which makes it usable from shell hooks or wrapper scripts. The bridge covers selected shell, network, MCP, file, memory, and recurring-loop classes; it is not a kernel driver, browser controller, or complete OS sandbox.
 
-The v0.7 shell guard is intentionally narrow. It recognizes only a small set
-of literal destructive command forms and does not interpret shell expansion,
-aliases, `eval`, wrappers, or every destructive tool. Treat it as a
-selected-effect guardrail, not a claim of comprehensive shell enforcement.
+### Shell classification modes
+
+The hook accepts `--shell-mode`, which selects the fail direction for `Bash`
+tool calls. The default is `denylist` through 0.7.x.
+
+`denylist` is the v0.7 shell guard. It is intentionally narrow: it recognizes
+only a small set of literal destructive command forms and does not interpret
+shell expansion, aliases, `eval`, wrappers, or every destructive tool. A
+command it does not recognize proceeds with no verdict and no receipt. Treat it
+as a selected-effect guardrail, not a claim of comprehensive shell enforcement.
+
+`allowlist` inverts that posture to match how the same hook already treats
+`mcp__` tools. A command is evaluated in two steps:
+
+1. If it is not statically analyzable — it chains, substitutes, redirects, spans
+   a newline, or spawns a nested shell — it is denied with reason code
+   `SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE`. This check runs first, which is
+   what stops `git status && rm -rf /` on the chaining rather than accepting it
+   on its first two tokens.
+2. Otherwise the command is matched against a recognition list that maps it to
+   an action ID such as `git.status` or `shell.read`. It passes only if that ID
+   appears in the active profile's `Observe.AllowedActions`. Anything else is
+   routed to the policy engine and denied when no operate permission is granted.
+
+The default profile is already a usable allowlist — five read-only actions in
+`Observe`, an empty `Operate.Permissions` — so `allowlist` mode works before any
+profile is written. The hook reads `<data-dir>/policy/workstation.json` when
+present and falls back to that built-in default.
+
+What `allowlist` mode still does not establish: it classifies the *shape* of a
+command, not the behavior of the program that command starts. `go test` and
+`make build` are recognized because an operator put `shell.test` / `shell.build`
+in the profile, which is a statement that running the repository's own tooling
+is acceptable. Ambient configuration outside the command line — a
+`diff.external` git setting, for instance — is likewise outside what argv
+analysis can see.
+
+Migration: `0.7.x` ships `allowlist` as opt-in with `denylist` as the default,
+so no upgrade changes behavior. `0.8.0` flips the binary default to `allowlist`,
+which is what carries the change to installs whose baked hook command was never
+rewritten; `--shell-mode=denylist` remains the escape hatch.
 
 ## Operator workflow
 


### PR DESCRIPTION
Implements Workstream B of the "vs harness approvals" plan. Draft: this is a fail-closed classification change, so it needs `kernel-guardian` review before it leaves draft (CLAUDE.md).

## The defect

The PreToolUse hook governed `Bash` with a 12-substring denylist while treating `mcp__` tools **ten lines below** as default-deny with an allowlist. On a denylist miss, `classifyPreToolPayload` returned a zero classification and `hook_cmd.go` returned 0 with empty stdout — which under hook semantics means "no decision". The command ran with no verdict, no receipt, and no record that HELM saw it.

The reason nobody had closed it: `Observe.AllowedActions` holds abstract action IDs (`git.status`, `shell.read`) while the hook receives raw shell strings, and **nothing mapped one to the other**. The field was populated by the profile constructor at `importer.go:494` and read by nothing.

## What changed

- **`core/pkg/shellscan`** — `StaticallyAnalyzable` + `ClassifyReadOnly`. The metacharacter check runs first, so allowlist matching only ever sees a single simple command and the repo needs no shell lexer. It also rejects bare redirects and newlines, which the lifted `mcp` patterns do not cover: without that, `git show HEAD > ~/.ssh/authorized_keys` passes the metachar gate and then matches `git show` on the allowlist.
- The three shell regexes now live in `shellscan` and are imported by `core/pkg/mcp/argscan.go`, so the two surfaces cannot drift apart.
- **Honest reason codes** — an unanalyzable command denies with `SHELL_COMMAND_NOT_STATICALLY_ANALYZABLE` in the *signed receipt*, instead of falling through to the generic `OPERATE_PERMISSIONS_EMPTY`.
- **Policy file** — the hook reads `<data-dir>/policy/workstation.json` with fallback to the built-in default, and reports a profile-load failure separately from a signer failure rather than misattributing it as "local receipt signer is unavailable".
- **`setup` dedup fix** — hook identity is now a marker, not the exact command string. Exact matching meant a changed command line installed a *second* PreToolUse entry beside the old one with both firing, and uninstall then matched neither.

## Migration

`denylist` stays the default through 0.7.x, so no upgrade changes behavior. `0.8.0` flips the binary default to `allowlist` — that is what carries the change to installs whose baked command line was never rewritten. `--shell-mode=denylist` remains the escape hatch.

## Verification

- `make test-race` — clean, no data races
- `make crucible` — 12/12 use cases pass
- `make docs-coverage docs-truth` — 684 rows resolve
- `go vet ./core/...` — clean
- `FuzzClassifyReadOnly` — 2.36M execs, no failures. It caught a real flaw in the *test* on first run (`git stAtus rm -r`: a pathspec named `rm`, harmless), which is why the invariant now checks the executable position and table contents rather than substrings anywhere in the command.

## Deliberately not claimed

Pinned in `shellscan_gap_test.go` rather than papered over: classification bounds the *shape* of a command, not the behavior of the program it starts (`go test`, `make build`), and ambient config outside argv (`diff.external`, `GIT_EXTERNAL_DIFF`) is outside what this can see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)