### PR TITLE
feat(kernel): add GeneratedSpec approval grant contract

### DIFF
--- a/core/pkg/boundary/generatedspecapproval/generated_spec_approval_test.go
+++ b/core/pkg/boundary/generatedspecapproval/generated_spec_approval_test.go
@@ -1,3 +1,6 @@
+// quantum_posture: GeneratedSpec approval tests exercise classical Ed25519
+// grant and consumption signatures only; they do not establish hybrid or
+// post-quantum approval support.
 package generatedspecapproval
 
 import (

--- a/core/pkg/boundary/generatedspecapproval/generated_spec_approval_test.go
+++ b/core/pkg/boundary/generatedspecapproval/generated_spec_approval_test.go
@@ -112,6 +112,24 @@ func TestIssueGrantRejectsModifiedVerifierResult(t *testing.T) {
 	}
 }
 
+func TestIssueGrantAcceptsSameInstantVerificationAndIssuance(t *testing.T) {
+	fixture := newApprovalFixture(t)
+	// The verifier stamps VerifiedAt with nanosecond precision while the
+	// issuer canonicalizes its clock to microseconds; issuance within the
+	// same microsecond as verification must not be rejected as preceding it.
+	verified, err := VerifyGeneratedSpecQuorum(fixture.challenge, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion}, fixture.store, fixture.options, fixture.now.Add(500*time.Nanosecond))
+	if err != nil {
+		t.Fatalf("VerifyGeneratedSpecQuorum() error = %v", err)
+	}
+	kernelSigner, err := crypto.NewEd25519Signer("generated-spec-kernel")
+	if err != nil {
+		t.Fatalf("NewEd25519Signer() error = %v", err)
+	}
+	if _, err := IssueGrant(fixture.challenge, verified, "grant-a", fixture.nonce("b"), kernelSigner, fixture.issuerConfig(), fixture.now.Add(999*time.Nanosecond)); err != nil {
+		t.Fatalf("IssueGrant() rejected same-instant issuance after verification: %v", err)
+	}
+}
+
 type approvalFixture struct {
 	challenge contracts.GeneratedSpecApprovalChallenge
 	assertion contracts.GeneratedSpecApprovalAssertion

--- a/core/pkg/boundary/generatedspecapproval/generated_spec_approval_test.go
+++ b/core/pkg/boundary/generatedspecapproval/generated_spec_approval_test.go
@@ -1,0 +1,198 @@
+package generatedspecapproval
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+func TestVerifyIssueAndConsumeGeneratedSpecApproval(t *testing.T) {
+	fixture := newApprovalFixture(t)
+	verified, err := VerifyGeneratedSpecQuorum(fixture.challenge, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion}, fixture.store, fixture.options, fixture.now)
+	if err != nil {
+		t.Fatalf("VerifyGeneratedSpecQuorum() error = %v", err)
+	}
+	kernelSigner, err := crypto.NewEd25519Signer("generated-spec-kernel")
+	if err != nil {
+		t.Fatalf("NewEd25519Signer() error = %v", err)
+	}
+	signedGrant, err := IssueGrant(fixture.challenge, verified, "grant-a", fixture.nonce("b"), kernelSigner, fixture.issuerConfig(), fixture.now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("IssueGrant() error = %v", err)
+	}
+	verifier, err := NewEd25519Verifier(kernelSigner.PublicKeyBytes(), fixture.issuerConfig().SigningKeyRef, fixture.issuerConfig().KernelTrustRootID)
+	if err != nil {
+		t.Fatalf("NewEd25519Verifier() error = %v", err)
+	}
+	if err := verifier.VerifyGrant(signedGrant, signedGrant.Grant.IssuedAt); err != nil {
+		t.Fatalf("VerifyGrant() error = %v", err)
+	}
+
+	consumption, err := NewConsumption(signedGrant.Grant, "spiffe://helm/control-plane-a", signedGrant.Grant.IssuedAt.Add(time.Second))
+	if err != nil {
+		t.Fatalf("NewConsumption() error = %v", err)
+	}
+	signedConsumption, err := SignConsumption(consumption, kernelSigner)
+	if err != nil {
+		t.Fatalf("SignConsumption() error = %v", err)
+	}
+	if err := verifier.VerifyConsumption(signedConsumption, signedGrant); err != nil {
+		t.Fatalf("VerifyConsumption() error = %v", err)
+	}
+	unsignedGrant := signedGrant
+	unsignedGrant.Signature = ""
+	if err := verifier.VerifyConsumption(signedConsumption, unsignedGrant); !errors.Is(err, ErrSignatureRejected) {
+		t.Fatalf("VerifyConsumption(unsigned grant) error = %v, want signature rejection", err)
+	}
+}
+
+func TestGeneratedSpecApprovalRejectsRequesterAndBindingTamper(t *testing.T) {
+	fixture := newApprovalFixture(t)
+	selfKey := fixture.store.Keys[fixture.assertion.KeyID]
+	selfKey.PrincipalID = fixture.challenge.RequestingPrincipalID
+	fixture.store.Keys[fixture.assertion.KeyID] = selfKey
+	if _, err := VerifyGeneratedSpecQuorum(fixture.challenge, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion}, fixture.store, fixture.options, fixture.now); !errors.Is(err, ErrAuthorityRejected) {
+		t.Fatalf("VerifyGeneratedSpecQuorum(self approval) error = %v, want authority rejected", err)
+	}
+
+	fixture = newApprovalFixture(t)
+	fixture.options.Expected.WriteSetHash = hash("9")
+	if _, err := VerifyGeneratedSpecQuorum(fixture.challenge, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion}, fixture.store, fixture.options, fixture.now); !errors.Is(err, ErrVerificationFailed) {
+		t.Fatalf("VerifyGeneratedSpecQuorum(write set mismatch) error = %v, want verification failed", err)
+	}
+}
+
+func TestGeneratedSpecApprovalSignaturesRejectTampering(t *testing.T) {
+	fixture := newApprovalFixture(t)
+	verified, err := VerifyGeneratedSpecQuorum(fixture.challenge, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion}, fixture.store, fixture.options, fixture.now)
+	if err != nil {
+		t.Fatalf("VerifyGeneratedSpecQuorum() error = %v", err)
+	}
+	kernelSigner, err := crypto.NewEd25519Signer("generated-spec-kernel")
+	if err != nil {
+		t.Fatalf("NewEd25519Signer() error = %v", err)
+	}
+	signedGrant, err := IssueGrant(fixture.challenge, verified, "grant-a", fixture.nonce("b"), kernelSigner, fixture.issuerConfig(), fixture.now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("IssueGrant() error = %v", err)
+	}
+	verifier, err := NewEd25519Verifier(kernelSigner.PublicKeyBytes(), fixture.issuerConfig().SigningKeyRef, fixture.issuerConfig().KernelTrustRootID)
+	if err != nil {
+		t.Fatalf("NewEd25519Verifier() error = %v", err)
+	}
+	signedGrant.Grant.GeneratedSpecHash = hash("9")
+	if err := verifier.VerifyGrant(signedGrant, fixture.now.Add(time.Second)); !errors.Is(err, ErrSignatureRejected) {
+		t.Fatalf("VerifyGrant(tampered) error = %v, want signature rejected", err)
+	}
+}
+
+func TestIssueGrantRejectsModifiedVerifierResult(t *testing.T) {
+	fixture := newApprovalFixture(t)
+	verified, err := VerifyGeneratedSpecQuorum(fixture.challenge, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion}, fixture.store, fixture.options, fixture.now)
+	if err != nil {
+		t.Fatalf("VerifyGeneratedSpecQuorum() error = %v", err)
+	}
+	verified.ApprovalID = "approval-substituted"
+	kernelSigner, err := crypto.NewEd25519Signer("generated-spec-kernel")
+	if err != nil {
+		t.Fatalf("NewEd25519Signer() error = %v", err)
+	}
+	if _, err := IssueGrant(fixture.challenge, verified, "grant-a", fixture.nonce("b"), kernelSigner, fixture.issuerConfig(), fixture.now.Add(time.Second)); err == nil {
+		t.Fatal("IssueGrant() accepted a modified verifier result")
+	}
+}
+
+type approvalFixture struct {
+	challenge contracts.GeneratedSpecApprovalChallenge
+	assertion contracts.GeneratedSpecApprovalAssertion
+	store     approvalverify.TrustStore
+	options   VerifyOptions
+	now       time.Time
+}
+
+func newApprovalFixture(t *testing.T) approvalFixture {
+	t.Helper()
+	now := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	challenge, err := (contracts.GeneratedSpecApprovalChallenge{
+		Domain: contracts.GeneratedSpecApprovalChallengeDomainV1, SchemaVersion: contracts.GeneratedSpecApprovalChallengeSchemaV1,
+		ContractVersion: contracts.GeneratedSpecApprovalChallengeContractV1,
+		ChallengeID:     "challenge-a", ApprovalID: "approval-a", TenantID: "tenant-a", WorkspaceID: "workspace-a",
+		Audience: contracts.GeneratedSpecApprovalAudienceV1, GeneratedSpecID: "spec-a", GeneratedSpecHash: hash("a"),
+		ExecutionPlanHash: hash("b"), PlanTransactionHash: hash("c"), WriteSetHash: hash("d"),
+		VerificationScopeHash: hash("e"), PolicyEnvelopeHash: hash("f"), PolicyVersion: "policy-v1", PolicyEpoch: "epoch-1",
+		Action: contracts.GeneratedSpecApprovalActionV1, RequestingPrincipalID: "user:requester-a",
+		AuthoritySource: "authority-a", AuthorityVersion: "version-a", AuthoritySnapshotHash: hash("0"),
+		RequiredRole: "generated-spec-approver", Quorum: 1, ServerIdentity: "spiffe://helm/kernel-a",
+		HoldStartedAt: now.Add(-time.Minute), EligibleAt: now.Add(-time.Second), IssuedAt: now,
+		ExpiresAt: now.Add(5 * time.Minute), Nonce: stringsRepeat("1", 64),
+	}).Seal()
+	if err != nil {
+		t.Fatalf("challenge Seal() error = %v", err)
+	}
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	assertion := contracts.GeneratedSpecApprovalAssertion{
+		Domain: contracts.GeneratedSpecApprovalAssertionDomainV1, SchemaVersion: contracts.GeneratedSpecApprovalAssertionSchemaV1,
+		ContractVersion: contracts.GeneratedSpecApprovalAssertionContractV1, ChallengeID: challenge.ChallengeID,
+		ChallengeHash: challenge.ChallengeHash, KeyID: "approver-key-a", Algorithm: contracts.GeneratedSpecApprovalAssertionEd25519,
+	}
+	digest, err := assertion.SigningDigest()
+	if err != nil {
+		t.Fatalf("SigningDigest() error = %v", err)
+	}
+	assertion.Signature = "ed25519:" + hex.EncodeToString(ed25519.Sign(private, digest))
+	store := approvalverify.TrustStore{
+		AuthoritySource: challenge.AuthoritySource, AuthorityVersion: challenge.AuthorityVersion,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash,
+		Keys: map[string]approvalverify.TrustedApproverKey{
+			assertion.KeyID: {
+				KeyID: assertion.KeyID, TenantID: challenge.TenantID, PrincipalID: "user:approver-a",
+				CredentialID: "credential-a", DeviceID: "device-a", PublicKey: public,
+				WorkspaceIDs: []string{challenge.WorkspaceID}, Roles: []string{challenge.RequiredRole},
+				Actions: []string{challenge.Action}, Audiences: []string{challenge.Audience}, Enabled: true,
+				NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+			},
+		},
+	}
+	return approvalFixture{challenge: challenge, assertion: assertion, store: store, now: now,
+		options: VerifyOptions{Expected: expectedFor(challenge), MinHoldDuration: time.Second, MaxChallengeTTL: 10 * time.Minute, MaxAssertions: 2}}
+}
+
+func (f approvalFixture) issuerConfig() IssuerConfig {
+	return IssuerConfig{GrantTTL: time.Minute, ServerIdentity: f.challenge.ServerIdentity, KernelTrustRootID: "kernel-root-a", SigningKeyRef: "kms://helm/generated-spec-a"}
+}
+
+func (f approvalFixture) nonce(character string) string { return stringsRepeat(character, 64) }
+
+func expectedFor(challenge contracts.GeneratedSpecApprovalChallenge) ExpectedBinding {
+	return ExpectedBinding{
+		ChallengeID: challenge.ChallengeID, ChallengeHash: challenge.ChallengeHash, ApprovalID: challenge.ApprovalID,
+		TenantID: challenge.TenantID, WorkspaceID: challenge.WorkspaceID, Audience: challenge.Audience,
+		GeneratedSpecID: challenge.GeneratedSpecID, GeneratedSpecHash: challenge.GeneratedSpecHash,
+		ExecutionPlanHash: challenge.ExecutionPlanHash, PlanTransactionHash: challenge.PlanTransactionHash,
+		WriteSetHash: challenge.WriteSetHash, VerificationScopeHash: challenge.VerificationScopeHash,
+		PolicyEnvelopeHash: challenge.PolicyEnvelopeHash, PolicyVersion: challenge.PolicyVersion,
+		PolicyEpoch: challenge.PolicyEpoch, Action: challenge.Action, RequestingPrincipalID: challenge.RequestingPrincipalID,
+		AuthoritySource: challenge.AuthoritySource, AuthorityVersion: challenge.AuthorityVersion,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash, RequiredRole: challenge.RequiredRole,
+		Quorum: challenge.Quorum, ServerIdentity: challenge.ServerIdentity,
+	}
+}
+
+func hash(character string) string { return "sha256:" + stringsRepeat(character, 64) }
+func stringsRepeat(character string, count int) string {
+	bytes := make([]byte, count)
+	for index := range bytes {
+		bytes[index] = character[0]
+	}
+	return string(bytes)
+}

--- a/core/pkg/boundary/generatedspecapproval/issuer.go
+++ b/core/pkg/boundary/generatedspecapproval/issuer.go
@@ -47,7 +47,10 @@ func IssueGrant(
 	if err := validateVerifiedApproval(challenge, verified); err != nil {
 		return SignedGrant{}, err
 	}
-	if now.Before(verified.VerifiedAt) {
+	// Compare at the grant's canonical microsecond precision: the verifier
+	// preserves nanoseconds in VerifiedAt, so a mixed-precision comparison
+	// would reject same-instant verification followed by issuance.
+	if now.Before(verified.VerifiedAt.UTC().Truncate(time.Microsecond)) {
 		return SignedGrant{}, errors.New("grant issuance precedes verified quorum")
 	}
 	if challenge.ServerIdentity != config.ServerIdentity {

--- a/core/pkg/boundary/generatedspecapproval/issuer.go
+++ b/core/pkg/boundary/generatedspecapproval/issuer.go
@@ -1,0 +1,192 @@
+package generatedspecapproval
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+// IssuerConfig names the Kernel signing identity and bounds a grant lifetime.
+// The service that uses this helper must provide IDs/nonces from cryptographic
+// randomness and persist the ceremony before returning the signed grant.
+type IssuerConfig struct {
+	GrantTTL          time.Duration
+	ServerIdentity    string
+	KernelTrustRootID string
+	SigningKeyRef     string
+}
+
+// IssueGrant turns a verifier-derived quorum into a short-lived signed
+// GeneratedSpec approval grant. It cannot issue execution authority and it
+// does not persist replay state; the durable ceremony owns those concerns.
+func IssueGrant(
+	challenge contracts.GeneratedSpecApprovalChallenge,
+	verified VerifiedApprovalRef,
+	grantID, nonce string,
+	signer crypto.Signer,
+	config IssuerConfig,
+	now time.Time,
+) (SignedGrant, error) {
+	if signer == nil {
+		return SignedGrant{}, errors.New("generated spec approval issuer requires a signer")
+	}
+	if config.GrantTTL <= 0 || !validToken(config.ServerIdentity) || !validToken(config.KernelTrustRootID) || !validToken(config.SigningKeyRef) {
+		return SignedGrant{}, errors.New("generated spec approval issuer config is invalid")
+	}
+	now = now.UTC().Truncate(time.Microsecond)
+	if err := challenge.ValidateAt(now); err != nil {
+		return SignedGrant{}, fmt.Errorf("validate generated spec approval challenge: %w", err)
+	}
+	if err := validateVerifiedApproval(challenge, verified); err != nil {
+		return SignedGrant{}, err
+	}
+	if now.Before(verified.VerifiedAt) {
+		return SignedGrant{}, errors.New("grant issuance precedes verified quorum")
+	}
+	if challenge.ServerIdentity != config.ServerIdentity {
+		return SignedGrant{}, errors.New("issuer server identity does not match challenge")
+	}
+	if !validToken(grantID) || len(nonce) != 64 {
+		return SignedGrant{}, errors.New("grant id and nonce are required")
+	}
+	ceremonyHash, err := CeremonyCommitment(challenge, verified)
+	if err != nil {
+		return SignedGrant{}, err
+	}
+	expiresAt := now.Add(config.GrantTTL)
+	if expiresAt.After(challenge.ExpiresAt) {
+		expiresAt = challenge.ExpiresAt
+	}
+	if !expiresAt.After(now) {
+		return SignedGrant{}, errors.New("grant lifetime is exhausted")
+	}
+	approvers := make([]string, len(verified.Signers))
+	for index, signer := range verified.Signers {
+		approvers[index] = signer.PrincipalID
+	}
+	sort.Strings(approvers)
+	grant, err := (contracts.GeneratedSpecApprovalGrant{
+		Domain: contracts.GeneratedSpecApprovalGrantDomainV1, SchemaVersion: contracts.GeneratedSpecApprovalGrantSchemaV1,
+		ContractVersion: contracts.GeneratedSpecApprovalGrantContractV1,
+		GrantID:         grantID, TenantID: challenge.TenantID, WorkspaceID: challenge.WorkspaceID, Audience: challenge.Audience,
+		GeneratedSpecID: challenge.GeneratedSpecID, GeneratedSpecHash: challenge.GeneratedSpecHash,
+		ExecutionPlanHash: challenge.ExecutionPlanHash, PlanTransactionHash: challenge.PlanTransactionHash,
+		WriteSetHash: challenge.WriteSetHash, VerificationScopeHash: challenge.VerificationScopeHash,
+		PolicyEnvelopeHash: challenge.PolicyEnvelopeHash, PolicyVersion: challenge.PolicyVersion,
+		PolicyEpoch: challenge.PolicyEpoch, Action: challenge.Action, RequestingPrincipalID: challenge.RequestingPrincipalID,
+		ApproverPrincipalIDs: approvers, ApprovalID: challenge.ApprovalID, ChallengeHash: challenge.ChallengeHash,
+		CeremonyHash: ceremonyHash, SignerSetHash: verified.SignerSetHash, AuthoritySource: challenge.AuthoritySource,
+		AuthorityVersion: challenge.AuthorityVersion, AuthoritySnapshotHash: challenge.AuthoritySnapshotHash,
+		ServerIdentity: config.ServerIdentity, KernelTrustRootID: config.KernelTrustRootID, SigningKeyRef: config.SigningKeyRef,
+		IssuedAt: now, ExpiresAt: expiresAt, Nonce: nonce,
+	}).Seal()
+	if err != nil {
+		return SignedGrant{}, fmt.Errorf("seal generated spec approval grant: %w", err)
+	}
+	return SignGrant(grant, signer)
+}
+
+// NewConsumption deterministically projects one grant onto the verified
+// workload that atomically consumed it. The caller must persist this sealed
+// value, sign it, and move the durable grant state in one transaction.
+func NewConsumption(grant contracts.GeneratedSpecApprovalGrant, consumedBy string, consumedAt time.Time) (contracts.GeneratedSpecApprovalConsumption, error) {
+	consumedAt = consumedAt.UTC().Truncate(time.Microsecond)
+	if !validToken(consumedBy) {
+		return contracts.GeneratedSpecApprovalConsumption{}, errors.New("consuming workload identity is required")
+	}
+	if err := grant.ValidateAt(consumedAt); err != nil {
+		return contracts.GeneratedSpecApprovalConsumption{}, fmt.Errorf("consume generated spec approval grant: %w", err)
+	}
+	consumption, err := (contracts.GeneratedSpecApprovalConsumption{
+		Domain: contracts.GeneratedSpecApprovalConsumptionDomainV1, SchemaVersion: contracts.GeneratedSpecApprovalConsumptionSchemaV1,
+		ContractVersion: contracts.GeneratedSpecApprovalConsumptionContractV1,
+		ApprovalID:      grant.ApprovalID, GrantID: grant.GrantID, GrantHash: grant.GrantHash,
+		TenantID: grant.TenantID, WorkspaceID: grant.WorkspaceID, Audience: grant.Audience, ConsumedBy: consumedBy,
+		GeneratedSpecID: grant.GeneratedSpecID, GeneratedSpecHash: grant.GeneratedSpecHash,
+		ExecutionPlanHash: grant.ExecutionPlanHash, PlanTransactionHash: grant.PlanTransactionHash,
+		WriteSetHash: grant.WriteSetHash, VerificationScopeHash: grant.VerificationScopeHash,
+		PolicyEnvelopeHash: grant.PolicyEnvelopeHash, PolicyVersion: grant.PolicyVersion,
+		PolicyEpoch: grant.PolicyEpoch, Action: grant.Action, RequestingPrincipalID: grant.RequestingPrincipalID,
+		ApproverPrincipalIDs: append([]string(nil), grant.ApproverPrincipalIDs...), ChallengeHash: grant.ChallengeHash,
+		CeremonyHash: grant.CeremonyHash, SignerSetHash: grant.SignerSetHash, AuthoritySource: grant.AuthoritySource,
+		AuthorityVersion: grant.AuthorityVersion, AuthoritySnapshotHash: grant.AuthoritySnapshotHash,
+		ServerIdentity: grant.ServerIdentity, KernelTrustRootID: grant.KernelTrustRootID, SigningKeyRef: grant.SigningKeyRef,
+		GrantIssuedAt: grant.IssuedAt, GrantExpiresAt: grant.ExpiresAt, ConsumedAt: consumedAt,
+	}).Seal()
+	if err != nil {
+		return contracts.GeneratedSpecApprovalConsumption{}, fmt.Errorf("seal generated spec approval consumption: %w", err)
+	}
+	return consumption, nil
+}
+
+// CeremonyCommitment is the deterministic link between the source-owned
+// challenge and independently verified human quorum. A durable service should
+// persist this exact commitment before issuing the grant that references it.
+func CeremonyCommitment(challenge contracts.GeneratedSpecApprovalChallenge, verified VerifiedApprovalRef) (string, error) {
+	if err := validateVerifiedApproval(challenge, verified); err != nil {
+		return "", err
+	}
+	payload, err := canonicalize.JCS(struct {
+		Domain                string    `json:"domain"`
+		ApprovalID            string    `json:"approval_id"`
+		TenantID              string    `json:"tenant_id"`
+		WorkspaceID           string    `json:"workspace_id"`
+		ChallengeHash         string    `json:"challenge_hash"`
+		GeneratedSpecHash     string    `json:"generated_spec_hash"`
+		ExecutionPlanHash     string    `json:"execution_plan_hash"`
+		PlanTransactionHash   string    `json:"plan_transaction_hash"`
+		WriteSetHash          string    `json:"write_set_hash"`
+		VerificationScopeHash string    `json:"verification_scope_hash"`
+		PolicyEnvelopeHash    string    `json:"policy_envelope_hash"`
+		AuthoritySnapshotHash string    `json:"authority_snapshot_hash"`
+		SignerSetHash         string    `json:"signer_set_hash"`
+		VerifiedAt            time.Time `json:"verified_at"`
+	}{
+		Domain: "HELM/GeneratedSpecApprovalCeremonyCommitment/v1", ApprovalID: challenge.ApprovalID,
+		TenantID: challenge.TenantID, WorkspaceID: challenge.WorkspaceID, ChallengeHash: challenge.ChallengeHash,
+		GeneratedSpecHash: challenge.GeneratedSpecHash, ExecutionPlanHash: challenge.ExecutionPlanHash,
+		PlanTransactionHash: challenge.PlanTransactionHash, WriteSetHash: challenge.WriteSetHash,
+		VerificationScopeHash: challenge.VerificationScopeHash, PolicyEnvelopeHash: challenge.PolicyEnvelopeHash,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash, SignerSetHash: verified.SignerSetHash,
+		VerifiedAt: verified.VerifiedAt,
+	})
+	if err != nil {
+		return "", fmt.Errorf("commit generated spec approval ceremony: %w", err)
+	}
+	hash := sha256.Sum256(payload)
+	return "sha256:" + hex.EncodeToString(hash[:]), nil
+}
+
+func validateVerifiedApproval(challenge contracts.GeneratedSpecApprovalChallenge, verified VerifiedApprovalRef) error {
+	if !verified.verified || verified.integrityHash == "" {
+		return errors.New("verified approval capability is missing")
+	}
+	integrityHash, err := verifiedApprovalIntegrityHash(verified)
+	if err != nil || integrityHash != verified.integrityHash {
+		return errors.New("verified approval integrity mismatch")
+	}
+	if verified.ApprovalID != challenge.ApprovalID || verified.ChallengeID != challenge.ChallengeID ||
+		verified.ChallengeHash != challenge.ChallengeHash || verified.TenantID != challenge.TenantID ||
+		verified.WorkspaceID != challenge.WorkspaceID || verified.Audience != challenge.Audience ||
+		verified.GeneratedSpecID != challenge.GeneratedSpecID || verified.GeneratedSpecHash != challenge.GeneratedSpecHash ||
+		verified.ExecutionPlanHash != challenge.ExecutionPlanHash || verified.PlanTransactionHash != challenge.PlanTransactionHash ||
+		verified.WriteSetHash != challenge.WriteSetHash || verified.VerificationScopeHash != challenge.VerificationScopeHash ||
+		verified.PolicyEnvelopeHash != challenge.PolicyEnvelopeHash || verified.PolicyVersion != challenge.PolicyVersion ||
+		verified.PolicyEpoch != challenge.PolicyEpoch || verified.Action != challenge.Action ||
+		verified.RequestingPrincipalID != challenge.RequestingPrincipalID || verified.AuthoritySource != challenge.AuthoritySource ||
+		verified.AuthorityVersion != challenge.AuthorityVersion || verified.AuthoritySnapshotHash != challenge.AuthoritySnapshotHash ||
+		verified.RequiredRole != challenge.RequiredRole || verified.Quorum != challenge.Quorum || verified.ServerIdentity != challenge.ServerIdentity {
+		return errors.New("verified approval binding mismatch")
+	}
+	if len(verified.Signers) < challenge.Quorum || verified.SignerSetHash == "" || verified.VerifiedAt.IsZero() || verified.VerifiedAt.Before(challenge.IssuedAt) || !verified.VerifiedAt.Before(challenge.ExpiresAt) {
+		return errors.New("verified approval quorum evidence is invalid")
+	}
+	return nil
+}

--- a/core/pkg/boundary/generatedspecapproval/signature.go
+++ b/core/pkg/boundary/generatedspecapproval/signature.go
@@ -1,0 +1,217 @@
+// quantum_posture: GeneratedSpec approval grant and consumption signatures are
+// classical Ed25519 only. No hybrid or post-quantum compatibility is implied.
+package generatedspecapproval
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+const (
+	SignatureAlgorithmEd25519    = "ed25519"
+	grantSignatureDomainV1       = "HELM/GeneratedSpecApprovalGrantSignature/v1"
+	consumptionSignatureDomainV1 = "HELM/GeneratedSpecApprovalConsumptionSignature/v1"
+)
+
+var ErrSignatureRejected = errors.New("generated spec approval signature rejected")
+
+// SignedGrant is the transport envelope for a sealed Kernel-issued grant. A
+// receiver must validate its lifetime, verify the pinned signature, and still
+// use a durable single-use transition before treating it as approval evidence.
+type SignedGrant struct {
+	Grant     contracts.GeneratedSpecApprovalGrant `json:"grant"`
+	Algorithm string                               `json:"algorithm"`
+	Signature string                               `json:"signature"`
+}
+
+// SignedConsumption is the transport envelope for the durable consume event.
+type SignedConsumption struct {
+	Consumption contracts.GeneratedSpecApprovalConsumption `json:"consumption"`
+	Algorithm   string                                     `json:"algorithm"`
+	Signature   string                                     `json:"signature"`
+}
+
+// Ed25519Verifier pins one Kernel signing public key and trust-root metadata.
+// Deployments rotate this verifier by installing a new source-owned key set;
+// callers must not accept arbitrary keys sent alongside a grant.
+type Ed25519Verifier struct {
+	publicKey         ed25519.PublicKey
+	signingKeyRef     string
+	kernelTrustRootID string
+}
+
+func NewEd25519Verifier(publicKey []byte, signingKeyRef, kernelTrustRootID string) (*Ed25519Verifier, error) {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("%w: invalid public key size", ErrSignatureRejected)
+	}
+	if signingKeyRef == "" || kernelTrustRootID == "" {
+		return nil, fmt.Errorf("%w: signing key ref and trust root are required", ErrSignatureRejected)
+	}
+	return &Ed25519Verifier{
+		publicKey: append(ed25519.PublicKey(nil), publicKey...), signingKeyRef: signingKeyRef,
+		kernelTrustRootID: kernelTrustRootID,
+	}, nil
+}
+
+func SignGrant(grant contracts.GeneratedSpecApprovalGrant, signer crypto.Signer) (SignedGrant, error) {
+	if signer == nil {
+		return SignedGrant{}, fmt.Errorf("%w: signer is not configured", ErrSignatureRejected)
+	}
+	payload, err := GrantSigningPayload(grant, SignatureAlgorithmEd25519)
+	if err != nil {
+		return SignedGrant{}, err
+	}
+	signature, err := signer.Sign(payload)
+	if err != nil {
+		return SignedGrant{}, fmt.Errorf("%w: sign grant: %v", ErrSignatureRejected, err)
+	}
+	if !validSignature(signature) {
+		return SignedGrant{}, fmt.Errorf("%w: signer returned invalid signature", ErrSignatureRejected)
+	}
+	return SignedGrant{Grant: grant, Algorithm: SignatureAlgorithmEd25519, Signature: signature}, nil
+}
+
+func SignConsumption(consumption contracts.GeneratedSpecApprovalConsumption, signer crypto.Signer) (SignedConsumption, error) {
+	if signer == nil {
+		return SignedConsumption{}, fmt.Errorf("%w: signer is not configured", ErrSignatureRejected)
+	}
+	payload, err := ConsumptionSigningPayload(consumption, SignatureAlgorithmEd25519)
+	if err != nil {
+		return SignedConsumption{}, err
+	}
+	signature, err := signer.Sign(payload)
+	if err != nil {
+		return SignedConsumption{}, fmt.Errorf("%w: sign consumption: %v", ErrSignatureRejected, err)
+	}
+	if !validSignature(signature) {
+		return SignedConsumption{}, fmt.Errorf("%w: signer returned invalid signature", ErrSignatureRejected)
+	}
+	return SignedConsumption{Consumption: consumption, Algorithm: SignatureAlgorithmEd25519, Signature: signature}, nil
+}
+
+func (v *Ed25519Verifier) VerifyGrant(signed SignedGrant, now time.Time) error {
+	if err := signed.Grant.ValidateAt(now); err != nil {
+		return fmt.Errorf("%w: grant: %v", ErrSignatureRejected, err)
+	}
+	return v.VerifyGrantSignature(signed)
+}
+
+func (v *Ed25519Verifier) VerifyGrantSignature(signed SignedGrant) error {
+	if v == nil || len(v.publicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: verifier is not configured", ErrSignatureRejected)
+	}
+	if signed.Algorithm != SignatureAlgorithmEd25519 || signed.Grant.SigningKeyRef != v.signingKeyRef || signed.Grant.KernelTrustRootID != v.kernelTrustRootID {
+		return fmt.Errorf("%w: trust-root metadata mismatch", ErrSignatureRejected)
+	}
+	payload, err := GrantSigningPayload(signed.Grant, signed.Algorithm)
+	if err != nil {
+		return err
+	}
+	if !verify(v.publicKey, payload, signed.Signature) {
+		return fmt.Errorf("%w: bad grant ed25519 signature", ErrSignatureRejected)
+	}
+	return nil
+}
+
+func (v *Ed25519Verifier) VerifyConsumption(signed SignedConsumption, grant SignedGrant) error {
+	if v == nil || len(v.publicKey) != ed25519.PublicKeySize {
+		return fmt.Errorf("%w: verifier is not configured", ErrSignatureRejected)
+	}
+	if err := v.VerifyGrantSignature(grant); err != nil {
+		return fmt.Errorf("%w: source grant: %v", ErrSignatureRejected, err)
+	}
+	if err := signed.Consumption.ValidateGrant(grant.Grant); err != nil {
+		return fmt.Errorf("%w: consumption grant projection: %v", ErrSignatureRejected, err)
+	}
+	if signed.Algorithm != SignatureAlgorithmEd25519 || signed.Consumption.SigningKeyRef != v.signingKeyRef || signed.Consumption.KernelTrustRootID != v.kernelTrustRootID {
+		return fmt.Errorf("%w: consumption trust-root metadata mismatch", ErrSignatureRejected)
+	}
+	payload, err := ConsumptionSigningPayload(signed.Consumption, signed.Algorithm)
+	if err != nil {
+		return err
+	}
+	if !verify(v.publicKey, payload, signed.Signature) {
+		return fmt.Errorf("%w: bad consumption ed25519 signature", ErrSignatureRejected)
+	}
+	return nil
+}
+
+func GrantSigningPayload(grant contracts.GeneratedSpecApprovalGrant, algorithm string) ([]byte, error) {
+	if algorithm != SignatureAlgorithmEd25519 {
+		return nil, fmt.Errorf("%w: unsupported algorithm", ErrSignatureRejected)
+	}
+	if grant.GrantHash == "" {
+		return nil, fmt.Errorf("%w: grant_hash is required", ErrSignatureRejected)
+	}
+	sealed, err := grant.Seal()
+	if err != nil || sealed.GrantHash != grant.GrantHash {
+		return nil, fmt.Errorf("%w: grant integrity mismatch", ErrSignatureRejected)
+	}
+	payload, err := canonicalize.JCS(struct {
+		Domain            string `json:"domain"`
+		ContractVersion   string `json:"contract_version"`
+		GrantHash         string `json:"grant_hash"`
+		KernelTrustRootID string `json:"kernel_trust_root_id"`
+		SigningKeyRef     string `json:"signing_key_ref"`
+		Algorithm         string `json:"algorithm"`
+	}{
+		Domain: grantSignatureDomainV1, ContractVersion: grant.ContractVersion, GrantHash: grant.GrantHash,
+		KernelTrustRootID: grant.KernelTrustRootID, SigningKeyRef: grant.SigningKeyRef, Algorithm: algorithm,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: canonicalize grant signing payload: %v", ErrSignatureRejected, err)
+	}
+	return payload, nil
+}
+
+func ConsumptionSigningPayload(consumption contracts.GeneratedSpecApprovalConsumption, algorithm string) ([]byte, error) {
+	if algorithm != SignatureAlgorithmEd25519 {
+		return nil, fmt.Errorf("%w: unsupported algorithm", ErrSignatureRejected)
+	}
+	if consumption.ConsumptionHash == "" {
+		return nil, fmt.Errorf("%w: consumption_hash is required", ErrSignatureRejected)
+	}
+	sealed, err := consumption.Seal()
+	if err != nil || sealed.ConsumptionHash != consumption.ConsumptionHash {
+		return nil, fmt.Errorf("%w: consumption integrity mismatch", ErrSignatureRejected)
+	}
+	payload, err := canonicalize.JCS(struct {
+		Domain            string `json:"domain"`
+		ContractVersion   string `json:"contract_version"`
+		ConsumptionHash   string `json:"consumption_hash"`
+		KernelTrustRootID string `json:"kernel_trust_root_id"`
+		SigningKeyRef     string `json:"signing_key_ref"`
+		Algorithm         string `json:"algorithm"`
+	}{
+		Domain: consumptionSignatureDomainV1, ContractVersion: consumption.ContractVersion,
+		ConsumptionHash: consumption.ConsumptionHash, KernelTrustRootID: consumption.KernelTrustRootID,
+		SigningKeyRef: consumption.SigningKeyRef, Algorithm: algorithm,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: canonicalize consumption signing payload: %v", ErrSignatureRejected, err)
+	}
+	return payload, nil
+}
+
+func verify(publicKey ed25519.PublicKey, payload []byte, signature string) bool {
+	if !validSignature(signature) {
+		return false
+	}
+	raw, _ := hex.DecodeString(signature)
+	return ed25519.Verify(publicKey, payload, raw)
+}
+
+func validSignature(signature string) bool {
+	if len(signature) != ed25519.SignatureSize*2 {
+		return false
+	}
+	decoded, err := hex.DecodeString(signature)
+	return err == nil && len(decoded) == ed25519.SignatureSize && hex.EncodeToString(decoded) == signature
+}

--- a/core/pkg/boundary/generatedspecapproval/verifier.go
+++ b/core/pkg/boundary/generatedspecapproval/verifier.go
@@ -1,3 +1,6 @@
+// quantum_posture: GeneratedSpec approval grants and consumption records use
+// classical Ed25519 signatures and SHA-256 content binding in this contract;
+// no hybrid or post-quantum approval assurance is claimed.
 package generatedspecapproval
 
 import (

--- a/core/pkg/boundary/generatedspecapproval/verifier.go
+++ b/core/pkg/boundary/generatedspecapproval/verifier.go
@@ -1,0 +1,402 @@
+package generatedspecapproval
+
+import (
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+var (
+	ErrVerificationFailed = errors.New("generated spec approval verification failed")
+	ErrAuthorityRejected  = errors.New("generated spec approval authority rejected")
+	ErrAssertionRejected  = errors.New("generated spec approval assertion rejected")
+	ErrDuplicateSigner    = errors.New("generated spec approval duplicate signer")
+	ErrQuorumNotMet       = errors.New("generated spec approval quorum not met")
+)
+
+// ExpectedBinding is independently loaded policy and source state. The route
+// that owns a ceremony constructs it; submitted assertions never define it.
+type ExpectedBinding struct {
+	ChallengeID   string
+	ChallengeHash string
+	ApprovalID    string
+	TenantID      string
+	WorkspaceID   string
+	Audience      string
+
+	GeneratedSpecID       string
+	GeneratedSpecHash     string
+	ExecutionPlanHash     string
+	PlanTransactionHash   string
+	WriteSetHash          string
+	VerificationScopeHash string
+	PolicyEnvelopeHash    string
+	PolicyVersion         string
+	PolicyEpoch           string
+	Action                string
+	RequestingPrincipalID string
+
+	AuthoritySource       string
+	AuthorityVersion      string
+	AuthoritySnapshotHash string
+	RequiredRole          string
+	Quorum                int
+	ServerIdentity        string
+}
+
+type VerifyOptions struct {
+	Expected        ExpectedBinding
+	MinHoldDuration time.Duration
+	MaxChallengeTTL time.Duration
+	MaxAssertions   int
+}
+
+// VerifiedApprovalRef is the verifier-derived human approval evidence that a
+// durable generated-spec ceremony may commit before issuing a signed grant.
+// It is not itself approval authority and cannot be client constructed into a
+// grant issuance path: Issuer validates every bound value again.
+type VerifiedApprovalRef struct {
+	ApprovalID    string
+	ChallengeID   string
+	ChallengeHash string
+	TenantID      string
+	WorkspaceID   string
+	Audience      string
+
+	GeneratedSpecID       string
+	GeneratedSpecHash     string
+	ExecutionPlanHash     string
+	PlanTransactionHash   string
+	WriteSetHash          string
+	VerificationScopeHash string
+	PolicyEnvelopeHash    string
+	PolicyVersion         string
+	PolicyEpoch           string
+	Action                string
+	RequestingPrincipalID string
+
+	AuthoritySource       string
+	AuthorityVersion      string
+	AuthoritySnapshotHash string
+	RequiredRole          string
+	Quorum                int
+	ServerIdentity        string
+	Signers               []approvalverify.VerifiedSigner
+	SignerSetHash         string
+	VerifiedAt            time.Time
+
+	// verified and integrityHash form an in-package capability. They prevent a
+	// future issuer from accepting a caller-assembled projection in place of
+	// the result of VerifyGeneratedSpecQuorum. Durable stores must re-verify
+	// assertions (or use an in-package verified reconstruction), never decode
+	// an untrusted JSON projection into issuance authority.
+	verified      bool
+	integrityHash string
+}
+
+// VerifyGeneratedSpecQuorum verifies distinct human assertions over one typed
+// GeneratedSpec challenge. It intentionally does not call the pack lifecycle
+// verifier or accept a union contract: a successful result is suitable only
+// for a later GeneratedSpec ceremony commitment and signed approval grant.
+func VerifyGeneratedSpecQuorum(
+	challenge contracts.GeneratedSpecApprovalChallenge,
+	assertions []contracts.GeneratedSpecApprovalAssertion,
+	store approvalverify.TrustStore,
+	opts VerifyOptions,
+	now time.Time,
+) (VerifiedApprovalRef, error) {
+	if err := validateVerifyOptions(opts); err != nil {
+		return VerifiedApprovalRef{}, err
+	}
+	if err := challenge.ValidateAt(now); err != nil {
+		return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+	}
+	if challenge.EligibleAt.Sub(challenge.HoldStartedAt) < opts.MinHoldDuration {
+		return VerifiedApprovalRef{}, verificationFailed("challenge hold duration is below policy minimum")
+	}
+	if challenge.ExpiresAt.Sub(challenge.HoldStartedAt) > opts.MaxChallengeTTL {
+		return VerifiedApprovalRef{}, verificationFailed("challenge ttl exceeds maximum")
+	}
+	if err := verifyExpectedBinding(challenge, opts.Expected); err != nil {
+		return VerifiedApprovalRef{}, err
+	}
+	if err := validateTrustStore(store, challenge); err != nil {
+		return VerifiedApprovalRef{}, err
+	}
+	if len(assertions) < challenge.Quorum {
+		return VerifiedApprovalRef{}, fmt.Errorf("%w: got %d assertions, need %d", ErrQuorumNotMet, len(assertions), challenge.Quorum)
+	}
+	if len(assertions) > opts.MaxAssertions {
+		return VerifiedApprovalRef{}, verificationFailed("assertion count exceeds policy maximum")
+	}
+
+	seenKeys := make(map[string]struct{}, len(assertions))
+	seenPrincipals := make(map[string]struct{}, len(assertions))
+	seenCredentials := make(map[string]struct{}, len(assertions))
+	seenDevices := make(map[string]struct{}, len(assertions))
+	seenPublicKeys := make(map[string]struct{}, len(assertions))
+	verified := make([]approvalverify.VerifiedSigner, 0, len(assertions))
+
+	for _, assertion := range assertions {
+		if err := assertion.Validate(); err != nil {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+		}
+		if assertion.ChallengeID != challenge.ChallengeID || assertion.ChallengeHash != challenge.ChallengeHash {
+			return VerifiedApprovalRef{}, verificationFailed("assertion challenge binding mismatch")
+		}
+		if _, duplicate := seenKeys[assertion.KeyID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("key_id", assertion.KeyID)
+		}
+		key, ok := store.Keys[assertion.KeyID]
+		if !ok {
+			return VerifiedApprovalRef{}, authorityRejected("unknown key")
+		}
+		if err := validateTrustedKey(key, assertion.KeyID, challenge, now); err != nil {
+			return VerifiedApprovalRef{}, err
+		}
+		if key.PrincipalID == challenge.RequestingPrincipalID {
+			return VerifiedApprovalRef{}, authorityRejected("requester cannot approve its own generated spec")
+		}
+		digest, err := assertion.SigningDigest()
+		if err != nil {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrVerificationFailed, err)
+		}
+		signature, err := assertion.SignatureBytes()
+		if err != nil {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: %w", ErrAssertionRejected, err)
+		}
+		if !ed25519.Verify(key.PublicKey, digest, signature) {
+			return VerifiedApprovalRef{}, fmt.Errorf("%w: bad ed25519 signature for key %s", ErrAssertionRejected, assertion.KeyID)
+		}
+		if _, duplicate := seenPrincipals[key.PrincipalID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("principal_id", key.PrincipalID)
+		}
+		if _, duplicate := seenCredentials[key.CredentialID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("credential_id", key.CredentialID)
+		}
+		if _, duplicate := seenDevices[key.DeviceID]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("device_id", key.DeviceID)
+		}
+		publicKeyIdentity := string(key.PublicKey)
+		if _, duplicate := seenPublicKeys[publicKeyIdentity]; duplicate {
+			return VerifiedApprovalRef{}, duplicateSigner("public_key", assertion.KeyID)
+		}
+		assertionHash, err := canonicalize.CanonicalHash(assertion)
+		if err != nil {
+			return VerifiedApprovalRef{}, verificationFailed("assertion canonicalization failed")
+		}
+		seenKeys[assertion.KeyID] = struct{}{}
+		seenPrincipals[key.PrincipalID] = struct{}{}
+		seenCredentials[key.CredentialID] = struct{}{}
+		seenDevices[key.DeviceID] = struct{}{}
+		seenPublicKeys[publicKeyIdentity] = struct{}{}
+		verified = append(verified, approvalverify.VerifiedSigner{
+			PrincipalID: key.PrincipalID, CredentialID: key.CredentialID, DeviceID: key.DeviceID,
+			KeyID: key.KeyID, Role: challenge.RequiredRole, AssertionHash: "sha256:" + assertionHash,
+		})
+	}
+	if len(verified) < challenge.Quorum {
+		return VerifiedApprovalRef{}, fmt.Errorf("%w: got %d unique signers, need %d", ErrQuorumNotMet, len(verified), challenge.Quorum)
+	}
+	sort.Slice(verified, func(i, j int) bool {
+		if verified[i].PrincipalID != verified[j].PrincipalID {
+			return verified[i].PrincipalID < verified[j].PrincipalID
+		}
+		if verified[i].CredentialID != verified[j].CredentialID {
+			return verified[i].CredentialID < verified[j].CredentialID
+		}
+		if verified[i].DeviceID != verified[j].DeviceID {
+			return verified[i].DeviceID < verified[j].DeviceID
+		}
+		return verified[i].KeyID < verified[j].KeyID
+	})
+	signerSetHash, err := canonicalize.CanonicalHash(struct {
+		Domain                string                          `json:"domain"`
+		ChallengeHash         string                          `json:"challenge_hash"`
+		AuthoritySnapshotHash string                          `json:"authority_snapshot_hash"`
+		Signers               []approvalverify.VerifiedSigner `json:"signers"`
+	}{
+		Domain: "HELM/GeneratedSpecApprovalSignerSet/v1", ChallengeHash: challenge.ChallengeHash,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash, Signers: verified,
+	})
+	if err != nil {
+		return VerifiedApprovalRef{}, verificationFailed("signer set canonicalization failed")
+	}
+	result := VerifiedApprovalRef{
+		ApprovalID: challenge.ApprovalID, ChallengeID: challenge.ChallengeID, ChallengeHash: challenge.ChallengeHash,
+		TenantID: challenge.TenantID, WorkspaceID: challenge.WorkspaceID, Audience: challenge.Audience,
+		GeneratedSpecID: challenge.GeneratedSpecID, GeneratedSpecHash: challenge.GeneratedSpecHash,
+		ExecutionPlanHash: challenge.ExecutionPlanHash, PlanTransactionHash: challenge.PlanTransactionHash,
+		WriteSetHash: challenge.WriteSetHash, VerificationScopeHash: challenge.VerificationScopeHash,
+		PolicyEnvelopeHash: challenge.PolicyEnvelopeHash, PolicyVersion: challenge.PolicyVersion,
+		PolicyEpoch: challenge.PolicyEpoch, Action: challenge.Action, RequestingPrincipalID: challenge.RequestingPrincipalID,
+		AuthoritySource: challenge.AuthoritySource, AuthorityVersion: challenge.AuthorityVersion,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash, RequiredRole: challenge.RequiredRole,
+		Quorum: challenge.Quorum, ServerIdentity: challenge.ServerIdentity, Signers: verified,
+		SignerSetHash: "sha256:" + signerSetHash, VerifiedAt: now.UTC(), verified: true,
+	}
+	integrityHash, err := verifiedApprovalIntegrityHash(result)
+	if err != nil {
+		return VerifiedApprovalRef{}, verificationFailed("verified approval canonicalization failed")
+	}
+	result.integrityHash = integrityHash
+	return result, nil
+}
+
+func validateVerifyOptions(opts VerifyOptions) error {
+	if opts.MinHoldDuration <= 0 || opts.MaxChallengeTTL <= opts.MinHoldDuration || opts.MaxAssertions <= 0 {
+		return verificationFailed("invalid verification policy limits")
+	}
+	if opts.MaxAssertions < opts.Expected.Quorum || opts.Expected.Quorum <= 0 {
+		return verificationFailed("maximum assertions must cover a positive quorum")
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "challenge_id", value: opts.Expected.ChallengeID}, {field: "challenge_hash", value: opts.Expected.ChallengeHash},
+		{field: "approval_id", value: opts.Expected.ApprovalID}, {field: "tenant_id", value: opts.Expected.TenantID},
+		{field: "workspace_id", value: opts.Expected.WorkspaceID}, {field: "audience", value: opts.Expected.Audience},
+		{field: "generated_spec_id", value: opts.Expected.GeneratedSpecID}, {field: "generated_spec_hash", value: opts.Expected.GeneratedSpecHash},
+		{field: "execution_plan_hash", value: opts.Expected.ExecutionPlanHash}, {field: "plan_transaction_hash", value: opts.Expected.PlanTransactionHash},
+		{field: "write_set_hash", value: opts.Expected.WriteSetHash}, {field: "verification_scope_hash", value: opts.Expected.VerificationScopeHash},
+		{field: "policy_envelope_hash", value: opts.Expected.PolicyEnvelopeHash}, {field: "policy_version", value: opts.Expected.PolicyVersion},
+		{field: "policy_epoch", value: opts.Expected.PolicyEpoch}, {field: "action", value: opts.Expected.Action},
+		{field: "requesting_principal_id", value: opts.Expected.RequestingPrincipalID}, {field: "authority_source", value: opts.Expected.AuthoritySource},
+		{field: "authority_version", value: opts.Expected.AuthorityVersion}, {field: "authority_snapshot_hash", value: opts.Expected.AuthoritySnapshotHash},
+		{field: "required_role", value: opts.Expected.RequiredRole}, {field: "server_identity", value: opts.Expected.ServerIdentity},
+	} {
+		if strings.TrimSpace(item.value) == "" {
+			return verificationFailed("expected " + item.field + " is required")
+		}
+	}
+	return nil
+}
+
+func verifyExpectedBinding(challenge contracts.GeneratedSpecApprovalChallenge, expected ExpectedBinding) error {
+	actual := []struct{ field, actual, expected string }{
+		{"challenge_id", challenge.ChallengeID, expected.ChallengeID}, {"challenge_hash", challenge.ChallengeHash, expected.ChallengeHash},
+		{"approval_id", challenge.ApprovalID, expected.ApprovalID}, {"tenant_id", challenge.TenantID, expected.TenantID},
+		{"workspace_id", challenge.WorkspaceID, expected.WorkspaceID}, {"audience", challenge.Audience, expected.Audience},
+		{"generated_spec_id", challenge.GeneratedSpecID, expected.GeneratedSpecID}, {"generated_spec_hash", challenge.GeneratedSpecHash, expected.GeneratedSpecHash},
+		{"execution_plan_hash", challenge.ExecutionPlanHash, expected.ExecutionPlanHash}, {"plan_transaction_hash", challenge.PlanTransactionHash, expected.PlanTransactionHash},
+		{"write_set_hash", challenge.WriteSetHash, expected.WriteSetHash}, {"verification_scope_hash", challenge.VerificationScopeHash, expected.VerificationScopeHash},
+		{"policy_envelope_hash", challenge.PolicyEnvelopeHash, expected.PolicyEnvelopeHash}, {"policy_version", challenge.PolicyVersion, expected.PolicyVersion},
+		{"policy_epoch", challenge.PolicyEpoch, expected.PolicyEpoch}, {"action", challenge.Action, expected.Action},
+		{"requesting_principal_id", challenge.RequestingPrincipalID, expected.RequestingPrincipalID}, {"authority_source", challenge.AuthoritySource, expected.AuthoritySource},
+		{"authority_version", challenge.AuthorityVersion, expected.AuthorityVersion}, {"authority_snapshot_hash", challenge.AuthoritySnapshotHash, expected.AuthoritySnapshotHash},
+		{"required_role", challenge.RequiredRole, expected.RequiredRole}, {"server_identity", challenge.ServerIdentity, expected.ServerIdentity},
+	}
+	for _, item := range actual {
+		if item.actual != item.expected {
+			return verificationFailed(item.field + " binding mismatch")
+		}
+	}
+	if challenge.Quorum != expected.Quorum {
+		return verificationFailed("quorum binding mismatch")
+	}
+	return nil
+}
+
+func validateTrustStore(store approvalverify.TrustStore, challenge contracts.GeneratedSpecApprovalChallenge) error {
+	if store.AuthoritySource != challenge.AuthoritySource || store.AuthorityVersion != challenge.AuthorityVersion || store.AuthoritySnapshotHash != challenge.AuthoritySnapshotHash || len(store.Keys) == 0 {
+		return authorityRejected("authority snapshot mismatch or empty")
+	}
+	return nil
+}
+
+func validateTrustedKey(key approvalverify.TrustedApproverKey, assertionKeyID string, challenge contracts.GeneratedSpecApprovalChallenge, now time.Time) error {
+	if !key.Enabled || key.KeyID == "" || key.KeyID != assertionKeyID || key.TenantID == "" || key.TenantID != challenge.TenantID {
+		return authorityRejected("key identity is invalid")
+	}
+	if !contains(key.WorkspaceIDs, challenge.WorkspaceID) || !validToken(key.PrincipalID) || !validToken(key.CredentialID) || !validToken(key.DeviceID) || len(key.PublicKey) != ed25519.PublicKeySize {
+		return authorityRejected("key scope or authority identity is invalid")
+	}
+	if key.NotBefore.IsZero() || key.NotAfter.IsZero() || !key.NotAfter.After(key.NotBefore) || now.Before(key.NotBefore) || !now.Before(key.NotAfter) {
+		return authorityRejected("key is outside its validity window")
+	}
+	if !contains(key.Roles, challenge.RequiredRole) || !contains(key.Actions, challenge.Action) || !contains(key.Audiences, challenge.Audience) {
+		return authorityRejected("key lacks required role, action, or audience")
+	}
+	return nil
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func validToken(value string) bool {
+	return value != "" && strings.IndexFunc(value, unicode.IsSpace) == -1
+}
+
+func verificationFailed(message string) error {
+	return fmt.Errorf("%w: %s", ErrVerificationFailed, message)
+}
+func authorityRejected(message string) error {
+	return fmt.Errorf("%w: %s", ErrAuthorityRejected, message)
+}
+func duplicateSigner(field, value string) error {
+	return fmt.Errorf("%w: duplicate %s %s", ErrDuplicateSigner, field, value)
+}
+
+func verifiedApprovalIntegrityHash(verified VerifiedApprovalRef) (string, error) {
+	hash, err := canonicalize.CanonicalHash(struct {
+		Domain                string                          `json:"domain"`
+		ApprovalID            string                          `json:"approval_id"`
+		ChallengeID           string                          `json:"challenge_id"`
+		ChallengeHash         string                          `json:"challenge_hash"`
+		TenantID              string                          `json:"tenant_id"`
+		WorkspaceID           string                          `json:"workspace_id"`
+		Audience              string                          `json:"audience"`
+		GeneratedSpecID       string                          `json:"generated_spec_id"`
+		GeneratedSpecHash     string                          `json:"generated_spec_hash"`
+		ExecutionPlanHash     string                          `json:"execution_plan_hash"`
+		PlanTransactionHash   string                          `json:"plan_transaction_hash"`
+		WriteSetHash          string                          `json:"write_set_hash"`
+		VerificationScopeHash string                          `json:"verification_scope_hash"`
+		PolicyEnvelopeHash    string                          `json:"policy_envelope_hash"`
+		PolicyVersion         string                          `json:"policy_version"`
+		PolicyEpoch           string                          `json:"policy_epoch"`
+		Action                string                          `json:"action"`
+		RequestingPrincipalID string                          `json:"requesting_principal_id"`
+		AuthoritySource       string                          `json:"authority_source"`
+		AuthorityVersion      string                          `json:"authority_version"`
+		AuthoritySnapshotHash string                          `json:"authority_snapshot_hash"`
+		RequiredRole          string                          `json:"required_role"`
+		Quorum                int                             `json:"quorum"`
+		ServerIdentity        string                          `json:"server_identity"`
+		Signers               []approvalverify.VerifiedSigner `json:"signers"`
+		SignerSetHash         string                          `json:"signer_set_hash"`
+		VerifiedAt            time.Time                       `json:"verified_at"`
+	}{
+		Domain: "HELM/GeneratedSpecVerifiedApproval/v1", ApprovalID: verified.ApprovalID,
+		ChallengeID: verified.ChallengeID, ChallengeHash: verified.ChallengeHash,
+		TenantID: verified.TenantID, WorkspaceID: verified.WorkspaceID, Audience: verified.Audience,
+		GeneratedSpecID: verified.GeneratedSpecID, GeneratedSpecHash: verified.GeneratedSpecHash,
+		ExecutionPlanHash: verified.ExecutionPlanHash, PlanTransactionHash: verified.PlanTransactionHash,
+		WriteSetHash: verified.WriteSetHash, VerificationScopeHash: verified.VerificationScopeHash,
+		PolicyEnvelopeHash: verified.PolicyEnvelopeHash, PolicyVersion: verified.PolicyVersion,
+		PolicyEpoch: verified.PolicyEpoch, Action: verified.Action, RequestingPrincipalID: verified.RequestingPrincipalID,
+		AuthoritySource: verified.AuthoritySource, AuthorityVersion: verified.AuthorityVersion,
+		AuthoritySnapshotHash: verified.AuthoritySnapshotHash, RequiredRole: verified.RequiredRole,
+		Quorum: verified.Quorum, ServerIdentity: verified.ServerIdentity, Signers: verified.Signers,
+		SignerSetHash: verified.SignerSetHash, VerifiedAt: verified.VerifiedAt,
+	})
+	if err != nil {
+		return "", err
+	}
+	return "sha256:" + hash, nil
+}

--- a/core/pkg/contracts/generated_spec_approval.go
+++ b/core/pkg/contracts/generated_spec_approval.go
@@ -1,0 +1,638 @@
+// quantum_posture: GeneratedSpec approval assertions and grants use classical
+// Ed25519 signatures only. This contract makes no hybrid or post-quantum claim.
+package contracts
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	GeneratedSpecApprovalChallengeDomainV1   = "HELM/GeneratedSpecApprovalChallenge/v1"
+	GeneratedSpecApprovalChallengeSchemaV1   = "generated-spec-approval-challenge.v1"
+	GeneratedSpecApprovalChallengeContractV1 = "2026-07-22"
+
+	GeneratedSpecApprovalAssertionDomainV1   = "HELM/GeneratedSpecApprovalAssertion/v1"
+	GeneratedSpecApprovalAssertionSchemaV1   = "generated-spec-approval-assertion.v1"
+	GeneratedSpecApprovalAssertionContractV1 = "2026-07-22"
+	GeneratedSpecApprovalAssertionEd25519    = "ed25519"
+
+	GeneratedSpecApprovalGrantDomainV1   = "HELM/GeneratedSpecApprovalGrant/v1"
+	GeneratedSpecApprovalGrantSchemaV1   = "generated-spec-approval-grant.v1"
+	GeneratedSpecApprovalGrantContractV1 = "2026-07-22"
+
+	GeneratedSpecApprovalConsumptionDomainV1   = "HELM/GeneratedSpecApprovalConsumption/v1"
+	GeneratedSpecApprovalConsumptionSchemaV1   = "generated-spec-approval-consumption.v1"
+	GeneratedSpecApprovalConsumptionContractV1 = "2026-07-22"
+
+	GeneratedSpecApprovalAudienceV1 = "generated-spec.approval"
+	GeneratedSpecApprovalActionV1   = "approve_generated_spec"
+)
+
+var (
+	ErrGeneratedSpecApprovalChallengeInvalid   = errors.New("generated spec approval challenge invalid")
+	ErrGeneratedSpecApprovalChallengeInactive  = errors.New("generated spec approval challenge inactive")
+	ErrGeneratedSpecApprovalChallengeIntegrity = errors.New("generated spec approval challenge integrity failure")
+	ErrGeneratedSpecApprovalAssertionInvalid   = errors.New("generated spec approval assertion invalid")
+	ErrGeneratedSpecApprovalGrantInvalid       = errors.New("generated spec approval grant invalid")
+	ErrGeneratedSpecApprovalGrantInactive      = errors.New("generated spec approval grant inactive")
+	ErrGeneratedSpecApprovalGrantIntegrity     = errors.New("generated spec approval grant integrity failure")
+)
+
+// GeneratedSpecApprovalChallenge is the exact server-issued proposal a human
+// approver signs. Its hashes bind the immutable GeneratedSpec source, the plan
+// proposed for later execution, and the policy envelope that governed review.
+//
+// A client-submitted copy is never evidence of issuance, elapsed hold time, or
+// authority. The owning ceremony must load the durable record before accepting
+// an assertion or issuing a grant.
+type GeneratedSpecApprovalChallenge struct {
+	Domain          string `json:"domain"`
+	SchemaVersion   string `json:"schema_version"`
+	ContractVersion string `json:"contract_version"`
+
+	ChallengeID string `json:"challenge_id"`
+	ApprovalID  string `json:"approval_id"`
+	TenantID    string `json:"tenant_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Audience    string `json:"audience"`
+
+	GeneratedSpecID       string `json:"generated_spec_id"`
+	GeneratedSpecHash     string `json:"generated_spec_hash"`
+	ExecutionPlanHash     string `json:"execution_plan_hash"`
+	PlanTransactionHash   string `json:"plan_transaction_hash"`
+	WriteSetHash          string `json:"write_set_hash"`
+	VerificationScopeHash string `json:"verification_scope_hash"`
+	PolicyEnvelopeHash    string `json:"policy_envelope_hash"`
+	PolicyVersion         string `json:"policy_version"`
+	PolicyEpoch           string `json:"policy_epoch"`
+	Action                string `json:"action"`
+
+	// RequestingPrincipalID is independently sourced by the owning control
+	// service. A verified signer with this identity is rejected, so the
+	// requester cannot approve their own GeneratedSpec under this v1 contract.
+	RequestingPrincipalID string `json:"requesting_principal_id"`
+
+	AuthoritySource       string `json:"authority_source"`
+	AuthorityVersion      string `json:"authority_version"`
+	AuthoritySnapshotHash string `json:"authority_snapshot_hash"`
+	RequiredRole          string `json:"required_role"`
+	Quorum                int    `json:"quorum"`
+
+	ServerIdentity string    `json:"server_identity"`
+	HoldStartedAt  time.Time `json:"hold_started_at"`
+	EligibleAt     time.Time `json:"eligible_at"`
+	IssuedAt       time.Time `json:"issued_at"`
+	ExpiresAt      time.Time `json:"expires_at"`
+	Nonce          string    `json:"nonce"`
+
+	ChallengeHash string `json:"challenge_hash,omitempty"`
+}
+
+func (c GeneratedSpecApprovalChallenge) Validate() error {
+	if c.Domain != GeneratedSpecApprovalChallengeDomainV1 {
+		return generatedSpecApprovalChallengeInvalid("unsupported domain")
+	}
+	if c.SchemaVersion != GeneratedSpecApprovalChallengeSchemaV1 {
+		return generatedSpecApprovalChallengeInvalid("unsupported schema_version")
+	}
+	if c.ContractVersion != GeneratedSpecApprovalChallengeContractV1 {
+		return generatedSpecApprovalChallengeInvalid("unsupported contract_version")
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "challenge_id", value: c.ChallengeID},
+		{field: "approval_id", value: c.ApprovalID},
+		{field: "tenant_id", value: c.TenantID},
+		{field: "workspace_id", value: c.WorkspaceID},
+		{field: "generated_spec_id", value: c.GeneratedSpecID},
+		{field: "policy_version", value: c.PolicyVersion},
+		{field: "policy_epoch", value: c.PolicyEpoch},
+		{field: "requesting_principal_id", value: c.RequestingPrincipalID},
+		{field: "authority_source", value: c.AuthoritySource},
+		{field: "authority_version", value: c.AuthorityVersion},
+		{field: "required_role", value: c.RequiredRole},
+		{field: "server_identity", value: c.ServerIdentity},
+	} {
+		if !isApprovalGrantToken(item.value) {
+			return generatedSpecApprovalChallengeInvalid(item.field + " is required and must not contain whitespace")
+		}
+	}
+	if c.Audience != GeneratedSpecApprovalAudienceV1 {
+		return generatedSpecApprovalChallengeInvalid("unsupported audience")
+	}
+	if c.Action != GeneratedSpecApprovalActionV1 {
+		return generatedSpecApprovalChallengeInvalid("unsupported action")
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "generated_spec_hash", value: c.GeneratedSpecHash},
+		{field: "execution_plan_hash", value: c.ExecutionPlanHash},
+		{field: "plan_transaction_hash", value: c.PlanTransactionHash},
+		{field: "write_set_hash", value: c.WriteSetHash},
+		{field: "verification_scope_hash", value: c.VerificationScopeHash},
+		{field: "policy_envelope_hash", value: c.PolicyEnvelopeHash},
+		{field: "authority_snapshot_hash", value: c.AuthoritySnapshotHash},
+	} {
+		if !isApprovalGrantSHA256(item.value) {
+			return generatedSpecApprovalChallengeInvalid(item.field + " must be a lowercase sha256 reference")
+		}
+	}
+	if c.Quorum <= 0 {
+		return generatedSpecApprovalChallengeInvalid("quorum must be positive")
+	}
+	if c.HoldStartedAt.IsZero() || c.EligibleAt.IsZero() || c.IssuedAt.IsZero() || c.ExpiresAt.IsZero() {
+		return generatedSpecApprovalChallengeInvalid("hold_started_at, eligible_at, issued_at, and expires_at are required")
+	}
+	if !isApprovalGrantUTC(c.HoldStartedAt) || !isApprovalGrantUTC(c.EligibleAt) || !isApprovalGrantUTC(c.IssuedAt) || !isApprovalGrantUTC(c.ExpiresAt) {
+		return generatedSpecApprovalChallengeInvalid("timestamps must use UTC")
+	}
+	if !c.EligibleAt.After(c.HoldStartedAt) {
+		return generatedSpecApprovalChallengeInvalid("eligible_at must be after hold_started_at")
+	}
+	if c.IssuedAt.Before(c.EligibleAt) {
+		return generatedSpecApprovalChallengeInvalid("issued_at must not be before eligible_at")
+	}
+	if !c.ExpiresAt.After(c.IssuedAt) {
+		return generatedSpecApprovalChallengeInvalid("expires_at must be after issued_at")
+	}
+	if !isApprovalGrantNonce(c.Nonce) {
+		return generatedSpecApprovalChallengeInvalid("nonce must be 32 lowercase hexadecimal bytes")
+	}
+	if c.ChallengeHash != "" && !isApprovalGrantSHA256(c.ChallengeHash) {
+		return generatedSpecApprovalChallengeInvalid("challenge_hash must be a lowercase sha256 reference")
+	}
+	return nil
+}
+
+func (c GeneratedSpecApprovalChallenge) Seal() (GeneratedSpecApprovalChallenge, error) {
+	if err := c.Validate(); err != nil {
+		return GeneratedSpecApprovalChallenge{}, err
+	}
+	c.ChallengeHash = ""
+	hash, err := hashJCS(c)
+	if err != nil {
+		return GeneratedSpecApprovalChallenge{}, fmt.Errorf("%w: seal: %v", ErrGeneratedSpecApprovalChallengeInvalid, err)
+	}
+	c.ChallengeHash = hash
+	return c, nil
+}
+
+func (c GeneratedSpecApprovalChallenge) ValidateAt(now time.Time) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	if c.ChallengeHash == "" {
+		return fmt.Errorf("%w: challenge_hash is required", ErrGeneratedSpecApprovalChallengeIntegrity)
+	}
+	sealed, err := c.Seal()
+	if err != nil {
+		return err
+	}
+	if sealed.ChallengeHash != c.ChallengeHash {
+		return fmt.Errorf("%w: challenge_hash mismatch", ErrGeneratedSpecApprovalChallengeIntegrity)
+	}
+	if now.Before(c.EligibleAt) || now.Before(c.IssuedAt) {
+		return fmt.Errorf("%w: challenge is not active", ErrGeneratedSpecApprovalChallengeInactive)
+	}
+	if !now.Before(c.ExpiresAt) {
+		return fmt.Errorf("%w: challenge is expired", ErrGeneratedSpecApprovalChallengeInactive)
+	}
+	return nil
+}
+
+// GeneratedSpecApprovalAssertion is a human signature over one exact
+// GeneratedSpecApprovalChallenge. Principal, tenant, device, role, and action
+// authority come exclusively from the trusted authority snapshot, never from
+// this submitted assertion.
+type GeneratedSpecApprovalAssertion struct {
+	Domain          string `json:"domain"`
+	SchemaVersion   string `json:"schema_version"`
+	ContractVersion string `json:"contract_version"`
+	ChallengeID     string `json:"challenge_id"`
+	ChallengeHash   string `json:"challenge_hash"`
+	KeyID           string `json:"key_id"`
+	Algorithm       string `json:"algorithm"`
+	Signature       string `json:"signature"`
+}
+
+func (a GeneratedSpecApprovalAssertion) Validate() error {
+	if err := a.validateSigningEnvelope(); err != nil {
+		return err
+	}
+	_, err := a.SignatureBytes()
+	return err
+}
+
+func (a GeneratedSpecApprovalAssertion) validateSigningEnvelope() error {
+	if a.Domain != GeneratedSpecApprovalAssertionDomainV1 {
+		return generatedSpecApprovalAssertionInvalid("unsupported domain")
+	}
+	if a.SchemaVersion != GeneratedSpecApprovalAssertionSchemaV1 {
+		return generatedSpecApprovalAssertionInvalid("unsupported schema_version")
+	}
+	if a.ContractVersion != GeneratedSpecApprovalAssertionContractV1 {
+		return generatedSpecApprovalAssertionInvalid("unsupported contract_version")
+	}
+	if !isApprovalGrantToken(a.ChallengeID) || !isApprovalGrantSHA256(a.ChallengeHash) || !isApprovalGrantToken(a.KeyID) {
+		return generatedSpecApprovalAssertionInvalid("challenge and key bindings are required")
+	}
+	if a.Algorithm != GeneratedSpecApprovalAssertionEd25519 {
+		return generatedSpecApprovalAssertionInvalid("algorithm must be ed25519")
+	}
+	return nil
+}
+
+func (a GeneratedSpecApprovalAssertion) SigningDigest() ([]byte, error) {
+	if err := a.validateSigningEnvelope(); err != nil {
+		return nil, err
+	}
+	hash, err := hashJCS(struct {
+		Domain          string `json:"domain"`
+		SchemaVersion   string `json:"schema_version"`
+		ContractVersion string `json:"contract_version"`
+		ChallengeID     string `json:"challenge_id"`
+		ChallengeHash   string `json:"challenge_hash"`
+		KeyID           string `json:"key_id"`
+		Algorithm       string `json:"algorithm"`
+	}{
+		Domain: a.Domain, SchemaVersion: a.SchemaVersion, ContractVersion: a.ContractVersion,
+		ChallengeID: a.ChallengeID, ChallengeHash: a.ChallengeHash, KeyID: a.KeyID, Algorithm: a.Algorithm,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: signing digest: %v", ErrGeneratedSpecApprovalAssertionInvalid, err)
+	}
+	return hex.DecodeString(strings.TrimPrefix(hash, "sha256:"))
+}
+
+func (a GeneratedSpecApprovalAssertion) SignatureBytes() ([]byte, error) {
+	const prefix = "ed25519:"
+	if !strings.HasPrefix(a.Signature, prefix) {
+		return nil, generatedSpecApprovalAssertionInvalid("signature must use the ed25519 prefix")
+	}
+	raw := strings.TrimPrefix(a.Signature, prefix)
+	if len(raw) != ed25519.SignatureSize*2 || strings.ToLower(raw) != raw {
+		return nil, generatedSpecApprovalAssertionInvalid("signature must be 64 lowercase hexadecimal bytes")
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil || len(decoded) != ed25519.SignatureSize {
+		return nil, generatedSpecApprovalAssertionInvalid("signature must be 64 lowercase hexadecimal bytes")
+	}
+	return decoded, nil
+}
+
+// GeneratedSpecApprovalGrant carries a Kernel-signed, short-lived approval of
+// one immutable GeneratedSpec. It is deliberately not execution authority:
+// the Control Plane must verify the signature and atomically consume this
+// grant while transitioning reviewed -> approved; execution still requires its
+// own Kernel boundary decision and receipt chain.
+type GeneratedSpecApprovalGrant struct {
+	Domain          string `json:"domain"`
+	SchemaVersion   string `json:"schema_version"`
+	ContractVersion string `json:"contract_version"`
+
+	GrantID     string `json:"grant_id"`
+	TenantID    string `json:"tenant_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Audience    string `json:"audience"`
+
+	GeneratedSpecID       string `json:"generated_spec_id"`
+	GeneratedSpecHash     string `json:"generated_spec_hash"`
+	ExecutionPlanHash     string `json:"execution_plan_hash"`
+	PlanTransactionHash   string `json:"plan_transaction_hash"`
+	WriteSetHash          string `json:"write_set_hash"`
+	VerificationScopeHash string `json:"verification_scope_hash"`
+	PolicyEnvelopeHash    string `json:"policy_envelope_hash"`
+	PolicyVersion         string `json:"policy_version"`
+	PolicyEpoch           string `json:"policy_epoch"`
+	Action                string `json:"action"`
+
+	RequestingPrincipalID string   `json:"requesting_principal_id"`
+	ApproverPrincipalIDs  []string `json:"approver_principal_ids"`
+
+	ApprovalID            string `json:"approval_id"`
+	ChallengeHash         string `json:"challenge_hash"`
+	CeremonyHash          string `json:"ceremony_hash"`
+	SignerSetHash         string `json:"signer_set_hash"`
+	AuthoritySource       string `json:"authority_source"`
+	AuthorityVersion      string `json:"authority_version"`
+	AuthoritySnapshotHash string `json:"authority_snapshot_hash"`
+
+	ServerIdentity    string    `json:"server_identity"`
+	KernelTrustRootID string    `json:"kernel_trust_root_id"`
+	SigningKeyRef     string    `json:"signing_key_ref"`
+	IssuedAt          time.Time `json:"issued_at"`
+	ExpiresAt         time.Time `json:"expires_at"`
+	Nonce             string    `json:"nonce"`
+
+	GrantHash string `json:"grant_hash,omitempty"`
+}
+
+func (g GeneratedSpecApprovalGrant) Validate() error {
+	if g.Domain != GeneratedSpecApprovalGrantDomainV1 {
+		return generatedSpecApprovalGrantInvalid("unsupported domain")
+	}
+	if g.SchemaVersion != GeneratedSpecApprovalGrantSchemaV1 {
+		return generatedSpecApprovalGrantInvalid("unsupported schema_version")
+	}
+	if g.ContractVersion != GeneratedSpecApprovalGrantContractV1 {
+		return generatedSpecApprovalGrantInvalid("unsupported contract_version")
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "grant_id", value: g.GrantID},
+		{field: "tenant_id", value: g.TenantID},
+		{field: "workspace_id", value: g.WorkspaceID},
+		{field: "generated_spec_id", value: g.GeneratedSpecID},
+		{field: "policy_version", value: g.PolicyVersion},
+		{field: "policy_epoch", value: g.PolicyEpoch},
+		{field: "requesting_principal_id", value: g.RequestingPrincipalID},
+		{field: "approval_id", value: g.ApprovalID},
+		{field: "authority_source", value: g.AuthoritySource},
+		{field: "authority_version", value: g.AuthorityVersion},
+		{field: "server_identity", value: g.ServerIdentity},
+		{field: "kernel_trust_root_id", value: g.KernelTrustRootID},
+		{field: "signing_key_ref", value: g.SigningKeyRef},
+	} {
+		if !isApprovalGrantToken(item.value) {
+			return generatedSpecApprovalGrantInvalid(item.field + " is required and must not contain whitespace")
+		}
+	}
+	if g.Audience != GeneratedSpecApprovalAudienceV1 {
+		return generatedSpecApprovalGrantInvalid("unsupported audience")
+	}
+	if g.Action != GeneratedSpecApprovalActionV1 {
+		return generatedSpecApprovalGrantInvalid("unsupported action")
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "generated_spec_hash", value: g.GeneratedSpecHash},
+		{field: "execution_plan_hash", value: g.ExecutionPlanHash},
+		{field: "plan_transaction_hash", value: g.PlanTransactionHash},
+		{field: "write_set_hash", value: g.WriteSetHash},
+		{field: "verification_scope_hash", value: g.VerificationScopeHash},
+		{field: "policy_envelope_hash", value: g.PolicyEnvelopeHash},
+		{field: "challenge_hash", value: g.ChallengeHash},
+		{field: "ceremony_hash", value: g.CeremonyHash},
+		{field: "signer_set_hash", value: g.SignerSetHash},
+		{field: "authority_snapshot_hash", value: g.AuthoritySnapshotHash},
+	} {
+		if !isApprovalGrantSHA256(item.value) {
+			return generatedSpecApprovalGrantInvalid(item.field + " must be a lowercase sha256 reference")
+		}
+	}
+	if err := validateGeneratedSpecApprovers(g.RequestingPrincipalID, g.ApproverPrincipalIDs); err != nil {
+		return generatedSpecApprovalGrantInvalid(err.Error())
+	}
+	if g.IssuedAt.IsZero() || g.ExpiresAt.IsZero() || !isApprovalGrantUTC(g.IssuedAt) || !isApprovalGrantUTC(g.ExpiresAt) || !g.ExpiresAt.After(g.IssuedAt) {
+		return generatedSpecApprovalGrantInvalid("issued_at and expires_at must be a valid UTC window")
+	}
+	if !isApprovalGrantNonce(g.Nonce) {
+		return generatedSpecApprovalGrantInvalid("nonce must be 32 lowercase hexadecimal bytes")
+	}
+	if g.GrantHash != "" && !isApprovalGrantSHA256(g.GrantHash) {
+		return generatedSpecApprovalGrantInvalid("grant_hash must be a lowercase sha256 reference")
+	}
+	return nil
+}
+
+func (g GeneratedSpecApprovalGrant) Seal() (GeneratedSpecApprovalGrant, error) {
+	if err := g.Validate(); err != nil {
+		return GeneratedSpecApprovalGrant{}, err
+	}
+	g.GrantHash = ""
+	hash, err := hashJCS(g)
+	if err != nil {
+		return GeneratedSpecApprovalGrant{}, fmt.Errorf("%w: seal: %v", ErrGeneratedSpecApprovalGrantInvalid, err)
+	}
+	g.GrantHash = hash
+	return g, nil
+}
+
+func (g GeneratedSpecApprovalGrant) ValidateAt(now time.Time) error {
+	if err := g.Validate(); err != nil {
+		return err
+	}
+	if g.GrantHash == "" {
+		return fmt.Errorf("%w: grant_hash is required", ErrGeneratedSpecApprovalGrantIntegrity)
+	}
+	sealed, err := g.Seal()
+	if err != nil {
+		return err
+	}
+	if sealed.GrantHash != g.GrantHash {
+		return fmt.Errorf("%w: grant_hash mismatch", ErrGeneratedSpecApprovalGrantIntegrity)
+	}
+	if now.Before(g.IssuedAt) || !now.Before(g.ExpiresAt) {
+		return fmt.Errorf("%w: grant is not active", ErrGeneratedSpecApprovalGrantInactive)
+	}
+	return nil
+}
+
+// GeneratedSpecApprovalConsumption is the signed record produced when the
+// control-plane workload consumes one approval grant. The durable store must
+// create it in the same transaction as its single-use grant state transition.
+type GeneratedSpecApprovalConsumption struct {
+	Domain          string `json:"domain"`
+	SchemaVersion   string `json:"schema_version"`
+	ContractVersion string `json:"contract_version"`
+
+	ApprovalID string `json:"approval_id"`
+	GrantID    string `json:"grant_id"`
+	GrantHash  string `json:"grant_hash"`
+
+	TenantID    string `json:"tenant_id"`
+	WorkspaceID string `json:"workspace_id"`
+	Audience    string `json:"audience"`
+	ConsumedBy  string `json:"consumed_by"`
+
+	GeneratedSpecID       string   `json:"generated_spec_id"`
+	GeneratedSpecHash     string   `json:"generated_spec_hash"`
+	ExecutionPlanHash     string   `json:"execution_plan_hash"`
+	PlanTransactionHash   string   `json:"plan_transaction_hash"`
+	WriteSetHash          string   `json:"write_set_hash"`
+	VerificationScopeHash string   `json:"verification_scope_hash"`
+	PolicyEnvelopeHash    string   `json:"policy_envelope_hash"`
+	PolicyVersion         string   `json:"policy_version"`
+	PolicyEpoch           string   `json:"policy_epoch"`
+	Action                string   `json:"action"`
+	RequestingPrincipalID string   `json:"requesting_principal_id"`
+	ApproverPrincipalIDs  []string `json:"approver_principal_ids"`
+
+	ChallengeHash         string `json:"challenge_hash"`
+	CeremonyHash          string `json:"ceremony_hash"`
+	SignerSetHash         string `json:"signer_set_hash"`
+	AuthoritySource       string `json:"authority_source"`
+	AuthorityVersion      string `json:"authority_version"`
+	AuthoritySnapshotHash string `json:"authority_snapshot_hash"`
+	ServerIdentity        string `json:"server_identity"`
+	KernelTrustRootID     string `json:"kernel_trust_root_id"`
+	SigningKeyRef         string `json:"signing_key_ref"`
+
+	GrantIssuedAt  time.Time `json:"grant_issued_at"`
+	GrantExpiresAt time.Time `json:"grant_expires_at"`
+	ConsumedAt     time.Time `json:"consumed_at"`
+
+	ConsumptionHash string `json:"consumption_hash,omitempty"`
+}
+
+func (c GeneratedSpecApprovalConsumption) Validate() error {
+	if c.Domain != GeneratedSpecApprovalConsumptionDomainV1 || c.SchemaVersion != GeneratedSpecApprovalConsumptionSchemaV1 || c.ContractVersion != GeneratedSpecApprovalConsumptionContractV1 {
+		return generatedSpecApprovalConsumptionInvalid("unsupported contract")
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "approval_id", value: c.ApprovalID}, {field: "grant_id", value: c.GrantID},
+		{field: "tenant_id", value: c.TenantID}, {field: "workspace_id", value: c.WorkspaceID},
+		{field: "consumed_by", value: c.ConsumedBy}, {field: "generated_spec_id", value: c.GeneratedSpecID},
+		{field: "policy_version", value: c.PolicyVersion}, {field: "policy_epoch", value: c.PolicyEpoch},
+		{field: "requesting_principal_id", value: c.RequestingPrincipalID}, {field: "authority_source", value: c.AuthoritySource},
+		{field: "authority_version", value: c.AuthorityVersion}, {field: "server_identity", value: c.ServerIdentity},
+		{field: "kernel_trust_root_id", value: c.KernelTrustRootID}, {field: "signing_key_ref", value: c.SigningKeyRef},
+	} {
+		if !isApprovalGrantToken(item.value) {
+			return generatedSpecApprovalConsumptionInvalid(item.field + " is required and must not contain whitespace")
+		}
+	}
+	if c.Audience != GeneratedSpecApprovalAudienceV1 || c.Action != GeneratedSpecApprovalActionV1 {
+		return generatedSpecApprovalConsumptionInvalid("unsupported audience or action")
+	}
+	for _, item := range []struct {
+		field string
+		value string
+	}{
+		{field: "grant_hash", value: c.GrantHash}, {field: "generated_spec_hash", value: c.GeneratedSpecHash},
+		{field: "execution_plan_hash", value: c.ExecutionPlanHash}, {field: "plan_transaction_hash", value: c.PlanTransactionHash},
+		{field: "write_set_hash", value: c.WriteSetHash}, {field: "verification_scope_hash", value: c.VerificationScopeHash},
+		{field: "policy_envelope_hash", value: c.PolicyEnvelopeHash}, {field: "challenge_hash", value: c.ChallengeHash},
+		{field: "ceremony_hash", value: c.CeremonyHash}, {field: "signer_set_hash", value: c.SignerSetHash},
+		{field: "authority_snapshot_hash", value: c.AuthoritySnapshotHash},
+	} {
+		if !isApprovalGrantSHA256(item.value) {
+			return generatedSpecApprovalConsumptionInvalid(item.field + " must be a lowercase sha256 reference")
+		}
+	}
+	if err := validateGeneratedSpecApprovers(c.RequestingPrincipalID, c.ApproverPrincipalIDs); err != nil {
+		return generatedSpecApprovalConsumptionInvalid(err.Error())
+	}
+	if c.GrantIssuedAt.IsZero() || c.GrantExpiresAt.IsZero() || c.ConsumedAt.IsZero() || !isApprovalGrantUTC(c.GrantIssuedAt) || !isApprovalGrantUTC(c.GrantExpiresAt) || !isApprovalGrantUTC(c.ConsumedAt) || c.ConsumedAt.Before(c.GrantIssuedAt) || !c.ConsumedAt.Before(c.GrantExpiresAt) {
+		return generatedSpecApprovalConsumptionInvalid("timestamps are outside the grant lifetime")
+	}
+	if c.ConsumptionHash != "" && !isApprovalGrantSHA256(c.ConsumptionHash) {
+		return generatedSpecApprovalConsumptionInvalid("consumption_hash must be a lowercase sha256 reference")
+	}
+	return nil
+}
+
+func (c GeneratedSpecApprovalConsumption) Seal() (GeneratedSpecApprovalConsumption, error) {
+	if err := c.Validate(); err != nil {
+		return GeneratedSpecApprovalConsumption{}, err
+	}
+	c.ConsumptionHash = ""
+	hash, err := hashJCS(c)
+	if err != nil {
+		return GeneratedSpecApprovalConsumption{}, fmt.Errorf("%w: seal: %v", ErrGeneratedSpecApprovalGrantIntegrity, err)
+	}
+	c.ConsumptionHash = hash
+	return c, nil
+}
+
+func (c GeneratedSpecApprovalConsumption) ValidateGrant(g GeneratedSpecApprovalGrant) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	if c.ConsumptionHash == "" {
+		return generatedSpecApprovalConsumptionInvalid("consumption_hash is required")
+	}
+	sealed, err := c.Seal()
+	if err != nil || sealed.ConsumptionHash != c.ConsumptionHash {
+		return generatedSpecApprovalConsumptionInvalid("consumption integrity mismatch")
+	}
+	if err := g.Validate(); err != nil || g.GrantHash == "" {
+		return generatedSpecApprovalConsumptionInvalid("sealed grant is required")
+	}
+	sealedGrant, err := g.Seal()
+	if err != nil || sealedGrant.GrantHash != g.GrantHash {
+		return generatedSpecApprovalConsumptionInvalid("grant integrity mismatch")
+	}
+	if c.ApprovalID != g.ApprovalID || c.GrantID != g.GrantID || c.GrantHash != g.GrantHash ||
+		c.TenantID != g.TenantID || c.WorkspaceID != g.WorkspaceID || c.Audience != g.Audience ||
+		c.GeneratedSpecID != g.GeneratedSpecID || c.GeneratedSpecHash != g.GeneratedSpecHash ||
+		c.ExecutionPlanHash != g.ExecutionPlanHash || c.PlanTransactionHash != g.PlanTransactionHash ||
+		c.WriteSetHash != g.WriteSetHash || c.VerificationScopeHash != g.VerificationScopeHash ||
+		c.PolicyEnvelopeHash != g.PolicyEnvelopeHash ||
+		c.PolicyVersion != g.PolicyVersion || c.PolicyEpoch != g.PolicyEpoch || c.Action != g.Action ||
+		c.RequestingPrincipalID != g.RequestingPrincipalID || !sameStringSlice(c.ApproverPrincipalIDs, g.ApproverPrincipalIDs) ||
+		c.ChallengeHash != g.ChallengeHash || c.CeremonyHash != g.CeremonyHash || c.SignerSetHash != g.SignerSetHash ||
+		c.AuthoritySource != g.AuthoritySource || c.AuthorityVersion != g.AuthorityVersion ||
+		c.AuthoritySnapshotHash != g.AuthoritySnapshotHash || c.ServerIdentity != g.ServerIdentity ||
+		c.KernelTrustRootID != g.KernelTrustRootID || c.SigningKeyRef != g.SigningKeyRef ||
+		!c.GrantIssuedAt.Equal(g.IssuedAt) || !c.GrantExpiresAt.Equal(g.ExpiresAt) {
+		return generatedSpecApprovalConsumptionInvalid("consumption does not match sealed grant")
+	}
+	return nil
+}
+
+func validateGeneratedSpecApprovers(requester string, approvers []string) error {
+	if len(approvers) == 0 {
+		return errors.New("approver_principal_ids is required")
+	}
+	if !sort.StringsAreSorted(approvers) {
+		return errors.New("approver_principal_ids must be sorted")
+	}
+	for index, approver := range approvers {
+		if !isApprovalGrantToken(approver) {
+			return errors.New("approver_principal_ids contains an invalid principal")
+		}
+		if approver == requester {
+			return errors.New("requester cannot approve its own generated spec")
+		}
+		if index > 0 && approvers[index-1] == approver {
+			return errors.New("approver_principal_ids must be unique")
+		}
+	}
+	return nil
+}
+
+func sameStringSlice(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func generatedSpecApprovalChallengeInvalid(message string) error {
+	return fmt.Errorf("%w: %s", ErrGeneratedSpecApprovalChallengeInvalid, message)
+}
+
+func generatedSpecApprovalAssertionInvalid(message string) error {
+	return fmt.Errorf("%w: %s", ErrGeneratedSpecApprovalAssertionInvalid, message)
+}
+
+func generatedSpecApprovalGrantInvalid(message string) error {
+	return fmt.Errorf("%w: %s", ErrGeneratedSpecApprovalGrantInvalid, message)
+}
+
+func generatedSpecApprovalConsumptionInvalid(message string) error {
+	return fmt.Errorf("%w: consumption: %s", ErrGeneratedSpecApprovalGrantIntegrity, message)
+}

--- a/core/pkg/contracts/generated_spec_approval_test.go
+++ b/core/pkg/contracts/generated_spec_approval_test.go
@@ -1,0 +1,168 @@
+package contracts
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGeneratedSpecApprovalChallengeSealsEveryAuthorityBearingField(t *testing.T) {
+	base := validGeneratedSpecApprovalChallenge()
+	sealed, err := base.Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+
+	mutations := map[string]func(*GeneratedSpecApprovalChallenge){
+		"tenant":              func(c *GeneratedSpecApprovalChallenge) { c.TenantID = "tenant-b" },
+		"workspace":           func(c *GeneratedSpecApprovalChallenge) { c.WorkspaceID = "workspace-b" },
+		"generated spec":      func(c *GeneratedSpecApprovalChallenge) { c.GeneratedSpecID = "spec-b" },
+		"generated spec hash": func(c *GeneratedSpecApprovalChallenge) { c.GeneratedSpecHash = sha256Ref("b") },
+		"execution plan":      func(c *GeneratedSpecApprovalChallenge) { c.ExecutionPlanHash = sha256Ref("c") },
+		"plan transaction":    func(c *GeneratedSpecApprovalChallenge) { c.PlanTransactionHash = sha256Ref("d") },
+		"write set":           func(c *GeneratedSpecApprovalChallenge) { c.WriteSetHash = sha256Ref("e") },
+		"verification scope":  func(c *GeneratedSpecApprovalChallenge) { c.VerificationScopeHash = sha256Ref("f") },
+		"policy":              func(c *GeneratedSpecApprovalChallenge) { c.PolicyEnvelopeHash = sha256Ref("0") },
+		"requester":           func(c *GeneratedSpecApprovalChallenge) { c.RequestingPrincipalID = "user:requester-b" },
+		"authority snapshot":  func(c *GeneratedSpecApprovalChallenge) { c.AuthoritySnapshotHash = sha256Ref("1") },
+		"nonce":               func(c *GeneratedSpecApprovalChallenge) { c.Nonce = repeatHex("2") },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			candidate := base
+			mutate(&candidate)
+			changed, err := candidate.Seal()
+			if err != nil {
+				t.Fatalf("Seal() error = %v", err)
+			}
+			if changed.ChallengeHash == sealed.ChallengeHash {
+				t.Fatal("authority mutation did not change challenge hash")
+			}
+		})
+	}
+}
+
+func TestGeneratedSpecApprovalChallengeChecksWindowAndHashIntegrity(t *testing.T) {
+	challenge, err := validGeneratedSpecApprovalChallenge().Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	if err := challenge.ValidateAt(challenge.IssuedAt); err != nil {
+		t.Fatalf("ValidateAt(issued) error = %v", err)
+	}
+	if err := challenge.ValidateAt(challenge.ExpiresAt); !errors.Is(err, ErrGeneratedSpecApprovalChallengeInactive) {
+		t.Fatalf("ValidateAt(expired) error = %v, want inactive", err)
+	}
+	challenge.GeneratedSpecHash = sha256Ref("b")
+	if err := challenge.ValidateAt(challenge.IssuedAt); !errors.Is(err, ErrGeneratedSpecApprovalChallengeIntegrity) {
+		t.Fatalf("ValidateAt(tampered) error = %v, want integrity", err)
+	}
+}
+
+func TestGeneratedSpecApprovalGrantRejectsSelfApprovalAndUnorderedApprovers(t *testing.T) {
+	grant := validGeneratedSpecApprovalGrant()
+	grant.ApproverPrincipalIDs = []string{grant.RequestingPrincipalID}
+	if err := grant.Validate(); !errors.Is(err, ErrGeneratedSpecApprovalGrantInvalid) {
+		t.Fatalf("Validate(self approval) error = %v, want invalid", err)
+	}
+	grant = validGeneratedSpecApprovalGrant()
+	grant.ApproverPrincipalIDs = []string{"user:z", "user:a"}
+	if err := grant.Validate(); !errors.Is(err, ErrGeneratedSpecApprovalGrantInvalid) {
+		t.Fatalf("Validate(unordered approvers) error = %v, want invalid", err)
+	}
+}
+
+func TestGeneratedSpecApprovalGrantSealsAndChecksActiveWindow(t *testing.T) {
+	grant := validGeneratedSpecApprovalGrant()
+	sealed, err := grant.Seal()
+	if err != nil {
+		t.Fatalf("Seal() error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.IssuedAt); err != nil {
+		t.Fatalf("ValidateAt(issued) error = %v", err)
+	}
+	if err := sealed.ValidateAt(sealed.ExpiresAt); !errors.Is(err, ErrGeneratedSpecApprovalGrantInactive) {
+		t.Fatalf("ValidateAt(expired) error = %v, want inactive", err)
+	}
+	sealed.WriteSetHash = sha256Ref("b")
+	if err := sealed.ValidateAt(sealed.IssuedAt); !errors.Is(err, ErrGeneratedSpecApprovalGrantIntegrity) {
+		t.Fatalf("ValidateAt(tampered) error = %v, want integrity", err)
+	}
+}
+
+func TestGeneratedSpecApprovalConsumptionMustProjectExactGrant(t *testing.T) {
+	grant, err := validGeneratedSpecApprovalGrant().Seal()
+	if err != nil {
+		t.Fatalf("grant Seal() error = %v", err)
+	}
+	consumption, err := generatedSpecApprovalConsumptionFor(grant).Seal()
+	if err != nil {
+		t.Fatalf("consumption Seal() error = %v", err)
+	}
+	if err := consumption.ValidateGrant(grant); err != nil {
+		t.Fatalf("ValidateGrant() error = %v", err)
+	}
+
+	consumption.ExecutionPlanHash = sha256Ref("9")
+	if err := consumption.ValidateGrant(grant); !errors.Is(err, ErrGeneratedSpecApprovalGrantIntegrity) {
+		t.Fatalf("ValidateGrant(tampered) error = %v, want integrity", err)
+	}
+}
+
+func validGeneratedSpecApprovalChallenge() GeneratedSpecApprovalChallenge {
+	issuedAt := time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC)
+	return GeneratedSpecApprovalChallenge{
+		Domain: GeneratedSpecApprovalChallengeDomainV1, SchemaVersion: GeneratedSpecApprovalChallengeSchemaV1,
+		ContractVersion: GeneratedSpecApprovalChallengeContractV1,
+		ChallengeID:     "generated-spec-challenge-a", ApprovalID: "generated-spec-approval-a",
+		TenantID: "tenant-a", WorkspaceID: "workspace-a", Audience: GeneratedSpecApprovalAudienceV1,
+		GeneratedSpecID: "generated-spec-a", GeneratedSpecHash: sha256Ref("a"),
+		ExecutionPlanHash: sha256Ref("b"), PlanTransactionHash: sha256Ref("c"), WriteSetHash: sha256Ref("d"),
+		VerificationScopeHash: sha256Ref("e"), PolicyEnvelopeHash: sha256Ref("f"),
+		PolicyVersion: "policy-v1", PolicyEpoch: "epoch-1", Action: GeneratedSpecApprovalActionV1,
+		RequestingPrincipalID: "user:requester-a", AuthoritySource: "authority-a", AuthorityVersion: "version-a",
+		AuthoritySnapshotHash: sha256Ref("0"), RequiredRole: "generated-spec-approver", Quorum: 1,
+		ServerIdentity: "spiffe://helm/kernel-a", HoldStartedAt: issuedAt.Add(-time.Minute), EligibleAt: issuedAt.Add(-time.Second),
+		IssuedAt: issuedAt, ExpiresAt: issuedAt.Add(5 * time.Minute), Nonce: repeatHex("1"),
+	}
+}
+
+func validGeneratedSpecApprovalGrant() GeneratedSpecApprovalGrant {
+	challenge, err := validGeneratedSpecApprovalChallenge().Seal()
+	if err != nil {
+		panic(err)
+	}
+	return GeneratedSpecApprovalGrant{
+		Domain: GeneratedSpecApprovalGrantDomainV1, SchemaVersion: GeneratedSpecApprovalGrantSchemaV1,
+		ContractVersion: GeneratedSpecApprovalGrantContractV1,
+		GrantID:         "generated-spec-grant-a", TenantID: challenge.TenantID, WorkspaceID: challenge.WorkspaceID,
+		Audience: challenge.Audience, GeneratedSpecID: challenge.GeneratedSpecID, GeneratedSpecHash: challenge.GeneratedSpecHash,
+		ExecutionPlanHash: challenge.ExecutionPlanHash, PlanTransactionHash: challenge.PlanTransactionHash,
+		WriteSetHash: challenge.WriteSetHash, VerificationScopeHash: challenge.VerificationScopeHash,
+		PolicyEnvelopeHash: challenge.PolicyEnvelopeHash, PolicyVersion: challenge.PolicyVersion, PolicyEpoch: challenge.PolicyEpoch,
+		Action: challenge.Action, RequestingPrincipalID: challenge.RequestingPrincipalID,
+		ApproverPrincipalIDs: []string{"user:approver-a"}, ApprovalID: challenge.ApprovalID,
+		ChallengeHash: challenge.ChallengeHash, CeremonyHash: sha256Ref("2"), SignerSetHash: sha256Ref("3"),
+		AuthoritySource: challenge.AuthoritySource, AuthorityVersion: challenge.AuthorityVersion,
+		AuthoritySnapshotHash: challenge.AuthoritySnapshotHash, ServerIdentity: challenge.ServerIdentity,
+		KernelTrustRootID: "kernel-root-a", SigningKeyRef: "kms://helm/generated-spec-a",
+		IssuedAt: challenge.IssuedAt, ExpiresAt: challenge.ExpiresAt, Nonce: repeatHex("4"),
+	}
+}
+
+func generatedSpecApprovalConsumptionFor(grant GeneratedSpecApprovalGrant) GeneratedSpecApprovalConsumption {
+	return GeneratedSpecApprovalConsumption{
+		Domain: GeneratedSpecApprovalConsumptionDomainV1, SchemaVersion: GeneratedSpecApprovalConsumptionSchemaV1,
+		ContractVersion: GeneratedSpecApprovalConsumptionContractV1,
+		ApprovalID:      grant.ApprovalID, GrantID: grant.GrantID, GrantHash: grant.GrantHash,
+		TenantID: grant.TenantID, WorkspaceID: grant.WorkspaceID, Audience: grant.Audience, ConsumedBy: "spiffe://helm/control-plane-a",
+		GeneratedSpecID: grant.GeneratedSpecID, GeneratedSpecHash: grant.GeneratedSpecHash, ExecutionPlanHash: grant.ExecutionPlanHash,
+		PlanTransactionHash: grant.PlanTransactionHash, WriteSetHash: grant.WriteSetHash, VerificationScopeHash: grant.VerificationScopeHash,
+		PolicyEnvelopeHash: grant.PolicyEnvelopeHash, PolicyVersion: grant.PolicyVersion, PolicyEpoch: grant.PolicyEpoch,
+		Action: grant.Action, RequestingPrincipalID: grant.RequestingPrincipalID, ApproverPrincipalIDs: append([]string(nil), grant.ApproverPrincipalIDs...),
+		ChallengeHash: grant.ChallengeHash, CeremonyHash: grant.CeremonyHash, SignerSetHash: grant.SignerSetHash,
+		AuthoritySource: grant.AuthoritySource, AuthorityVersion: grant.AuthorityVersion, AuthoritySnapshotHash: grant.AuthoritySnapshotHash,
+		ServerIdentity: grant.ServerIdentity, KernelTrustRootID: grant.KernelTrustRootID, SigningKeyRef: grant.SigningKeyRef,
+		GrantIssuedAt: grant.IssuedAt, GrantExpiresAt: grant.ExpiresAt, ConsumedAt: grant.IssuedAt.Add(time.Minute),
+	}
+}


### PR DESCRIPTION
## Summary

Adds a standalone, typed Kernel contract family for GeneratedSpec human approval. It does not reuse pack-lifecycle ApprovalGrant authority and does not authorize execution.

- binds the immutable GeneratedSpec, execution plan, plan transaction, write set, verification scope, and policy envelope
- requires a separate signed human-quorum verification path and rejects requester self-approval
- produces pinned Ed25519 Kernel-signed grant and consumption envelopes
- verifies the source grant before accepting consumption and makes a verifier result capability-bound to prevent fabricated issuance

## Validation

- `go test ./core/pkg/contracts ./core/pkg/boundary/generatedspecapproval -count=1`
- `go vet ./core/pkg/contracts ./core/pkg/boundary/generatedspecapproval`
- `make verify-fixtures`
- independent security review; two findings were remediated and re-reviewed

## Deliberate scope

This is the canonical Kernel contract and verifier slice only. It remains draft because the next required work is a dedicated RLS-backed ceremony/consume store, internal workload routes, and Control Plane prepare/consume-before-run integration. No browser route or console session can issue this grant.