### PR TITLE
fix(release-permit): accept pinned workflow SHA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@ Welcome to the **helm-ai-kernel** repository. This is the core, open-source exec
 2. Maintain strict zero-dependency boundaries on volatile commercial components.
 3. Every functional path must maintain green unit/integration tests and high coverage metrics.
 4. Treat RLM outputs as input evidence only. They become Kernel truth only when represented through existing verdict, receipt, ProofGraph, EvidencePack, contract, conformance, or verifier paths; do not add a separate RLM proof universe.
+5. When a workflow ruleset is pinned solely by SHA, GitHub emits `github.workflow_ref` as `<repository>/<path>@<workflow_sha>`. The release-permit verifier must accept this form only when the suffix exactly matches the validated `workflow_sha`; never restore a mutable `ref` for compatibility. Changes require matching- and mismatching-SHA regression tests plus a runtime permit check.

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -189,8 +189,11 @@ func validateExactShape(content []byte, destination any) error {
 			"schema", "repository", "event", "pull_request", "base_ref", "base_sha",
 			"head_sha", "merge_sha", "merge_tree_sha", "workflow_repository",
 			"workflow_path", "workflow_ref", "workflow_sha", "run_id", "run_attempt",
-			"issued_at", "required_reviewers",
+			"issued_at", "authority", "required_reviewers",
 		}, nil, "context"); err != nil {
+			return err
+		}
+		if err := validateAuthority(root["authority"], "authority"); err != nil {
 			return err
 		}
 		reviewers, err := decodeArray(root["required_reviewers"], "required_reviewers")
@@ -236,6 +239,33 @@ func validateExactShape(content []byte, destination any) error {
 		return fmt.Errorf("unsupported strict JSON destination %T", destination)
 	}
 	return nil
+}
+
+func validateAuthority(raw json.RawMessage, label string) error {
+	authority, err := decodeObject(raw, label)
+	if err != nil {
+		return err
+	}
+	if err := requireKeys(authority, []string{
+		"schema", "generation", "kernel_sha", "gate_profiles_sha256",
+		"adversarial_corpus_sha256", "parent",
+	}, nil, label); err != nil {
+		return err
+	}
+	parent := bytes.TrimSpace(authority["parent"])
+	if bytes.Equal(parent, []byte("null")) {
+		return nil
+	}
+	parentObject, err := decodeObject(parent, label+".parent")
+	if err != nil {
+		return err
+	}
+	return requireKeys(
+		parentObject,
+		[]string{"generation", "workflow_sha"},
+		nil,
+		label+".parent",
+	)
 }
 
 func validateReviewer(raw json.RawMessage, label string) error {

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -40,13 +40,9 @@ func main() {
 		if contextPath != "" || len(reviewPaths) != 0 || flagWasSet("output") {
 			fatal(errors.New("--verify-permit cannot be combined with --context, --review, or --output"))
 		}
-		var permit releasepermit.Permit
-		content, err := decodeStrictFile(permitPath, &permit)
+		content, err := verifyPermitFile(permitPath)
 		if err != nil {
-			fatal(fmt.Errorf("read permit: %w", err))
-		}
-		if err := releasepermit.ValidateAllowPermit(permit); err != nil {
-			fatal(fmt.Errorf("validate ALLOW permit: %w", err))
+			fatal(err)
 		}
 		if _, err := os.Stdout.Write(content); err != nil {
 			fatal(fmt.Errorf("print permit: %w", err))
@@ -92,6 +88,18 @@ func main() {
 	if permit.Decision != releasepermit.DecisionAllow {
 		os.Exit(3)
 	}
+}
+
+func verifyPermitFile(path string) ([]byte, error) {
+	var permit releasepermit.Permit
+	content, err := decodeStrictFile(path, &permit)
+	if err != nil {
+		return nil, fmt.Errorf("read permit: %w", err)
+	}
+	if err := releasepermit.ValidateAllowPermit(permit); err != nil {
+		return nil, fmt.Errorf("validate ALLOW permit: %w", err)
+	}
+	return content, nil
 }
 
 func flagWasSet(name string) bool {

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -34,13 +34,16 @@ func main() {
 	flag.StringVar(&contextPath, "context", "", "path to release-permit context JSON")
 	flag.Var(&reviewPaths, "review", "path to review JSON; provide once per required reviewer")
 	flag.StringVar(&outputPath, "output", "release-permit.json", "path for the permit JSON")
-	flag.StringVar(&permitPath, "verify-permit", "", "verify an existing ALLOW permit and exit")
+	flag.StringVar(&permitPath, "verify-permit", "", "semantically validate an ALLOW permit against trusted --context; verify signed provenance separately")
 	flag.Parse()
 	if permitPath != "" {
-		if contextPath != "" || len(reviewPaths) != 0 || flagWasSet("output") {
-			fatal(errors.New("--verify-permit cannot be combined with --context, --review, or --output"))
+		if contextPath == "" {
+			fatal(errors.New("--verify-permit requires an independently trusted --context"))
 		}
-		content, err := verifyPermitFile(permitPath)
+		if len(reviewPaths) != 0 || flagWasSet("output") {
+			fatal(errors.New("--verify-permit cannot be combined with --review or --output"))
+		}
+		content, err := verifyPermitFile(permitPath, contextPath)
 		if err != nil {
 			fatal(err)
 		}
@@ -90,13 +93,21 @@ func main() {
 	}
 }
 
-func verifyPermitFile(path string) ([]byte, error) {
+func verifyPermitFile(path, contextPath string) ([]byte, error) {
+	var trustedContext releasepermit.Context
+	contextContent, err := decodeStrictFile(contextPath, &trustedContext)
+	if err != nil {
+		return nil, fmt.Errorf("read trusted context: %w", err)
+	}
+	contextDigest := sha256.Sum256(contextContent)
+	contextSHA256 := hex.EncodeToString(contextDigest[:])
+
 	var permit releasepermit.Permit
 	content, err := decodeStrictFile(path, &permit)
 	if err != nil {
 		return nil, fmt.Errorf("read permit: %w", err)
 	}
-	if err := releasepermit.ValidateAllowPermit(permit); err != nil {
+	if err := releasepermit.ValidateAllowPermit(permit, trustedContext, contextSHA256); err != nil {
 		return nil, fmt.Errorf("validate ALLOW permit: %w", err)
 	}
 	return content, nil

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -29,11 +29,30 @@ func (values *repeatedFlag) Set(value string) error {
 func main() {
 	var contextPath string
 	var outputPath string
+	var permitPath string
 	var reviewPaths repeatedFlag
 	flag.StringVar(&contextPath, "context", "", "path to release-permit context JSON")
 	flag.Var(&reviewPaths, "review", "path to review JSON; provide once per required reviewer")
 	flag.StringVar(&outputPath, "output", "release-permit.json", "path for the permit JSON")
+	flag.StringVar(&permitPath, "verify-permit", "", "verify an existing ALLOW permit and exit")
 	flag.Parse()
+	if permitPath != "" {
+		if contextPath != "" || len(reviewPaths) != 0 || flagWasSet("output") {
+			fatal(errors.New("--verify-permit cannot be combined with --context, --review, or --output"))
+		}
+		var permit releasepermit.Permit
+		content, err := decodeStrictFile(permitPath, &permit)
+		if err != nil {
+			fatal(fmt.Errorf("read permit: %w", err))
+		}
+		if err := releasepermit.ValidateAllowPermit(permit); err != nil {
+			fatal(fmt.Errorf("validate ALLOW permit: %w", err))
+		}
+		if _, err := os.Stdout.Write(content); err != nil {
+			fatal(fmt.Errorf("print permit: %w", err))
+		}
+		return
+	}
 
 	if contextPath == "" || len(reviewPaths) == 0 || outputPath == "" {
 		fatal(errors.New("--context, at least one --review, and --output are required"))
@@ -73,6 +92,16 @@ func main() {
 	if permit.Decision != releasepermit.DecisionAllow {
 		os.Exit(3)
 	}
+}
+
+func flagWasSet(name string) bool {
+	set := false
+	flag.Visit(func(current *flag.Flag) {
+		if current.Name == name {
+			set = true
+		}
+	})
+	return set
 }
 
 func decodeStrictFile(path string, destination any) ([]byte, error) {
@@ -239,6 +268,49 @@ func validateExactShape(content []byte, destination any) error {
 				[]string{"path", "line"},
 				fmt.Sprintf("findings[%d]", index),
 			); err != nil {
+				return err
+			}
+		}
+	case *releasepermit.Permit:
+		if err := requireKeys(root, []string{
+			"schema", "permit_id", "decision", "repository", "pull_request", "base_ref",
+			"base_sha", "head_sha", "merge_sha", "merge_tree_sha", "workflow_repository",
+			"workflow_path", "workflow_ref", "workflow_sha", "run_id", "run_attempt",
+			"issued_at", "authority", "context_sha256", "reviews", "reasons",
+		}, nil, "permit"); err != nil {
+			return err
+		}
+		if err := validateAuthority(root["authority"], "authority"); err != nil {
+			return err
+		}
+		reviews, err := decodeArray(root["reviews"], "reviews")
+		if err != nil {
+			return err
+		}
+		for index, raw := range reviews {
+			review, err := decodeObject(raw, fmt.Sprintf("reviews[%d]", index))
+			if err != nil {
+				return err
+			}
+			if err := requireKeys(review, []string{
+				"reviewer", "verdict", "response_sha256", "blocking_findings", "advisory_findings",
+			}, nil, fmt.Sprintf("reviews[%d]", index)); err != nil {
+				return err
+			}
+			if err := validateReviewer(review["reviewer"], fmt.Sprintf("reviews[%d].reviewer", index)); err != nil {
+				return err
+			}
+		}
+		reasons, err := decodeArray(root["reasons"], "reasons")
+		if err != nil {
+			return err
+		}
+		for index, raw := range reasons {
+			reason, err := decodeObject(raw, fmt.Sprintf("reasons[%d]", index))
+			if err != nil {
+				return err
+			}
+			if err := requireKeys(reason, []string{"code", "detail"}, []string{"reviewer"}, fmt.Sprintf("reasons[%d]", index)); err != nil {
 				return err
 			}
 		}

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -76,6 +76,13 @@ func main() {
 }
 
 func decodeStrictFile(path string, destination any) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() > maxInputBytes {
+		return nil, fmt.Errorf("input exceeds %d bytes", maxInputBytes)
+	}
 	// #nosec G304 -- paths are explicit command inputs in a protected workflow.
 	content, err := os.ReadFile(path)
 	if err != nil {

--- a/core/cmd/release-permit-verify/main.go
+++ b/core/cmd/release-permit-verify/main.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/releasepermit"
+)
+
+const maxInputBytes = 2 << 20
+
+type repeatedFlag []string
+
+func (values *repeatedFlag) String() string { return fmt.Sprint([]string(*values)) }
+func (values *repeatedFlag) Set(value string) error {
+	*values = append(*values, value)
+	return nil
+}
+
+func main() {
+	var contextPath string
+	var outputPath string
+	var reviewPaths repeatedFlag
+	flag.StringVar(&contextPath, "context", "", "path to release-permit context JSON")
+	flag.Var(&reviewPaths, "review", "path to review JSON; provide once per required reviewer")
+	flag.StringVar(&outputPath, "output", "release-permit.json", "path for the permit JSON")
+	flag.Parse()
+
+	if contextPath == "" || len(reviewPaths) == 0 || outputPath == "" {
+		fatal(errors.New("--context, at least one --review, and --output are required"))
+	}
+
+	var context releasepermit.Context
+	contextContent, err := decodeStrictFile(contextPath, &context)
+	if err != nil {
+		fatal(fmt.Errorf("read context: %w", err))
+	}
+	contextDigest := sha256.Sum256(contextContent)
+	contextSHA256 := hex.EncodeToString(contextDigest[:])
+	reviews := make([]releasepermit.Review, 0, len(reviewPaths))
+	for _, path := range reviewPaths {
+		var review releasepermit.Review
+		if _, err := decodeStrictFile(path, &review); err != nil {
+			fatal(fmt.Errorf("read review %q: %w", path, err))
+		}
+		reviews = append(reviews, review)
+	}
+
+	permit, err := releasepermit.Evaluate(context, contextSHA256, reviews)
+	if err != nil {
+		fatal(fmt.Errorf("evaluate release permit: %w", err))
+	}
+	encoded, err := json.MarshalIndent(permit, "", "  ")
+	if err != nil {
+		fatal(fmt.Errorf("encode release permit: %w", err))
+	}
+	encoded = append(encoded, '\n')
+	if err := os.WriteFile(outputPath, encoded, 0o644); err != nil {
+		fatal(fmt.Errorf("write release permit: %w", err))
+	}
+	if _, err := os.Stdout.Write(encoded); err != nil {
+		fatal(fmt.Errorf("print release permit: %w", err))
+	}
+	if permit.Decision != releasepermit.DecisionAllow {
+		os.Exit(3)
+	}
+}
+
+func decodeStrictFile(path string, destination any) ([]byte, error) {
+	// #nosec G304 -- paths are explicit command inputs in a protected workflow.
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) > maxInputBytes {
+		return nil, fmt.Errorf("input exceeds %d bytes", maxInputBytes)
+	}
+	if !json.Valid(content) {
+		return nil, errors.New("input is not exactly one valid JSON value")
+	}
+	if err := rejectDuplicateKeys(content); err != nil {
+		return nil, err
+	}
+	if err := validateExactShape(content, destination); err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("input contains more than one JSON value")
+		}
+		return nil, fmt.Errorf("read trailing data: %w", err)
+	}
+	return content, nil
+}
+
+func rejectDuplicateKeys(content []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
+	if err := scanJSONValue(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("input contains more than one JSON value")
+		}
+		return fmt.Errorf("read trailing token: %w", err)
+	}
+	return nil
+}
+
+func scanJSONValue(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		seen := map[string]struct{}{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("object key is not a string")
+			}
+			if _, duplicate := seen[key]; duplicate {
+				return fmt.Errorf("duplicate JSON key %q", key)
+			}
+			seen[key] = struct{}{}
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim('}') {
+			return errors.New("object did not end with }")
+		}
+	case '[':
+		for decoder.More() {
+			if err := scanJSONValue(decoder); err != nil {
+				return err
+			}
+		}
+		end, err := decoder.Token()
+		if err != nil {
+			return err
+		}
+		if end != json.Delim(']') {
+			return errors.New("array did not end with ]")
+		}
+	default:
+		return fmt.Errorf("unexpected JSON delimiter %q", delimiter)
+	}
+	return nil
+}
+
+func validateExactShape(content []byte, destination any) error {
+	root, err := decodeObject(content, "root")
+	if err != nil {
+		return err
+	}
+	switch destination.(type) {
+	case *releasepermit.Context:
+		if err := requireKeys(root, []string{
+			"schema", "repository", "event", "pull_request", "base_ref", "base_sha",
+			"head_sha", "merge_sha", "merge_tree_sha", "workflow_repository",
+			"workflow_path", "workflow_ref", "workflow_sha", "run_id", "run_attempt",
+			"issued_at", "required_reviewers",
+		}, nil, "context"); err != nil {
+			return err
+		}
+		reviewers, err := decodeArray(root["required_reviewers"], "required_reviewers")
+		if err != nil {
+			return err
+		}
+		for index, raw := range reviewers {
+			if err := validateReviewer(raw, fmt.Sprintf("required_reviewers[%d]", index)); err != nil {
+				return err
+			}
+		}
+	case *releasepermit.Review:
+		if err := requireKeys(root, []string{
+			"schema", "repository", "pull_request", "base_sha", "head_sha", "merge_sha",
+			"merge_tree_sha", "workflow_sha",
+			"run_id", "run_attempt", "context_sha256", "reviewer", "verdict",
+			"response_sha256", "findings",
+		}, nil, "review"); err != nil {
+			return err
+		}
+		if err := validateReviewer(root["reviewer"], "reviewer"); err != nil {
+			return err
+		}
+		findings, err := decodeArray(root["findings"], "findings")
+		if err != nil {
+			return err
+		}
+		for index, raw := range findings {
+			finding, err := decodeObject(raw, fmt.Sprintf("findings[%d]", index))
+			if err != nil {
+				return err
+			}
+			if err := requireKeys(
+				finding,
+				[]string{"severity", "code", "summary"},
+				[]string{"path", "line"},
+				fmt.Sprintf("findings[%d]", index),
+			); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unsupported strict JSON destination %T", destination)
+	}
+	return nil
+}
+
+func validateReviewer(raw json.RawMessage, label string) error {
+	reviewer, err := decodeObject(raw, label)
+	if err != nil {
+		return err
+	}
+	return requireKeys(reviewer, []string{"provider", "model"}, nil, label)
+}
+
+func decodeObject(content []byte, label string) (map[string]json.RawMessage, error) {
+	if trimmed := bytes.TrimSpace(content); len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil, fmt.Errorf("%s must be an object", label)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(content, &object); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", label, err)
+	}
+	return object, nil
+}
+
+func decodeArray(content []byte, label string) ([]json.RawMessage, error) {
+	if trimmed := bytes.TrimSpace(content); len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil, fmt.Errorf("%s must be an explicit array", label)
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(content, &values); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", label, err)
+	}
+	return values, nil
+}
+
+func requireKeys(
+	object map[string]json.RawMessage,
+	required []string,
+	optional []string,
+	label string,
+) error {
+	requiredSet := make(map[string]struct{}, len(required))
+	allowed := make(map[string]struct{}, len(required)+len(optional))
+	for _, key := range required {
+		requiredSet[key] = struct{}{}
+		allowed[key] = struct{}{}
+	}
+	for _, key := range optional {
+		allowed[key] = struct{}{}
+	}
+	var missing, unexpected []string
+	for key := range requiredSet {
+		if _, ok := object[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	for key := range object {
+		if _, ok := allowed[key]; !ok {
+			unexpected = append(unexpected, key)
+		}
+	}
+	if len(missing) == 0 && len(unexpected) == 0 {
+		return nil
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+	return fmt.Errorf(
+		"%s keys invalid; missing=%s unexpected=%s",
+		label,
+		strings.Join(missing, ","),
+		strings.Join(unexpected, ","),
+	)
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "release-permit-verify:", err)
+	os.Exit(2)
+}

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -40,6 +40,13 @@ func TestDecodeStrictPermitAcceptsExactShape(t *testing.T) {
 	}
 }
 
+func TestVerifyPermitFileRejectsTamperedPermit(t *testing.T) {
+	path := writeJSONFixture(t, validPermitJSON())
+	if _, err := verifyPermitFile(path); err == nil || !strings.Contains(err.Error(), "permit_id") {
+		t.Fatalf("verifyPermitFile() error = %v, want permit digest rejection", err)
+	}
+}
+
 func TestDecodeStrictContextRequiresExactAuthorityShape(t *testing.T) {
 	valid := validContextJSON()
 	for _, test := range []struct {

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/releasepermit"
+)
+
+func TestDecodeStrictReviewAcceptsExactShape(t *testing.T) {
+	var review releasepermit.Review
+	if _, err := decodeStrictFile(writeJSONFixture(t, validReviewJSON()), &review); err != nil {
+		t.Fatalf("decodeStrictFile() error = %v", err)
+	}
+	if review.Findings == nil {
+		t.Fatal("Findings = nil, want explicit empty array")
+	}
+}
+
+func TestDecodeStrictReviewRejectsAmbiguousShapes(t *testing.T) {
+	valid := validReviewJSON()
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "duplicate key",
+			content: strings.Replace(valid, `"verdict":"ALLOW"`, `"verdict":"ALLOW","verdict":"DENY"`, 1),
+			want:    `duplicate JSON key "verdict"`,
+		},
+		{
+			name:    "case folded key",
+			content: strings.Replace(valid, `"verdict":"ALLOW"`, `"Verdict":"ALLOW"`, 1),
+			want:    "keys invalid",
+		},
+		{
+			name:    "null findings",
+			content: strings.Replace(valid, `"findings":[]`, `"findings":null`, 1),
+			want:    "findings must be an explicit array",
+		},
+		{
+			name:    "missing findings",
+			content: strings.Replace(valid, `,"findings":[]`, "", 1),
+			want:    "missing=findings",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var review releasepermit.Review
+			_, err := decodeStrictFile(writeJSONFixture(t, test.content), &review)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("decodeStrictFile() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func writeJSONFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fixture.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func validReviewJSON() string {
+	return `{"schema":"mindburn.release-review/v1","repository":"Mindburn-Labs/example","pull_request":42,"base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","merge_sha":"4444444444444444444444444444444444444444","merge_tree_sha":"5555555555555555555555555555555555555555","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"context_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","reviewer":{"provider":"anthropic","model":"claude-fable-5"},"verdict":"ALLOW","response_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","findings":[]}`
+}

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,8 +45,52 @@ func TestDecodeStrictPermitAcceptsExactShape(t *testing.T) {
 
 func TestVerifyPermitFileRejectsTamperedPermit(t *testing.T) {
 	path := writeJSONFixture(t, validPermitJSON())
-	if _, err := verifyPermitFile(path); err == nil || !strings.Contains(err.Error(), "permit_id") {
+	contextPath := writeJSONFixture(t, validContextJSON())
+	if _, err := verifyPermitFile(path, contextPath); err == nil || !strings.Contains(err.Error(), "permit_id") {
 		t.Fatalf("verifyPermitFile() error = %v, want permit digest rejection", err)
+	}
+}
+
+func TestVerifyPermitFileAcceptsReducerPermitAgainstTrustedContext(t *testing.T) {
+	contextContent := []byte(validContextJSON())
+	var context releasepermit.Context
+	if err := json.Unmarshal(contextContent, &context); err != nil {
+		t.Fatalf("decode context fixture: %v", err)
+	}
+	contextDigest := sha256.Sum256(contextContent)
+	contextSHA256 := hex.EncodeToString(contextDigest[:])
+	reviews := make([]releasepermit.Review, 0, len(context.RequiredReviewers))
+	for index, reviewer := range context.RequiredReviewers {
+		reviews = append(reviews, releasepermit.Review{
+			Schema:         releasepermit.ReviewSchema,
+			Repository:     context.Repository,
+			PullRequest:    context.PullRequest,
+			BaseSHA:        context.BaseSHA,
+			HeadSHA:        context.HeadSHA,
+			MergeSHA:       context.MergeSHA,
+			MergeTreeSHA:   context.MergeTreeSHA,
+			WorkflowSHA:    context.WorkflowSHA,
+			RunID:          context.RunID,
+			RunAttempt:     context.RunAttempt,
+			ContextSHA256:  contextSHA256,
+			Reviewer:       reviewer,
+			Verdict:        releasepermit.DecisionAllow,
+			ResponseSHA256: strings.Repeat(string(rune('a'+index)), 64),
+			Findings:       []releasepermit.Finding{},
+		})
+	}
+	permit, err := releasepermit.Evaluate(context, contextSHA256, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	permitContent, err := json.Marshal(permit)
+	if err != nil {
+		t.Fatalf("encode permit: %v", err)
+	}
+	permitPath := writeJSONFixture(t, string(permitContent))
+	contextPath := writeJSONFixture(t, string(contextContent))
+	if _, err := verifyPermitFile(permitPath, contextPath); err != nil {
+		t.Fatalf("verifyPermitFile() error = %v", err)
 	}
 }
 

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -19,6 +19,17 @@ func TestDecodeStrictReviewAcceptsExactShape(t *testing.T) {
 	}
 }
 
+func TestDecodeStrictFileRejectsOversizedInputBeforeDecode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oversized.json")
+	if err := os.WriteFile(path, make([]byte, maxInputBytes+1), 0o600); err != nil {
+		t.Fatalf("write oversized fixture: %v", err)
+	}
+	var review releasepermit.Review
+	if _, err := decodeStrictFile(path, &review); err == nil || !strings.Contains(err.Error(), "input exceeds") {
+		t.Fatalf("decodeStrictFile() error = %v, want input size error", err)
+	}
+}
+
 func TestDecodeStrictContextRequiresExactAuthorityShape(t *testing.T) {
 	valid := validContextJSON()
 	for _, test := range []struct {

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -30,6 +30,16 @@ func TestDecodeStrictFileRejectsOversizedInputBeforeDecode(t *testing.T) {
 	}
 }
 
+func TestDecodeStrictPermitAcceptsExactShape(t *testing.T) {
+	var permit releasepermit.Permit
+	if _, err := decodeStrictFile(writeJSONFixture(t, validPermitJSON()), &permit); err != nil {
+		t.Fatalf("decodeStrictFile() error = %v", err)
+	}
+	if permit.Reviews == nil || permit.Reasons == nil {
+		t.Fatal("Reviews and Reasons must be explicit arrays")
+	}
+}
+
 func TestDecodeStrictContextRequiresExactAuthorityShape(t *testing.T) {
 	valid := validContextJSON()
 	for _, test := range []struct {
@@ -120,4 +130,8 @@ func validReviewJSON() string {
 
 func validContextJSON() string {
 	return `{"schema":"mindburn.release-permit-context/v2","repository":"Mindburn-Labs/example","event":"pull_request","pull_request":42,"base_ref":"refs/heads/main","base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","merge_sha":"4444444444444444444444444444444444444444","merge_tree_sha":"5555555555555555555555555555555555555555","workflow_repository":"Mindburn-Labs/.github","workflow_path":".github/workflows/ci.yml","workflow_ref":"refs/heads/main","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"issued_at":"2026-07-14T10:00:00Z","authority":{"schema":"mindburn.release-authority/v1","generation":2,"kernel_sha":"6666666666666666666666666666666666666666","gate_profiles_sha256":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","adversarial_corpus_sha256":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","parent":{"generation":1,"workflow_sha":"7777777777777777777777777777777777777777"}},"required_reviewers":[{"provider":"anthropic","model":"claude-fable-5"},{"provider":"openai","model":"gpt-5.6-sol"}]}`
+}
+
+func validPermitJSON() string {
+	return `{"schema":"mindburn.release-permit/v2","permit_id":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","decision":"ALLOW","repository":"Mindburn-Labs/example","pull_request":42,"base_ref":"refs/heads/main","base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","merge_sha":"4444444444444444444444444444444444444444","merge_tree_sha":"5555555555555555555555555555555555555555","workflow_repository":"Mindburn-Labs/.github","workflow_path":".github/workflows/ci.yml","workflow_ref":"refs/heads/main","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"issued_at":"2026-07-14T10:00:00Z","authority":{"schema":"mindburn.release-authority/v1","generation":2,"kernel_sha":"6666666666666666666666666666666666666666","gate_profiles_sha256":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","adversarial_corpus_sha256":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","parent":{"generation":1,"workflow_sha":"7777777777777777777777777777777777777777"}},"context_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","reviews":[{"reviewer":{"provider":"anthropic","model":"claude-fable-5"},"verdict":"ALLOW","response_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","blocking_findings":0,"advisory_findings":0},{"reviewer":{"provider":"openai","model":"gpt-5.6-sol"},"verdict":"ALLOW","response_sha256":"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff","blocking_findings":0,"advisory_findings":0}],"reasons":[]}`
 }

--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -19,6 +19,41 @@ func TestDecodeStrictReviewAcceptsExactShape(t *testing.T) {
 	}
 }
 
+func TestDecodeStrictContextRequiresExactAuthorityShape(t *testing.T) {
+	valid := validContextJSON()
+	for _, test := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "valid",
+			content: valid,
+		},
+		{
+			name:    "authority extra key",
+			content: strings.Replace(valid, `"generation":2`, `"generation":2,"approval":true`, 1),
+			want:    "authority keys invalid",
+		},
+		{
+			name:    "parent extra key",
+			content: strings.Replace(valid, `"generation":1,"workflow_sha"`, `"generation":1,"approval":true,"workflow_sha"`, 1),
+			want:    "authority.parent keys invalid",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var context releasepermit.Context
+			_, err := decodeStrictFile(writeJSONFixture(t, test.content), &context)
+			if test.want == "" && err != nil {
+				t.Fatalf("decodeStrictFile() error = %v", err)
+			}
+			if test.want != "" && (err == nil || !strings.Contains(err.Error(), test.want)) {
+				t.Fatalf("decodeStrictFile() error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
 func TestDecodeStrictReviewRejectsAmbiguousShapes(t *testing.T) {
 	valid := validReviewJSON()
 	tests := []struct {
@@ -70,4 +105,8 @@ func writeJSONFixture(t *testing.T, content string) string {
 
 func validReviewJSON() string {
 	return `{"schema":"mindburn.release-review/v1","repository":"Mindburn-Labs/example","pull_request":42,"base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","merge_sha":"4444444444444444444444444444444444444444","merge_tree_sha":"5555555555555555555555555555555555555555","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"context_sha256":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","reviewer":{"provider":"anthropic","model":"claude-fable-5"},"verdict":"ALLOW","response_sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","findings":[]}`
+}
+
+func validContextJSON() string {
+	return `{"schema":"mindburn.release-permit-context/v2","repository":"Mindburn-Labs/example","event":"pull_request","pull_request":42,"base_ref":"refs/heads/main","base_sha":"1111111111111111111111111111111111111111","head_sha":"2222222222222222222222222222222222222222","merge_sha":"4444444444444444444444444444444444444444","merge_tree_sha":"5555555555555555555555555555555555555555","workflow_repository":"Mindburn-Labs/.github","workflow_path":".github/workflows/ci.yml","workflow_ref":"refs/heads/main","workflow_sha":"3333333333333333333333333333333333333333","run_id":101,"run_attempt":1,"issued_at":"2026-07-14T10:00:00Z","authority":{"schema":"mindburn.release-authority/v1","generation":2,"kernel_sha":"6666666666666666666666666666666666666666","gate_profiles_sha256":"dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","adversarial_corpus_sha256":"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee","parent":{"generation":1,"workflow_sha":"7777777777777777777777777777777777777777"}},"required_reviewers":[{"provider":"anthropic","model":"claude-fable-5"},{"provider":"openai","model":"gpt-5.6-sol"}]}`
 }

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -169,7 +169,7 @@ func validateContext(context Context) error {
 	if !hexSHA40Pattern.MatchString(context.WorkflowSHA) {
 		problems = append(problems, "workflow_sha must be a lowercase 40-character Git SHA")
 	}
-	if context.Repository == context.WorkflowRepository &&
+	if strings.EqualFold(context.Repository, context.WorkflowRepository) &&
 		(context.WorkflowSHA == context.HeadSHA || context.WorkflowSHA == context.MergeSHA) {
 		problems = append(problems, "authority workflow cannot review its own head or merge commit")
 	}

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -47,6 +47,7 @@ func Evaluate(context Context, contextSHA256 string, reviews []Review) (Permit, 
 		RunID:              context.RunID,
 		RunAttempt:         context.RunAttempt,
 		IssuedAt:           context.IssuedAt,
+		Authority:          context.Authority,
 		ContextSHA256:      contextSHA256,
 		Reviews:            make([]ReviewSummary, 0, len(context.RequiredReviewers)),
 		Reasons:            []Reason{},
@@ -178,6 +179,7 @@ func validateContext(context Context) error {
 	if _, err := time.Parse(time.RFC3339, context.IssuedAt); err != nil {
 		problems = append(problems, "issued_at must be RFC3339")
 	}
+	problems = append(problems, validateAuthority(context.Authority, context.WorkflowSHA)...)
 	if len(context.RequiredReviewers) != 2 {
 		problems = append(problems, "exactly two reviewers are required")
 	} else {
@@ -205,6 +207,43 @@ func validateContext(context Context) error {
 		return errors.New(strings.Join(problems, "; "))
 	}
 	return nil
+}
+
+func validateAuthority(authority Authority, workflowSHA string) []string {
+	var problems []string
+	if authority.Schema != AuthoritySchema {
+		problems = append(problems, "unsupported authority schema")
+	}
+	if authority.Generation <= 0 {
+		problems = append(problems, "authority generation must be positive")
+	}
+	if !hexSHA40Pattern.MatchString(authority.KernelSHA) {
+		problems = append(problems, "authority kernel_sha must be a lowercase 40-character Git SHA")
+	}
+	if !hexSHA256Pattern.MatchString(authority.GateProfilesSHA256) {
+		problems = append(problems, "authority gate_profiles_sha256 must be lowercase hexadecimal")
+	}
+	if !hexSHA256Pattern.MatchString(authority.AdversarialCorpusSHA256) {
+		problems = append(problems, "authority adversarial_corpus_sha256 must be lowercase hexadecimal")
+	}
+	if authority.Generation == 1 {
+		if authority.Parent != nil {
+			problems = append(problems, "authority generation 1 cannot declare a parent")
+		}
+		return problems
+	}
+	if authority.Parent == nil {
+		return append(problems, "authority generations after 1 require a parent")
+	}
+	if authority.Parent.Generation != authority.Generation-1 {
+		problems = append(problems, "authority parent generation must immediately precede the current generation")
+	}
+	if !hexSHA40Pattern.MatchString(authority.Parent.WorkflowSHA) {
+		problems = append(problems, "authority parent workflow_sha must be a lowercase 40-character Git SHA")
+	} else if authority.Parent.WorkflowSHA == workflowSHA {
+		problems = append(problems, "authority cannot name its own workflow SHA as its parent")
+	}
+	return problems
 }
 
 func validateReview(context Context, contextSHA256 string, review Review) (ReviewSummary, []Reason) {

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -120,11 +121,43 @@ func Evaluate(context Context, contextSHA256 string, reviews []Review) (Permit, 
 }
 
 // ValidateAllowPermit verifies that an existing serialized permit is a complete,
-// internally consistent ALLOW decision issued by this reducer schema. Callers
-// must still bind the permit artifact to the expected Actions run and candidate
-// tree; this function owns permit semantics and canonical digest verification.
-func ValidateAllowPermit(permit Permit) error {
+// internally consistent ALLOW decision bound to an independently trusted
+// context and exact reviewer quorum. This is semantic validation, not artifact
+// authentication: callers must first verify the permit's signed provenance.
+func ValidateAllowPermit(permit Permit, trustedContext Context, contextSHA256 string) error {
 	var problems []string
+	if err := validateContext(trustedContext); err != nil {
+		problems = append(problems, "trusted context is invalid: "+err.Error())
+	}
+	if !hexSHA256Pattern.MatchString(contextSHA256) {
+		problems = append(problems, "trusted context_sha256 must be lowercase hexadecimal")
+	}
+	contextMatch := func(label string, matches bool) {
+		if !matches {
+			problems = append(problems, label+" does not match the trusted context")
+		}
+	}
+	contextMatch("repository", permit.Repository == trustedContext.Repository)
+	contextMatch("pull_request", permit.PullRequest == trustedContext.PullRequest)
+	contextMatch("base_ref", permit.BaseRef == trustedContext.BaseRef)
+	contextMatch("base_sha", permit.BaseSHA == trustedContext.BaseSHA)
+	contextMatch("head_sha", permit.HeadSHA == trustedContext.HeadSHA)
+	contextMatch("merge_sha", permit.MergeSHA == trustedContext.MergeSHA)
+	contextMatch("merge_tree_sha", permit.MergeTreeSHA == trustedContext.MergeTreeSHA)
+	contextMatch("workflow_repository", permit.WorkflowRepository == trustedContext.WorkflowRepository)
+	contextMatch("workflow_path", permit.WorkflowPath == trustedContext.WorkflowPath)
+	contextMatch("workflow_ref", permit.WorkflowRef == trustedContext.WorkflowRef)
+	contextMatch("workflow_sha", permit.WorkflowSHA == trustedContext.WorkflowSHA)
+	contextMatch("run_id", permit.RunID == trustedContext.RunID)
+	contextMatch("run_attempt", permit.RunAttempt == trustedContext.RunAttempt)
+	contextMatch("issued_at", permit.IssuedAt == trustedContext.IssuedAt)
+	contextMatch("authority", reflect.DeepEqual(permit.Authority, trustedContext.Authority))
+	contextMatch("context_sha256", permit.ContextSHA256 == contextSHA256)
+
+	expectedReviewers := make(map[string]struct{}, len(trustedContext.RequiredReviewers))
+	for _, reviewer := range trustedContext.RequiredReviewers {
+		expectedReviewers[reviewerKey(reviewer)] = struct{}{}
+	}
 	if permit.Schema != PermitSchema {
 		problems = append(problems, "unsupported permit schema")
 	}
@@ -200,6 +233,9 @@ func ValidateAllowPermit(permit Permit) error {
 			if seenKeys[key] || seenProviders[review.Reviewer.Provider] {
 				problems = append(problems, "ALLOW permit reviews must use unique reviewers and distinct providers")
 			}
+			if _, expected := expectedReviewers[key]; !expected {
+				problems = append(problems, "ALLOW permit reviewer is not in the trusted context quorum")
+			}
 			seenKeys[key] = true
 			seenProviders[review.Reviewer.Provider] = true
 			if review.Verdict != DecisionAllow || review.BlockingFindings != 0 {
@@ -211,6 +247,9 @@ func ValidateAllowPermit(permit Permit) error {
 			if !hexSHA256Pattern.MatchString(review.ResponseSHA256) {
 				problems = append(problems, "review response_sha256 must be lowercase hexadecimal")
 			}
+		}
+		if len(seenKeys) != len(expectedReviewers) {
+			problems = append(problems, "ALLOW permit reviewer quorum does not match the trusted context")
 		}
 	}
 	permitID, err := calculatePermitID(permit)

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -170,8 +170,9 @@ func ValidateAllowPermit(permit Permit) error {
 		(permit.WorkflowSHA == permit.HeadSHA || permit.WorkflowSHA == permit.MergeSHA) {
 		problems = append(problems, "authority workflow cannot review its own head or merge commit")
 	}
-	if permit.Authority.Generation > 1 && permit.Authority.KernelSHA == permit.HeadSHA {
-		problems = append(problems, "non-bootstrap authority cannot use the target head as its Kernel")
+	if permit.Authority.Generation > 1 &&
+		(permit.Authority.KernelSHA == permit.HeadSHA || permit.Authority.KernelSHA == permit.MergeSHA) {
+		problems = append(problems, "non-bootstrap authority cannot use the target head or merge commit as its Kernel")
 	}
 	if permit.RunID <= 0 || permit.RunAttempt <= 0 {
 		problems = append(problems, "run_id and run_attempt must be positive")

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -1,0 +1,289 @@
+package releasepermit
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+var (
+	repositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+	hexSHA40Pattern   = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	hexSHA256Pattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
+)
+
+// Evaluate validates a two-provider review quorum and returns a deterministic
+// permit. A structurally invalid context is an error because no trustworthy
+// decision can be bound to it. Invalid, stale, missing, or denying reviews
+// produce a well-formed DENY permit.
+func Evaluate(context Context, contextSHA256 string, reviews []Review) (Permit, error) {
+	if err := validateContext(context); err != nil {
+		return Permit{}, err
+	}
+	if !hexSHA256Pattern.MatchString(contextSHA256) {
+		return Permit{}, errors.New("context_sha256 must be lowercase hexadecimal")
+	}
+
+	permit := Permit{
+		Schema:             PermitSchema,
+		Decision:           DecisionAllow,
+		Repository:         context.Repository,
+		PullRequest:        context.PullRequest,
+		BaseRef:            context.BaseRef,
+		BaseSHA:            context.BaseSHA,
+		HeadSHA:            context.HeadSHA,
+		MergeSHA:           context.MergeSHA,
+		MergeTreeSHA:       context.MergeTreeSHA,
+		WorkflowRepository: context.WorkflowRepository,
+		WorkflowPath:       context.WorkflowPath,
+		WorkflowRef:        context.WorkflowRef,
+		WorkflowSHA:        context.WorkflowSHA,
+		RunID:              context.RunID,
+		RunAttempt:         context.RunAttempt,
+		IssuedAt:           context.IssuedAt,
+		ContextSHA256:      contextSHA256,
+		Reviews:            make([]ReviewSummary, 0, len(context.RequiredReviewers)),
+		Reasons:            []Reason{},
+	}
+
+	required := make(map[string]Reviewer, len(context.RequiredReviewers))
+	for _, reviewer := range context.RequiredReviewers {
+		required[reviewerKey(reviewer)] = reviewer
+	}
+
+	provided := make(map[string][]Review, len(reviews))
+	for _, review := range reviews {
+		key := reviewerKey(review.Reviewer)
+		provided[key] = append(provided[key], review)
+		if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
+			strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
+			permit.addReason("REVIEW_REVIEWER_INVALID", key, "reviewer provider and model must be non-empty and cannot contain slash")
+		}
+		if _, expected := required[key]; !expected {
+			permit.addReason("REVIEW_UNEXPECTED", key, "reviewer is not part of the required quorum")
+		}
+	}
+	for key, group := range provided {
+		if len(group) > 1 {
+			permit.addReason("REVIEW_DUPLICATE", key, "more than one review used the same provider and model")
+		}
+	}
+
+	for _, expected := range context.RequiredReviewers {
+		key := reviewerKey(expected)
+		group := provided[key]
+		if len(group) == 0 {
+			permit.addReason("REVIEW_MISSING", key, "required reviewer did not produce a result")
+			continue
+		}
+		if len(group) > 1 {
+			permit.addReason("REVIEW_MISSING", key, "required reviewer did not produce one unique result")
+			continue
+		}
+
+		summary, reasons := validateReview(context, contextSHA256, group[0])
+		permit.Reviews = append(permit.Reviews, summary)
+		for _, reason := range reasons {
+			permit.addReason(reason.Code, reason.Reviewer, reason.Detail)
+		}
+	}
+
+	if len(reviews) != len(context.RequiredReviewers) {
+		permit.addReason("REVIEW_COUNT_MISMATCH", "", fmt.Sprintf(
+			"received %d reviews for a %d-reviewer quorum",
+			len(reviews), len(context.RequiredReviewers),
+		))
+	}
+
+	if len(permit.Reasons) > 0 {
+		permit.Decision = DecisionDeny
+	}
+	sort.Slice(permit.Reasons, func(i, j int) bool {
+		left := permit.Reasons[i].Code + "\x00" + permit.Reasons[i].Reviewer + "\x00" + permit.Reasons[i].Detail
+		right := permit.Reasons[j].Code + "\x00" + permit.Reasons[j].Reviewer + "\x00" + permit.Reasons[j].Detail
+		return left < right
+	})
+
+	digestInput := permit
+	digestInput.PermitID = ""
+	encoded, err := json.Marshal(digestInput)
+	if err != nil {
+		return Permit{}, fmt.Errorf("marshal permit digest input: %w", err)
+	}
+	digest := sha256.Sum256(encoded)
+	permit.PermitID = "sha256:" + hex.EncodeToString(digest[:])
+	return permit, nil
+}
+
+func validateContext(context Context) error {
+	var problems []string
+	if context.Schema != ContextSchema {
+		problems = append(problems, "unsupported context schema")
+	}
+	if !repositoryPattern.MatchString(context.Repository) {
+		problems = append(problems, "invalid repository")
+	}
+	if context.Event != "pull_request" {
+		problems = append(problems, "event must be pull_request")
+	}
+	if context.PullRequest <= 0 {
+		problems = append(problems, "pull_request must be positive")
+	}
+	if !strings.HasPrefix(context.BaseRef, "refs/heads/") {
+		problems = append(problems, "base_ref must be a branch ref")
+	}
+	if !hexSHA40Pattern.MatchString(context.BaseSHA) {
+		problems = append(problems, "base_sha must be a lowercase 40-character Git SHA")
+	}
+	if !hexSHA40Pattern.MatchString(context.HeadSHA) {
+		problems = append(problems, "head_sha must be a lowercase 40-character Git SHA")
+	}
+	if !hexSHA40Pattern.MatchString(context.MergeSHA) {
+		problems = append(problems, "merge_sha must be a lowercase 40-character Git SHA")
+	}
+	if !hexSHA40Pattern.MatchString(context.MergeTreeSHA) {
+		problems = append(problems, "merge_tree_sha must be a lowercase 40-character Git SHA")
+	}
+	if !repositoryPattern.MatchString(context.WorkflowRepository) {
+		problems = append(problems, "invalid workflow_repository")
+	}
+	if !strings.HasPrefix(context.WorkflowPath, ".github/workflows/") ||
+		(!strings.HasSuffix(context.WorkflowPath, ".yml") && !strings.HasSuffix(context.WorkflowPath, ".yaml")) {
+		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
+	}
+	workflowRef := context.WorkflowRef
+	workflowIdentityPrefix := context.WorkflowRepository + "/" + context.WorkflowPath + "@"
+	if strings.HasPrefix(workflowRef, workflowIdentityPrefix) {
+		workflowRef = strings.TrimPrefix(workflowRef, workflowIdentityPrefix)
+	}
+	if !strings.HasPrefix(workflowRef, "refs/heads/") && !strings.HasPrefix(workflowRef, "refs/tags/") {
+		problems = append(problems, "workflow_ref must be a branch or tag ref")
+	}
+	if !hexSHA40Pattern.MatchString(context.WorkflowSHA) {
+		problems = append(problems, "workflow_sha must be a lowercase 40-character Git SHA")
+	}
+	if context.Repository == context.WorkflowRepository &&
+		(context.WorkflowSHA == context.HeadSHA || context.WorkflowSHA == context.MergeSHA) {
+		problems = append(problems, "authority workflow cannot review its own head or merge commit")
+	}
+	if context.RunID <= 0 || context.RunAttempt <= 0 {
+		problems = append(problems, "run_id and run_attempt must be positive")
+	}
+	if _, err := time.Parse(time.RFC3339, context.IssuedAt); err != nil {
+		problems = append(problems, "issued_at must be RFC3339")
+	}
+	if len(context.RequiredReviewers) != 2 {
+		problems = append(problems, "exactly two reviewers are required")
+	} else {
+		seenKeys := map[string]bool{}
+		seenProviders := map[string]bool{}
+		for _, reviewer := range context.RequiredReviewers {
+			key := reviewerKey(reviewer)
+			if reviewer.Provider == "" || reviewer.Model == "" {
+				problems = append(problems, "reviewer provider and model are required")
+			}
+			if strings.Contains(reviewer.Provider, "/") || strings.Contains(reviewer.Model, "/") {
+				problems = append(problems, "reviewer provider and model cannot contain slash")
+			}
+			if seenKeys[key] {
+				problems = append(problems, "required reviewers must be unique")
+			}
+			if seenProviders[reviewer.Provider] {
+				problems = append(problems, "required reviewers must use distinct providers")
+			}
+			seenKeys[key] = true
+			seenProviders[reviewer.Provider] = true
+		}
+	}
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func validateReview(context Context, contextSHA256 string, review Review) (ReviewSummary, []Reason) {
+	key := reviewerKey(review.Reviewer)
+	summary := ReviewSummary{
+		Reviewer:       review.Reviewer,
+		Verdict:        review.Verdict,
+		ResponseSHA256: review.ResponseSHA256,
+	}
+	var reasons []Reason
+	add := func(code, detail string) {
+		reasons = append(reasons, Reason{Code: code, Reviewer: key, Detail: detail})
+	}
+
+	if review.Schema != ReviewSchema {
+		add("REVIEW_SCHEMA_INVALID", "unsupported review schema")
+	}
+	if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
+		strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
+		add("REVIEW_REVIEWER_INVALID", "reviewer provider and model must be non-empty and cannot contain slash")
+	}
+	if review.Repository != context.Repository ||
+		review.PullRequest != context.PullRequest ||
+		review.BaseSHA != context.BaseSHA ||
+		review.HeadSHA != context.HeadSHA ||
+		review.MergeSHA != context.MergeSHA ||
+		review.MergeTreeSHA != context.MergeTreeSHA ||
+		review.WorkflowSHA != context.WorkflowSHA ||
+		review.RunID != context.RunID ||
+		review.RunAttempt != context.RunAttempt {
+		add("REVIEW_METADATA_MISMATCH", "review is not bound to the requested repository, commit, workflow, and run")
+	}
+	if review.ContextSHA256 != contextSHA256 {
+		add("REVIEW_CONTEXT_MISMATCH", "review is not bound to the complete permit context")
+	}
+	if !hexSHA256Pattern.MatchString(review.ResponseSHA256) {
+		add("REVIEW_DIGEST_INVALID", "response_sha256 must be lowercase hexadecimal")
+	}
+	if review.Verdict != DecisionAllow && review.Verdict != DecisionDeny {
+		add("REVIEW_VERDICT_INVALID", "verdict must be ALLOW or DENY")
+	} else if review.Verdict == DecisionDeny {
+		add("REVIEW_DENIED", "reviewer denied the proposed change")
+	}
+	if review.Findings == nil || len(review.Findings) > 200 {
+		add("REVIEW_FINDINGS_INVALID", "review findings must be an explicit array of at most 200 items")
+	}
+	for _, finding := range review.Findings {
+		if finding.Code == "" || finding.Summary == "" || len(finding.Code) > 120 || len(finding.Summary) > 2000 {
+			add("REVIEW_FINDINGS_INVALID", "finding code and bounded summary are required")
+			continue
+		}
+		if finding.Line < 0 {
+			add("REVIEW_FINDINGS_INVALID", "finding line cannot be negative")
+			continue
+		}
+		switch finding.Severity {
+		case "P0", "P1", "P2":
+			summary.BlockingFindings++
+		case "P3":
+			summary.AdvisoryFindings++
+		default:
+			add("REVIEW_FINDINGS_INVALID", "finding severity must be P0, P1, P2, or P3")
+		}
+	}
+	if summary.BlockingFindings > 0 {
+		add("BLOCKING_FINDING", fmt.Sprintf("review contains %d P0-P2 findings", summary.BlockingFindings))
+	}
+	return summary, reasons
+}
+
+func (permit *Permit) addReason(code, reviewer, detail string) {
+	for _, existing := range permit.Reasons {
+		if existing.Code == code && existing.Reviewer == reviewer && existing.Detail == detail {
+			return
+		}
+	}
+	permit.Reasons = append(permit.Reasons, Reason{Code: code, Reviewer: reviewer, Detail: detail})
+}
+
+func reviewerKey(reviewer Reviewer) string {
+	return reviewer.Provider + "/" + reviewer.Model
+}

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -16,6 +16,7 @@ var (
 	repositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
 	hexSHA40Pattern   = regexp.MustCompile(`^[0-9a-f]{40}$`)
 	hexSHA256Pattern  = regexp.MustCompile(`^[0-9a-f]{64}$`)
+	reviewerPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]{0,127}$`)
 )
 
 // Evaluate validates a two-provider review quorum and returns a deterministic
@@ -62,9 +63,8 @@ func Evaluate(context Context, contextSHA256 string, reviews []Review) (Permit, 
 	for _, review := range reviews {
 		key := reviewerKey(review.Reviewer)
 		provided[key] = append(provided[key], review)
-		if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
-			strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
-			permit.addReason("REVIEW_REVIEWER_INVALID", key, "reviewer provider and model must be non-empty and cannot contain slash")
+		if !reviewerPattern.MatchString(review.Reviewer.Provider) || !reviewerPattern.MatchString(review.Reviewer.Model) {
+			permit.addReason("REVIEW_REVIEWER_INVALID", key, "reviewer provider and model must be canonical lowercase identifiers")
 		}
 		if _, expected := required[key]; !expected {
 			permit.addReason("REVIEW_UNEXPECTED", key, "reviewer is not part of the required quorum")
@@ -170,6 +170,9 @@ func ValidateAllowPermit(permit Permit) error {
 		(permit.WorkflowSHA == permit.HeadSHA || permit.WorkflowSHA == permit.MergeSHA) {
 		problems = append(problems, "authority workflow cannot review its own head or merge commit")
 	}
+	if permit.Authority.Generation > 1 && permit.Authority.KernelSHA == permit.HeadSHA {
+		problems = append(problems, "non-bootstrap authority cannot use the target head as its Kernel")
+	}
 	if permit.RunID <= 0 || permit.RunAttempt <= 0 {
 		problems = append(problems, "run_id and run_attempt must be positive")
 	}
@@ -190,9 +193,8 @@ func ValidateAllowPermit(permit Permit) error {
 		seenProviders := map[string]bool{}
 		for _, review := range permit.Reviews {
 			key := reviewerKey(review.Reviewer)
-			if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
-				strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
-				problems = append(problems, "reviewer provider and model must be non-empty and cannot contain slash")
+			if !reviewerPattern.MatchString(review.Reviewer.Provider) || !reviewerPattern.MatchString(review.Reviewer.Model) {
+				problems = append(problems, "reviewer provider and model must be canonical lowercase identifiers")
 			}
 			if seenKeys[key] || seenProviders[review.Reviewer.Provider] {
 				problems = append(problems, "ALLOW permit reviews must use unique reviewers and distinct providers")
@@ -284,6 +286,9 @@ func validateContext(context Context) error {
 		(context.WorkflowSHA == context.HeadSHA || context.WorkflowSHA == context.MergeSHA) {
 		problems = append(problems, "authority workflow cannot review its own head or merge commit")
 	}
+	if context.Authority.Generation > 1 && context.Authority.KernelSHA == context.HeadSHA {
+		problems = append(problems, "non-bootstrap authority cannot use the target head as its Kernel")
+	}
 	if context.RunID <= 0 || context.RunAttempt <= 0 {
 		problems = append(problems, "run_id and run_attempt must be positive")
 	}
@@ -298,11 +303,8 @@ func validateContext(context Context) error {
 		seenProviders := map[string]bool{}
 		for _, reviewer := range context.RequiredReviewers {
 			key := reviewerKey(reviewer)
-			if reviewer.Provider == "" || reviewer.Model == "" {
-				problems = append(problems, "reviewer provider and model are required")
-			}
-			if strings.Contains(reviewer.Provider, "/") || strings.Contains(reviewer.Model, "/") {
-				problems = append(problems, "reviewer provider and model cannot contain slash")
+			if !reviewerPattern.MatchString(reviewer.Provider) || !reviewerPattern.MatchString(reviewer.Model) {
+				problems = append(problems, "reviewer provider and model must be canonical lowercase identifiers")
 			}
 			if seenKeys[key] {
 				problems = append(problems, "required reviewers must be unique")
@@ -372,9 +374,8 @@ func validateReview(context Context, contextSHA256 string, review Review) (Revie
 	if review.Schema != ReviewSchema {
 		add("REVIEW_SCHEMA_INVALID", "unsupported review schema")
 	}
-	if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
-		strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
-		add("REVIEW_REVIEWER_INVALID", "reviewer provider and model must be non-empty and cannot contain slash")
+	if !reviewerPattern.MatchString(review.Reviewer.Provider) || !reviewerPattern.MatchString(review.Reviewer.Model) {
+		add("REVIEW_REVIEWER_INVALID", "reviewer provider and model must be canonical lowercase identifiers")
 	}
 	if review.Repository != context.Repository ||
 		review.PullRequest != context.PullRequest ||
@@ -435,5 +436,5 @@ func (permit *Permit) addReason(code, reviewer, detail string) {
 }
 
 func reviewerKey(reviewer Reviewer) string {
-	return reviewer.Provider + "/" + reviewer.Model
+	return strings.ToLower(reviewer.Provider) + "/" + strings.ToLower(reviewer.Model)
 }

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -111,15 +111,126 @@ func Evaluate(context Context, contextSHA256 string, reviews []Review) (Permit, 
 		return left < right
 	})
 
+	permitID, err := calculatePermitID(permit)
+	if err != nil {
+		return Permit{}, err
+	}
+	permit.PermitID = permitID
+	return permit, nil
+}
+
+// ValidateAllowPermit verifies that an existing serialized permit is a complete,
+// internally consistent ALLOW decision issued by this reducer schema. Callers
+// must still bind the permit artifact to the expected Actions run and candidate
+// tree; this function owns permit semantics and canonical digest verification.
+func ValidateAllowPermit(permit Permit) error {
+	var problems []string
+	if permit.Schema != PermitSchema {
+		problems = append(problems, "unsupported permit schema")
+	}
+	if permit.Decision != DecisionAllow {
+		problems = append(problems, "permit decision must be ALLOW")
+	}
+	if !repositoryPattern.MatchString(permit.Repository) {
+		problems = append(problems, "invalid repository")
+	}
+	if permit.PullRequest <= 0 {
+		problems = append(problems, "pull_request must be positive")
+	}
+	if !strings.HasPrefix(permit.BaseRef, "refs/heads/") {
+		problems = append(problems, "base_ref must be a branch ref")
+	}
+	for label, value := range map[string]string{
+		"base_sha":       permit.BaseSHA,
+		"head_sha":       permit.HeadSHA,
+		"merge_sha":      permit.MergeSHA,
+		"merge_tree_sha": permit.MergeTreeSHA,
+		"workflow_sha":   permit.WorkflowSHA,
+	} {
+		if !hexSHA40Pattern.MatchString(value) {
+			problems = append(problems, label+" must be a lowercase 40-character Git SHA")
+		}
+	}
+	if !repositoryPattern.MatchString(permit.WorkflowRepository) {
+		problems = append(problems, "invalid workflow_repository")
+	}
+	if !strings.HasPrefix(permit.WorkflowPath, ".github/workflows/") ||
+		(!strings.HasSuffix(permit.WorkflowPath, ".yml") && !strings.HasSuffix(permit.WorkflowPath, ".yaml")) {
+		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
+	}
+	workflowRef := permit.WorkflowRef
+	workflowIdentityPrefix := permit.WorkflowRepository + "/" + permit.WorkflowPath + "@"
+	if strings.HasPrefix(workflowRef, workflowIdentityPrefix) {
+		workflowRef = strings.TrimPrefix(workflowRef, workflowIdentityPrefix)
+	}
+	if !strings.HasPrefix(workflowRef, "refs/heads/") && !strings.HasPrefix(workflowRef, "refs/tags/") {
+		problems = append(problems, "workflow_ref must be a branch or tag ref")
+	}
+	if strings.EqualFold(permit.Repository, permit.WorkflowRepository) &&
+		(permit.WorkflowSHA == permit.HeadSHA || permit.WorkflowSHA == permit.MergeSHA) {
+		problems = append(problems, "authority workflow cannot review its own head or merge commit")
+	}
+	if permit.RunID <= 0 || permit.RunAttempt <= 0 {
+		problems = append(problems, "run_id and run_attempt must be positive")
+	}
+	if _, err := time.Parse(time.RFC3339, permit.IssuedAt); err != nil {
+		problems = append(problems, "issued_at must be RFC3339")
+	}
+	problems = append(problems, validateAuthority(permit.Authority, permit.WorkflowSHA)...)
+	if !hexSHA256Pattern.MatchString(permit.ContextSHA256) {
+		problems = append(problems, "context_sha256 must be lowercase hexadecimal")
+	}
+	if permit.Reasons == nil || len(permit.Reasons) != 0 {
+		problems = append(problems, "ALLOW permit reasons must be an explicit empty array")
+	}
+	if len(permit.Reviews) != 2 {
+		problems = append(problems, "ALLOW permit must contain exactly two reviews")
+	} else {
+		seenKeys := map[string]bool{}
+		seenProviders := map[string]bool{}
+		for _, review := range permit.Reviews {
+			key := reviewerKey(review.Reviewer)
+			if review.Reviewer.Provider == "" || review.Reviewer.Model == "" ||
+				strings.Contains(review.Reviewer.Provider, "/") || strings.Contains(review.Reviewer.Model, "/") {
+				problems = append(problems, "reviewer provider and model must be non-empty and cannot contain slash")
+			}
+			if seenKeys[key] || seenProviders[review.Reviewer.Provider] {
+				problems = append(problems, "ALLOW permit reviews must use unique reviewers and distinct providers")
+			}
+			seenKeys[key] = true
+			seenProviders[review.Reviewer.Provider] = true
+			if review.Verdict != DecisionAllow || review.BlockingFindings != 0 {
+				problems = append(problems, "every ALLOW permit review must be non-blocking ALLOW")
+			}
+			if review.AdvisoryFindings < 0 {
+				problems = append(problems, "review advisory_findings cannot be negative")
+			}
+			if !hexSHA256Pattern.MatchString(review.ResponseSHA256) {
+				problems = append(problems, "review response_sha256 must be lowercase hexadecimal")
+			}
+		}
+	}
+	permitID, err := calculatePermitID(permit)
+	if err != nil {
+		problems = append(problems, err.Error())
+	} else if permit.PermitID != permitID {
+		problems = append(problems, "permit_id does not match the canonical permit body")
+	}
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "; "))
+	}
+	return nil
+}
+
+func calculatePermitID(permit Permit) (string, error) {
 	digestInput := permit
 	digestInput.PermitID = ""
 	encoded, err := json.Marshal(digestInput)
 	if err != nil {
-		return Permit{}, fmt.Errorf("marshal permit digest input: %w", err)
+		return "", fmt.Errorf("marshal permit digest input: %w", err)
 	}
 	digest := sha256.Sum256(encoded)
-	permit.PermitID = "sha256:" + hex.EncodeToString(digest[:])
-	return permit, nil
+	return "sha256:" + hex.EncodeToString(digest[:]), nil
 }
 
 func validateContext(context Context) error {

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -286,8 +286,9 @@ func validateContext(context Context) error {
 		(context.WorkflowSHA == context.HeadSHA || context.WorkflowSHA == context.MergeSHA) {
 		problems = append(problems, "authority workflow cannot review its own head or merge commit")
 	}
-	if context.Authority.Generation > 1 && context.Authority.KernelSHA == context.HeadSHA {
-		problems = append(problems, "non-bootstrap authority cannot use the target head as its Kernel")
+	if context.Authority.Generation > 1 &&
+		(context.Authority.KernelSHA == context.HeadSHA || context.Authority.KernelSHA == context.MergeSHA) {
+		problems = append(problems, "non-bootstrap authority cannot use the target head or merge commit as its Kernel")
 	}
 	if context.RunID <= 0 || context.RunAttempt <= 0 {
 		problems = append(problems, "run_id and run_attempt must be positive")

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -20,6 +20,16 @@ var (
 	reviewerPattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9_.-]{0,127}$`)
 )
 
+func isWorkflowRefAllowed(workflowRef, workflowRepository, workflowPath, workflowSHA string) bool {
+	workflowIdentityPrefix := workflowRepository + "/" + workflowPath + "@"
+	if strings.HasPrefix(workflowRef, workflowIdentityPrefix) {
+		workflowRef = strings.TrimPrefix(workflowRef, workflowIdentityPrefix)
+	}
+	return workflowRef == workflowSHA ||
+		strings.HasPrefix(workflowRef, "refs/heads/") ||
+		strings.HasPrefix(workflowRef, "refs/tags/")
+}
+
 // Evaluate validates a two-provider review quorum and returns a deterministic
 // permit. A structurally invalid context is an error because no trustworthy
 // decision can be bound to it. Invalid, stale, missing, or denying reviews
@@ -191,13 +201,13 @@ func ValidateAllowPermit(permit Permit, trustedContext Context, contextSHA256 st
 		(!strings.HasSuffix(permit.WorkflowPath, ".yml") && !strings.HasSuffix(permit.WorkflowPath, ".yaml")) {
 		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
 	}
-	workflowRef := permit.WorkflowRef
-	workflowIdentityPrefix := permit.WorkflowRepository + "/" + permit.WorkflowPath + "@"
-	if strings.HasPrefix(workflowRef, workflowIdentityPrefix) {
-		workflowRef = strings.TrimPrefix(workflowRef, workflowIdentityPrefix)
-	}
-	if !strings.HasPrefix(workflowRef, "refs/heads/") && !strings.HasPrefix(workflowRef, "refs/tags/") {
-		problems = append(problems, "workflow_ref must be a branch or tag ref")
+	if !isWorkflowRefAllowed(
+		permit.WorkflowRef,
+		permit.WorkflowRepository,
+		permit.WorkflowPath,
+		permit.WorkflowSHA,
+	) {
+		problems = append(problems, "workflow_ref must be a branch or tag ref or match workflow_sha")
 	}
 	if strings.EqualFold(permit.Repository, permit.WorkflowRepository) &&
 		(permit.WorkflowSHA == permit.HeadSHA || permit.WorkflowSHA == permit.MergeSHA) {
@@ -311,13 +321,13 @@ func validateContext(context Context) error {
 		(!strings.HasSuffix(context.WorkflowPath, ".yml") && !strings.HasSuffix(context.WorkflowPath, ".yaml")) {
 		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
 	}
-	workflowRef := context.WorkflowRef
-	workflowIdentityPrefix := context.WorkflowRepository + "/" + context.WorkflowPath + "@"
-	if strings.HasPrefix(workflowRef, workflowIdentityPrefix) {
-		workflowRef = strings.TrimPrefix(workflowRef, workflowIdentityPrefix)
-	}
-	if !strings.HasPrefix(workflowRef, "refs/heads/") && !strings.HasPrefix(workflowRef, "refs/tags/") {
-		problems = append(problems, "workflow_ref must be a branch or tag ref")
+	if !isWorkflowRefAllowed(
+		context.WorkflowRef,
+		context.WorkflowRepository,
+		context.WorkflowPath,
+		context.WorkflowSHA,
+	) {
+		problems = append(problems, "workflow_ref must be a branch or tag ref or match workflow_sha")
 	}
 	if !hexSHA40Pattern.MatchString(context.WorkflowSHA) {
 		problems = append(problems, "workflow_sha must be a lowercase 40-character Git SHA")

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -138,6 +138,62 @@ func TestEvaluateAcceptsGitHubWorkflowRefIdentity(t *testing.T) {
 	}
 }
 
+func TestEvaluateAcceptsGitHubWorkflowSHAIdentity(t *testing.T) {
+	context := validContext()
+	context.WorkflowRef = context.WorkflowRepository + "/" + context.WorkflowPath + "@" + context.WorkflowSHA
+
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if permit.Decision != DecisionAllow {
+		t.Fatalf("Decision = %q, want %q; reasons = %#v", permit.Decision, DecisionAllow, permit.Reasons)
+	}
+}
+
+func TestWorkflowRefAllowsOnlyBoundSHA(t *testing.T) {
+	workflowIdentityPrefix := "Mindburn-Labs/.github/.github/workflows/ci.yml@"
+	tests := []struct {
+		name        string
+		workflowRef string
+		workflowSHA string
+		want        bool
+	}{
+		{
+			name:        "matching SHA",
+			workflowRef: workflowIdentityPrefix + testWorkflowSHA,
+			workflowSHA: testWorkflowSHA,
+			want:        true,
+		},
+		{
+			name:        "mismatched SHA",
+			workflowRef: workflowIdentityPrefix + testMergeSHA,
+			workflowSHA: testWorkflowSHA,
+			want:        false,
+		},
+		{
+			name:        "pull ref",
+			workflowRef: workflowIdentityPrefix + "refs/pull/42/merge",
+			workflowSHA: testWorkflowSHA,
+			want:        false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := isWorkflowRefAllowed(
+				test.workflowRef,
+				"Mindburn-Labs/.github",
+				".github/workflows/ci.yml",
+				test.workflowSHA,
+			)
+			if got != test.want {
+				t.Fatalf("isWorkflowRefAllowed() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateRejectsMismatchedGitHubWorkflowRefIdentity(t *testing.T) {
 	context := validContext()
 	context.WorkflowRef = "Mindburn-Labs/other/.github/workflows/ci.yml@refs/heads/main"

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -1,0 +1,341 @@
+package releasepermit
+
+import (
+	"reflect"
+	"testing"
+)
+
+const (
+	testBaseSHA     = "1111111111111111111111111111111111111111"
+	testHeadSHA     = "2222222222222222222222222222222222222222"
+	testWorkflowSHA = "3333333333333333333333333333333333333333"
+	testMergeSHA    = "4444444444444444444444444444444444444444"
+	testMergeTree   = "5555555555555555555555555555555555555555"
+	testContextSHA  = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	testResponseA   = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testResponseB   = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func TestEvaluateAllowsTwoProviderQuorum(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].Findings = []Finding{{Severity: "P3", Code: "STYLE", Summary: "Non-blocking naming improvement"}}
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if permit.Decision != DecisionAllow {
+		t.Fatalf("Decision = %q, want %q; reasons = %#v", permit.Decision, DecisionAllow, permit.Reasons)
+	}
+	if permit.PermitID == "" {
+		t.Fatal("PermitID is empty")
+	}
+	if got := permit.Reviews[0].AdvisoryFindings; got != 1 {
+		t.Fatalf("AdvisoryFindings = %d, want 1", got)
+	}
+}
+
+func TestEvaluateDeniesBlockingFinding(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[1].Findings = []Finding{{Severity: "P1", Code: "AUTH_BYPASS", Summary: "Authorization is bypassed"}}
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "BLOCKING_FINDING")
+}
+
+func TestEvaluateDeniesStaleHead(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].HeadSHA = "4444444444444444444444444444444444444444"
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_METADATA_MISMATCH")
+}
+
+func TestEvaluateDeniesMergeTreeSubstitution(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].MergeTreeSHA = "6666666666666666666666666666666666666666"
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_METADATA_MISMATCH")
+}
+
+func TestEvaluateDeniesMissingReviewer(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)[:1]
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_MISSING")
+	assertDeniedFor(t, permit, "REVIEW_COUNT_MISMATCH")
+}
+
+func TestEvaluateDeniesDuplicateReviewer(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[1].Reviewer = reviews[0].Reviewer
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_DUPLICATE")
+	assertDeniedFor(t, permit, "REVIEW_MISSING")
+}
+
+func TestEvaluateDuplicateEvidenceIsOrderIndependent(t *testing.T) {
+	context := validContext()
+	firstReview := validReview(context, context.RequiredReviewers[0], testResponseA)
+	secondReview := validReview(context, context.RequiredReviewers[0], testResponseB)
+
+	first, err := Evaluate(context, testContextSHA, []Review{firstReview, secondReview})
+	if err != nil {
+		t.Fatalf("Evaluate(first) error = %v", err)
+	}
+	second, err := Evaluate(context, testContextSHA, []Review{secondReview, firstReview})
+	if err != nil {
+		t.Fatalf("Evaluate(second) error = %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("duplicate permits differ by input order:\nfirst: %#v\nsecond: %#v", first, second)
+	}
+}
+
+func TestEvaluateRejectsInvalidContext(t *testing.T) {
+	context := validContext()
+	context.RequiredReviewers[1].Provider = context.RequiredReviewers[0].Provider
+
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want invalid distinct-provider context error")
+	}
+}
+
+func TestEvaluateAcceptsGitHubWorkflowRefIdentity(t *testing.T) {
+	context := validContext()
+	context.WorkflowRef = context.WorkflowRepository + "/" + context.WorkflowPath + "@refs/heads/codex/autonomous-release-permit"
+
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if permit.Decision != DecisionAllow {
+		t.Fatalf("Decision = %q, want %q; reasons = %#v", permit.Decision, DecisionAllow, permit.Reasons)
+	}
+}
+
+func TestEvaluateRejectsMismatchedGitHubWorkflowRefIdentity(t *testing.T) {
+	context := validContext()
+	context.WorkflowRef = "Mindburn-Labs/other/.github/workflows/ci.yml@refs/heads/main"
+
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want mismatched workflow identity error")
+	}
+}
+
+func TestEvaluateRejectsSelfReviewingAuthorityContext(t *testing.T) {
+	for _, authoritySHA := range []string{testHeadSHA, testMergeSHA} {
+		context := validContext()
+		context.Repository = context.WorkflowRepository
+		context.WorkflowSHA = authoritySHA
+
+		if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+			t.Fatalf("Evaluate() error = nil for workflow SHA %q, want self-reviewing authority context error", authoritySHA)
+		}
+	}
+}
+
+func TestEvaluateRejectsAmbiguousReviewerIdentity(t *testing.T) {
+	context := validContext()
+	context.RequiredReviewers[0].Provider = "anthropic/team"
+
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want ambiguous reviewer identity error")
+	}
+}
+
+func TestEvaluatePermitIDIsIndependentOfInputReviewOrder(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	first, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate(first) error = %v", err)
+	}
+	reversed := []Review{reviews[1], reviews[0]}
+	second, err := Evaluate(context, testContextSHA, reversed)
+	if err != nil {
+		t.Fatalf("Evaluate(second) error = %v", err)
+	}
+	if first.PermitID != second.PermitID {
+		t.Fatalf("PermitID differs by input order: %q != %q", first.PermitID, second.PermitID)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("permits differ by input order:\nfirst: %#v\nsecond: %#v", first, second)
+	}
+}
+
+func TestEvaluateDeniesContextSubstitution(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].ContextSHA256 = "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_CONTEXT_MISMATCH")
+}
+
+func TestEvaluateDeniesNilFindings(t *testing.T) {
+	context := validContext()
+	reviews := validReviews(context)
+	reviews[0].Findings = nil
+
+	permit, err := Evaluate(context, testContextSHA, reviews)
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	assertDeniedFor(t, permit, "REVIEW_FINDINGS_INVALID")
+}
+
+func TestEvaluateDeniesInvalidReviewFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Review)
+		code   string
+	}{
+		{
+			name: "empty reviewer",
+			mutate: func(review *Review) {
+				review.Reviewer.Provider = ""
+			},
+			code: "REVIEW_REVIEWER_INVALID",
+		},
+		{
+			name: "invalid verdict",
+			mutate: func(review *Review) {
+				review.Verdict = "MAYBE"
+			},
+			code: "REVIEW_VERDICT_INVALID",
+		},
+		{
+			name: "denied verdict",
+			mutate: func(review *Review) {
+				review.Verdict = DecisionDeny
+			},
+			code: "REVIEW_DENIED",
+		},
+		{
+			name: "invalid response digest",
+			mutate: func(review *Review) {
+				review.ResponseSHA256 = "not-a-digest"
+			},
+			code: "REVIEW_DIGEST_INVALID",
+		},
+		{
+			name: "invalid finding severity",
+			mutate: func(review *Review) {
+				review.Findings = []Finding{{Severity: "P4", Code: "BAD", Summary: "invalid severity"}}
+			},
+			code: "REVIEW_FINDINGS_INVALID",
+		},
+		{
+			name: "too many findings",
+			mutate: func(review *Review) {
+				review.Findings = make([]Finding, 201)
+			},
+			code: "REVIEW_FINDINGS_INVALID",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context := validContext()
+			reviews := validReviews(context)
+			test.mutate(&reviews[0])
+			permit, err := Evaluate(context, testContextSHA, reviews)
+			if err != nil {
+				t.Fatalf("Evaluate() error = %v", err)
+			}
+			assertDeniedFor(t, permit, test.code)
+		})
+	}
+}
+
+func validContext() Context {
+	return Context{
+		Schema:             ContextSchema,
+		Repository:         "Mindburn-Labs/example",
+		Event:              "pull_request",
+		PullRequest:        42,
+		BaseRef:            "refs/heads/main",
+		BaseSHA:            testBaseSHA,
+		HeadSHA:            testHeadSHA,
+		MergeSHA:           testMergeSHA,
+		MergeTreeSHA:       testMergeTree,
+		WorkflowRepository: "Mindburn-Labs/.github",
+		WorkflowPath:       ".github/workflows/autonomous-release-permit.yml",
+		WorkflowRef:        "refs/heads/main",
+		WorkflowSHA:        testWorkflowSHA,
+		RunID:              101,
+		RunAttempt:         1,
+		IssuedAt:           "2026-07-14T10:00:00Z",
+		RequiredReviewers: []Reviewer{
+			{Provider: "anthropic", Model: "claude-fable-5"},
+			{Provider: "openai", Model: "gpt-5.6-sol"},
+		},
+	}
+}
+
+func validReviews(context Context) []Review {
+	return []Review{
+		validReview(context, context.RequiredReviewers[0], testResponseA),
+		validReview(context, context.RequiredReviewers[1], testResponseB),
+	}
+}
+
+func validReview(context Context, reviewer Reviewer, digest string) Review {
+	return Review{
+		Schema:         ReviewSchema,
+		Repository:     context.Repository,
+		PullRequest:    context.PullRequest,
+		BaseSHA:        context.BaseSHA,
+		HeadSHA:        context.HeadSHA,
+		MergeSHA:       context.MergeSHA,
+		MergeTreeSHA:   context.MergeTreeSHA,
+		WorkflowSHA:    context.WorkflowSHA,
+		RunID:          context.RunID,
+		RunAttempt:     context.RunAttempt,
+		ContextSHA256:  testContextSHA,
+		Reviewer:       reviewer,
+		Verdict:        DecisionAllow,
+		ResponseSHA256: digest,
+		Findings:       []Finding{},
+	}
+}
+
+func assertDeniedFor(t *testing.T, permit Permit, code string) {
+	t.Helper()
+	if permit.Decision != DecisionDeny {
+		t.Fatalf("Decision = %q, want %q", permit.Decision, DecisionDeny)
+	}
+	for _, reason := range permit.Reasons {
+		if reason.Code == code {
+			return
+		}
+	}
+	t.Fatalf("reasons %#v do not contain %q", permit.Reasons, code)
+}

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -313,6 +313,25 @@ func TestValidateAllowPermitRejectsDigestOrQuorumSubstitution(t *testing.T) {
 	}
 }
 
+func TestValidateAllowPermitRejectsRecomputedKernelSelfPin(t *testing.T) {
+	context := validContext()
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	for _, kernelSHA := range []string{testHeadSHA, testMergeSHA} {
+		candidate := permit
+		candidate.Authority.KernelSHA = kernelSHA
+		candidate.PermitID, err = calculatePermitID(candidate)
+		if err != nil {
+			t.Fatalf("calculatePermitID() error = %v", err)
+		}
+		if err := ValidateAllowPermit(candidate); err == nil {
+			t.Fatalf("ValidateAllowPermit() error = nil for recomputed Kernel SHA %q", kernelSHA)
+		}
+	}
+}
+
 func TestEvaluateDeniesContextSubstitution(t *testing.T) {
 	context := validContext()
 	reviews := validReviews(context)

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -245,6 +245,51 @@ func TestEvaluatePermitIDIsIndependentOfInputReviewOrder(t *testing.T) {
 	}
 }
 
+func TestValidateAllowPermitAcceptsReducerOutput(t *testing.T) {
+	context := validContext()
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if err := ValidateAllowPermit(permit); err != nil {
+		t.Fatalf("ValidateAllowPermit() error = %v", err)
+	}
+}
+
+func TestValidateAllowPermitRejectsDigestOrQuorumSubstitution(t *testing.T) {
+	context := validContext()
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*Permit)
+	}{
+		{
+			name: "digest",
+			mutate: func(candidate *Permit) {
+				candidate.HeadSHA = testBaseSHA
+			},
+		},
+		{
+			name: "duplicate provider",
+			mutate: func(candidate *Permit) {
+				candidate.Reviews[1].Reviewer.Provider = candidate.Reviews[0].Reviewer.Provider
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := permit
+			candidate.Reviews = append([]ReviewSummary(nil), permit.Reviews...)
+			test.mutate(&candidate)
+			if err := ValidateAllowPermit(candidate); err == nil {
+				t.Fatal("ValidateAllowPermit() error = nil, want rejection")
+			}
+		})
+	}
+}
+
 func TestEvaluateDeniesContextSubstitution(t *testing.T) {
 	context := validContext()
 	reviews := validReviews(context)

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -160,6 +160,27 @@ func TestEvaluateRejectsSelfReviewingAuthorityContext(t *testing.T) {
 	}
 }
 
+func TestEvaluateRejectsCaseAliasedProviderQuorum(t *testing.T) {
+	context := validContext()
+	context.RequiredReviewers[1].Provider = "Anthropic"
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want non-canonical provider rejection")
+	}
+}
+
+func TestEvaluateRejectsNonBootstrapKernelSelfPin(t *testing.T) {
+	context := validContext()
+	context.Authority.KernelSHA = context.HeadSHA
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want target-head Kernel rejection")
+	}
+	context.Authority.Generation = 1
+	context.Authority.Parent = nil
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err != nil {
+		t.Fatalf("generation 1 bootstrap Evaluate() error = %v", err)
+	}
+}
+
 func TestEvaluateRejectsBrokenAuthorityLineage(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -158,6 +158,62 @@ func TestEvaluateRejectsSelfReviewingAuthorityContext(t *testing.T) {
 	}
 }
 
+func TestEvaluateRejectsBrokenAuthorityLineage(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Context)
+	}{
+		{
+			name: "missing parent",
+			mutate: func(context *Context) {
+				context.Authority.Parent = nil
+			},
+		},
+		{
+			name: "skipped generation",
+			mutate: func(context *Context) {
+				context.Authority.Parent.Generation = 7
+			},
+		},
+		{
+			name: "self parent",
+			mutate: func(context *Context) {
+				context.Authority.Parent.WorkflowSHA = context.WorkflowSHA
+			},
+		},
+		{
+			name: "invalid corpus digest",
+			mutate: func(context *Context) {
+				context.Authority.AdversarialCorpusSHA256 = "not-a-digest"
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			context := validContext()
+			test.mutate(&context)
+			if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+				t.Fatal("Evaluate() error = nil, want invalid authority lineage error")
+			}
+		})
+	}
+}
+
+func TestEvaluateAllowsBootstrapAuthorityGeneration(t *testing.T) {
+	context := validContext()
+	context.Authority.Generation = 1
+	context.Authority.Parent = nil
+
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if permit.Decision != DecisionAllow {
+		t.Fatalf("Decision = %q, want %q", permit.Decision, DecisionAllow)
+	}
+}
+
 func TestEvaluateRejectsAmbiguousReviewerIdentity(t *testing.T) {
 	context := validContext()
 	context.RequiredReviewers[0].Provider = "anthropic/team"
@@ -293,6 +349,17 @@ func validContext() Context {
 		RunID:              101,
 		RunAttempt:         1,
 		IssuedAt:           "2026-07-14T10:00:00Z",
+		Authority: Authority{
+			Schema:                  AuthoritySchema,
+			Generation:              2,
+			KernelSHA:               "6666666666666666666666666666666666666666",
+			GateProfilesSHA256:      "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			AdversarialCorpusSHA256: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			Parent: &AuthorityParent{
+				Generation:  1,
+				WorkflowSHA: "7777777777777777777777777777777777777777",
+			},
+		},
 		RequiredReviewers: []Reviewer{
 			{Provider: "anthropic", Model: "claude-fable-5"},
 			{Provider: "openai", Model: "gpt-5.6-sol"},

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -169,15 +169,17 @@ func TestEvaluateRejectsCaseAliasedProviderQuorum(t *testing.T) {
 }
 
 func TestEvaluateRejectsNonBootstrapKernelSelfPin(t *testing.T) {
-	context := validContext()
-	context.Authority.KernelSHA = context.HeadSHA
-	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
-		t.Fatal("Evaluate() error = nil, want target-head Kernel rejection")
-	}
-	context.Authority.Generation = 1
-	context.Authority.Parent = nil
-	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err != nil {
-		t.Fatalf("generation 1 bootstrap Evaluate() error = %v", err)
+	for _, kernelSHA := range []string{testHeadSHA, testMergeSHA} {
+		context := validContext()
+		context.Authority.KernelSHA = kernelSHA
+		if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+			t.Fatalf("Evaluate() error = nil for Kernel SHA %q, want target-tree Kernel rejection", kernelSHA)
+		}
+		context.Authority.Generation = 1
+		context.Authority.Parent = nil
+		if _, err := Evaluate(context, testContextSHA, validReviews(context)); err != nil {
+			t.Fatalf("generation 1 bootstrap Evaluate() error = %v", err)
+		}
 	}
 }
 

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -2,6 +2,7 @@ package releasepermit
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -274,7 +275,7 @@ func TestValidateAllowPermitAcceptsReducerOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Evaluate() error = %v", err)
 	}
-	if err := ValidateAllowPermit(permit); err != nil {
+	if err := ValidateAllowPermit(permit, context, testContextSHA); err != nil {
 		t.Fatalf("ValidateAllowPermit() error = %v", err)
 	}
 }
@@ -306,7 +307,7 @@ func TestValidateAllowPermitRejectsDigestOrQuorumSubstitution(t *testing.T) {
 			candidate := permit
 			candidate.Reviews = append([]ReviewSummary(nil), permit.Reviews...)
 			test.mutate(&candidate)
-			if err := ValidateAllowPermit(candidate); err == nil {
+			if err := ValidateAllowPermit(candidate, context, testContextSHA); err == nil {
 				t.Fatal("ValidateAllowPermit() error = nil, want rejection")
 			}
 		})
@@ -326,9 +327,43 @@ func TestValidateAllowPermitRejectsRecomputedKernelSelfPin(t *testing.T) {
 		if err != nil {
 			t.Fatalf("calculatePermitID() error = %v", err)
 		}
-		if err := ValidateAllowPermit(candidate); err == nil {
+		if err := ValidateAllowPermit(candidate, context, testContextSHA); err == nil {
 			t.Fatalf("ValidateAllowPermit() error = nil for recomputed Kernel SHA %q", kernelSHA)
 		}
+	}
+}
+
+func TestValidateAllowPermitRejectsRecomputedContextSubstitution(t *testing.T) {
+	context := validContext()
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	permit.HeadSHA = testBaseSHA
+	permit.PermitID, err = calculatePermitID(permit)
+	if err != nil {
+		t.Fatalf("calculatePermitID() error = %v", err)
+	}
+	if err := ValidateAllowPermit(permit, context, testContextSHA); err == nil ||
+		!strings.Contains(err.Error(), "head_sha does not match the trusted context") {
+		t.Fatalf("ValidateAllowPermit() error = %v, want trusted context rejection", err)
+	}
+}
+
+func TestValidateAllowPermitRejectsRecomputedReviewerSubstitution(t *testing.T) {
+	context := validContext()
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	permit.Reviews[1].Reviewer.Model = "substituted-model"
+	permit.PermitID, err = calculatePermitID(permit)
+	if err != nil {
+		t.Fatalf("calculatePermitID() error = %v", err)
+	}
+	if err := ValidateAllowPermit(permit, context, testContextSHA); err == nil ||
+		!strings.Contains(err.Error(), "reviewer is not in the trusted context quorum") {
+		t.Fatalf("ValidateAllowPermit() error = %v, want trusted quorum rejection", err)
 	}
 }
 

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -147,13 +147,15 @@ func TestEvaluateRejectsMismatchedGitHubWorkflowRefIdentity(t *testing.T) {
 }
 
 func TestEvaluateRejectsSelfReviewingAuthorityContext(t *testing.T) {
-	for _, authoritySHA := range []string{testHeadSHA, testMergeSHA} {
-		context := validContext()
-		context.Repository = context.WorkflowRepository
-		context.WorkflowSHA = authoritySHA
+	for _, repository := range []string{"Mindburn-Labs/.github", "MINDBURN-LABS/.GITHUB"} {
+		for _, authoritySHA := range []string{testHeadSHA, testMergeSHA} {
+			context := validContext()
+			context.Repository = repository
+			context.WorkflowSHA = authoritySHA
 
-		if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
-			t.Fatalf("Evaluate() error = nil for workflow SHA %q, want self-reviewing authority context error", authoritySHA)
+			if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+				t.Fatalf("Evaluate() error = nil for repository %q and workflow SHA %q, want self-reviewing authority context error", repository, authoritySHA)
+			}
 		}
 	}
 }

--- a/core/pkg/releasepermit/types.go
+++ b/core/pkg/releasepermit/types.go
@@ -4,13 +4,33 @@
 package releasepermit
 
 const (
-	ContextSchema = "mindburn.release-permit-context/v1"
-	ReviewSchema  = "mindburn.release-review/v1"
-	PermitSchema  = "mindburn.release-permit/v1"
+	ContextSchema   = "mindburn.release-permit-context/v2"
+	ReviewSchema    = "mindburn.release-review/v1"
+	PermitSchema    = "mindburn.release-permit/v2"
+	AuthoritySchema = "mindburn.release-authority/v1"
 
 	DecisionAllow = "ALLOW"
 	DecisionDeny  = "DENY"
 )
+
+// AuthorityParent identifies the immediately preceding immutable workflow
+// generation. The previous generation must review and ratify the complete next
+// generation before an external promotion broker advances the ruleset pin.
+type AuthorityParent struct {
+	Generation  int64  `json:"generation"`
+	WorkflowSHA string `json:"workflow_sha"`
+}
+
+// Authority binds the workflow generation to the exact Kernel verifier and
+// source-owned deterministic/adversarial policy inputs it executes.
+type Authority struct {
+	Schema                  string           `json:"schema"`
+	Generation              int64            `json:"generation"`
+	KernelSHA               string           `json:"kernel_sha"`
+	GateProfilesSHA256      string           `json:"gate_profiles_sha256"`
+	AdversarialCorpusSHA256 string           `json:"adversarial_corpus_sha256"`
+	Parent                  *AuthorityParent `json:"parent"`
+}
 
 // Reviewer identifies one independently executed model review lane.
 type Reviewer struct {
@@ -37,6 +57,7 @@ type Context struct {
 	RunID              int64      `json:"run_id"`
 	RunAttempt         int64      `json:"run_attempt"`
 	IssuedAt           string     `json:"issued_at"`
+	Authority          Authority  `json:"authority"`
 	RequiredReviewers  []Reviewer `json:"required_reviewers"`
 }
 
@@ -106,6 +127,7 @@ type Permit struct {
 	RunID              int64           `json:"run_id"`
 	RunAttempt         int64           `json:"run_attempt"`
 	IssuedAt           string          `json:"issued_at"`
+	Authority          Authority       `json:"authority"`
 	ContextSHA256      string          `json:"context_sha256"`
 	Reviews            []ReviewSummary `json:"reviews"`
 	Reasons            []Reason        `json:"reasons"`

--- a/core/pkg/releasepermit/types.go
+++ b/core/pkg/releasepermit/types.go
@@ -1,0 +1,112 @@
+// Package releasepermit reduces independent, commit-bound AI review results
+// into a deterministic release decision. Model output is advisory until this
+// reducer validates the complete review quorum and its GitHub workflow binding.
+package releasepermit
+
+const (
+	ContextSchema = "mindburn.release-permit-context/v1"
+	ReviewSchema  = "mindburn.release-review/v1"
+	PermitSchema  = "mindburn.release-permit/v1"
+
+	DecisionAllow = "ALLOW"
+	DecisionDeny  = "DENY"
+)
+
+// Reviewer identifies one independently executed model review lane.
+type Reviewer struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// Context binds a permit to the exact pull request, commit, policy workflow,
+// and GitHub Actions execution that requested it.
+type Context struct {
+	Schema             string     `json:"schema"`
+	Repository         string     `json:"repository"`
+	Event              string     `json:"event"`
+	PullRequest        int64      `json:"pull_request"`
+	BaseRef            string     `json:"base_ref"`
+	BaseSHA            string     `json:"base_sha"`
+	HeadSHA            string     `json:"head_sha"`
+	MergeSHA           string     `json:"merge_sha"`
+	MergeTreeSHA       string     `json:"merge_tree_sha"`
+	WorkflowRepository string     `json:"workflow_repository"`
+	WorkflowPath       string     `json:"workflow_path"`
+	WorkflowRef        string     `json:"workflow_ref"`
+	WorkflowSHA        string     `json:"workflow_sha"`
+	RunID              int64      `json:"run_id"`
+	RunAttempt         int64      `json:"run_attempt"`
+	IssuedAt           string     `json:"issued_at"`
+	RequiredReviewers  []Reviewer `json:"required_reviewers"`
+}
+
+// Finding is one model-reported issue. P0-P2 findings block a permit; P3 is
+// retained as advisory evidence.
+type Finding struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Summary  string `json:"summary"`
+	Path     string `json:"path,omitempty"`
+	Line     int    `json:"line,omitempty"`
+}
+
+// Review is the protected workflow envelope around one model response.
+type Review struct {
+	Schema         string    `json:"schema"`
+	Repository     string    `json:"repository"`
+	PullRequest    int64     `json:"pull_request"`
+	BaseSHA        string    `json:"base_sha"`
+	HeadSHA        string    `json:"head_sha"`
+	MergeSHA       string    `json:"merge_sha"`
+	MergeTreeSHA   string    `json:"merge_tree_sha"`
+	WorkflowSHA    string    `json:"workflow_sha"`
+	RunID          int64     `json:"run_id"`
+	RunAttempt     int64     `json:"run_attempt"`
+	ContextSHA256  string    `json:"context_sha256"`
+	Reviewer       Reviewer  `json:"reviewer"`
+	Verdict        string    `json:"verdict"`
+	ResponseSHA256 string    `json:"response_sha256"`
+	Findings       []Finding `json:"findings"`
+}
+
+// Reason records one deterministic cause for a denied permit.
+type Reason struct {
+	Code     string `json:"code"`
+	Reviewer string `json:"reviewer,omitempty"`
+	Detail   string `json:"detail"`
+}
+
+// ReviewSummary retains the model identity and response digest without
+// treating raw model prose as an authorization record.
+type ReviewSummary struct {
+	Reviewer         Reviewer `json:"reviewer"`
+	Verdict          string   `json:"verdict"`
+	ResponseSHA256   string   `json:"response_sha256"`
+	BlockingFindings int      `json:"blocking_findings"`
+	AdvisoryFindings int      `json:"advisory_findings"`
+}
+
+// Permit is the deterministic output consumed by a required GitHub workflow.
+// PermitID is a SHA-256 digest over the same structure with PermitID empty.
+type Permit struct {
+	Schema             string          `json:"schema"`
+	PermitID           string          `json:"permit_id"`
+	Decision           string          `json:"decision"`
+	Repository         string          `json:"repository"`
+	PullRequest        int64           `json:"pull_request"`
+	BaseRef            string          `json:"base_ref"`
+	BaseSHA            string          `json:"base_sha"`
+	HeadSHA            string          `json:"head_sha"`
+	MergeSHA           string          `json:"merge_sha"`
+	MergeTreeSHA       string          `json:"merge_tree_sha"`
+	WorkflowRepository string          `json:"workflow_repository"`
+	WorkflowPath       string          `json:"workflow_path"`
+	WorkflowRef        string          `json:"workflow_ref"`
+	WorkflowSHA        string          `json:"workflow_sha"`
+	RunID              int64           `json:"run_id"`
+	RunAttempt         int64           `json:"run_attempt"`
+	IssuedAt           string          `json:"issued_at"`
+	ContextSHA256      string          `json:"context_sha256"`
+	Reviews            []ReviewSummary `json:"reviews"`
+	Reasons            []Reason        `json:"reasons"`
+}


### PR DESCRIPTION
## Summary

- Accept a SHA-form `workflow_ref` only when it exactly equals the already trusted `workflow_sha`.
- Apply the same rule to both live context validation and serialized ALLOW-permit validation.
- Keep branch and tag refs valid; reject any other SHA or ambiguous reference.

## Context

The active immutable permit workflow is pinned at `c585fc546d398c183f71bf5b4f66fa2d90c57e35` and reports the workflow reference as that immutable SHA. The verifier previously accepted only branch or tag references, so it rejected the trusted immutable source form.

## Validation

- `go test ./core/pkg/releasepermit ./core/cmd/release-permit-verify -count=1`

Refs HELM-329
