### PR TITLE
fix(tracing): proxy SSE correlation echo + observability follow-ups (HELM-325/333/345)

### DIFF
--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -193,7 +193,7 @@ func runServerWithOptions(opts serverOptions) error {
 	// handler must be an explicit sink handler: wrapping the stdlib bridge
 	// (slog.Default().Handler()) and re-SetDefault-ing creates a log→slog→log
 	// cycle that deadlocks the first log.Printf at boot.
-	logger := slog.New(tracing.NewSlogHandler(slog.NewTextHandler(os.Stderr, nil)))
+	logger := slog.New(tracing.NewSlogHandler(slog.NewTextHandler(opts.Stderr, nil)))
 	slog.SetDefault(logger)
 	dataDir := opts.DataDir
 	if dataDir == "" {

--- a/core/cmd/helm-ai-kernel/proxy_cmd.go
+++ b/core/cmd/helm-ai-kernel/proxy_cmd.go
@@ -573,6 +573,13 @@ func runProxyCmd(args []string, stdout, stderr io.Writer) int {
 			}
 		},
 		ModifyResponse: func(resp *http.Response) error {
+			// The correlation ID is a client-visible join key for both regular
+			// responses and SSE streams, which return before receipt creation.
+			correlationID, _ := resp.Request.Context().Value(ctxKeyCorrelationID).(string)
+			if correlationID != "" {
+				resp.Header.Set("X-Helm-Correlation-ID", correlationID)
+			}
+
 			// Detect SSE streaming response
 			contentType := resp.Header.Get("Content-Type")
 			isSSE := strings.Contains(contentType, "text/event-stream")
@@ -604,7 +611,6 @@ func runProxyCmd(args []string, stdout, stderr io.Writer) int {
 
 			// Pull per-request governance state stashed by Director.
 			reqCtx := resp.Request.Context()
-			correlationID, _ := reqCtx.Value(ctxKeyCorrelationID).(string)
 			requestModel, _ := reqCtx.Value(ctxKeyRequestModel).(string)
 			traceparent, _ := reqCtx.Value(ctxKeyTraceparent).(string)
 
@@ -813,9 +819,6 @@ func runProxyCmd(args []string, stdout, stderr io.Writer) int {
 			resp.Header.Set("X-Helm-Output-Hash", rcpt.OutputHash)
 			resp.Header.Set("X-Helm-Lamport-Clock", fmt.Sprintf("%d", rcpt.LamportClock))
 			resp.Header.Set("X-Helm-Status", rcpt.Status)
-			if correlationID != "" {
-				resp.Header.Set("X-Helm-Correlation-ID", correlationID)
-			}
 			if traceparent != "" {
 				resp.Header.Set("traceparent", traceparent)
 			}

--- a/core/cmd/helm-ai-kernel/proxy_live_test.go
+++ b/core/cmd/helm-ai-kernel/proxy_live_test.go
@@ -307,6 +307,9 @@ func runLocalDenyTamperProof(t *testing.T) redactedDenyTamperProof {
 	assertReceiptHeaders(t, resp.Header, "DENIED")
 
 	receipt := readLatestProxyReceipt(t, proxy.receiptsDir)
+	if receipt.CorrelationID != resp.Header.Get("X-Helm-Correlation-ID") {
+		t.Fatalf("correlation id mismatch: receipt=%s header=%s", receipt.CorrelationID, resp.Header.Get("X-Helm-Correlation-ID"))
+	}
 	if receipt.Status != "DENIED" {
 		t.Fatalf("deny receipt status = %s", receipt.Status)
 	}
@@ -340,6 +343,52 @@ func runLocalDenyTamperProof(t *testing.T) redactedDenyTamperProof {
 		SignaturePayloadChanged:       originalSignaturePayload != tamperedSignaturePayload,
 		SignaturePresent:              receipt.Signature != "",
 		ReceiptHashChangedAfterTamper: originalHash != tamperedHash,
+	}
+}
+
+func TestLiveProxyEchoesMintedCorrelationIDForSSE(t *testing.T) {
+	var upstreamCorrelationID string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" || r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		if r.URL.Path != "/v1/chat/completions" {
+			http.NotFound(w, r)
+			return
+		}
+		upstreamCorrelationID = r.Header.Get("X-Helm-Correlation-ID")
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-sse\"}\n\n"))
+	}))
+	defer upstream.Close()
+
+	proxy := startLiveProxy(t, upstream.URL+"/v1", "fixture-key", "live-proxy-sse-fixture")
+	req, err := http.NewRequest(http.MethodPost, proxy.baseURL+"/v1/chat/completions", strings.NewReader(`{"model":"helm-local-sse-fixture","stream":true}`))
+	if err != nil {
+		t.Fatalf("build SSE request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Helm-Correlation-ID", "not-a-canonical-uuid")
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatalf("post SSE fixture through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("read SSE response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("SSE fixture status = %d", resp.StatusCode)
+	}
+	correlationID := resp.Header.Get("X-Helm-Correlation-ID")
+	if correlationID == "" || correlationID == "not-a-canonical-uuid" {
+		t.Fatalf("SSE response did not echo a minted correlation id: %q", correlationID)
+	}
+	if correlationID != upstreamCorrelationID {
+		t.Fatalf("SSE correlation id mismatch: response=%s upstream=%s", correlationID, upstreamCorrelationID)
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/proxy_live_test.go
+++ b/core/cmd/helm-ai-kernel/proxy_live_test.go
@@ -347,7 +347,9 @@ func runLocalDenyTamperProof(t *testing.T) redactedDenyTamperProof {
 }
 
 func TestLiveProxyEchoesMintedCorrelationIDForSSE(t *testing.T) {
-	var upstreamCorrelationID string
+	// Handler goroutine → test goroutine handoff; a plain shared variable
+	// here is a data race under -race.
+	upstreamCorrelationIDs := make(chan string, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthz" || r.URL.Path == "/health" {
 			w.Header().Set("Content-Type", "application/json")
@@ -358,7 +360,10 @@ func TestLiveProxyEchoesMintedCorrelationIDForSSE(t *testing.T) {
 			http.NotFound(w, r)
 			return
 		}
-		upstreamCorrelationID = r.Header.Get("X-Helm-Correlation-ID")
+		select {
+		case upstreamCorrelationIDs <- r.Header.Get("X-Helm-Correlation-ID"):
+		default:
+		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl-sse\"}\n\n"))
 	}))
@@ -386,6 +391,12 @@ func TestLiveProxyEchoesMintedCorrelationIDForSSE(t *testing.T) {
 	correlationID := resp.Header.Get("X-Helm-Correlation-ID")
 	if correlationID == "" || correlationID == "not-a-canonical-uuid" {
 		t.Fatalf("SSE response did not echo a minted correlation id: %q", correlationID)
+	}
+	var upstreamCorrelationID string
+	select {
+	case upstreamCorrelationID = <-upstreamCorrelationIDs:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream never received the chat completion request")
 	}
 	if correlationID != upstreamCorrelationID {
 		t.Fatalf("SSE correlation id mismatch: response=%s upstream=%s", correlationID, upstreamCorrelationID)

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -134,13 +134,22 @@ func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logg
 	logger.Info("subsystem ready", "component", " Config loaded")
 
 	// --- 2. Observability ---
-	obsCfg := observability.DefaultConfig()
-	obs, err := observability.New(ctx, obsCfg)
-	if err != nil {
-		logger.Warn("Observability init skipped (no OTLP endpoint)", "error", err)
+	// Inert unless an OTLP endpoint is explicitly configured — same posture
+	// as the edge tracing and the console (unset = no exporter). Without this
+	// gate the default localhost:4317 exporter dials a collector that doesn't
+	// exist and logs an export failure every 15s.
+	if endpoint := otlpEndpointFromEnv(); endpoint == "" {
+		logger.Info("Observability init skipped (no OTLP endpoint configured)")
 	} else {
-		s.Observability = obs
-		logger.Info("subsystem ready", "component", " Observability provider initialized")
+		obsCfg := observability.DefaultConfig()
+		obsCfg.OTLPEndpoint = endpoint
+		obs, err := observability.New(ctx, obsCfg)
+		if err != nil {
+			logger.Warn("Observability init failed", "error", err)
+		} else {
+			s.Observability = obs
+			logger.Info("subsystem ready", "component", " Observability provider initialized")
+		}
 	}
 
 	// --- 3. Authorization ---
@@ -203,10 +212,11 @@ func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logg
 	// Pack execution is fail-closed until a PackVerifier (trust.PackLoader
 	// with TUF roots) is configured; the nil verifier is that explicit
 	// posture, not an oversight — Run refuses with ERR_PACK_TRUST_UNVERIFIED.
-	s.Sandbox, err = sandbox.NewWasiSandboxWithVerifier(ctx, artStore, sandboxConfig, nil)
+	wasiSandbox, err := sandbox.NewWasiSandboxWithVerifier(ctx, artStore, sandboxConfig, nil)
 	if err != nil {
 		return nil, fmt.Errorf("sandbox init: %w", err)
 	}
+	s.Sandbox = wasiSandbox
 	logger.Info("subsystem ready", "component", " Sandbox initialized (pack execution fail-closed: no PackVerifier configured)")
 
 	// --- 7. Boundary ---
@@ -374,4 +384,14 @@ func evidenceSigningSeedFromEnv() (string, bool, error) {
 		return "", false, fmt.Errorf("production mode requires EVIDENCE_SIGNING_KEY")
 	}
 	return "helm-evidence-bundle", true, nil
+}
+
+// otlpEndpointFromEnv returns the OTLP gRPC target from the standard
+// OTEL_EXPORTER_OTLP_ENDPOINT variable, or "" when unset. The env value may
+// carry a URL scheme; the gRPC exporters want host:port.
+func otlpEndpointFromEnv() string {
+	endpoint := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	endpoint = strings.TrimPrefix(endpoint, "https://")
+	endpoint = strings.TrimPrefix(endpoint, "http://")
+	return strings.TrimSuffix(endpoint, "/")
 }

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -396,9 +396,13 @@ func evidenceSigningSeedFromEnv() (string, bool, error) {
 // to insecure rather than be silently dropped.
 func otlpEndpointFromEnv() (endpoint string, insecure bool) {
 	endpoint = strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
-	if rest, ok := strings.CutPrefix(endpoint, "http://"); ok {
-		return strings.TrimSuffix(rest, "/"), true
+	endpoint, insecure = strings.CutPrefix(endpoint, "http://")
+	if !insecure {
+		endpoint = strings.TrimPrefix(endpoint, "https://")
 	}
-	endpoint = strings.TrimPrefix(endpoint, "https://")
-	return strings.TrimSuffix(endpoint, "/"), false
+	// URL forms may carry a path/query; the gRPC exporters want pure host:port.
+	if host, _, ok := strings.Cut(endpoint, "/"); ok {
+		endpoint = host
+	}
+	return endpoint, insecure
 }

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -138,11 +138,14 @@ func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logg
 	// as the edge tracing and the console (unset = no exporter). Without this
 	// gate the default localhost:4317 exporter dials a collector that doesn't
 	// exist and logs an export failure every 15s.
-	if endpoint := otlpEndpointFromEnv(); endpoint == "" {
+	if endpoint, insecure := otlpEndpointFromEnv(); endpoint == "" {
 		logger.Info("Observability init skipped (no OTLP endpoint configured)")
 	} else {
 		obsCfg := observability.DefaultConfig()
 		obsCfg.OTLPEndpoint = endpoint
+		if insecure {
+			obsCfg.Insecure = true
+		}
 		obs, err := observability.New(ctx, obsCfg)
 		if err != nil {
 			logger.Warn("Observability init failed", "error", err)
@@ -388,10 +391,14 @@ func evidenceSigningSeedFromEnv() (string, bool, error) {
 
 // otlpEndpointFromEnv returns the OTLP gRPC target from the standard
 // OTEL_EXPORTER_OTLP_ENDPOINT variable, or "" when unset. The env value may
-// carry a URL scheme; the gRPC exporters want host:port.
-func otlpEndpointFromEnv() string {
-	endpoint := strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+// carry a URL scheme; the gRPC exporters want host:port, and an explicit
+// http:// scheme means a plaintext collector, so it must flip the connection
+// to insecure rather than be silently dropped.
+func otlpEndpointFromEnv() (endpoint string, insecure bool) {
+	endpoint = strings.TrimSpace(os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	if rest, ok := strings.CutPrefix(endpoint, "http://"); ok {
+		return strings.TrimSuffix(rest, "/"), true
+	}
 	endpoint = strings.TrimPrefix(endpoint, "https://")
-	endpoint = strings.TrimPrefix(endpoint, "http://")
-	return strings.TrimSuffix(endpoint, "/")
+	return strings.TrimSuffix(endpoint, "/"), false
 }

--- a/core/pkg/metrics/label_policy_test.go
+++ b/core/pkg/metrics/label_policy_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -54,6 +56,31 @@ var expositionBlockRe = regexp.MustCompile(`\{([^{}\n]*=\s*["']?%[^{}\n]*)\}`)
 // quotes in the format string (`{tool=%q,correlation_id="%s"}`).
 var expositionLabelRe = regexp.MustCompile(`(\w+)\s*=\s*["']?%`)
 
+func scanDecodedExpositionStringLiterals(fset *token.FileSet, f *ast.File, report func(string, string)) error {
+	var unquoteErr error
+	ast.Inspect(f, func(n ast.Node) bool {
+		if unquoteErr != nil {
+			return false
+		}
+		basic, ok := n.(*ast.BasicLit)
+		if !ok || basic.Kind != token.STRING {
+			return true
+		}
+		value, err := strconv.Unquote(basic.Value)
+		if err != nil {
+			unquoteErr = fmt.Errorf("decode string literal at %s: %w", fset.Position(basic.Pos()), err)
+			return false
+		}
+		for _, block := range expositionBlockRe.FindAllStringSubmatch(value, -1) {
+			for _, match := range expositionLabelRe.FindAllStringSubmatch(block[1], -1) {
+				report(fset.Position(basic.Pos()).String(), match[1])
+			}
+		}
+		return true
+	})
+	return unquoteErr
+}
+
 // TestNoProhibitedMetricLabels statically scans core/ for metric label
 // registrations — both prometheus *Vec constructors and hand-rolled
 // exposition format strings — and fails when a label name is on the
@@ -94,22 +121,22 @@ func TestNoProhibitedMetricLabels(t *testing.T) {
 			return err
 		}
 
-		// Hand-rolled exposition strings: helm_metric{label=%q}.
-		for _, block := range expositionBlockRe.FindAllSubmatch(src, -1) {
-			for _, m := range expositionLabelRe.FindAllSubmatch(block[1], -1) {
-				label := string(m[1])
-				seenLabels++
-				if prohibitedMetricLabels[label] {
-					violations = append(violations, finding{pos: path, label: label})
-				}
-			}
-		}
-
 		// prometheus *Vec constructors: the []string label-name argument.
 		// A parse failure fails the gate: silently skipping a file would
 		// exempt its metric registrations from the scan.
 		f, err := parser.ParseFile(fset, path, src, 0)
 		if err != nil {
+			return err
+		}
+		// Hand-rolled exposition strings: helm_metric{label=%q}. Decode only
+		// Go string literals before applying the bounded scan so every legal Go
+		// escape form is covered without scanning comments or arbitrary source.
+		if err := scanDecodedExpositionStringLiterals(fset, f, func(pos, label string) {
+			seenLabels++
+			if prohibitedMetricLabels[label] {
+				violations = append(violations, finding{pos: pos, label: label})
+			}
+		}); err != nil {
 			return err
 		}
 		ast.Inspect(f, func(n ast.Node) bool {
@@ -174,5 +201,34 @@ func TestNoProhibitedMetricLabels(t *testing.T) {
 
 	for _, v := range violations {
 		t.Errorf("prohibited metric label %q registered at %s (telemetry contract §6: request-scoped identity never becomes a metric label)", v.label, v.pos)
+	}
+}
+
+func TestDecodedExpositionStringLiteralsCatchEscapedQuotes(t *testing.T) {
+	tests := map[string]string{
+		"escaped quote": `package probe
+const metric = "helm_metric{correlation_id=\"%s\"}"`,
+		"hex quote": `package probe
+const metric = "helm_metric{correlation_id=\x22%s\x22}"`,
+	}
+
+	for name, source := range tests {
+		t.Run(name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "probe.go", source, 0)
+			if err != nil {
+				t.Fatalf("parse probe source: %v", err)
+			}
+
+			var labels []string
+			if err := scanDecodedExpositionStringLiterals(fset, f, func(_ string, label string) {
+				labels = append(labels, label)
+			}); err != nil {
+				t.Fatalf("scan decoded literals: %v", err)
+			}
+			if !slices.Contains(labels, "correlation_id") {
+				t.Fatalf("decoded scanner labels = %v, want correlation_id", labels)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Four small tracing follow-ups bundled into one CI pass, closing out the correlation/OTel work:

1. **Proxy echoes the correlation id before the SSE early-return** — cherry-picked from #653 (`sergey/helm-325-correlation-id-slice-v2`, authorship preserved). Closes `PROXY_CORRELATION_NOT_ECHOED`: SSE streams previously bypassed the response echo, so streaming callers never learned the minted id. Includes the header↔receipt equality assertion and the live proxy-child SSE test. Completes the §2.2 echo rule at the proxy edge (REST edge echoes since #643/#648). With this landed, #653 can be closed — its remaining commits are already on main via #643.
2. **Metric-label scanner decodes exposition literals** — also cherry-picked from #653 (refs HELM-329's scanner-hardening finding). Test-only.
3. **Root logger honors `opts.Stderr`** ([HELM-333](https://linear.app/mindburn/issue/HELM-333) follow-up from the #648 review thread) — one line.
4. **Observability init gated on an explicit OTLP endpoint** ([HELM-345](https://linear.app/mindburn/issue/HELM-345)): `DefaultConfig` dials `localhost:4317` and `New` never fails on a missing collector, so stands without one logged an export failure every 15s forever. Now: `OTEL_EXPORTER_OTLP_ENDPOINT` unset → one INFO skip line, no providers, no dialing — the same inert-by-default posture as the edge tracing (#648) and the console (app-helm-console#88). Boot A/B evidence: pre-gate log spams `failed to upload metrics: dial tcp 127.0.0.1:4317`; post-gate boots clean, `/health` in ~2s, zero export lines over 30s.

## Tests

- `go test ./core/cmd/helm-ai-kernel ./core/pkg/metrics ./core/pkg/tracing ./core/pkg/api` green; `go vet` clean; `gofmt` clean.
- Local boot verification for item 4 (logs in HELM-345).

Refs HELM-325, HELM-333, HELM-345, HELM-329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Vxjnf9PNiaTN1ceqDF9zt