### PR TITLE
feat(kernel): add generated spec approval ceremony foundation

### DIFF
--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
@@ -1,0 +1,749 @@
+// quantum_posture: this ceremony uses the GeneratedSpec approval contract's
+// classical Ed25519 signatures only. It makes no hybrid or post-quantum claim.
+// Package generatedspecapprovalceremony owns the source-side lifecycle for a
+// GeneratedSpec approval. Store is deliberately an interface: production must
+// provide durable, atomic transitions; the package's memory store is test-only.
+package generatedspecapprovalceremony
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapproval"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+type State string
+
+const (
+	StateHoldPending     State = "HOLD_PENDING"
+	StateChallengeIssued State = "CHALLENGE_ISSUED"
+	StateQuorumVerified  State = "QUORUM_VERIFIED"
+	StateGrantIssued     State = "GRANT_ISSUED"
+	StateConsumed        State = "CONSUMED"
+	StateDenied          State = "DENIED"
+	StateExpired         State = "EXPIRED"
+)
+
+var (
+	ErrInvalidRecord        = errors.New("generated spec approval ceremony record invalid")
+	ErrNotFound             = errors.New("generated spec approval ceremony not found")
+	ErrTransitionConflict   = errors.New("generated spec approval ceremony transition conflict")
+	ErrHoldPending          = errors.New("generated spec approval ceremony hold pending")
+	ErrExpired              = errors.New("generated spec approval ceremony expired")
+	ErrBindingUnavailable   = errors.New("generated spec approval ceremony binding unavailable")
+	ErrAuthorityUnavailable = errors.New("generated spec approval ceremony authority unavailable")
+	ErrControlUnavailable   = errors.New("generated spec approval ceremony control identity unavailable")
+	ErrConsumerUnavailable  = errors.New("generated spec approval ceremony consumer identity unavailable")
+)
+
+// Binding is the server-owned, immutable input to a challenge. Clients submit
+// only BindingRef to the provider; they never construct this value.
+type Binding struct {
+	BindingRef            string
+	TenantID              string
+	WorkspaceID           string
+	Audience              string
+	GeneratedSpecID       string
+	GeneratedSpecHash     string
+	ExecutionPlanHash     string
+	PlanTransactionHash   string
+	WriteSetHash          string
+	VerificationScopeHash string
+	PolicyEnvelopeHash    string
+	PolicyVersion         string
+	PolicyEpoch           string
+	Action                string
+	RequestingPrincipalID string
+	AuthoritySource       string
+	AuthorityVersion      string
+	AuthoritySnapshotHash string
+	RequiredRole          string
+	Quorum                int
+	ServerIdentity        string
+}
+
+func (b Binding) Validate() error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"binding_ref", b.BindingRef}, {"tenant_id", b.TenantID}, {"workspace_id", b.WorkspaceID},
+		{"generated_spec_id", b.GeneratedSpecID}, {"policy_version", b.PolicyVersion},
+		{"policy_epoch", b.PolicyEpoch}, {"requesting_principal_id", b.RequestingPrincipalID},
+		{"authority_source", b.AuthoritySource}, {"authority_version", b.AuthorityVersion},
+		{"required_role", b.RequiredRole}, {"server_identity", b.ServerIdentity},
+	} {
+		if !validToken(field.value) {
+			return invalidRecord("binding " + field.name + " is invalid")
+		}
+	}
+	if b.Audience != contracts.GeneratedSpecApprovalAudienceV1 || b.Action != contracts.GeneratedSpecApprovalActionV1 {
+		return invalidRecord("binding audience or action is unsupported")
+	}
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"generated_spec_hash", b.GeneratedSpecHash}, {"execution_plan_hash", b.ExecutionPlanHash},
+		{"plan_transaction_hash", b.PlanTransactionHash}, {"write_set_hash", b.WriteSetHash},
+		{"verification_scope_hash", b.VerificationScopeHash}, {"policy_envelope_hash", b.PolicyEnvelopeHash},
+		{"authority_snapshot_hash", b.AuthoritySnapshotHash},
+	} {
+		if !validSHA256(field.value) {
+			return invalidRecord("binding " + field.name + " is invalid")
+		}
+	}
+	if b.Quorum <= 0 {
+		return invalidRecord("binding quorum must be positive")
+	}
+	return nil
+}
+
+// BindingProvider resolves a server-side opaque binding. The control plane
+// supplies scope only through its verified identity, never in request fields.
+type BindingProvider interface {
+	LoadGeneratedSpecApprovalBinding(context.Context, string, string, string) (Binding, error)
+}
+
+// AuthorityProvider loads the exact trust snapshot named by the binding.
+// It is the authority owner; control-plane callers cannot replace its result.
+type AuthorityProvider interface {
+	LoadGeneratedSpecApprovalAuthority(context.Context, string, string, string, string, string) (approvalverify.TrustStore, error)
+}
+
+type ControlIdentity struct {
+	Subject     string
+	TenantID    string
+	WorkspaceID string
+}
+
+type ControlIdentityProvider interface {
+	LoadControlIdentity(context.Context) (ControlIdentity, error)
+}
+
+type ConsumerIdentity struct {
+	Subject     string
+	TenantID    string
+	WorkspaceID string
+	Audience    string
+}
+
+type ConsumerIdentityProvider interface {
+	LoadConsumerIdentity(context.Context) (ConsumerIdentity, error)
+}
+
+// GrantSignatureVerifier pins the Kernel signing key and trust-root metadata.
+// It is required at the persistence boundary: envelope syntax alone is never
+// proof that a stored grant or consumption record is authentic.
+type GrantSignatureVerifier interface {
+	VerifyGrant(generatedspecapproval.SignedGrant, time.Time) error
+	VerifyConsumption(generatedspecapproval.SignedConsumption, generatedspecapproval.SignedGrant) error
+}
+
+// Record contains source-owned lifecycle state. Raw assertions are retained so
+// IssueGrant can verify them again against a freshly loaded exact snapshot.
+// A generatedspecapproval.VerifiedApprovalRef is intentionally never stored.
+type Record struct {
+	ApprovalID  string
+	TenantID    string
+	WorkspaceID string
+	State       State
+
+	Binding           Binding
+	HoldStartedAt     time.Time
+	Challenge         *contracts.GeneratedSpecApprovalChallenge
+	Assertions        []contracts.GeneratedSpecApprovalAssertion
+	QuorumVerifiedAt  *time.Time
+	SignedGrant       *generatedspecapproval.SignedGrant
+	SignedConsumption *generatedspecapproval.SignedConsumption
+	ExpiresAt         *time.Time
+	ConsumedAt        *time.Time
+	ConsumedBy        string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	Version           int64
+}
+
+// ConsumptionSealer must run inside Store.ConsumeGrant's atomic transition.
+// A durable implementation must keep the grant state update and resulting
+// signed consumption in the same transaction.
+type ConsumptionSealer func(generatedspecapproval.SignedGrant, string, time.Time) (generatedspecapproval.SignedConsumption, error)
+
+// Store is the future production persistence seam. Each transition must be
+// atomic and scope by tenant/workspace/approval ID. IssueGrant and ConsumeGrant
+// must validate through the pinned GrantSignatureVerifier inside the transition.
+// The package's unexported memory implementation exists only for unit tests.
+type Store interface {
+	CreateHold(context.Context, Record) (Record, error)
+	Get(context.Context, string, string, string) (Record, error)
+	IssueChallenge(context.Context, string, string, string, contracts.GeneratedSpecApprovalChallenge, time.Time) (Record, error)
+	RecordQuorum(context.Context, string, string, string, []contracts.GeneratedSpecApprovalAssertion, time.Time) (Record, error)
+	IssueGrant(context.Context, string, string, string, generatedspecapproval.SignedGrant, GrantSignatureVerifier, time.Time) (Record, error)
+	ConsumeGrant(context.Context, string, string, string, string, string, string, string, string, GrantSignatureVerifier, time.Time, ConsumptionSealer) (Record, error)
+	Deny(context.Context, string, string, string, time.Time) (Record, error)
+	Expire(context.Context, string, string, string, time.Time) (Record, error)
+}
+
+type ServiceConfig struct {
+	MinHoldDuration      time.Duration
+	ChallengeTTL         time.Duration
+	MaxChallengeLifetime time.Duration
+	GrantTTL             time.Duration
+	MaxAssertions        int
+	ServerIdentity       string
+	KernelTrustRootID    string
+	SigningKeyRef        string
+}
+
+// Service is the only authority-bearing API in this package. It sources the
+// binding, authority snapshot, and identities server-side before transitions.
+type Service struct {
+	store     Store
+	bindings  BindingProvider
+	authority AuthorityProvider
+	control   ControlIdentityProvider
+	consumer  ConsumerIdentityProvider
+	signer    crypto.Signer
+	verifier  GrantSignatureVerifier
+	clock     func() time.Time
+	random    io.Reader
+	config    ServiceConfig
+}
+
+func NewService(store Store, bindings BindingProvider, authority AuthorityProvider, control ControlIdentityProvider, consumer ConsumerIdentityProvider, signer crypto.Signer, verifier GrantSignatureVerifier, config ServiceConfig) (*Service, error) {
+	return newService(store, bindings, authority, control, consumer, signer, verifier, time.Now, rand.Reader, config)
+}
+
+func newService(store Store, bindings BindingProvider, authority AuthorityProvider, control ControlIdentityProvider, consumer ConsumerIdentityProvider, signer crypto.Signer, verifier GrantSignatureVerifier, clock func() time.Time, random io.Reader, config ServiceConfig) (*Service, error) {
+	if store == nil || bindings == nil || authority == nil || control == nil || consumer == nil || signer == nil || verifier == nil || clock == nil || random == nil {
+		return nil, errors.New("generated spec approval ceremony dependencies are required")
+	}
+	if config.MinHoldDuration <= 0 || config.ChallengeTTL <= 0 || config.MaxChallengeLifetime <= config.MinHoldDuration || config.GrantTTL <= 0 || config.MaxAssertions <= 0 {
+		return nil, errors.New("generated spec approval ceremony durations and max assertions are invalid")
+	}
+	if config.ChallengeTTL > config.MaxChallengeLifetime-config.MinHoldDuration || !validToken(config.ServerIdentity) || !validToken(config.KernelTrustRootID) || !validToken(config.SigningKeyRef) {
+		return nil, errors.New("generated spec approval ceremony authority configuration is invalid")
+	}
+	return &Service{store: store, bindings: bindings, authority: authority, control: control, consumer: consumer, signer: signer, verifier: verifier, clock: clock, random: random, config: config}, nil
+}
+
+func (s *Service) BeginHold(ctx context.Context, bindingRef string) (Record, error) {
+	if !validToken(bindingRef) {
+		return Record{}, invalidRecord("binding_ref is required")
+	}
+	identity, err := s.controlIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	binding, err := s.bindings.LoadGeneratedSpecApprovalBinding(ctx, identity.TenantID, identity.WorkspaceID, bindingRef)
+	if err != nil {
+		return Record{}, fmt.Errorf("%w: %v", ErrBindingUnavailable, err)
+	}
+	if err := binding.Validate(); err != nil {
+		return Record{}, fmt.Errorf("%w: %v", ErrBindingUnavailable, err)
+	}
+	if binding.BindingRef != bindingRef || binding.TenantID != identity.TenantID || binding.WorkspaceID != identity.WorkspaceID || binding.ServerIdentity != s.config.ServerIdentity || binding.Quorum > s.config.MaxAssertions {
+		return Record{}, fmt.Errorf("%w: binding scope or configured authority mismatch", ErrBindingUnavailable)
+	}
+	if _, err := s.loadAuthority(ctx, binding); err != nil {
+		return Record{}, err
+	}
+	approvalID, err := s.randomToken("approval", 16)
+	if err != nil {
+		return Record{}, err
+	}
+	now := s.now()
+	return s.store.CreateHold(ctx, Record{
+		ApprovalID: approvalID, TenantID: identity.TenantID, WorkspaceID: identity.WorkspaceID,
+		State: StateHoldPending, Binding: binding, HoldStartedAt: now, CreatedAt: now, UpdatedAt: now, Version: 1,
+	})
+}
+
+func (s *Service) IssueChallenge(ctx context.Context, approvalID string) (Record, error) {
+	identity, err := s.controlIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	record, err := s.get(ctx, identity.TenantID, identity.WorkspaceID, approvalID)
+	if err != nil {
+		return Record{}, err
+	}
+	if record.State != StateHoldPending {
+		return Record{}, ErrTransitionConflict
+	}
+	now := s.now()
+	eligibleAt := record.HoldStartedAt.Add(s.config.MinHoldDuration)
+	if now.Before(eligibleAt) {
+		return Record{}, ErrHoldPending
+	}
+	maxExpiresAt := record.HoldStartedAt.Add(s.config.MaxChallengeLifetime)
+	if !maxExpiresAt.After(now) {
+		return Record{}, ErrExpired
+	}
+	if _, err := s.loadAuthority(ctx, record.Binding); err != nil {
+		return Record{}, err
+	}
+	challengeID, err := s.randomToken("challenge", 16)
+	if err != nil {
+		return Record{}, err
+	}
+	nonce, err := s.randomHex(32)
+	if err != nil {
+		return Record{}, err
+	}
+	expiresAt := now.Add(s.config.ChallengeTTL)
+	if expiresAt.After(maxExpiresAt) {
+		expiresAt = maxExpiresAt
+	}
+	challenge, err := challengeFor(record, challengeID, nonce, eligibleAt, now, expiresAt)
+	if err != nil {
+		return Record{}, err
+	}
+	return s.store.IssueChallenge(ctx, identity.TenantID, identity.WorkspaceID, approvalID, challenge, now)
+}
+
+func (s *Service) VerifyQuorum(ctx context.Context, approvalID string, assertions []contracts.GeneratedSpecApprovalAssertion) (Record, error) {
+	identity, err := s.controlIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	record, err := s.get(ctx, identity.TenantID, identity.WorkspaceID, approvalID)
+	if err != nil {
+		return Record{}, err
+	}
+	if record.State != StateChallengeIssued || record.Challenge == nil {
+		return Record{}, ErrTransitionConflict
+	}
+	now := s.now()
+	if err := s.ensureChallengeActive(record, now); err != nil {
+		return Record{}, err
+	}
+	if _, err := s.verify(ctx, record, assertions, now); err != nil {
+		return Record{}, err
+	}
+	return s.store.RecordQuorum(ctx, identity.TenantID, identity.WorkspaceID, approvalID, assertions, now)
+}
+
+// IssueGrant intentionally reconstructs verification from raw stored
+// assertions. A VerifiedApprovalRef is an in-memory verifier capability, not
+// durable issuance authority and is never decoded from Record.
+func (s *Service) IssueGrant(ctx context.Context, approvalID string) (Record, error) {
+	identity, err := s.controlIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	record, err := s.get(ctx, identity.TenantID, identity.WorkspaceID, approvalID)
+	if err != nil {
+		return Record{}, err
+	}
+	if record.State != StateQuorumVerified || record.Challenge == nil || record.QuorumVerifiedAt == nil {
+		return Record{}, ErrTransitionConflict
+	}
+	now := s.now()
+	if err := s.ensureChallengeActive(record, now); err != nil {
+		return Record{}, err
+	}
+	verified, err := s.verify(ctx, record, record.Assertions, now)
+	if err != nil {
+		return Record{}, err
+	}
+	grantID, err := s.randomToken("grant", 16)
+	if err != nil {
+		return Record{}, err
+	}
+	nonce, err := s.randomHex(32)
+	if err != nil {
+		return Record{}, err
+	}
+	signed, err := generatedspecapproval.IssueGrant(*record.Challenge, verified, grantID, nonce, s.signer, generatedspecapproval.IssuerConfig{
+		GrantTTL: s.config.GrantTTL, ServerIdentity: s.config.ServerIdentity, KernelTrustRootID: s.config.KernelTrustRootID, SigningKeyRef: s.config.SigningKeyRef,
+	}, now)
+	if err != nil {
+		return Record{}, err
+	}
+	if err := s.verifier.VerifyGrant(signed, now); err != nil {
+		return Record{}, err
+	}
+	return s.store.IssueGrant(ctx, identity.TenantID, identity.WorkspaceID, approvalID, signed, s.verifier, now)
+}
+
+func (s *Service) ConsumeGrant(ctx context.Context, approvalID, grantID, grantHash, nonce string) (Record, error) {
+	identity, err := s.consumerIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	now := s.now()
+	return s.store.ConsumeGrant(ctx, identity.TenantID, identity.WorkspaceID, approvalID, grantID, grantHash, nonce, identity.Subject, identity.Audience, s.verifier, now,
+		func(signed generatedspecapproval.SignedGrant, consumedBy string, consumedAt time.Time) (generatedspecapproval.SignedConsumption, error) {
+			if signed.Grant.Audience != identity.Audience {
+				return generatedspecapproval.SignedConsumption{}, fmt.Errorf("%w: signed grant workload scope mismatch", ErrConsumerUnavailable)
+			}
+			consumption, err := generatedspecapproval.NewConsumption(signed.Grant, consumedBy, consumedAt)
+			if err != nil {
+				return generatedspecapproval.SignedConsumption{}, err
+			}
+			return generatedspecapproval.SignConsumption(consumption, s.signer)
+		},
+	)
+}
+
+// RecoverGrantConsumption returns the same persisted consumption only to the
+// same verified workload. It never performs a second consume transition.
+func (s *Service) RecoverGrantConsumption(ctx context.Context, approvalID, grantID, grantHash, nonce string) (Record, error) {
+	identity, err := s.consumerIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	record, err := s.get(ctx, identity.TenantID, identity.WorkspaceID, approvalID)
+	if err != nil {
+		return Record{}, err
+	}
+	if record.State != StateConsumed || record.SignedGrant == nil || record.SignedConsumption == nil || record.ConsumedAt == nil ||
+		record.SignedGrant.Grant.GrantID != grantID || record.SignedGrant.Grant.GrantHash != grantHash || record.SignedGrant.Grant.Nonce != nonce {
+		return Record{}, ErrTransitionConflict
+	}
+	if record.ConsumedBy != identity.Subject || record.SignedConsumption.Consumption.ConsumedBy != identity.Subject || record.SignedGrant.Grant.Audience != identity.Audience {
+		return Record{}, fmt.Errorf("%w: persisted consumption identity mismatch", ErrConsumerUnavailable)
+	}
+	now := s.now()
+	if err := ensureGrantActive(record.SignedGrant.Grant, now); err != nil {
+		return Record{}, err
+	}
+	if err := s.verifier.VerifyGrant(*record.SignedGrant, now); err != nil {
+		return Record{}, err
+	}
+	if err := s.verifier.VerifyConsumption(*record.SignedConsumption, *record.SignedGrant); err != nil {
+		return Record{}, err
+	}
+	return record, nil
+}
+
+func (s *Service) Deny(ctx context.Context, approvalID string) (Record, error) {
+	identity, err := s.controlIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	return s.store.Deny(ctx, identity.TenantID, identity.WorkspaceID, approvalID, s.now())
+}
+
+func (s *Service) Expire(ctx context.Context, approvalID string) (Record, error) {
+	identity, err := s.controlIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	return s.store.Expire(ctx, identity.TenantID, identity.WorkspaceID, approvalID, s.now())
+}
+
+func (s *Service) Get(ctx context.Context, approvalID string) (Record, error) {
+	identity, err := s.controlIdentity(ctx)
+	if err != nil {
+		return Record{}, err
+	}
+	return s.get(ctx, identity.TenantID, identity.WorkspaceID, approvalID)
+}
+
+func (s *Service) verify(ctx context.Context, record Record, assertions []contracts.GeneratedSpecApprovalAssertion, now time.Time) (generatedspecapproval.VerifiedApprovalRef, error) {
+	if record.Challenge == nil {
+		return generatedspecapproval.VerifiedApprovalRef{}, ErrTransitionConflict
+	}
+	trust, err := s.loadAuthority(ctx, record.Binding)
+	if err != nil {
+		return generatedspecapproval.VerifiedApprovalRef{}, err
+	}
+	return generatedspecapproval.VerifyGeneratedSpecQuorum(*record.Challenge, assertions, trust, generatedspecapproval.VerifyOptions{
+		Expected: expectedBinding(record.Binding, *record.Challenge), MinHoldDuration: s.config.MinHoldDuration,
+		MaxChallengeTTL: s.config.MaxChallengeLifetime, MaxAssertions: s.config.MaxAssertions,
+	}, now)
+}
+
+func (s *Service) ensureChallengeActive(record Record, now time.Time) error {
+	if record.Challenge == nil {
+		return ErrTransitionConflict
+	}
+	if !now.Before(record.Challenge.ExpiresAt) {
+		return fmt.Errorf("%w: challenge has expired", ErrExpired)
+	}
+	if err := record.Challenge.ValidateAt(now); err != nil {
+		return fmt.Errorf("%w: challenge is not active: %v", ErrTransitionConflict, err)
+	}
+	return nil
+}
+
+func ensureGrantActive(grant contracts.GeneratedSpecApprovalGrant, now time.Time) error {
+	if !now.Before(grant.ExpiresAt) {
+		return fmt.Errorf("%w: grant has expired", ErrExpired)
+	}
+	if err := grant.ValidateAt(now); err != nil {
+		return fmt.Errorf("%w: grant is not active: %v", ErrTransitionConflict, err)
+	}
+	return nil
+}
+
+func (s *Service) get(ctx context.Context, tenantID, workspaceID, approvalID string) (Record, error) {
+	record, err := s.store.Get(ctx, tenantID, workspaceID, approvalID)
+	if err != nil {
+		return Record{}, err
+	}
+	if err := record.validate(); err != nil {
+		return Record{}, err
+	}
+	return record, nil
+}
+
+func (s *Service) loadAuthority(ctx context.Context, binding Binding) (approvalverify.TrustStore, error) {
+	store, err := s.authority.LoadGeneratedSpecApprovalAuthority(ctx, binding.TenantID, binding.WorkspaceID, binding.AuthoritySource, binding.AuthorityVersion, binding.AuthoritySnapshotHash)
+	if err != nil {
+		return approvalverify.TrustStore{}, fmt.Errorf("%w: %v", ErrAuthorityUnavailable, err)
+	}
+	if store.AuthoritySource != binding.AuthoritySource || store.AuthorityVersion != binding.AuthorityVersion || store.AuthoritySnapshotHash != binding.AuthoritySnapshotHash {
+		return approvalverify.TrustStore{}, fmt.Errorf("%w: snapshot metadata mismatch", ErrAuthorityUnavailable)
+	}
+	return store, nil
+}
+
+func (s *Service) controlIdentity(ctx context.Context) (ControlIdentity, error) {
+	identity, err := s.control.LoadControlIdentity(ctx)
+	if err != nil || !validToken(identity.Subject) || !validToken(identity.TenantID) || !validToken(identity.WorkspaceID) {
+		return ControlIdentity{}, fmt.Errorf("%w: verified control subject, tenant, and workspace are required", ErrControlUnavailable)
+	}
+	return identity, nil
+}
+
+func (s *Service) consumerIdentity(ctx context.Context) (ConsumerIdentity, error) {
+	identity, err := s.consumer.LoadConsumerIdentity(ctx)
+	if err != nil || !validToken(identity.Subject) || !validToken(identity.TenantID) || !validToken(identity.WorkspaceID) || !validToken(identity.Audience) {
+		return ConsumerIdentity{}, fmt.Errorf("%w: verified workload subject, tenant, workspace, and audience are required", ErrConsumerUnavailable)
+	}
+	return identity, nil
+}
+
+func (s *Service) now() time.Time { return s.clock().UTC().Truncate(time.Microsecond) }
+
+func (s *Service) randomToken(prefix string, size int) (string, error) {
+	raw, err := s.randomBytes(size)
+	if err != nil {
+		return "", err
+	}
+	return prefix + "-" + hex.EncodeToString(raw), nil
+}
+
+func (s *Service) randomHex(size int) (string, error) {
+	raw, err := s.randomBytes(size)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+func (s *Service) randomBytes(size int) ([]byte, error) {
+	raw := make([]byte, size)
+	if _, err := io.ReadFull(s.random, raw); err != nil {
+		return nil, fmt.Errorf("generate generated spec approval ceremony randomness: %w", err)
+	}
+	return raw, nil
+}
+
+func challengeFor(record Record, challengeID, nonce string, eligibleAt, issuedAt, expiresAt time.Time) (contracts.GeneratedSpecApprovalChallenge, error) {
+	b := record.Binding
+	challenge, err := (contracts.GeneratedSpecApprovalChallenge{
+		Domain: contracts.GeneratedSpecApprovalChallengeDomainV1, SchemaVersion: contracts.GeneratedSpecApprovalChallengeSchemaV1,
+		ContractVersion: contracts.GeneratedSpecApprovalChallengeContractV1,
+		ChallengeID:     challengeID, ApprovalID: record.ApprovalID, TenantID: b.TenantID, WorkspaceID: b.WorkspaceID, Audience: b.Audience,
+		GeneratedSpecID: b.GeneratedSpecID, GeneratedSpecHash: b.GeneratedSpecHash, ExecutionPlanHash: b.ExecutionPlanHash,
+		PlanTransactionHash: b.PlanTransactionHash, WriteSetHash: b.WriteSetHash, VerificationScopeHash: b.VerificationScopeHash,
+		PolicyEnvelopeHash: b.PolicyEnvelopeHash, PolicyVersion: b.PolicyVersion, PolicyEpoch: b.PolicyEpoch, Action: b.Action,
+		RequestingPrincipalID: b.RequestingPrincipalID, AuthoritySource: b.AuthoritySource, AuthorityVersion: b.AuthorityVersion,
+		AuthoritySnapshotHash: b.AuthoritySnapshotHash, RequiredRole: b.RequiredRole, Quorum: b.Quorum, ServerIdentity: b.ServerIdentity,
+		HoldStartedAt: record.HoldStartedAt, EligibleAt: eligibleAt, IssuedAt: issuedAt, ExpiresAt: expiresAt, Nonce: nonce,
+	}).Seal()
+	if err != nil {
+		return contracts.GeneratedSpecApprovalChallenge{}, fmt.Errorf("seal generated spec approval challenge: %w", err)
+	}
+	return challenge, nil
+}
+
+func expectedBinding(binding Binding, challenge contracts.GeneratedSpecApprovalChallenge) generatedspecapproval.ExpectedBinding {
+	return generatedspecapproval.ExpectedBinding{
+		ChallengeID: challenge.ChallengeID, ChallengeHash: challenge.ChallengeHash, ApprovalID: challenge.ApprovalID,
+		TenantID: binding.TenantID, WorkspaceID: binding.WorkspaceID, Audience: binding.Audience,
+		GeneratedSpecID: binding.GeneratedSpecID, GeneratedSpecHash: binding.GeneratedSpecHash,
+		ExecutionPlanHash: binding.ExecutionPlanHash, PlanTransactionHash: binding.PlanTransactionHash,
+		WriteSetHash: binding.WriteSetHash, VerificationScopeHash: binding.VerificationScopeHash,
+		PolicyEnvelopeHash: binding.PolicyEnvelopeHash, PolicyVersion: binding.PolicyVersion, PolicyEpoch: binding.PolicyEpoch,
+		Action: binding.Action, RequestingPrincipalID: binding.RequestingPrincipalID,
+		AuthoritySource: binding.AuthoritySource, AuthorityVersion: binding.AuthorityVersion,
+		AuthoritySnapshotHash: binding.AuthoritySnapshotHash, RequiredRole: binding.RequiredRole,
+		Quorum: binding.Quorum, ServerIdentity: binding.ServerIdentity,
+	}
+}
+
+func (r Record) validate() error {
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"approval_id", r.ApprovalID}, {"tenant_id", r.TenantID}, {"workspace_id", r.WorkspaceID},
+	} {
+		if !validToken(field.value) {
+			return invalidRecord(field.name + " is invalid")
+		}
+	}
+	if !r.State.valid() || r.HoldStartedAt.IsZero() || r.CreatedAt.IsZero() || r.UpdatedAt.IsZero() || r.Version <= 0 || !isUTC(r.HoldStartedAt) || !isUTC(r.CreatedAt) || !isUTC(r.UpdatedAt) || !r.CreatedAt.Equal(r.HoldStartedAt) || r.UpdatedAt.Before(r.CreatedAt) {
+		return invalidRecord("record lifecycle timestamps are invalid")
+	}
+	if err := r.Binding.Validate(); err != nil || r.Binding.TenantID != r.TenantID || r.Binding.WorkspaceID != r.WorkspaceID {
+		return invalidRecord("record binding is invalid or out of scope")
+	}
+	if r.Challenge != nil {
+		if err := validateChallenge(r); err != nil {
+			return err
+		}
+	}
+	if r.ExpiresAt != nil && !isUTC(*r.ExpiresAt) {
+		return invalidRecord("expires_at is not UTC")
+	}
+	if r.ConsumedAt != nil && !isUTC(*r.ConsumedAt) {
+		return invalidRecord("consumed_at is not UTC")
+	}
+	switch r.State {
+	case StateHoldPending:
+		if r.Challenge != nil || r.QuorumVerifiedAt != nil || len(r.Assertions) != 0 || r.SignedGrant != nil || r.SignedConsumption != nil || r.ExpiresAt != nil || r.ConsumedAt != nil || r.ConsumedBy != "" || !r.UpdatedAt.Equal(r.HoldStartedAt) {
+			return invalidRecord("hold pending artifacts are invalid")
+		}
+	case StateChallengeIssued:
+		if r.Challenge == nil || r.QuorumVerifiedAt != nil || len(r.Assertions) != 0 || r.SignedGrant != nil || r.SignedConsumption != nil || r.ExpiresAt == nil || !r.ExpiresAt.Equal(r.Challenge.ExpiresAt) || !r.UpdatedAt.Equal(r.Challenge.IssuedAt) {
+			return invalidRecord("challenge issued artifacts are invalid")
+		}
+	case StateQuorumVerified:
+		if r.Challenge == nil || r.QuorumVerifiedAt == nil || len(r.Assertions) < r.Binding.Quorum || r.SignedGrant != nil || r.SignedConsumption != nil || r.ExpiresAt == nil || !r.ExpiresAt.Equal(r.Challenge.ExpiresAt) || !r.UpdatedAt.Equal(*r.QuorumVerifiedAt) || r.QuorumVerifiedAt.Before(r.Challenge.IssuedAt) || !r.QuorumVerifiedAt.Before(r.Challenge.ExpiresAt) {
+			return invalidRecord("quorum verified artifacts are invalid")
+		}
+	case StateGrantIssued, StateConsumed:
+		if err := validateGrantRecord(r); err != nil {
+			return err
+		}
+		if r.State == StateConsumed {
+			if r.SignedConsumption == nil || r.ConsumedAt == nil || !validToken(r.ConsumedBy) || !r.UpdatedAt.Equal(*r.ConsumedAt) || r.SignedConsumption.Consumption.ConsumedBy != r.ConsumedBy || !r.SignedConsumption.Consumption.ConsumedAt.Equal(*r.ConsumedAt) || r.SignedConsumption.Consumption.ValidateGrant(r.SignedGrant.Grant) != nil || !validSignature(r.SignedConsumption.Signature) || r.SignedConsumption.Algorithm != generatedspecapproval.SignatureAlgorithmEd25519 {
+				return invalidRecord("consumed artifacts are invalid")
+			}
+		} else if r.SignedConsumption != nil || r.ConsumedAt != nil || r.ConsumedBy != "" {
+			return invalidRecord("grant issued cannot contain consumption")
+		}
+	case StateDenied, StateExpired:
+		if r.SignedConsumption != nil || r.ConsumedAt != nil || r.ConsumedBy != "" {
+			return invalidRecord("terminal non-consumed state contains consumption")
+		}
+		if r.SignedGrant != nil {
+			if err := validateGrantRecord(r); err != nil {
+				return err
+			}
+		} else if r.Challenge != nil && (r.ExpiresAt == nil || !r.ExpiresAt.Equal(r.Challenge.ExpiresAt)) {
+			return invalidRecord("terminal challenge expiry mismatch")
+		}
+		if r.State == StateExpired && (r.ExpiresAt == nil || r.UpdatedAt.Before(*r.ExpiresAt)) {
+			return invalidRecord("expired before the committed lifetime")
+		}
+	}
+	if r.State != StateConsumed && (r.SignedConsumption != nil || r.ConsumedAt != nil || r.ConsumedBy != "") {
+		return invalidRecord("consumption fields require consumed state")
+	}
+	return nil
+}
+
+func validateChallenge(record Record) error {
+	challenge := *record.Challenge
+	if err := challenge.Validate(); err != nil {
+		return invalidRecord("challenge: " + err.Error())
+	}
+	sealed, err := challenge.Seal()
+	if err != nil || sealed.ChallengeHash != challenge.ChallengeHash {
+		return invalidRecord("challenge integrity mismatch")
+	}
+	b := record.Binding
+	if challenge.ApprovalID != record.ApprovalID || challenge.TenantID != record.TenantID || challenge.WorkspaceID != record.WorkspaceID || !challenge.HoldStartedAt.Equal(record.HoldStartedAt) ||
+		challenge.Audience != b.Audience || challenge.GeneratedSpecID != b.GeneratedSpecID || challenge.GeneratedSpecHash != b.GeneratedSpecHash ||
+		challenge.ExecutionPlanHash != b.ExecutionPlanHash || challenge.PlanTransactionHash != b.PlanTransactionHash || challenge.WriteSetHash != b.WriteSetHash ||
+		challenge.VerificationScopeHash != b.VerificationScopeHash || challenge.PolicyEnvelopeHash != b.PolicyEnvelopeHash || challenge.PolicyVersion != b.PolicyVersion ||
+		challenge.PolicyEpoch != b.PolicyEpoch || challenge.Action != b.Action || challenge.RequestingPrincipalID != b.RequestingPrincipalID ||
+		challenge.AuthoritySource != b.AuthoritySource || challenge.AuthorityVersion != b.AuthorityVersion || challenge.AuthoritySnapshotHash != b.AuthoritySnapshotHash ||
+		challenge.RequiredRole != b.RequiredRole || challenge.Quorum != b.Quorum || challenge.ServerIdentity != b.ServerIdentity {
+		return invalidRecord("challenge does not match immutable binding")
+	}
+	return nil
+}
+
+func validateGrantRecord(record Record) error {
+	if record.Challenge == nil || record.QuorumVerifiedAt == nil || len(record.Assertions) < record.Binding.Quorum || record.SignedGrant == nil || record.ExpiresAt == nil {
+		return invalidRecord("grant record chain is incomplete")
+	}
+	grant := record.SignedGrant.Grant
+	if err := grant.Validate(); err != nil {
+		return invalidRecord("grant: " + err.Error())
+	}
+	sealed, err := grant.Seal()
+	if err != nil || sealed.GrantHash != grant.GrantHash || !validSignature(record.SignedGrant.Signature) || record.SignedGrant.Algorithm != generatedspecapproval.SignatureAlgorithmEd25519 || !record.UpdatedAt.Equal(grant.IssuedAt) && record.State == StateGrantIssued {
+		return invalidRecord("signed grant integrity is invalid")
+	}
+	challenge := *record.Challenge
+	if grant.ApprovalID != record.ApprovalID || grant.TenantID != record.TenantID || grant.WorkspaceID != record.WorkspaceID ||
+		grant.Audience != challenge.Audience || grant.GeneratedSpecID != challenge.GeneratedSpecID || grant.GeneratedSpecHash != challenge.GeneratedSpecHash ||
+		grant.ExecutionPlanHash != challenge.ExecutionPlanHash || grant.PlanTransactionHash != challenge.PlanTransactionHash || grant.WriteSetHash != challenge.WriteSetHash ||
+		grant.VerificationScopeHash != challenge.VerificationScopeHash || grant.PolicyEnvelopeHash != challenge.PolicyEnvelopeHash || grant.PolicyVersion != challenge.PolicyVersion ||
+		grant.PolicyEpoch != challenge.PolicyEpoch || grant.Action != challenge.Action || grant.RequestingPrincipalID != challenge.RequestingPrincipalID ||
+		grant.ChallengeHash != challenge.ChallengeHash || grant.AuthoritySource != challenge.AuthoritySource || grant.AuthorityVersion != challenge.AuthorityVersion ||
+		grant.AuthoritySnapshotHash != challenge.AuthoritySnapshotHash || grant.ServerIdentity != challenge.ServerIdentity || grant.IssuedAt.Before(*record.QuorumVerifiedAt) || grant.ExpiresAt.After(challenge.ExpiresAt) || !record.ExpiresAt.Equal(grant.ExpiresAt) {
+		return invalidRecord("grant does not match verified challenge")
+	}
+	return nil
+}
+
+func (s State) valid() bool {
+	switch s {
+	case StateHoldPending, StateChallengeIssued, StateQuorumVerified, StateGrantIssued, StateConsumed, StateDenied, StateExpired:
+		return true
+	default:
+		return false
+	}
+}
+
+func validToken(value string) bool {
+	return value != "" && strings.IndexFunc(value, unicode.IsSpace) == -1
+}
+
+func validSHA256(value string) bool {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	raw := strings.TrimPrefix(value, prefix)
+	if len(raw) != 64 || strings.ToLower(raw) != raw {
+		return false
+	}
+	decoded, err := hex.DecodeString(raw)
+	return err == nil && len(decoded) == 32
+}
+
+func validSignature(value string) bool {
+	if len(value) != 128 || strings.ToLower(value) != value {
+		return false
+	}
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == 64
+}
+
+func isUTC(value time.Time) bool {
+	_, offset := value.Zone()
+	return offset == 0
+}
+
+func invalidRecord(message string) error { return fmt.Errorf("%w: %s", ErrInvalidRecord, message) }

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
@@ -147,6 +147,10 @@ type ConsumerIdentityProvider interface {
 // proof that a stored grant or consumption record is authentic.
 type GrantSignatureVerifier interface {
 	VerifyGrant(generatedspecapproval.SignedGrant, time.Time) error
+	// VerifyGrantSignature checks envelope integrity, trust-root metadata, and
+	// the signature without any liveness bound; recovery paths use it for
+	// grants whose committed lifetime has already passed.
+	VerifyGrantSignature(generatedspecapproval.SignedGrant) error
 	VerifyConsumption(generatedspecapproval.SignedConsumption, generatedspecapproval.SignedGrant) error
 }
 
@@ -182,7 +186,10 @@ type ConsumptionSealer func(generatedspecapproval.SignedGrant, string, time.Time
 // Store is the future production persistence seam. Each transition must be
 // atomic and scope by tenant/workspace/approval ID. IssueGrant and ConsumeGrant
 // must validate through the pinned GrantSignatureVerifier inside the transition.
-// The package's unexported memory implementation exists only for unit tests.
+// Expire must also release never-challenged holds once HoldStartedAt plus the
+// configured MaxChallengeLifetime has passed, committing that deadline as the
+// record expiry. The package's unexported memory implementation exists only
+// for unit tests.
 type Store interface {
 	CreateHold(context.Context, Record) (Record, error)
 	Get(context.Context, string, string, string) (Record, error)
@@ -415,11 +422,11 @@ func (s *Service) RecoverGrantConsumption(ctx context.Context, approvalID, grant
 	if record.ConsumedBy != identity.Subject || record.SignedConsumption.Consumption.ConsumedBy != identity.Subject || record.SignedGrant.Grant.Audience != identity.Audience {
 		return Record{}, fmt.Errorf("%w: persisted consumption identity mismatch", ErrConsumerUnavailable)
 	}
-	now := s.now()
-	if err := ensureGrantActive(record.SignedGrant.Grant, now); err != nil {
-		return Record{}, err
-	}
-	if err := s.verifier.VerifyGrant(*record.SignedGrant, now); err != nil {
+	// Recovery re-serves a consumption that was atomically recorded before the
+	// grant expired; it never performs a second consume transition. Grant
+	// expiry bounds new consumption, not retrieval of the persisted receipt,
+	// so verify envelope integrity and signatures without a liveness check.
+	if err := s.verifier.VerifyGrantSignature(*record.SignedGrant); err != nil {
 		return Record{}, err
 	}
 	if err := s.verifier.VerifyConsumption(*record.SignedConsumption, *record.SignedGrant); err != nil {

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
@@ -392,8 +392,18 @@ func (s *Service) ConsumeGrant(ctx context.Context, approvalID, grantID, grantHa
 	now := s.now()
 	return s.store.ConsumeGrant(ctx, identity.TenantID, identity.WorkspaceID, approvalID, grantID, grantHash, nonce, identity.Subject, identity.Audience, s.verifier, now,
 		func(signed generatedspecapproval.SignedGrant, consumedBy string, consumedAt time.Time) (generatedspecapproval.SignedConsumption, error) {
-			if signed.Grant.Audience != identity.Audience {
-				return generatedspecapproval.SignedConsumption{}, fmt.Errorf("%w: signed grant workload scope mismatch", ErrConsumerUnavailable)
+			// The store controls the sealer arguments, so pin every one of them:
+			// the grant must be the caller-named grant in the verified tenant,
+			// workspace, and audience scope, and the consumer and timestamp must
+			// be the service-verified identity and service time. Anything less
+			// would let a store substitute arguments and use this closure as a
+			// signing oracle for an authentic consumption receipt.
+			if signed.Grant.GrantID != grantID || signed.Grant.GrantHash != grantHash || signed.Grant.Nonce != nonce ||
+				signed.Grant.TenantID != identity.TenantID || signed.Grant.WorkspaceID != identity.WorkspaceID || signed.Grant.Audience != identity.Audience {
+				return generatedspecapproval.SignedConsumption{}, fmt.Errorf("%w: signed grant does not match the requested consumption scope", ErrConsumerUnavailable)
+			}
+			if consumedBy != identity.Subject || !consumedAt.Equal(now) {
+				return generatedspecapproval.SignedConsumption{}, fmt.Errorf("%w: consumption identity or timestamp mismatch", ErrConsumerUnavailable)
 			}
 			consumption, err := generatedspecapproval.NewConsumption(signed.Grant, consumedBy, consumedAt)
 			if err != nil {
@@ -707,7 +717,7 @@ func validateGrantRecord(record Record) error {
 		return invalidRecord("grant: " + err.Error())
 	}
 	sealed, err := grant.Seal()
-	if err != nil || sealed.GrantHash != grant.GrantHash || !validSignature(record.SignedGrant.Signature) || record.SignedGrant.Algorithm != generatedspecapproval.SignatureAlgorithmEd25519 || !record.UpdatedAt.Equal(grant.IssuedAt) && record.State == StateGrantIssued {
+	if err != nil || sealed.GrantHash != grant.GrantHash || !validSignature(record.SignedGrant.Signature) || record.SignedGrant.Algorithm != generatedspecapproval.SignatureAlgorithmEd25519 || (!record.UpdatedAt.Equal(grant.IssuedAt) && record.State == StateGrantIssued) {
 		return invalidRecord("signed grant integrity is invalid")
 	}
 	challenge := *record.Challenge

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
@@ -405,6 +405,13 @@ func (s *Service) ConsumeGrant(ctx context.Context, approvalID, grantID, grantHa
 			if consumedBy != identity.Subject || !consumedAt.Equal(now) {
 				return generatedspecapproval.SignedConsumption{}, fmt.Errorf("%w: consumption identity or timestamp mismatch", ErrConsumerUnavailable)
 			}
+			// Field pins alone cannot stop a store that alters unchecked grant
+			// fields or the signature envelope, so re-verify the exact grant
+			// being consumed through the pinned verifier at the pinned
+			// consumption time before signing anything.
+			if err := s.verifier.VerifyGrant(signed, consumedAt); err != nil {
+				return generatedspecapproval.SignedConsumption{}, err
+			}
 			consumption, err := generatedspecapproval.NewConsumption(signed.Grant, consumedBy, consumedAt)
 			if err != nil {
 				return generatedspecapproval.SignedConsumption{}, err

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
@@ -523,6 +523,19 @@ func (s *Service) get(ctx context.Context, tenantID, workspaceID, approvalID str
 	if err := record.validate(); err != nil {
 		return Record{}, err
 	}
+	// The persistence seam is untrusted: re-verify pinned envelope integrity
+	// and signatures before any caller can act on stored grant or consumption
+	// data. Record.validate() only checks syntax and lifecycle consistency.
+	if record.SignedGrant != nil {
+		if err := s.verifier.VerifyGrantSignature(*record.SignedGrant); err != nil {
+			return Record{}, err
+		}
+		if record.SignedConsumption != nil {
+			if err := s.verifier.VerifyConsumption(*record.SignedConsumption, *record.SignedGrant); err != nil {
+				return Record{}, err
+			}
+		}
+	}
 	return record, nil
 }
 
@@ -633,6 +646,16 @@ func (r Record) validate() error {
 	if r.Challenge != nil {
 		if err := validateChallenge(r); err != nil {
 			return err
+		}
+	}
+	if len(r.Assertions) > 0 {
+		if r.Challenge == nil {
+			return invalidRecord("assertions require a stored challenge")
+		}
+		for _, assertion := range r.Assertions {
+			if err := assertion.Validate(); err != nil || assertion.ChallengeID != r.Challenge.ChallengeID || assertion.ChallengeHash != r.Challenge.ChallengeHash {
+				return invalidRecord("assertion is invalid or not bound to the stored challenge")
+			}
 		}
 	}
 	if r.ExpiresAt != nil && !isUTC(*r.ExpiresAt) {

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
@@ -456,6 +456,15 @@ func (s *Service) verify(ctx context.Context, record Record, assertions []contra
 	if record.Challenge == nil {
 		return generatedspecapproval.VerifiedApprovalRef{}, ErrTransitionConflict
 	}
+	// A persisted challenge must still honor the configured per-issuance TTL.
+	// IssueChallenge sets ExpiresAt = IssuedAt + ChallengeTTL (clamped only to
+	// MaxChallengeLifetime), so a larger span means the stored challenge was
+	// resealed with an extended expiry. The verifier's MaxChallengeTTL option
+	// spans the full hold-to-expiry lifetime, so it cannot catch that tampering
+	// on its own.
+	if record.Challenge.ExpiresAt.Sub(record.Challenge.IssuedAt) > s.config.ChallengeTTL {
+		return generatedspecapproval.VerifiedApprovalRef{}, fmt.Errorf("%w: persisted challenge ttl exceeds configured challenge ttl", generatedspecapproval.ErrVerificationFailed)
+	}
 	trust, err := s.loadAuthority(ctx, record.Binding)
 	if err != nil {
 		return generatedspecapproval.VerifiedApprovalRef{}, err

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony.go
@@ -557,7 +557,7 @@ func (s *Service) randomHex(size int) (string, error) {
 func (s *Service) randomBytes(size int) ([]byte, error) {
 	raw := make([]byte, size)
 	if _, err := io.ReadFull(s.random, raw); err != nil {
-		return nil, fmt.Errorf("generate generated spec approval ceremony randomness: %w", err)
+		return nil, fmt.Errorf("generated spec approval ceremony randomness: %w", err)
 	}
 	return raw, nil
 }

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -245,6 +245,19 @@ func TestConsumeGrantSealerPinsCallerScope(t *testing.T) {
 			t.Fatalf("ConsumeGrant(substituted grant) error = %v, want consumer rejection", err)
 		}
 	})
+
+	t.Run("forged signature envelope", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		svc := newTamperedService(t, fixture, func(signed *generatedspecapproval.SignedGrant, _ *string, _ *time.Time) {
+			signed.Signature = strings.Repeat("0", 128)
+		})
+		if _, err := svc.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, generatedspecapproval.ErrSignatureRejected) {
+			t.Fatalf("ConsumeGrant(forged signature envelope) error = %v, want signature rejection", err)
+		}
+	})
 }
 
 func TestDenyFencesAnIssuedGrant(t *testing.T) {

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -124,6 +124,36 @@ func TestVerifyQuorumRejectsRequesterAndChallengeMismatch(t *testing.T) {
 	})
 }
 
+func TestVerifyQuorumRejectsResealedChallengeBeyondConfiguredTTL(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+	challenged := fixture.toChallenge(t, ctx)
+
+	// Simulate a store-level reseal that extends the persisted challenge expiry
+	// past the configured per-issuance ChallengeTTL while keeping the challenge
+	// inside its maximum lifetime, then verify with assertions bound to the
+	// resealed hash. Verification must still reject the extended TTL.
+	var resealed contracts.GeneratedSpecApprovalChallenge
+	fixture.mutate(challenged.ApprovalID, func(record *Record) {
+		updated := *record.Challenge
+		updated.ExpiresAt = updated.IssuedAt.Add(fixture.config.ChallengeTTL + time.Minute)
+		sealed, sealErr := updated.Seal()
+		if sealErr != nil {
+			t.Errorf("Seal() error = %v", sealErr)
+			return
+		}
+		record.Challenge = &sealed
+		record.ExpiresAt = &sealed.ExpiresAt
+		resealed = sealed
+	})
+	if resealed.ChallengeHash == challenged.Challenge.ChallengeHash {
+		t.Fatal("resealed challenge must carry a new challenge hash")
+	}
+	if _, err := fixture.service.VerifyQuorum(ctx, challenged.ApprovalID, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion(t, resealed)}); !errors.Is(err, generatedspecapproval.ErrVerificationFailed) {
+		t.Fatalf("VerifyQuorum(resealed challenge) error = %v, want verification failure", err)
+	}
+}
+
 func TestConsumeRejectsWrongConsumerAndReplay(t *testing.T) {
 	fixture := newCeremonyFixture(t)
 	ctx := context.Background()

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -1,3 +1,6 @@
+// quantum_posture: GeneratedSpec approval ceremony tests exercise classical
+// Ed25519 ceremony and grant signatures only; they do not establish hybrid or
+// post-quantum ceremony support.
 package generatedspecapprovalceremony
 
 import (

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -1,0 +1,406 @@
+package generatedspecapprovalceremony
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	cryptorand "crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapproval"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+)
+
+func TestLifecycleAndSameIdentityRecovery(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+
+	hold, err := fixture.service.BeginHold(ctx, fixture.binding.BindingRef)
+	if err != nil {
+		t.Fatalf("BeginHold() error = %v", err)
+	}
+	if hold.State != StateHoldPending || hold.TenantID != fixture.control.identity.TenantID || hold.WorkspaceID != fixture.control.identity.WorkspaceID {
+		t.Fatalf("BeginHold() record = %+v, want source-owned hold scope", hold)
+	}
+	if _, err := fixture.service.IssueChallenge(ctx, hold.ApprovalID); !errors.Is(err, ErrHoldPending) {
+		t.Fatalf("IssueChallenge(before hold) error = %v, want hold pending", err)
+	}
+
+	fixture.advance(fixture.config.MinHoldDuration)
+	challenged, err := fixture.service.IssueChallenge(ctx, hold.ApprovalID)
+	if err != nil {
+		t.Fatalf("IssueChallenge() error = %v", err)
+	}
+	if challenged.State != StateChallengeIssued || challenged.Challenge == nil {
+		t.Fatalf("IssueChallenge() record = %+v, want issued challenge", challenged)
+	}
+	assertChallengeBinding(t, fixture.binding, *challenged.Challenge)
+
+	assertion := fixture.assertion(t, *challenged.Challenge)
+	quorum, err := fixture.service.VerifyQuorum(ctx, hold.ApprovalID, []contracts.GeneratedSpecApprovalAssertion{assertion})
+	if err != nil {
+		t.Fatalf("VerifyQuorum() error = %v", err)
+	}
+	if quorum.State != StateQuorumVerified || quorum.QuorumVerifiedAt == nil || len(quorum.Assertions) != 1 {
+		t.Fatalf("VerifyQuorum() record = %+v, want stored raw quorum assertions", quorum)
+	}
+
+	granted, err := fixture.service.IssueGrant(ctx, hold.ApprovalID)
+	if err != nil {
+		t.Fatalf("IssueGrant() error = %v", err)
+	}
+	if granted.State != StateGrantIssued || granted.SignedGrant == nil {
+		t.Fatalf("IssueGrant() record = %+v, want signed grant", granted)
+	}
+	if err := fixture.verifier.VerifyGrant(*granted.SignedGrant, fixture.now); err != nil {
+		t.Fatalf("VerifyGrant() error = %v", err)
+	}
+
+	consumed, err := fixture.service.ConsumeGrant(ctx, hold.ApprovalID, granted.SignedGrant.Grant.GrantID, granted.SignedGrant.Grant.GrantHash, granted.SignedGrant.Grant.Nonce)
+	if err != nil {
+		t.Fatalf("ConsumeGrant() error = %v", err)
+	}
+	if consumed.State != StateConsumed || consumed.ConsumedBy != fixture.consumer.identity.Subject || consumed.SignedConsumption == nil {
+		t.Fatalf("ConsumeGrant() record = %+v, want source-owned consumption identity", consumed)
+	}
+	if err := fixture.verifier.VerifyConsumption(*consumed.SignedConsumption, *consumed.SignedGrant); err != nil {
+		t.Fatalf("VerifyConsumption() error = %v", err)
+	}
+
+	recovered, err := fixture.service.RecoverGrantConsumption(ctx, hold.ApprovalID, granted.SignedGrant.Grant.GrantID, granted.SignedGrant.Grant.GrantHash, granted.SignedGrant.Grant.Nonce)
+	if err != nil {
+		t.Fatalf("RecoverGrantConsumption() error = %v", err)
+	}
+	if recovered.Version != consumed.Version || !recovered.ConsumedAt.Equal(*consumed.ConsumedAt) || recovered.SignedConsumption.Consumption.ConsumptionHash != consumed.SignedConsumption.Consumption.ConsumptionHash {
+		t.Fatalf("RecoverGrantConsumption() = %+v, want exact persisted consumption", recovered)
+	}
+}
+
+func TestIssueGrantRevalidatesRawAssertionsAgainstAuthoritySnapshot(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+	quorum := fixture.toQuorum(t, ctx)
+
+	key := fixture.authority.store.Keys[fixture.keyID]
+	key.Enabled = false
+	fixture.authority.store.Keys[fixture.keyID] = key
+	if _, err := fixture.service.IssueGrant(ctx, quorum.ApprovalID); !errors.Is(err, generatedspecapproval.ErrAuthorityRejected) {
+		t.Fatalf("IssueGrant() after authority key revocation error = %v, want authority rejection", err)
+	}
+}
+
+func TestVerifyQuorumRejectsRequesterAndChallengeMismatch(t *testing.T) {
+	t.Run("requester self approval", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		challenged := fixture.toChallenge(t, ctx)
+		key := fixture.authority.store.Keys[fixture.keyID]
+		key.PrincipalID = fixture.binding.RequestingPrincipalID
+		fixture.authority.store.Keys[fixture.keyID] = key
+		if _, err := fixture.service.VerifyQuorum(ctx, challenged.ApprovalID, []contracts.GeneratedSpecApprovalAssertion{fixture.assertion(t, *challenged.Challenge)}); !errors.Is(err, generatedspecapproval.ErrAuthorityRejected) {
+			t.Fatalf("VerifyQuorum(self approval) error = %v, want authority rejection", err)
+		}
+	})
+
+	t.Run("assertion replayed from another challenge", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		challenged := fixture.toChallenge(t, ctx)
+		assertion := fixture.assertion(t, *challenged.Challenge)
+		assertion.ChallengeHash = testHash("9")
+		if _, err := fixture.service.VerifyQuorum(ctx, challenged.ApprovalID, []contracts.GeneratedSpecApprovalAssertion{assertion}); !errors.Is(err, generatedspecapproval.ErrVerificationFailed) {
+			t.Fatalf("VerifyQuorum(mismatched challenge) error = %v, want verification failure", err)
+		}
+	})
+}
+
+func TestConsumeRejectsWrongConsumerAndReplay(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+	granted := fixture.toGrant(t, ctx)
+	grant := granted.SignedGrant.Grant
+
+	fixture.consumer.identity.Audience = "wrong-audience"
+	if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrConsumerUnavailable) {
+		t.Fatalf("ConsumeGrant(wrong consumer audience) error = %v, want consumer rejection", err)
+	}
+	fixture.consumer.identity.Audience = contracts.GeneratedSpecApprovalAudienceV1
+	consumed, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce)
+	if err != nil {
+		t.Fatalf("ConsumeGrant() error = %v", err)
+	}
+	if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrTransitionConflict) {
+		t.Fatalf("ConsumeGrant(replay) error = %v, want transition conflict", err)
+	}
+
+	fixture.consumer.identity.Subject = "spiffe://helm/control-plane-b"
+	if _, err := fixture.service.RecoverGrantConsumption(ctx, consumed.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrConsumerUnavailable) {
+		t.Fatalf("RecoverGrantConsumption(other identity) error = %v, want consumer rejection", err)
+	}
+}
+
+func TestDenyFencesAnIssuedGrant(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+	granted := fixture.toGrant(t, ctx)
+	grant := granted.SignedGrant.Grant
+
+	denied, err := fixture.service.Deny(ctx, granted.ApprovalID)
+	if err != nil {
+		t.Fatalf("Deny() error = %v", err)
+	}
+	if denied.State != StateDenied {
+		t.Fatalf("Deny() state = %s, want %s", denied.State, StateDenied)
+	}
+	if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrTransitionConflict) {
+		t.Fatalf("ConsumeGrant(denied) error = %v, want transition conflict", err)
+	}
+}
+
+func TestExpiryFailsClosedForConsumptionAndRecovery(t *testing.T) {
+	t.Run("unconsumed grant", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		fixture.now = grant.ExpiresAt
+		if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrExpired) {
+			t.Fatalf("ConsumeGrant(expired) error = %v, want expiry", err)
+		}
+		expired, err := fixture.service.Expire(ctx, granted.ApprovalID)
+		if err != nil {
+			t.Fatalf("Expire() error = %v", err)
+		}
+		if expired.State != StateExpired {
+			t.Fatalf("Expire() state = %s, want %s", expired.State, StateExpired)
+		}
+	})
+
+	t.Run("consumption recovery", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); err != nil {
+			t.Fatalf("ConsumeGrant() error = %v", err)
+		}
+		fixture.now = grant.ExpiresAt
+		if _, err := fixture.service.RecoverGrantConsumption(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrExpired) {
+			t.Fatalf("RecoverGrantConsumption(expired) error = %v, want expiry", err)
+		}
+	})
+}
+
+func TestStoredEnvelopesRequirePinnedSignatureVerification(t *testing.T) {
+	t.Run("grant", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		fixture.mutate(granted.ApprovalID, func(record *Record) {
+			record.SignedGrant.Signature = strings.Repeat("0", 128)
+		})
+		if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, generatedspecapproval.ErrSignatureRejected) {
+			t.Fatalf("ConsumeGrant(tampered stored grant) error = %v, want signature rejection", err)
+		}
+	})
+
+	t.Run("consumption", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); err != nil {
+			t.Fatalf("ConsumeGrant() error = %v", err)
+		}
+		fixture.mutate(granted.ApprovalID, func(record *Record) {
+			record.SignedConsumption.Signature = strings.Repeat("0", 128)
+		})
+		if _, err := fixture.service.RecoverGrantConsumption(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, generatedspecapproval.ErrSignatureRejected) {
+			t.Fatalf("RecoverGrantConsumption(tampered stored consumption) error = %v, want signature rejection", err)
+		}
+	})
+}
+
+type ceremonyFixture struct {
+	now        time.Time
+	config     ServiceConfig
+	binding    Binding
+	store      *memoryStore
+	authority  *authorityStub
+	control    *controlStub
+	consumer   *consumerStub
+	service    *Service
+	verifier   *generatedspecapproval.Ed25519Verifier
+	privateKey ed25519.PrivateKey
+	keyID      string
+}
+
+func newCeremonyFixture(t *testing.T) *ceremonyFixture {
+	t.Helper()
+	fixture := &ceremonyFixture{
+		now: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+		config: ServiceConfig{
+			MinHoldDuration: time.Minute, ChallengeTTL: 4 * time.Minute, MaxChallengeLifetime: 8 * time.Minute,
+			GrantTTL: 2 * time.Minute, MaxAssertions: 2, ServerIdentity: "spiffe://helm/kernel-a",
+			KernelTrustRootID: "kernel-root-a", SigningKeyRef: "kms://helm/generated-spec-a",
+		},
+		binding: Binding{
+			BindingRef: "binding-a", TenantID: "tenant-a", WorkspaceID: "workspace-a", Audience: contracts.GeneratedSpecApprovalAudienceV1,
+			GeneratedSpecID: "spec-a", GeneratedSpecHash: testHash("a"), ExecutionPlanHash: testHash("b"),
+			PlanTransactionHash: testHash("c"), WriteSetHash: testHash("d"), VerificationScopeHash: testHash("e"),
+			PolicyEnvelopeHash: testHash("f"), PolicyVersion: "policy-v1", PolicyEpoch: "epoch-1", Action: contracts.GeneratedSpecApprovalActionV1,
+			RequestingPrincipalID: "user:requester-a", AuthoritySource: "authority-a", AuthorityVersion: "version-a",
+			AuthoritySnapshotHash: testHash("0"), RequiredRole: "generated-spec-approver", Quorum: 1, ServerIdentity: "spiffe://helm/kernel-a",
+		},
+		store:    newMemoryStore(),
+		control:  &controlStub{identity: ControlIdentity{Subject: "spiffe://helm/control-api", TenantID: "tenant-a", WorkspaceID: "workspace-a"}},
+		consumer: &consumerStub{identity: ConsumerIdentity{Subject: "spiffe://helm/control-plane-a", TenantID: "tenant-a", WorkspaceID: "workspace-a", Audience: contracts.GeneratedSpecApprovalAudienceV1}},
+		keyID:    "approver-key-a",
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(cryptorand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	fixture.privateKey = privateKey
+	fixture.authority = &authorityStub{store: approvalverify.TrustStore{
+		AuthoritySource: fixture.binding.AuthoritySource, AuthorityVersion: fixture.binding.AuthorityVersion, AuthoritySnapshotHash: fixture.binding.AuthoritySnapshotHash,
+		Keys: map[string]approvalverify.TrustedApproverKey{
+			fixture.keyID: {
+				KeyID: fixture.keyID, TenantID: fixture.binding.TenantID, PrincipalID: "user:approver-a", CredentialID: "credential-a", DeviceID: "device-a",
+				PublicKey: publicKey, WorkspaceIDs: []string{fixture.binding.WorkspaceID}, Roles: []string{fixture.binding.RequiredRole},
+				Actions: []string{fixture.binding.Action}, Audiences: []string{fixture.binding.Audience}, Enabled: true,
+				NotBefore: fixture.now.Add(-time.Hour), NotAfter: fixture.now.Add(time.Hour),
+			},
+		},
+	}}
+	signer, err := crypto.NewEd25519Signer("generated-spec-kernel")
+	if err != nil {
+		t.Fatalf("NewEd25519Signer() error = %v", err)
+	}
+	fixture.verifier, err = generatedspecapproval.NewEd25519Verifier(signer.PublicKeyBytes(), fixture.config.SigningKeyRef, fixture.config.KernelTrustRootID)
+	if err != nil {
+		t.Fatalf("NewEd25519Verifier() error = %v", err)
+	}
+	bindingProvider := bindingStub{binding: fixture.binding}
+	fixture.service, err = newService(fixture.store, bindingProvider, fixture.authority, fixture.control, fixture.consumer, signer, fixture.verifier,
+		func() time.Time { return fixture.now }, bytes.NewReader(bytes.Repeat([]byte{0x42}, 256)), fixture.config)
+	if err != nil {
+		t.Fatalf("newService() error = %v", err)
+	}
+	return fixture
+}
+
+func (f *ceremonyFixture) advance(duration time.Duration) { f.now = f.now.Add(duration) }
+
+func (f *ceremonyFixture) toChallenge(t *testing.T, ctx context.Context) Record {
+	t.Helper()
+	hold, err := f.service.BeginHold(ctx, f.binding.BindingRef)
+	if err != nil {
+		t.Fatalf("BeginHold() error = %v", err)
+	}
+	f.advance(f.config.MinHoldDuration)
+	challenged, err := f.service.IssueChallenge(ctx, hold.ApprovalID)
+	if err != nil {
+		t.Fatalf("IssueChallenge() error = %v", err)
+	}
+	return challenged
+}
+
+func (f *ceremonyFixture) toQuorum(t *testing.T, ctx context.Context) Record {
+	t.Helper()
+	challenged := f.toChallenge(t, ctx)
+	quorum, err := f.service.VerifyQuorum(ctx, challenged.ApprovalID, []contracts.GeneratedSpecApprovalAssertion{f.assertion(t, *challenged.Challenge)})
+	if err != nil {
+		t.Fatalf("VerifyQuorum() error = %v", err)
+	}
+	return quorum
+}
+
+func (f *ceremonyFixture) toGrant(t *testing.T, ctx context.Context) Record {
+	t.Helper()
+	quorum := f.toQuorum(t, ctx)
+	granted, err := f.service.IssueGrant(ctx, quorum.ApprovalID)
+	if err != nil {
+		t.Fatalf("IssueGrant() error = %v", err)
+	}
+	return granted
+}
+
+func (f *ceremonyFixture) assertion(t *testing.T, challenge contracts.GeneratedSpecApprovalChallenge) contracts.GeneratedSpecApprovalAssertion {
+	t.Helper()
+	assertion := contracts.GeneratedSpecApprovalAssertion{
+		Domain: contracts.GeneratedSpecApprovalAssertionDomainV1, SchemaVersion: contracts.GeneratedSpecApprovalAssertionSchemaV1,
+		ContractVersion: contracts.GeneratedSpecApprovalAssertionContractV1, ChallengeID: challenge.ChallengeID, ChallengeHash: challenge.ChallengeHash,
+		KeyID: f.keyID, Algorithm: contracts.GeneratedSpecApprovalAssertionEd25519,
+	}
+	digest, err := assertion.SigningDigest()
+	if err != nil {
+		t.Fatalf("SigningDigest() error = %v", err)
+	}
+	assertion.Signature = "ed25519:" + hex.EncodeToString(ed25519.Sign(f.privateKey, digest))
+	return assertion
+}
+
+func (f *ceremonyFixture) mutate(approvalID string, mutate func(*Record)) {
+	f.store.mu.Lock()
+	defer f.store.mu.Unlock()
+	key := keyFor(f.binding.TenantID, f.binding.WorkspaceID, approvalID)
+	record := f.store.records[key]
+	mutate(&record)
+	f.store.records[key] = record
+}
+
+type bindingStub struct{ binding Binding }
+
+func (s bindingStub) LoadGeneratedSpecApprovalBinding(_ context.Context, tenantID, workspaceID, bindingRef string) (Binding, error) {
+	if tenantID != s.binding.TenantID || workspaceID != s.binding.WorkspaceID || bindingRef != s.binding.BindingRef {
+		return Binding{}, fmt.Errorf("unexpected binding request")
+	}
+	return s.binding, nil
+}
+
+type authorityStub struct{ store approvalverify.TrustStore }
+
+func (s *authorityStub) LoadGeneratedSpecApprovalAuthority(_ context.Context, tenantID, workspaceID, source, version, snapshotHash string) (approvalverify.TrustStore, error) {
+	if tenantID == "" || workspaceID == "" || source != s.store.AuthoritySource || version != s.store.AuthorityVersion || snapshotHash != s.store.AuthoritySnapshotHash {
+		return approvalverify.TrustStore{}, fmt.Errorf("unexpected authority request")
+	}
+	return s.store, nil
+}
+
+type controlStub struct{ identity ControlIdentity }
+
+func (s *controlStub) LoadControlIdentity(context.Context) (ControlIdentity, error) {
+	return s.identity, nil
+}
+
+type consumerStub struct{ identity ConsumerIdentity }
+
+func (s *consumerStub) LoadConsumerIdentity(context.Context) (ConsumerIdentity, error) {
+	return s.identity, nil
+}
+
+func assertChallengeBinding(t *testing.T, binding Binding, challenge contracts.GeneratedSpecApprovalChallenge) {
+	t.Helper()
+	if challenge.TenantID != binding.TenantID || challenge.WorkspaceID != binding.WorkspaceID || challenge.Audience != binding.Audience ||
+		challenge.GeneratedSpecID != binding.GeneratedSpecID || challenge.GeneratedSpecHash != binding.GeneratedSpecHash ||
+		challenge.ExecutionPlanHash != binding.ExecutionPlanHash || challenge.PlanTransactionHash != binding.PlanTransactionHash ||
+		challenge.WriteSetHash != binding.WriteSetHash || challenge.VerificationScopeHash != binding.VerificationScopeHash ||
+		challenge.PolicyEnvelopeHash != binding.PolicyEnvelopeHash || challenge.PolicyVersion != binding.PolicyVersion ||
+		challenge.PolicyEpoch != binding.PolicyEpoch || challenge.Action != binding.Action || challenge.RequestingPrincipalID != binding.RequestingPrincipalID ||
+		challenge.AuthoritySource != binding.AuthoritySource || challenge.AuthorityVersion != binding.AuthorityVersion ||
+		challenge.AuthoritySnapshotHash != binding.AuthoritySnapshotHash || challenge.RequiredRole != binding.RequiredRole ||
+		challenge.Quorum != binding.Quorum || challenge.ServerIdentity != binding.ServerIdentity {
+		t.Fatalf("challenge did not exactly bind server-owned GeneratedSpec fields: %+v", challenge)
+	}
+}
+
+func testHash(character string) string { return "sha256:" + strings.Repeat(character, 64) }

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -344,6 +344,9 @@ func TestStoredEnvelopesRequirePinnedSignatureVerification(t *testing.T) {
 		if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, generatedspecapproval.ErrSignatureRejected) {
 			t.Fatalf("ConsumeGrant(tampered stored grant) error = %v, want signature rejection", err)
 		}
+		if _, err := fixture.service.Get(ctx, granted.ApprovalID); !errors.Is(err, generatedspecapproval.ErrSignatureRejected) {
+			t.Fatalf("Get(tampered stored grant) error = %v, want signature rejection", err)
+		}
 	})
 
 	t.Run("consumption", func(t *testing.T) {
@@ -359,6 +362,35 @@ func TestStoredEnvelopesRequirePinnedSignatureVerification(t *testing.T) {
 		})
 		if _, err := fixture.service.RecoverGrantConsumption(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, generatedspecapproval.ErrSignatureRejected) {
 			t.Fatalf("RecoverGrantConsumption(tampered stored consumption) error = %v, want signature rejection", err)
+		}
+	})
+}
+
+func TestTransitionsRejectCorruptedPersistedState(t *testing.T) {
+	t.Run("invalid pre-state", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		hold, err := fixture.service.BeginHold(ctx, fixture.binding.BindingRef)
+		if err != nil {
+			t.Fatalf("BeginHold() error = %v", err)
+		}
+		fixture.mutate(hold.ApprovalID, func(record *Record) {
+			record.UpdatedAt = record.CreatedAt.Add(-time.Minute)
+		})
+		if _, err := fixture.service.Deny(ctx, hold.ApprovalID); !errors.Is(err, ErrInvalidRecord) {
+			t.Fatalf("Deny(corrupted pre-state) error = %v, want invalid record", err)
+		}
+	})
+
+	t.Run("assertion not bound to challenge", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		quorum := fixture.toQuorum(t, ctx)
+		fixture.mutate(quorum.ApprovalID, func(record *Record) {
+			record.Assertions[0].ChallengeHash = testHash("9")
+		})
+		if _, err := fixture.service.IssueGrant(ctx, quorum.ApprovalID); !errors.Is(err, ErrInvalidRecord) {
+			t.Fatalf("IssueGrant(unbound assertion) error = %v, want invalid record", err)
 		}
 	})
 }

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -154,6 +154,20 @@ func TestVerifyQuorumRejectsResealedChallengeBeyondConfiguredTTL(t *testing.T) {
 	}
 }
 
+func TestMemoryStoreCreateHoldRejectsNonHoldRecords(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+	hold, err := fixture.service.BeginHold(ctx, fixture.binding.BindingRef)
+	if err != nil {
+		t.Fatalf("BeginHold() error = %v", err)
+	}
+	hold.ApprovalID = "approval-forged"
+	hold.State = StateChallengeIssued
+	if _, err := fixture.store.CreateHold(ctx, hold); !errors.Is(err, ErrTransitionConflict) {
+		t.Fatalf("CreateHold(non-hold record) error = %v, want transition conflict", err)
+	}
+}
+
 func TestConsumeRejectsWrongConsumerAndReplay(t *testing.T) {
 	fixture := newCeremonyFixture(t)
 	ctx := context.Background()

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -211,7 +211,7 @@ func TestDenyFencesAnIssuedGrant(t *testing.T) {
 	}
 }
 
-func TestExpiryFailsClosedForConsumptionAndRecovery(t *testing.T) {
+func TestExpiryFailsClosedForConsumption(t *testing.T) {
 	t.Run("unconsumed grant", func(t *testing.T) {
 		fixture := newCeremonyFixture(t)
 		ctx := context.Background()
@@ -229,20 +229,53 @@ func TestExpiryFailsClosedForConsumptionAndRecovery(t *testing.T) {
 			t.Fatalf("Expire() state = %s, want %s", expired.State, StateExpired)
 		}
 	})
+}
 
-	t.Run("consumption recovery", func(t *testing.T) {
-		fixture := newCeremonyFixture(t)
-		ctx := context.Background()
-		granted := fixture.toGrant(t, ctx)
-		grant := granted.SignedGrant.Grant
-		if _, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); err != nil {
-			t.Fatalf("ConsumeGrant() error = %v", err)
-		}
-		fixture.now = grant.ExpiresAt
-		if _, err := fixture.service.RecoverGrantConsumption(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrExpired) {
-			t.Fatalf("RecoverGrantConsumption(expired) error = %v, want expiry", err)
-		}
-	})
+func TestRecoverGrantConsumptionServesPersistedReceiptAfterGrantExpiry(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+	granted := fixture.toGrant(t, ctx)
+	grant := granted.SignedGrant.Grant
+	consumed, err := fixture.service.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce)
+	if err != nil {
+		t.Fatalf("ConsumeGrant() error = %v", err)
+	}
+	// The grant lapses after consumption was recorded; the same workload must
+	// still be able to recover its persisted receipt.
+	fixture.now = grant.ExpiresAt
+	recovered, err := fixture.service.RecoverGrantConsumption(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce)
+	if err != nil {
+		t.Fatalf("RecoverGrantConsumption(after grant expiry) error = %v, want persisted receipt", err)
+	}
+	if recovered.State != StateConsumed || recovered.SignedConsumption.Consumption.ConsumptionHash != consumed.SignedConsumption.Consumption.ConsumptionHash {
+		t.Fatalf("RecoverGrantConsumption() = %+v, want exact persisted consumption", recovered)
+	}
+}
+
+func TestExpireReleasesHoldAfterMaxChallengeLifetime(t *testing.T) {
+	fixture := newCeremonyFixture(t)
+	ctx := context.Background()
+	hold, err := fixture.service.BeginHold(ctx, fixture.binding.BindingRef)
+	if err != nil {
+		t.Fatalf("BeginHold() error = %v", err)
+	}
+	if _, err := fixture.service.Expire(ctx, hold.ApprovalID); !errors.Is(err, ErrTransitionConflict) {
+		t.Fatalf("Expire(before challenge lifetime) error = %v, want transition conflict", err)
+	}
+	fixture.advance(fixture.config.MaxChallengeLifetime)
+	if _, err := fixture.service.IssueChallenge(ctx, hold.ApprovalID); !errors.Is(err, ErrExpired) {
+		t.Fatalf("IssueChallenge(after challenge lifetime) error = %v, want expiry", err)
+	}
+	expired, err := fixture.service.Expire(ctx, hold.ApprovalID)
+	if err != nil {
+		t.Fatalf("Expire() error = %v", err)
+	}
+	if expired.State != StateExpired {
+		t.Fatalf("Expire() state = %s, want %s", expired.State, StateExpired)
+	}
+	if expired.ExpiresAt == nil || !expired.ExpiresAt.Equal(hold.HoldStartedAt.Add(fixture.config.MaxChallengeLifetime)) {
+		t.Fatalf("Expire() expires_at = %v, want committed challenge lifetime deadline", expired.ExpiresAt)
+	}
 }
 
 func TestStoredEnvelopesRequirePinnedSignatureVerification(t *testing.T) {
@@ -307,7 +340,7 @@ func newCeremonyFixture(t *testing.T) *ceremonyFixture {
 			RequestingPrincipalID: "user:requester-a", AuthoritySource: "authority-a", AuthorityVersion: "version-a",
 			AuthoritySnapshotHash: testHash("0"), RequiredRole: "generated-spec-approver", Quorum: 1, ServerIdentity: "spiffe://helm/kernel-a",
 		},
-		store:    newMemoryStore(),
+		store:    newMemoryStore(8 * time.Minute),
 		control:  &controlStub{identity: ControlIdentity{Subject: "spiffe://helm/control-api", TenantID: "tenant-a", WorkspaceID: "workspace-a"}},
 		consumer: &consumerStub{identity: ConsumerIdentity{Subject: "spiffe://helm/control-plane-a", TenantID: "tenant-a", WorkspaceID: "workspace-a", Audience: contracts.GeneratedSpecApprovalAudienceV1}},
 		keyID:    "approver-key-a",

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -193,6 +193,60 @@ func TestConsumeRejectsWrongConsumerAndReplay(t *testing.T) {
 	}
 }
 
+func TestConsumeGrantSealerPinsCallerScope(t *testing.T) {
+	newTamperedService := func(t *testing.T, fixture *ceremonyFixture, tamper func(*generatedspecapproval.SignedGrant, *string, *time.Time)) *Service {
+		t.Helper()
+		svc, err := newService(
+			tamperedSealerStore{Store: fixture.store, tamper: tamper},
+			bindingStub{binding: fixture.binding}, fixture.authority, fixture.control, fixture.consumer,
+			fixture.signer, fixture.verifier, func() time.Time { return fixture.now },
+			bytes.NewReader(bytes.Repeat([]byte{0x42}, 256)), fixture.config)
+		if err != nil {
+			t.Fatalf("newService() error = %v", err)
+		}
+		return svc
+	}
+
+	t.Run("substituted consumer", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		svc := newTamperedService(t, fixture, func(_ *generatedspecapproval.SignedGrant, consumedBy *string, _ *time.Time) {
+			*consumedBy = "spiffe://helm/control-plane-mallory"
+		})
+		if _, err := svc.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrConsumerUnavailable) {
+			t.Fatalf("ConsumeGrant(substituted consumer) error = %v, want consumer rejection", err)
+		}
+	})
+
+	t.Run("substituted timestamp", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		svc := newTamperedService(t, fixture, func(_ *generatedspecapproval.SignedGrant, _ *string, consumedAt *time.Time) {
+			*consumedAt = consumedAt.Add(-time.Minute)
+		})
+		if _, err := svc.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrConsumerUnavailable) {
+			t.Fatalf("ConsumeGrant(substituted timestamp) error = %v, want consumer rejection", err)
+		}
+	})
+
+	t.Run("substituted grant", func(t *testing.T) {
+		fixture := newCeremonyFixture(t)
+		ctx := context.Background()
+		granted := fixture.toGrant(t, ctx)
+		grant := granted.SignedGrant.Grant
+		svc := newTamperedService(t, fixture, func(signed *generatedspecapproval.SignedGrant, _ *string, _ *time.Time) {
+			signed.Grant.Nonce = strings.Repeat("f", 64)
+		})
+		if _, err := svc.ConsumeGrant(ctx, granted.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrConsumerUnavailable) {
+			t.Fatalf("ConsumeGrant(substituted grant) error = %v, want consumer rejection", err)
+		}
+	})
+}
+
 func TestDenyFencesAnIssuedGrant(t *testing.T) {
 	fixture := newCeremonyFixture(t)
 	ctx := context.Background()
@@ -319,6 +373,7 @@ type ceremonyFixture struct {
 	consumer   *consumerStub
 	service    *Service
 	verifier   *generatedspecapproval.Ed25519Verifier
+	signer     crypto.Signer
 	privateKey ed25519.PrivateKey
 	keyID      string
 }
@@ -365,6 +420,7 @@ func newCeremonyFixture(t *testing.T) *ceremonyFixture {
 	if err != nil {
 		t.Fatalf("NewEd25519Signer() error = %v", err)
 	}
+	fixture.signer = signer
 	fixture.verifier, err = generatedspecapproval.NewEd25519Verifier(signer.PublicKeyBytes(), fixture.config.SigningKeyRef, fixture.config.KernelTrustRootID)
 	if err != nil {
 		t.Fatalf("NewEd25519Verifier() error = %v", err)
@@ -466,6 +522,22 @@ type consumerStub struct{ identity ConsumerIdentity }
 
 func (s *consumerStub) LoadConsumerIdentity(context.Context) (ConsumerIdentity, error) {
 	return s.identity, nil
+}
+
+// tamperedSealerStore wraps a Store and rewrites the arguments handed to the
+// consumption sealer, simulating a store that tries to use the sealer as a
+// signing oracle for a substituted grant, consumer, or timestamp.
+type tamperedSealerStore struct {
+	Store
+	tamper func(*generatedspecapproval.SignedGrant, *string, *time.Time)
+}
+
+func (s tamperedSealerStore) ConsumeGrant(ctx context.Context, tenantID, workspaceID, approvalID, grantID, grantHash, nonce, consumedBy, audience string, verifier GrantSignatureVerifier, consumedAt time.Time, seal ConsumptionSealer) (Record, error) {
+	return s.Store.ConsumeGrant(ctx, tenantID, workspaceID, approvalID, grantID, grantHash, nonce, consumedBy, audience, verifier, consumedAt,
+		func(signed generatedspecapproval.SignedGrant, by string, at time.Time) (generatedspecapproval.SignedConsumption, error) {
+			s.tamper(&signed, &by, &at)
+			return seal(signed, by, at)
+		})
 }
 
 func assertChallengeBinding(t *testing.T, binding Binding, challenge contracts.GeneratedSpecApprovalChallenge) {

--- a/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
@@ -209,6 +209,9 @@ func (s *memoryStore) update(ctx context.Context, tenantID, workspaceID, approva
 	if !ok {
 		return Record{}, ErrNotFound
 	}
+	if err := record.validate(); err != nil {
+		return Record{}, err
+	}
 	if err := mutate(&record); err != nil {
 		return Record{}, err
 	}

--- a/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
@@ -13,8 +13,9 @@ import (
 // memoryStore is intentionally unexported and process-local. It exists solely
 // for unit tests; it is not a durable-store substitute.
 type memoryStore struct {
-	mu      sync.Mutex
-	records map[recordKey]Record
+	mu                   sync.Mutex
+	records              map[recordKey]Record
+	maxChallengeLifetime time.Duration
 }
 
 type recordKey struct {
@@ -23,7 +24,9 @@ type recordKey struct {
 	approvalID  string
 }
 
-func newMemoryStore() *memoryStore { return &memoryStore{records: make(map[recordKey]Record)} }
+func newMemoryStore(maxChallengeLifetime time.Duration) *memoryStore {
+	return &memoryStore{records: make(map[recordKey]Record), maxChallengeLifetime: maxChallengeLifetime}
+}
 
 func (s *memoryStore) CreateHold(ctx context.Context, record Record) (Record, error) {
 	if err := ctx.Err(); err != nil {
@@ -169,11 +172,24 @@ func (s *memoryStore) Deny(ctx context.Context, tenantID, workspaceID, approvalI
 func (s *memoryStore) Expire(ctx context.Context, tenantID, workspaceID, approvalID string, expiredAt time.Time) (Record, error) {
 	return s.update(ctx, tenantID, workspaceID, approvalID, func(record *Record) error {
 		switch record.State {
+		case StateHoldPending:
+			// A never-challenged hold commits to HoldStartedAt + MaxChallengeLifetime:
+			// IssueChallenge refuses challenges past that point, so without an expiry
+			// path the record would stay pending forever. Committing the deadline as
+			// the record expiry keeps the terminal-state invariant intact.
+			if s.maxChallengeLifetime <= 0 {
+				return ErrTransitionConflict
+			}
+			deadline := record.HoldStartedAt.Add(s.maxChallengeLifetime)
+			if expiredAt.Before(deadline) {
+				return ErrTransitionConflict
+			}
+			record.ExpiresAt = &deadline
 		case StateChallengeIssued, StateQuorumVerified, StateGrantIssued:
+			if record.ExpiresAt == nil || expiredAt.Before(*record.ExpiresAt) {
+				return ErrTransitionConflict
+			}
 		default:
-			return ErrTransitionConflict
-		}
-		if record.ExpiresAt == nil || expiredAt.Before(*record.ExpiresAt) {
 			return ErrTransitionConflict
 		}
 		record.State = StateExpired

--- a/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
@@ -29,6 +29,9 @@ func (s *memoryStore) CreateHold(ctx context.Context, record Record) (Record, er
 	if err := ctx.Err(); err != nil {
 		return Record{}, err
 	}
+	if record.State != StateHoldPending {
+		return Record{}, ErrTransitionConflict
+	}
 	if err := record.validate(); err != nil {
 		return Record{}, err
 	}

--- a/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/memory_store.go
@@ -1,0 +1,249 @@
+package generatedspecapprovalceremony
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapproval"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// memoryStore is intentionally unexported and process-local. It exists solely
+// for unit tests; it is not a durable-store substitute.
+type memoryStore struct {
+	mu      sync.Mutex
+	records map[recordKey]Record
+}
+
+type recordKey struct {
+	tenantID    string
+	workspaceID string
+	approvalID  string
+}
+
+func newMemoryStore() *memoryStore { return &memoryStore{records: make(map[recordKey]Record)} }
+
+func (s *memoryStore) CreateHold(ctx context.Context, record Record) (Record, error) {
+	if err := ctx.Err(); err != nil {
+		return Record{}, err
+	}
+	if err := record.validate(); err != nil {
+		return Record{}, err
+	}
+	key := keyFor(record.TenantID, record.WorkspaceID, record.ApprovalID)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.records[key]; exists {
+		return Record{}, ErrTransitionConflict
+	}
+	s.records[key] = cloneRecord(record)
+	return cloneRecord(record), nil
+}
+
+func (s *memoryStore) Get(ctx context.Context, tenantID, workspaceID, approvalID string) (Record, error) {
+	if err := ctx.Err(); err != nil {
+		return Record{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	record, ok := s.records[keyFor(tenantID, workspaceID, approvalID)]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	return cloneRecord(record), nil
+}
+
+func (s *memoryStore) IssueChallenge(ctx context.Context, tenantID, workspaceID, approvalID string, challenge contracts.GeneratedSpecApprovalChallenge, issuedAt time.Time) (Record, error) {
+	return s.update(ctx, tenantID, workspaceID, approvalID, func(record *Record) error {
+		if record.State != StateHoldPending || !issuedAt.Equal(challenge.IssuedAt) {
+			return ErrTransitionConflict
+		}
+		record.State = StateChallengeIssued
+		record.Challenge = &challenge
+		expiresAt := challenge.ExpiresAt
+		record.ExpiresAt = &expiresAt
+		record.UpdatedAt = issuedAt
+		return nil
+	})
+}
+
+func (s *memoryStore) RecordQuorum(ctx context.Context, tenantID, workspaceID, approvalID string, assertions []contracts.GeneratedSpecApprovalAssertion, verifiedAt time.Time) (Record, error) {
+	return s.update(ctx, tenantID, workspaceID, approvalID, func(record *Record) error {
+		if record.State != StateChallengeIssued || record.Challenge == nil || len(assertions) < record.Binding.Quorum || !verifiedAt.Before(record.Challenge.ExpiresAt) {
+			return ErrTransitionConflict
+		}
+		record.State = StateQuorumVerified
+		record.Assertions = append([]contracts.GeneratedSpecApprovalAssertion(nil), assertions...)
+		at := verifiedAt
+		record.QuorumVerifiedAt = &at
+		record.UpdatedAt = verifiedAt
+		return nil
+	})
+}
+
+func (s *memoryStore) IssueGrant(ctx context.Context, tenantID, workspaceID, approvalID string, signed generatedspecapproval.SignedGrant, verifier GrantSignatureVerifier, issuedAt time.Time) (Record, error) {
+	return s.update(ctx, tenantID, workspaceID, approvalID, func(record *Record) error {
+		if verifier == nil || record.State != StateQuorumVerified || record.Challenge == nil || record.QuorumVerifiedAt == nil || !issuedAt.Equal(signed.Grant.IssuedAt) || !issuedAt.Before(signed.Grant.ExpiresAt) {
+			return ErrTransitionConflict
+		}
+		if err := verifier.VerifyGrant(signed, issuedAt); err != nil {
+			return err
+		}
+		record.State = StateGrantIssued
+		record.SignedGrant = cloneSignedGrant(&signed)
+		expiresAt := signed.Grant.ExpiresAt
+		record.ExpiresAt = &expiresAt
+		record.UpdatedAt = issuedAt
+		return nil
+	})
+}
+
+func (s *memoryStore) ConsumeGrant(ctx context.Context, tenantID, workspaceID, approvalID, grantID, grantHash, nonce, consumedBy, audience string, verifier GrantSignatureVerifier, consumedAt time.Time, seal ConsumptionSealer) (Record, error) {
+	if err := ctx.Err(); err != nil {
+		return Record{}, err
+	}
+	if seal == nil || verifier == nil {
+		return Record{}, ErrTransitionConflict
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := keyFor(tenantID, workspaceID, approvalID)
+	record, ok := s.records[key]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	if err := record.validate(); err != nil {
+		return Record{}, err
+	}
+	if record.State != StateGrantIssued || record.SignedGrant == nil || record.SignedGrant.Grant.GrantID != grantID || record.SignedGrant.Grant.GrantHash != grantHash || record.SignedGrant.Grant.Nonce != nonce || record.SignedGrant.Grant.TenantID != tenantID || record.SignedGrant.Grant.WorkspaceID != workspaceID {
+		return Record{}, ErrTransitionConflict
+	}
+	if record.SignedGrant.Grant.Audience != audience {
+		return Record{}, fmt.Errorf("%w: signed grant workload scope mismatch", ErrConsumerUnavailable)
+	}
+	if err := ensureGrantActive(record.SignedGrant.Grant, consumedAt); err != nil {
+		return Record{}, err
+	}
+	if err := verifier.VerifyGrant(*record.SignedGrant, consumedAt); err != nil {
+		return Record{}, err
+	}
+	signedConsumption, err := seal(*cloneSignedGrant(record.SignedGrant), consumedBy, consumedAt)
+	if err != nil {
+		return Record{}, err
+	}
+	if err := verifier.VerifyConsumption(signedConsumption, *record.SignedGrant); err != nil {
+		return Record{}, err
+	}
+	record.State = StateConsumed
+	record.SignedConsumption = cloneSignedConsumption(&signedConsumption)
+	at := consumedAt
+	record.ConsumedAt = &at
+	record.ConsumedBy = consumedBy
+	record.UpdatedAt = consumedAt
+	record.Version++
+	if err := record.validate(); err != nil {
+		return Record{}, err
+	}
+	s.records[key] = cloneRecord(record)
+	return cloneRecord(record), nil
+}
+
+func (s *memoryStore) Deny(ctx context.Context, tenantID, workspaceID, approvalID string, deniedAt time.Time) (Record, error) {
+	return s.update(ctx, tenantID, workspaceID, approvalID, func(record *Record) error {
+		switch record.State {
+		case StateHoldPending, StateChallengeIssued, StateQuorumVerified, StateGrantIssued:
+		default:
+			return ErrTransitionConflict
+		}
+		record.State = StateDenied
+		record.UpdatedAt = deniedAt
+		return nil
+	})
+}
+
+func (s *memoryStore) Expire(ctx context.Context, tenantID, workspaceID, approvalID string, expiredAt time.Time) (Record, error) {
+	return s.update(ctx, tenantID, workspaceID, approvalID, func(record *Record) error {
+		switch record.State {
+		case StateChallengeIssued, StateQuorumVerified, StateGrantIssued:
+		default:
+			return ErrTransitionConflict
+		}
+		if record.ExpiresAt == nil || expiredAt.Before(*record.ExpiresAt) {
+			return ErrTransitionConflict
+		}
+		record.State = StateExpired
+		record.UpdatedAt = expiredAt
+		return nil
+	})
+}
+
+func (s *memoryStore) update(ctx context.Context, tenantID, workspaceID, approvalID string, mutate func(*Record) error) (Record, error) {
+	if err := ctx.Err(); err != nil {
+		return Record{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := keyFor(tenantID, workspaceID, approvalID)
+	record, ok := s.records[key]
+	if !ok {
+		return Record{}, ErrNotFound
+	}
+	if err := mutate(&record); err != nil {
+		return Record{}, err
+	}
+	record.Version++
+	if err := record.validate(); err != nil {
+		return Record{}, err
+	}
+	s.records[key] = cloneRecord(record)
+	return cloneRecord(record), nil
+}
+
+func keyFor(tenantID, workspaceID, approvalID string) recordKey {
+	return recordKey{tenantID: tenantID, workspaceID: workspaceID, approvalID: approvalID}
+}
+
+func cloneRecord(record Record) Record {
+	copy := record
+	if record.Challenge != nil {
+		challenge := *record.Challenge
+		copy.Challenge = &challenge
+	}
+	copy.Assertions = append([]contracts.GeneratedSpecApprovalAssertion(nil), record.Assertions...)
+	copy.QuorumVerifiedAt = cloneTime(record.QuorumVerifiedAt)
+	copy.SignedGrant = cloneSignedGrant(record.SignedGrant)
+	copy.SignedConsumption = cloneSignedConsumption(record.SignedConsumption)
+	copy.ExpiresAt = cloneTime(record.ExpiresAt)
+	copy.ConsumedAt = cloneTime(record.ConsumedAt)
+	return copy
+}
+
+func cloneSignedGrant(signed *generatedspecapproval.SignedGrant) *generatedspecapproval.SignedGrant {
+	if signed == nil {
+		return nil
+	}
+	copy := *signed
+	copy.Grant.ApproverPrincipalIDs = append([]string(nil), signed.Grant.ApproverPrincipalIDs...)
+	return &copy
+}
+
+func cloneSignedConsumption(signed *generatedspecapproval.SignedConsumption) *generatedspecapproval.SignedConsumption {
+	if signed == nil {
+		return nil
+	}
+	copy := *signed
+	copy.Consumption.ApproverPrincipalIDs = append([]string(nil), signed.Consumption.ApproverPrincipalIDs...)
+	return &copy
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	copy := *value
+	return &copy
+}
+
+var _ Store = (*memoryStore)(nil)


### PR DESCRIPTION
## Summary
- adds a source-shaped GeneratedSpec approval ceremony lifecycle: hold, challenge, quorum verification, grant issuance, consume/recovery, deny, and expiry
- binds every challenge to opaque server-owned binding, authority snapshot, verified control identity, and verified workload identity
- re-verifies raw quorum assertions at issuance and requires pinned grant/consumption signature verification inside the persistence seam
- keeps the only implementation process-local and unexported for unit tests; it is explicitly not production authority

## Security boundary
This does not activate a public approval route, Control Plane adapter, client integration, or runtime authority. It intentionally has no Postgres/RLS/FENCE/CAS durable store, no transport identity injection, and no source-owned runtime binding/authority providers. The current Control Plane remains fail-closed.

## Validation
- cd core && GOWORK=off go test ./pkg/contracts ./pkg/boundary/generatedspecapproval ./pkg/boundary/generatedspecapprovalceremony -count=1
- cd core && GOWORK=off go vet ./pkg/boundary/generatedspecapprovalceremony
- cd core && GOWORK=off go test -race ./pkg/boundary/generatedspecapprovalceremony -count=1
- make test-approval-ceremony
- make verify-approval-ceremony-vectors (existing generic ceremony/reference-pack baseline)
- git diff --check

## Follow-up
A durable Postgres store with tenant/workspace isolation, atomic CAS/FENCE transitions, and recovery integration is required before any adapter or approval route can be considered.