### PR TITLE
fix(release-permit): accept pinned workflow SHA

### DIFF
--- a/core/cmd/release-permit-verify/main_test.go
+++ b/core/cmd/release-permit-verify/main_test.go
@@ -72,11 +72,15 @@ func TestVerifyPermitFileRejectsTamperedPermit(t *testing.T) {
 	}
 }
 
-func TestVerifyPermitFileAcceptsReducerPermitAgainstTrustedContext(t *testing.T) {
-	contextContent := []byte(validContextJSON())
+func TestVerifyPermitFileAcceptsSHAWorkflowRefAgainstTrustedContext(t *testing.T) {
 	var context releasepermit.Context
-	if err := json.Unmarshal(contextContent, &context); err != nil {
+	if err := json.Unmarshal([]byte(validContextJSON()), &context); err != nil {
 		t.Fatalf("decode context fixture: %v", err)
+	}
+	context.WorkflowRef = context.WorkflowRepository + "/" + context.WorkflowPath + "@" + context.WorkflowSHA
+	contextContent, err := json.Marshal(context)
+	if err != nil {
+		t.Fatalf("encode context fixture: %v", err)
 	}
 	contextDigest := sha256.Sum256(contextContent)
 	contextSHA256 := hex.EncodeToString(contextDigest[:])

--- a/core/pkg/releasepermit/evaluate.go
+++ b/core/pkg/releasepermit/evaluate.go
@@ -196,8 +196,8 @@ func ValidateAllowPermit(permit Permit, trustedContext Context, contextSHA256 st
 		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
 	}
 	workflowRef := normalizeWorkflowRef(permit.WorkflowRepository, permit.WorkflowPath, permit.WorkflowRef)
-	if !validGitRef(workflowRef, true) {
-		problems = append(problems, "workflow_ref must be a branch or tag ref")
+	if !validWorkflowRef(workflowRef, permit.WorkflowSHA) {
+		problems = append(problems, "workflow_ref must be a branch or tag ref or match workflow_sha")
 	}
 	if strings.EqualFold(permit.Repository, permit.WorkflowRepository) &&
 		(permit.WorkflowSHA == permit.HeadSHA || permit.WorkflowSHA == permit.MergeSHA) {
@@ -323,8 +323,8 @@ func validateContext(context Context) error {
 		problems = append(problems, "workflow_path must name a GitHub Actions workflow")
 	}
 	workflowRef := normalizeWorkflowRef(context.WorkflowRepository, context.WorkflowPath, context.WorkflowRef)
-	if !validGitRef(workflowRef, true) {
-		problems = append(problems, "workflow_ref must be a branch or tag ref")
+	if !validWorkflowRef(workflowRef, context.WorkflowSHA) {
+		problems = append(problems, "workflow_ref must be a branch or tag ref or match workflow_sha")
 	}
 	if !hexSHA40Pattern.MatchString(context.WorkflowSHA) {
 		problems = append(problems, "workflow_sha must be a lowercase 40-character Git SHA")
@@ -501,6 +501,10 @@ func validWorkflowPath(path string) bool {
 
 func normalizeWorkflowRef(repository, path, ref string) string {
 	return strings.TrimPrefix(ref, repository+"/"+path+"@")
+}
+
+func validWorkflowRef(ref, workflowSHA string) bool {
+	return validGitRef(ref, true) || ref == workflowSHA
 }
 
 func validGitRef(ref string, allowTag bool) bool {

--- a/core/pkg/releasepermit/evaluate_test.go
+++ b/core/pkg/releasepermit/evaluate_test.go
@@ -138,12 +138,34 @@ func TestEvaluateAcceptsGitHubWorkflowRefIdentity(t *testing.T) {
 	}
 }
 
+func TestEvaluateAcceptsGitHubWorkflowSHAIdentity(t *testing.T) {
+	context := validContext()
+	context.WorkflowRef = context.WorkflowRepository + "/" + context.WorkflowPath + "@" + context.WorkflowSHA
+
+	permit, err := Evaluate(context, testContextSHA, validReviews(context))
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if permit.Decision != DecisionAllow {
+		t.Fatalf("Decision = %q, want %q; reasons = %#v", permit.Decision, DecisionAllow, permit.Reasons)
+	}
+}
+
 func TestEvaluateRejectsMismatchedGitHubWorkflowRefIdentity(t *testing.T) {
 	context := validContext()
 	context.WorkflowRef = "Mindburn-Labs/other/.github/workflows/ci.yml@refs/heads/main"
 
 	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
 		t.Fatal("Evaluate() error = nil, want mismatched workflow identity error")
+	}
+}
+
+func TestEvaluateRejectsMismatchedGitHubWorkflowSHAIdentity(t *testing.T) {
+	context := validContext()
+	context.WorkflowRef = context.WorkflowRepository + "/" + context.WorkflowPath + "@" + testMergeSHA
+
+	if _, err := Evaluate(context, testContextSHA, validReviews(context)); err == nil {
+		t.Fatal("Evaluate() error = nil, want mismatched workflow SHA identity error")
 	}
 }
 


### PR DESCRIPTION
## HELM-350: accept the immutable workflow SHA as a permit workflow reference

The release-permit verifier validates the provenance of a permit against the workflow that issued it. The active GitHub ruleset [`18924515`](https://github.com/Mindburn-Labs/.github/rules/18924515) pins its workflow to immutable source [`c585fc5`](https://github.com/Mindburn-Labs/.github/commit/c585fc546d398c183f71bf5b4f66fa2d90c57e35).

GitHub can therefore provide the permit's `workflow_ref` in SHA form. Before this change, the kernel accepted branch and tag-style Git refs only. A genuine permit tied to the pinned workflow SHA could consequently be rejected, even though that SHA is the expected trusted workflow source.

## Solution

Allow a SHA-form `workflow_ref` **only** when it exactly equals the already trusted `workflow_sha`.

This is intentionally narrower than accepting arbitrary SHAs:

- Existing valid branch and tag references remain accepted.
- A SHA-form `workflow_ref` is accepted only on exact equality with `workflow_sha`.
- A mismatched SHA, malformed reference, or other untrusted value remains rejected.

The same rule is applied in both the permit-policy validation path (`ValidateAllowPermit`) and runtime context validation (`Evaluate` / standalone `release-permit-verify`). This keeps policy evaluation and command-line verification consistent.

## Test coverage

- A permit using the trusted workflow SHA is accepted during evaluation.
- A different SHA is rejected, even though it has SHA syntax.
- The standalone verifier accepts a valid SHA-pinned workflow context.
- Existing branch/tag and rejection coverage remains in place.

## Validation

- `go test ./core/pkg/releasepermit ./core/cmd/release-permit-verify -count=1`
- `make lint`
- `make test`
- `make verify-boundary` — passed: 1,054 current files, 0 stale, 0 errors

## Scope and sequencing

This is a fresh, minimal patch from current `main`. It does not modify a GitHub ruleset, release workflow, permit-authority configuration, or the legacy conflicting kernel PR [#656](https://github.com/Mindburn-Labs/helm-ai-kernel/pull/656).

After an operator merge, #656 can be closed as superseded while retaining its branch for provenance. The standard downstream OSS-sync flow starts only from a fresh post-merge worktree and is not part of this PR.

## Related work

- Governing task: HELM-350
- Active ruleset: [Mindburn-Labs/.github ruleset 18924515](https://github.com/Mindburn-Labs/.github/rules/18924515)
- Immutable workflow source: [Mindburn-Labs/.github@c585fc5](https://github.com/Mindburn-Labs/.github/commit/c585fc546d398c183f71bf5b4f66fa2d90c57e35)
- Companion content-adoption record: [Mindburn-Labs/.github#64](https://github.com/Mindburn-Labs/.github/pull/64)
- Legacy kernel attempt retained until superseded: [Mindburn-Labs/helm-ai-kernel#656](https://github.com/Mindburn-Labs/helm-ai-kernel/pull/656)
