### PR TITLE
feat(actioninbox+hook): model-actionable deny feedback, cascade-reject, doom-loop breaker (W5)

### DIFF
--- a/core/cmd/helm-ai-kernel/hook_cmd.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd.go
@@ -15,10 +15,12 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/actioninbox"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/shellscan"
@@ -127,28 +129,100 @@ func runHookPreToolCmd(args []string, stdin io.Reader, stdout, stderr io.Writer)
 	}
 	classifications := classifyPreToolPayloads(payload)
 	if len(classifications) == 0 {
+		// An unclassified call is successful progress, so it breaks any
+		// consecutive-denial run without changing the fail-closed policy path.
+		recordHookDoomLoopOutcome(opts, payload, hookClassification{}, false, stderr)
 		return 0
 	}
 	for _, decision := range classifications {
 		receipt, err := buildHookDecisionReceipt(opts, payload, decision)
 		if err != nil {
 			fmt.Fprintf(stderr, "hook pre-tool: %v\n", err)
-			reason := "HELM denied operation: local receipt signer is unavailable"
+			tripped, run := recordHookDoomLoopOutcome(opts, payload, decision, true, stderr)
 			if errors.Is(err, errHookPolicyProfile) {
-				reason = "HELM denied operation: policy profile is unavailable"
+				return emitHookDenyOrFail(stdout, stderr, withDoomLoopSteering(tripped, decision, run, failClosedSteeringText(
+					"HELM denied operation: policy profile is unavailable",
+					actioninbox.ReasonPolicyProfileUnavailable,
+					"HELM cannot load or verify the selected workstation policy profile, so the operation fails closed.",
+					"Do not retry until the policy profile and its approved digest are restored.",
+					"Escalate to the human operator; policy profile repair is an operator action.",
+				)))
 			}
-			return emitHookDenyOrFail(stdout, stderr, reason)
+			return emitHookDenyOrFail(stdout, stderr, withDoomLoopSteering(tripped, decision, run, failClosedSteeringText(
+				"HELM denied operation: local receipt signer is unavailable",
+				actioninbox.ReasonSignerUnavailable,
+				"HELM cannot sign a local decision receipt, so the operation fails closed.",
+				"Do not retry until the signer is fixed. Run helm-ai-kernel doctor or helm-ai-kernel setup, or pass --signing-seed-file.",
+				"Escalate to the human operator; signer repair is an operator action, not an agent action.",
+			)))
 		}
 		receiptPath, err := writeDecisionReceipt("", filepath.Join(opts.DataDir, "receipts", "hooks"), receipt)
 		if err != nil {
 			fmt.Fprintf(stderr, "hook pre-tool: write receipt: %v\n", err)
-			return emitHookDenyOrFail(stdout, stderr, "HELM denied operation: receipt persistence is unavailable")
+			tripped, run := recordHookDoomLoopOutcome(opts, payload, decision, true, stderr)
+			return emitHookDenyOrFail(stdout, stderr, withDoomLoopSteering(tripped, decision, run, failClosedSteeringText(
+				"HELM denied operation: receipt persistence is unavailable",
+				actioninbox.ReasonReceiptPersistence,
+				"HELM cannot persist the signed decision receipt, so the operation fails closed.",
+				"Do not retry until receipt storage is fixed; check the data directory is writable.",
+				"Escalate to the human operator; storage repair is an operator action, not an agent action.",
+			)))
 		}
 		if receipt.Verdict == contracts.WorkstationVerdictDeny {
-			return emitHookDenyOrFail(stdout, stderr, fmt.Sprintf("HELM denied %s: %s (receipt: %s)", decision.Reason, receipt.ReasonCode, receiptPath))
+			// The receipt has already been persisted. The breaker only enriches
+			// the denial text after repeated identical failures; it never
+			// decides the effect or bypasses receipt generation.
+			tripped, run := recordHookDoomLoopOutcome(opts, payload, decision, true, stderr)
+			feedback := actioninbox.DenyFeedbackFor(receipt.ReasonCode, receipt.CreatedAt)
+			return emitHookDenyOrFail(stdout, stderr, withDoomLoopSteering(tripped, decision, run,
+				fmt.Sprintf("HELM denied %s: %s (receipt: %s) %s",
+					decision.Reason, receipt.ReasonCode, receiptPath, actioninbox.RenderSteeringText(feedback))))
 		}
 	}
+	// A fully allowed multi-effect call is successful progress only after
+	// every current-main classification has produced a signed receipt.
+	recordHookDoomLoopOutcome(opts, payload, hookClassification{}, false, stderr)
 	return 0
+}
+
+// withDoomLoopSteering appends circuit-breaker escalation guidance to an
+// already-denied outcome when the breaker has latched for this call signature.
+// The base denial (policy or fail-closed) is always preserved; the breaker
+// only adds steering, never authority.
+func withDoomLoopSteering(tripped bool, classification hookClassification, runLength int, base string) string {
+	if !tripped {
+		return base
+	}
+	return base + " " + doomLoopSteeringText(classification, runLength)
+}
+
+// failClosedSteeringText keeps the operator-facing prefix intact and appends
+// model-actionable steering guidance.
+func failClosedSteeringText(prefix, code, explanation, remediation, escalation string) string {
+	return prefix + " " + actioninbox.RenderSteeringText(actioninbox.DenialRecord{
+		SchemaVersion: actioninbox.DenyFeedbackSchemaVersion,
+		ReasonCode:    code,
+		Explanation:   explanation,
+		Remediation:   remediation,
+		Escalation:    escalation,
+		DecidedAt:     hookNow(),
+	})
+}
+
+// doomLoopSteeringText renders circuit-breaker escalation guidance. The
+// breaker only enriches a denial that already exists; it never authorizes and
+// never denies on its own.
+func doomLoopSteeringText(classification hookClassification, runLength int) string {
+	d := actioninbox.DenialRecord{
+		SchemaVersion: actioninbox.DenyFeedbackSchemaVersion,
+		ReasonCode:    actioninbox.ReasonDoomLoopDetected,
+		Explanation: fmt.Sprintf("The identical call (%s via %s) has now been denied %d consecutive times in this session; the doom-loop circuit breaker is forcing escalation.",
+			classification.Action, classification.ToolID, runLength),
+		Remediation: "Stop retrying the identical call. Change the approach, gather the missing information, or abandon the attempt.",
+		Escalation:  "Ask the human operator to review the repeated denials and either take over or adjust policy.",
+		DecidedAt:   hookNow(),
+	}
+	return actioninbox.RenderSteeringText(d)
 }
 
 func emitHookDenyOrFail(stdout, stderr io.Writer, reason string) int {
@@ -170,6 +244,296 @@ func writeHookDeny(stdout io.Writer, reason string) error {
 
 func printHookUsage(w io.Writer) {
 	fmt.Fprintln(w, "Usage: helm-ai-kernel hook pre-tool --client <claude-code|codex> [--data-dir DIR] [--policy-profile PATH --policy-profile-sha256 SHA256] [--signing-seed-file PATH]")
+}
+
+// hookDoomLoopFile is the on-disk circuit-breaker state for the pre-tool
+// hook. The hook process is stateless between invocations, so the identical-
+// denial run is persisted per session under the HELM data dir. The state is
+// advisory evidence for the breaker only; losing it never weakens the base
+// policy decision path, which remains fail-closed on its own.
+type hookDoomLoopFile struct {
+	Sessions map[string]*hookDoomLoopSession `json:"sessions"`
+}
+
+// hookDoomLoopSession tracks one session's consecutive-denial run. The trip
+// latch is keyed per call signature (TrippedSignatures), never per session:
+// a changed approach (different signature) is always evaluated fresh, while
+// retrying an already-tripped identical call keeps the escalation steering.
+type hookDoomLoopSession struct {
+	LastSignature     string          `json:"last_signature"`
+	RunLength         int             `json:"run_length"`
+	TrippedSignatures map[string]bool `json:"tripped_signatures,omitempty"`
+	TripCount         int             `json:"trip_count,omitempty"`
+	LastTrippedAt     *time.Time      `json:"last_tripped_at,omitempty"`
+	LastSeenAt        time.Time       `json:"last_seen_at"`
+}
+
+const (
+	// hookDoomLoopStateTTL prunes idle sessions from the state file.
+	hookDoomLoopStateTTL = 24 * time.Hour
+	// hookDoomLoopMaxSessions bounds the state file (oldest LastSeenAt is
+	// evicted first).
+	hookDoomLoopMaxSessions = 128
+	// hookDoomLoopMaxTrippedSignatures bounds the per-session latch map so
+	// the persisted state cannot grow without bound. Eviction is
+	// deterministic (lexicographically smallest signature); an evicted
+	// signature simply re-trips after another threshold run of denials.
+	hookDoomLoopMaxTrippedSignatures = 64
+	// hookDoomLoopLockWait bounds how long a hook waits for the state lock
+	// before giving up (the breaker is advisory; the policy path proceeds).
+	hookDoomLoopLockWait = 2 * time.Second
+	// hookDoomLoopMaxStateBytes bounds reads of locally tampered state.
+	hookDoomLoopMaxStateBytes = 1 << 20
+)
+
+// hookSessionKey maps a client-supplied session ID to a fixed-size state
+// key (sha256 hex). This bounds JSON map-key size regardless of ID length
+// and keeps raw client identifiers out of the persisted state.
+func hookSessionKey(sessionID string) string {
+	sum := sha256.Sum256([]byte("helm-hook-doomloop-session\x00" + sessionID))
+	return hex.EncodeToString(sum[:])
+}
+
+// recordDenied counts one final fail-closed denial for the signature and
+// reports whether the breaker has latched for THIS signature, plus the current
+// run length. A fully allowed hook outcome resets the run and never trips it.
+func (s *hookDoomLoopSession) recordDenied(signature string, now time.Time) (bool, int) {
+	if s.LastSignature == signature {
+		s.RunLength++
+	} else {
+		s.LastSignature = signature
+		s.RunLength = 1
+	}
+	if s.RunLength >= actioninbox.DefaultDoomLoopThreshold {
+		if s.TrippedSignatures == nil {
+			s.TrippedSignatures = map[string]bool{}
+		}
+		if !s.TrippedSignatures[signature] {
+			if len(s.TrippedSignatures) >= hookDoomLoopMaxTrippedSignatures {
+				// Bounded latch map: evict the deterministic victim
+				// (smallest key). An evicted signature re-trips after
+				// another threshold run of consecutive denials.
+				victim := ""
+				for k := range s.TrippedSignatures {
+					if victim == "" || k < victim {
+						victim = k
+					}
+				}
+				delete(s.TrippedSignatures, victim)
+			}
+			s.TrippedSignatures[signature] = true
+			s.TripCount++
+			s.LastTrippedAt = &now
+		}
+	}
+	return s.TrippedSignatures[signature], s.RunLength
+}
+
+// recordAllowed breaks the consecutive-denial run: a successful call means
+// the agent is making progress, not looping. It never sets a latch.
+func (s *hookDoomLoopSession) recordAllowed() {
+	s.LastSignature = ""
+	s.RunLength = 0
+}
+
+// recordHookDoomLoopOutcome records one final classified outcome (denied or
+// allowed) for the session and reports whether the breaker has latched for
+// this call signature. A signer/profile/receipt persistence failure is a final
+// fail-closed denial and therefore counts. The read-modify-write is serialized
+// with a lock file so concurrent hook processes cannot lose updates.
+//
+// Advisory note: the session ID is supplied by the agent client payload and
+// is not authenticated — a client rotating session IDs could evade the
+// breaker. The breaker is defense-in-depth UX steering on top of the
+// authoritative fail-closed policy path, not a security boundary.
+func recordHookDoomLoopOutcome(opts hookOptions, payload preToolPayload, classification hookClassification, denied bool, stderr io.Writer) (bool, int) {
+	if strings.TrimSpace(opts.DataDir) == "" {
+		// No local state dir (e.g. HOME-less environment): the breaker is
+		// disabled rather than writing state into the caller's CWD.
+		return false, 0
+	}
+	inputHash, err := canonicalize.CanonicalHash(payload.ToolInput)
+	if err != nil {
+		// Advisory state must never conflate an input it cannot identify.
+		return false, 0
+	}
+	signature := actioninbox.SignatureFor(classification.ToolID, classification.Action, classification.Target+":"+inputHash)
+	sessionID := strings.TrimSpace(payload.SessionID)
+	if sessionID == "" {
+		// No session identity: unrelated invocations must never share a
+		// breaker bucket (a shared "_default" key would let one session's
+		// denials falsely trip another's). Without a session ID the
+		// breaker cannot attribute the run, so it stays out of the way —
+		// same rule as DenyCascade: empty session never collides.
+		return false, 0
+	}
+	// The session ID is client-supplied and unauthenticated; map it to a
+	// fixed-size key so oversized IDs cannot bloat the persisted state
+	// (keys are always 64 hex chars, preserving the bounded-state
+	// guarantee) and raw client identifiers are never written to disk.
+	sessionKey := hookSessionKey(sessionID)
+	statePath := filepath.Join(opts.DataDir, "state", "hook-doomloop.json")
+	unlock, ok := acquireHookDoomLoopLock(statePath+".lock", stderr)
+	if !ok {
+		return false, 0
+	}
+	defer unlock()
+
+	now := hookNow()
+	state := loadHookDoomLoopState(statePath, stderr)
+	pruneHookDoomLoopSessions(state, now)
+	sess, ok := state.Sessions[sessionKey]
+	if !ok || sess == nil {
+		if !denied {
+			// No recorded run for this session and nothing to reset:
+			// avoid creating breaker state for never-denied sessions.
+			return false, 0
+		}
+		sess = &hookDoomLoopSession{}
+		state.Sessions[sessionKey] = sess
+	}
+	sess.LastSeenAt = now
+	var trippedB bool
+	var runN int
+	if denied {
+		trippedB, runN = sess.recordDenied(signature, now)
+	} else {
+		sess.recordAllowed()
+	}
+	if err := saveHookDoomLoopState(statePath, state); err != nil {
+		// Best-effort persistence: the base policy decision path is
+		// unaffected and remains fail-closed; log and continue.
+		fmt.Fprintf(stderr, "hook pre-tool: persist doom-loop state: %v\n", err)
+	}
+	return trippedB, runN
+}
+
+// pruneHookDoomLoopSessions drops sessions idle beyond the TTL and evicts
+// the oldest sessions beyond the cap, keeping the state file bounded.
+// Nil session entries (defensive: valid JSON can carry nulls) are dropped.
+func pruneHookDoomLoopSessions(state *hookDoomLoopFile, now time.Time) {
+	for id, sess := range state.Sessions {
+		if sess == nil || sess.LastSeenAt.IsZero() || now.Sub(sess.LastSeenAt) > hookDoomLoopStateTTL {
+			delete(state.Sessions, id)
+		}
+	}
+	for len(state.Sessions) > hookDoomLoopMaxSessions {
+		var oldestID string
+		var oldest time.Time
+		for id, sess := range state.Sessions {
+			if sess == nil {
+				oldestID = id
+				break
+			}
+			if oldestID == "" || sess.LastSeenAt.Before(oldest) {
+				oldestID, oldest = id, sess.LastSeenAt
+			}
+		}
+		delete(state.Sessions, oldestID)
+	}
+}
+
+// acquireHookDoomLoopLock takes the state lock as an OS-level advisory
+// lock (flock / LockFileEx). The OS releases it on process exit, so a
+// crashed holder can never leave a stale lock and no age-based reclaim can
+// ever delete a live holder's lock. On contention past hookDoomLoopLockWait
+// it reports ok=false; callers must treat the breaker update as skipped
+// (advisory) and continue on the authoritative policy path.
+func acquireHookDoomLoopLock(lockPath string, stderr io.Writer) (unlock func(), ok bool) {
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		fmt.Fprintf(stderr, "hook pre-tool: doom-loop lock dir: %v\n", err)
+		return nil, false
+	}
+	unlock, held, err := hookDoomLoopFlock(lockPath, time.Now().Add(hookDoomLoopLockWait))
+	if err != nil {
+		fmt.Fprintf(stderr, "hook pre-tool: doom-loop lock: %v\n", err)
+		return nil, false
+	}
+	if !held {
+		fmt.Fprintf(stderr, "hook pre-tool: doom-loop state lock busy; skipping breaker update\n")
+		return nil, false
+	}
+	return unlock, true
+}
+
+func loadHookDoomLoopState(path string, stderr io.Writer) *hookDoomLoopFile {
+	state := &hookDoomLoopFile{Sessions: map[string]*hookDoomLoopSession{}}
+	file, err := os.Open(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintf(stderr, "hook pre-tool: read doom-loop state: %v\n", err)
+		}
+		return state
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, hookDoomLoopMaxStateBytes+1))
+	if err != nil {
+		fmt.Fprintf(stderr, "hook pre-tool: read doom-loop state: %v\n", err)
+		return state
+	}
+	if len(raw) > hookDoomLoopMaxStateBytes {
+		fmt.Fprintf(stderr, "hook pre-tool: doom-loop state exceeds %d bytes, starting fresh\n", hookDoomLoopMaxStateBytes)
+		return state
+	}
+	if err := json.Unmarshal(raw, state); err != nil {
+		fmt.Fprintf(stderr, "hook pre-tool: doom-loop state unreadable, starting fresh: %v\n", err)
+		return &hookDoomLoopFile{Sessions: map[string]*hookDoomLoopSession{}}
+	}
+	if state.Sessions == nil {
+		fmt.Fprintln(stderr, "hook pre-tool: doom-loop state has no sessions map, starting fresh")
+		return &hookDoomLoopFile{Sessions: map[string]*hookDoomLoopSession{}}
+	}
+	// Valid JSON can still carry null session values ("sessions":{"s":null});
+	// drop them so no later traversal can dereference a nil session.
+	for id, sess := range state.Sessions {
+		if sess == nil {
+			delete(state.Sessions, id)
+		}
+	}
+	return state
+}
+
+func saveHookDoomLoopState(path string, state *hookDoomLoopFile) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".hook-doomloop-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err == nil {
+		return nil
+	} else if runtime.GOOS != "windows" {
+		return err
+	}
+	// Windows rename does not replace an existing destination. The hook
+	// state lock serializes writers; remove-and-rename is sufficient for
+	// this advisory state file.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.Rename(tmpName, path)
 }
 
 func decodePreToolPayload(stdin io.Reader) (preToolPayload, error) {

--- a/core/cmd/helm-ai-kernel/hook_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/hook_cmd_test.go
@@ -6,12 +6,17 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/actioninbox"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/shellscan"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/workstation"
@@ -510,6 +515,9 @@ func TestHookPreToolReportsPolicyProfileErrorSeparately(t *testing.T) {
 	if !strings.Contains(stdout.String(), "policy profile is unavailable") || strings.Contains(stdout.String(), "signer is unavailable") {
 		t.Fatalf("policy profile failure was not distinguished: %s", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "[INBOX_POLICY_PROFILE_UNAVAILABLE]") {
+		t.Fatalf("policy profile failure missing steering code: %s", stdout.String())
+	}
 	if !strings.Contains(stderr.String(), "read policy profile") {
 		t.Fatalf("missing policy diagnostic: %s", stderr.String())
 	}
@@ -927,6 +935,506 @@ func TestHookPreToolStillAllowsBenignBashAfterASTClassifier(t *testing.T) {
 	}
 	if receipts := globReceipts(t, tmp); len(receipts) != 0 {
 		t.Fatalf("benign commands wrote receipts: %v", receipts)
+	}
+}
+
+func TestHookPreToolDenyIncludesModelActionableFeedback(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	payload := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/helm-demo"},"session_id":"s-feedback","cwd":"/repo"}`
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("hook exit = %d stderr = %s", code, stderr.String())
+	}
+	var out hookDecisionOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("hook output JSON: %v\n%s", err, stdout.String())
+	}
+	reason := out.HookSpecificOutput.PermissionDecisionReason
+	for _, want := range []string{
+		"[INBOX_KERNEL_POLICY_DENY]",
+		"kernel=OPERATE_PERMISSIONS_EMPTY",
+		"Remediation:",
+		"Escalation:",
+		"Do not retry",
+	} {
+		if !strings.Contains(reason, want) {
+			t.Fatalf("deny reason missing %q:\n%s", want, reason)
+		}
+	}
+}
+
+func TestHookPreToolFailClosedDenyIncludesSteeringCode(t *testing.T) {
+	tmp := t.TempDir()
+	keyDir := filepath.Join(tmp, workstationSigningKeyDirectory)
+	if err := os.MkdirAll(keyDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workstationSigningSeedPath(tmp), []byte(strings.Repeat("0", 64)+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /srv/production"},"session_id":"s-signer"}`
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("hook exit = %d stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "signer is unavailable") {
+		t.Fatalf("operator-facing prefix lost: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "[INBOX_SIGNER_UNAVAILABLE]") || !strings.Contains(stdout.String(), "Remediation:") {
+		t.Fatalf("fail-closed deny missing steering feedback: %s", stdout.String())
+	}
+}
+
+func TestHookPreToolDoomLoopBreakerTripsOnIdenticalAttempts(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	payload := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/helm-demo"},"session_id":"s-loop","cwd":"/repo"}`
+
+	// First two identical settled denials: ordinary policy deny, no trip.
+	for i := 1; i <= 2; i++ {
+		var stdout, stderr bytes.Buffer
+		code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("attempt %d exit = %d stderr = %s", i, code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), "OPERATE_PERMISSIONS_EMPTY") {
+			t.Fatalf("attempt %d should be a policy deny, got %s", i, stdout.String())
+		}
+		if strings.Contains(stdout.String(), "INBOX_DOOM_LOOP_DETECTED") {
+			t.Fatalf("attempt %d must not trip the breaker yet: %s", i, stdout.String())
+		}
+	}
+
+	// Third identical settled denial: policy deny stands, breaker upgrades
+	// the steering text. The denial is still evaluated and receipted — the
+	// breaker never short-circuits the authoritative policy path.
+	var stdout, stderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("tripped exit = %d stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) || !strings.Contains(stdout.String(), "INBOX_DOOM_LOOP_DETECTED") {
+		t.Fatalf("third identical denial must trip the breaker: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "OPERATE_PERMISSIONS_EMPTY") {
+		t.Fatalf("tripped denial must still carry the kernel reason code: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Stop retrying the identical call") {
+		t.Fatalf("doom-loop deny missing steering remediation: %s", stdout.String())
+	}
+	if receipts := globReceipts(t, tmp); len(receipts) == 0 {
+		t.Fatal("tripped denial must still produce a decision receipt")
+	}
+
+	// Breaker state is persisted per session under the data dir, latched
+	// per call signature.
+	statePath := filepath.Join(tmp, "state", "hook-doomloop.json")
+	raw, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read doom-loop state: %v", err)
+	}
+	if !strings.Contains(string(raw), `"tripped_signatures"`) || !strings.Contains(string(raw), hookSessionKey("s-loop")) {
+		t.Fatalf("doom-loop state missing per-signature trip record: %s", raw)
+	}
+	if strings.Contains(string(raw), "s-loop") {
+		t.Fatalf("raw client session ID must not be persisted: %s", raw)
+	}
+
+	// A different session is unaffected by the tripped session.
+	other := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/helm-demo"},"session_id":"s-other","cwd":"/repo"}`
+	stdout.Reset()
+	stderr.Reset()
+	code = runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(other), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("other session exit = %d stderr = %s", code, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "INBOX_DOOM_LOOP_DETECTED") {
+		t.Fatalf("breaker leaked across sessions: %s", stdout.String())
+	}
+}
+
+func TestHookDoomLoopSignatureIncludesFullToolInput(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	opts := hookOptions{DataDir: tmp}
+	classification := hookClassification{
+		ToolID: "file.write",
+		Action: "write",
+		Target: "/repo/config.yaml",
+	}
+	payloadA := preToolPayload{
+		SessionID: "s-input",
+		ToolInput: map[string]any{"file_path": "/repo/config.yaml", "content": "first"},
+	}
+	payloadB := preToolPayload{
+		SessionID: "s-input",
+		ToolInput: map[string]any{"file_path": "/repo/config.yaml", "content": "second"},
+	}
+
+	for range 2 {
+		tripped, _ := recordHookDoomLoopOutcome(opts, payloadA, classification, true, io.Discard)
+		if tripped {
+			t.Fatal("breaker tripped before three identical inputs")
+		}
+	}
+	tripped, runLength := recordHookDoomLoopOutcome(opts, payloadB, classification, true, io.Discard)
+	if tripped || runLength != 1 {
+		t.Fatalf("changed tool input produced tripped=%t run=%d, want false/1", tripped, runLength)
+	}
+}
+
+// TestHookPreToolDoomLoopLatchIsPerSignature is the regression test for the
+// session-permalock blocker: after a trip, a CHANGED approach (different
+// signature) in the same session must go through the normal policy path
+// without doom-loop steering, while retrying the tripped identical call
+// keeps the escalation steering.
+func TestHookPreToolDoomLoopLatchIsPerSignature(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	sigA := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/helm-demo"},"session_id":"s-latch","cwd":"/repo"}`
+	sigB := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /var/other-target"},"session_id":"s-latch","cwd":"/repo"}`
+
+	run := func(payload string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("hook exit = %d stderr = %s", code, stderr.String())
+		}
+		return stdout.String()
+	}
+
+	// Trip the breaker on sigA (3 identical settled denials).
+	for i := 1; i <= 3; i++ {
+		run(sigA)
+	}
+
+	// Post-trip, a different signature in the same session is a fresh
+	// evaluation: policy deny without doom-loop steering.
+	out := run(sigB)
+	if !strings.Contains(out, `"permissionDecision":"deny"`) || !strings.Contains(out, "OPERATE_PERMISSIONS_EMPTY") {
+		t.Fatalf("changed approach must follow the normal policy path: %s", out)
+	}
+	if strings.Contains(out, "INBOX_DOOM_LOOP_DETECTED") {
+		t.Fatalf("changed approach must not inherit the tripped session's latch: %s", out)
+	}
+
+	// Retrying the tripped identical call keeps the escalation steering
+	// (latch is per signature and survives interleaved calls).
+	out = run(sigA)
+	if !strings.Contains(out, "INBOX_DOOM_LOOP_DETECTED") {
+		t.Fatalf("retry of tripped signature must keep escalation steering: %s", out)
+	}
+}
+
+// TestHookPreToolDoomLoopSafeCallsBreakTheRun is the regression test for
+// the false-consecutive finding: identical denials separated by successful
+// unclassified (safe) calls must NOT count as consecutive, so the breaker
+// cannot trip on non-consecutive denials.
+func TestHookPreToolDoomLoopSafeCallsBreakTheRun(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	deny := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/helm-demo"},"session_id":"s-gap","cwd":"/repo"}`
+	safe := `{"tool_name":"Bash","tool_input":{"command":"git status --short"},"session_id":"s-gap","cwd":"/repo"}`
+
+	run := func(payload string) string {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("hook exit = %d stderr = %s", code, stderr.String())
+		}
+		return stdout.String()
+	}
+
+	// Denial, successful safe work, denial, successful safe work, denial:
+	// three identical denials but never consecutive — no trip allowed.
+	run(deny)
+	if out := run(safe); out != "" {
+		t.Fatalf("safe call must not emit output: %s", out)
+	}
+	run(deny)
+	if out := run(safe); out != "" {
+		t.Fatalf("safe call must not emit output: %s", out)
+	}
+	out := run(deny)
+	if strings.Contains(out, "INBOX_DOOM_LOOP_DETECTED") {
+		t.Fatalf("denials separated by successful work must not trip the breaker: %s", out)
+	}
+
+	// And a genuinely consecutive triple in the same session still trips.
+	for i := 0; i < 2; i++ {
+		run(deny)
+	}
+	out = run(deny)
+	if !strings.Contains(out, "INBOX_DOOM_LOOP_DETECTED") {
+		t.Fatalf("consecutive identical denials must still trip: %s", out)
+	}
+}
+
+// TestHookPreToolDoomLoopSkipsSessionlessPayloads is the regression test
+// for the session-collision finding: payloads without a session ID must
+// not be bucketed together — the breaker records nothing and never trips,
+// so unrelated sessionless invocations cannot false-trip each other.
+func TestHookPreToolDoomLoopSkipsSessionlessPayloads(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	payload := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/helm-demo"},"cwd":"/repo"}`
+
+	for i := 1; i <= 4; i++ {
+		var stdout, stderr bytes.Buffer
+		code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(payload), &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("attempt %d exit = %d stderr = %s", i, code, stderr.String())
+		}
+		if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+			t.Fatalf("attempt %d must still be policy-denied: %s", i, stdout.String())
+		}
+		if strings.Contains(stdout.String(), "INBOX_DOOM_LOOP_DETECTED") {
+			t.Fatalf("sessionless attempt %d must never trip the breaker: %s", i, stdout.String())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "state", "hook-doomloop.json")); !os.IsNotExist(err) {
+		t.Fatalf("sessionless payloads must not create breaker state: %v", err)
+	}
+}
+
+// TestHookDoomLoopOutcomeLogic unit-tests the denied-outcome logic: denied
+// outcomes count, allowed calls reset the run and can never trip, and the
+// latch is per signature.
+func TestHookDoomLoopOutcomeLogic(t *testing.T) {
+	now := time.Unix(1000, 0).UTC()
+	sigA := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /a")
+	sigB := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /b")
+
+	sess := &hookDoomLoopSession{}
+	// Allowed calls never trip and reset the run.
+	sess.recordAllowed()
+	if tripped, run := sess.recordDenied(sigA, now); tripped || run != 1 {
+		t.Fatalf("first denial: tripped=%v run=%d, want false/1", tripped, run)
+	}
+	sess.recordAllowed()
+	if tripped, run := sess.recordDenied(sigA, now); tripped || run != 1 {
+		t.Fatalf("allowed call must reset the run: tripped=%v run=%d, want false/1", tripped, run)
+	}
+	// Consecutive denials trip at the threshold.
+	sess.recordDenied(sigA, now)
+	if tripped, _ := sess.recordDenied(sigA, now); !tripped {
+		t.Fatal("third consecutive identical denial must trip")
+	}
+	// Latch is per signature: sigB fresh, sigA latched even interleaved.
+	if tripped, run := sess.recordDenied(sigB, now); tripped || run != 1 {
+		t.Fatalf("different signature must start fresh: tripped=%v run=%d", tripped, run)
+	}
+	if tripped, _ := sess.recordDenied(sigA, now); !tripped {
+		t.Fatal("latched signature must stay tripped after interleave")
+	}
+}
+
+// TestHookDoomLoopTrippedSignaturesBounded is the regression test for the
+// unbounded-state finding: the per-session latch map is capped, so many
+// distinct tripped signatures cannot grow the persisted state without
+// bound. Eviction is deterministic and an evicted signature re-trips.
+func TestHookDoomLoopTrippedSignaturesBounded(t *testing.T) {
+	now := time.Unix(1000, 0).UTC()
+	sess := &hookDoomLoopSession{}
+
+	total := hookDoomLoopMaxTrippedSignatures + 10
+	for i := 0; i < total; i++ {
+		sig := actioninbox.SignatureFor("shell", "shell_operate", fmt.Sprintf("target-%03d", i))
+		for j := 0; j < actioninbox.DefaultDoomLoopThreshold; j++ {
+			sess.recordDenied(sig, now)
+		}
+		if len(sess.TrippedSignatures) > hookDoomLoopMaxTrippedSignatures {
+			t.Fatalf("latch map exceeded cap after %d trips: %d", i+1, len(sess.TrippedSignatures))
+		}
+	}
+	if len(sess.TrippedSignatures) != hookDoomLoopMaxTrippedSignatures {
+		t.Fatalf("latch map = %d, want cap %d", len(sess.TrippedSignatures), hookDoomLoopMaxTrippedSignatures)
+	}
+
+	// The most recently tripped signature must still be latched.
+	last := actioninbox.SignatureFor("shell", "shell_operate", fmt.Sprintf("target-%03d", total-1))
+	if !sess.TrippedSignatures[last] {
+		t.Fatal("newest trip must be latched")
+	}
+}
+
+// TestHookDoomLoopPrune covers TTL expiry and the session cap.
+func TestHookDoomLoopPrune(t *testing.T) {
+	now := time.Unix(100000, 0).UTC()
+	state := &hookDoomLoopFile{Sessions: map[string]*hookDoomLoopSession{}}
+	state.Sessions["fresh"] = &hookDoomLoopSession{LastSeenAt: now.Add(-time.Hour)}
+	state.Sessions["stale"] = &hookDoomLoopSession{LastSeenAt: now.Add(-48 * time.Hour)}
+	state.Sessions["legacy-zero"] = &hookDoomLoopSession{}
+	pruneHookDoomLoopSessions(state, now)
+	if _, ok := state.Sessions["stale"]; ok {
+		t.Fatal("TTL-expired session must be pruned")
+	}
+	if _, ok := state.Sessions["legacy-zero"]; ok {
+		t.Fatal("zero LastSeenAt (legacy state) must be pruned")
+	}
+	if _, ok := state.Sessions["fresh"]; !ok {
+		t.Fatal("fresh session must survive pruning")
+	}
+
+	for i := 0; i < hookDoomLoopMaxSessions+10; i++ {
+		id := fmt.Sprintf("s-%d", i)
+		state.Sessions[id] = &hookDoomLoopSession{LastSeenAt: now.Add(time.Duration(i) * time.Second)}
+	}
+	pruneHookDoomLoopSessions(state, now)
+	if len(state.Sessions) != hookDoomLoopMaxSessions {
+		t.Fatalf("session cap: got %d, want %d", len(state.Sessions), hookDoomLoopMaxSessions)
+	}
+}
+
+// TestHookSessionKeyBoundsIdentifiers is the regression test for the
+// unbounded-session-identifier finding: arbitrarily long client-supplied
+// session IDs map to a fixed-size state key, and oversized IDs never
+// appear in the persisted state.
+func TestHookSessionKeyBoundsIdentifiers(t *testing.T) {
+	long := strings.Repeat("x", 1<<20) // 1 MiB client-supplied ID
+	key := hookSessionKey(long)
+	if len(key) != 64 {
+		t.Fatalf("session key length = %d, want 64 hex chars", len(key))
+	}
+	if key == hookSessionKey(long+"y") {
+		t.Fatal("distinct session IDs must map to distinct keys")
+	}
+
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	payload := preToolPayload{ToolName: "Bash", SessionID: long}
+	classification := hookClassification{ToolID: "shell", Action: "shell_operate", Target: "rm -rf /big"}
+	var stderr bytes.Buffer
+	recordHookDoomLoopOutcome(hookOptions{DataDir: tmp}, payload, classification, true, &stderr)
+	raw, err := os.ReadFile(filepath.Join(tmp, "state", "hook-doomloop.json"))
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if len(raw) > 1<<16 {
+		t.Fatalf("state bloated by oversized session ID: %d bytes", len(raw))
+	}
+	if strings.Contains(string(raw), long[:64]) {
+		t.Fatal("raw oversized session ID must not be persisted")
+	}
+}
+
+// TestHookDoomLoopConcurrentRecordsNoLostUpdates is the regression test for
+// the state race: parallel hook invocations must serialize through the lock
+// so no settled-denial record is lost.
+func TestHookDoomLoopConcurrentRecordsNoLostUpdates(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	opts := hookOptions{DataDir: tmp}
+	payload := preToolPayload{ToolName: "Bash", SessionID: "s-race"}
+	classification := hookClassification{ToolID: "shell", Action: "shell_operate", Target: "rm -rf /race"}
+
+	const workers = 12
+	var wg sync.WaitGroup
+	var stderr bytes.Buffer
+	var mu sync.Mutex
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var buf bytes.Buffer
+			recordHookDoomLoopOutcome(opts, payload, classification, true, &buf)
+			mu.Lock()
+			stderr.Write(buf.Bytes())
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	raw, err := os.ReadFile(filepath.Join(tmp, "state", "hook-doomloop.json"))
+	if err != nil {
+		t.Fatalf("read state: %v (stderr: %s)", err, stderr.String())
+	}
+	var state hookDoomLoopFile
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("parse state: %v", err)
+	}
+	sess := state.Sessions[hookSessionKey("s-race")]
+	if sess == nil {
+		t.Fatalf("session missing after concurrent records: %s", raw)
+	}
+	if sess.RunLength != workers {
+		t.Fatalf("lost updates under concurrency: run=%d, want %d", sess.RunLength, workers)
+	}
+	inputHash, err := canonicalize.CanonicalHash(payload.ToolInput)
+	if err != nil {
+		t.Fatalf("hash tool input: %v", err)
+	}
+	sig := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /race:"+inputHash)
+	if !sess.TrippedSignatures[sig] {
+		t.Fatalf("breaker must be latched after %d identical denials", workers)
+	}
+}
+
+// TestHookDoomLoopNullSessionState is the regression test for the
+// null-session panic: valid state JSON carrying "sessions":{"s":null} must
+// be sanitized on load and must never crash a classified hook invocation.
+func TestHookDoomLoopNullSessionState(t *testing.T) {
+	tmp := t.TempDir()
+	restoreHookClock(t)
+	stateDir := filepath.Join(tmp, "state")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "hook-doomloop.json"),
+		[]byte(`{"sessions":{"bad":null,"s-x":{"last_signature":"a","run_length":5,"last_seen_at":"1970-01-01T00:00:00Z"}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load + prune must not panic on the null entry.
+	var stderr bytes.Buffer
+	state := loadHookDoomLoopState(filepath.Join(stateDir, "hook-doomloop.json"), &stderr)
+	pruneHookDoomLoopSessions(state, time.Unix(100000, 0).UTC())
+
+	// A full outcome record over the poisoned file must not panic and must
+	// keep functioning (null entry dropped, new session recorded).
+	opts := hookOptions{DataDir: tmp}
+	payload := preToolPayload{ToolName: "Bash", SessionID: "s-x"}
+	classification := hookClassification{ToolID: "shell", Action: "shell_operate", Target: "rm -rf /null"}
+	tripped, run := recordHookDoomLoopOutcome(opts, payload, classification, true, &stderr)
+	if tripped || run != 1 {
+		t.Fatalf("record over poisoned state: tripped=%v run=%d, want false/1", tripped, run)
+	}
+
+	// And the end-to-end hook path must still emit its denial.
+	hookPayload := `{"tool_name":"Bash","tool_input":{"command":"rm -rf /tmp/helm-demo"},"session_id":"s-null"}`
+	var stdout, hookStderr bytes.Buffer
+	code := runHookPreToolCmd([]string{"--client", "claude-code", "--data-dir", tmp}, strings.NewReader(hookPayload), &stdout, &hookStderr)
+	if code != 0 {
+		t.Fatalf("hook exit = %d stderr = %s", code, hookStderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"permissionDecision":"deny"`) {
+		t.Fatalf("hook must still deny over poisoned state: %s", stdout.String())
+	}
+}
+
+func TestLoadHookDoomLoopStateRejectsOversizedAndNilSessions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hook-doomloop.json")
+	if err := os.WriteFile(path, bytes.Repeat([]byte("x"), hookDoomLoopMaxStateBytes+1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr bytes.Buffer
+	state := loadHookDoomLoopState(path, &stderr)
+	if len(state.Sessions) != 0 || !strings.Contains(stderr.String(), "exceeds") {
+		t.Fatalf("oversized state was not rejected: state=%v stderr=%q", state, stderr.String())
+	}
+
+	if err := os.WriteFile(path, []byte(`{"sessions":null}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stderr.Reset()
+	state = loadHookDoomLoopState(path, &stderr)
+	if len(state.Sessions) != 0 || !strings.Contains(stderr.String(), "no sessions map") {
+		t.Fatalf("nil sessions diagnostic: state=%v stderr=%q", state, stderr.String())
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/hook_doomloop_lock_other.go
+++ b/core/cmd/helm-ai-kernel/hook_doomloop_lock_other.go
@@ -1,0 +1,14 @@
+//go:build !linux && !darwin && !freebsd && !netbsd && !openbsd && !dragonfly && !windows
+
+package main
+
+import (
+	"time"
+)
+
+// hookDoomLoopFlock has no OS advisory-lock primitive on this platform
+// (e.g. plan9, js/wasm). The breaker update is skipped (advisory only);
+// the authoritative fail-closed policy decision path is unaffected.
+func hookDoomLoopFlock(lockPath string, deadline time.Time) (unlock func(), held bool, err error) {
+	return nil, false, nil
+}

--- a/core/cmd/helm-ai-kernel/hook_doomloop_lock_test.go
+++ b/core/cmd/helm-ai-kernel/hook_doomloop_lock_test.go
@@ -1,0 +1,45 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly || windows
+
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// This file is tagged to the platforms that have a real OS advisory-lock
+// primitive. The same explicit flock-capable GOOS set is used by the
+// agentruntime store lock; other platforms compile the documented no-op
+// fallback, where these mutual-exclusion assertions do not hold.
+
+// TestHookDoomLoopFlockMutualExclusion covers the lock ownership fix: while
+// one holder holds the OS lock, a second acquisition within its deadline
+// must report busy (not delete the live holder's lock); after release,
+// acquisition succeeds again.
+func TestHookDoomLoopFlockMutualExclusion(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "hook-doomloop.json.lock")
+
+	unlock, held, err := hookDoomLoopFlock(lockPath, time.Now().Add(time.Second))
+	if err != nil || !held {
+		t.Fatalf("first acquire: held=%v err=%v", held, err)
+	}
+
+	// A second acquirer must not steal or delete the live lock.
+	_, held2, err2 := hookDoomLoopFlock(lockPath, time.Now().Add(150*time.Millisecond))
+	if err2 != nil {
+		t.Fatalf("second acquire err: %v", err2)
+	}
+	if held2 {
+		t.Fatal("second acquire must report busy while the first holder is live")
+	}
+
+	unlock()
+
+	// After release the lock is acquirable again (no stale state).
+	unlock3, held3, err3 := hookDoomLoopFlock(lockPath, time.Now().Add(time.Second))
+	if err3 != nil || !held3 {
+		t.Fatalf("re-acquire after release: held=%v err=%v", held3, err3)
+	}
+	unlock3()
+}

--- a/core/cmd/helm-ai-kernel/hook_doomloop_lock_unix.go
+++ b/core/cmd/helm-ai-kernel/hook_doomloop_lock_unix.go
@@ -1,0 +1,41 @@
+//go:build linux || darwin || freebsd || netbsd || openbsd || dragonfly
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// hookDoomLoopFlock serializes doom-loop state updates with an flock(2)
+// advisory lock. The OS releases the lock when the holder's process exits
+// (even on crash), so there are no stale locks and no age-based reclaim
+// that could delete a live holder's lock — the ownership race of marker-
+// file locks is eliminated by construction. Returns (nil, false, nil) when
+// the lock is busy past the deadline: callers treat the breaker update as
+// skipped (advisory) and continue on the authoritative policy path.
+func hookDoomLoopFlock(lockPath string, deadline time.Time) (unlock func(), held bool, err error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, false, err
+	}
+	for {
+		err = unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = unix.Flock(int(f.Fd()), unix.LOCK_UN)
+				_ = f.Close()
+			}, true, nil
+		}
+		if err != unix.EWOULDBLOCK || time.Now().After(deadline) {
+			_ = f.Close()
+			if err == unix.EWOULDBLOCK {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/core/cmd/helm-ai-kernel/hook_doomloop_lock_windows.go
+++ b/core/cmd/helm-ai-kernel/hook_doomloop_lock_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package main
+
+import (
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// hookDoomLoopFlock is the Windows equivalent of the unix flock guard: an
+// OS-level byte-range exclusive lock via LockFileEx. The OS releases the
+// lock when the holder's handle closes (including process exit/crash), so
+// there are no stale locks and no age-based reclaim that could delete a
+// live holder's lock. Returns (nil, false, nil) when the lock is busy past
+// the deadline: callers treat the breaker update as skipped (advisory).
+func hookDoomLoopFlock(lockPath string, deadline time.Time) (unlock func(), held bool, err error) {
+	pathPtr, err := windows.UTF16PtrFromString(lockPath)
+	if err != nil {
+		return nil, false, err
+	}
+	h, err := windows.CreateFile(
+		pathPtr,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.OPEN_ALWAYS,
+		windows.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	var ol windows.Overlapped
+	for {
+		err = windows.LockFileEx(h, windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, &ol)
+		if err == nil {
+			return func() {
+				var unlockOl windows.Overlapped
+				_ = windows.UnlockFileEx(h, 0, 1, 0, &unlockOl)
+				_ = windows.CloseHandle(h)
+			}, true, nil
+		}
+		if errno, ok := err.(windows.Errno); !ok || errno != windows.ERROR_LOCK_VIOLATION || time.Now().After(deadline) {
+			_ = windows.CloseHandle(h)
+			if errno, ok := err.(windows.Errno); ok && errno == windows.ERROR_LOCK_VIOLATION {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/core/go.mod
+++ b/core/go.mod
@@ -36,6 +36,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.53.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/text v0.39.0
 	golang.org/x/time v0.15.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478
@@ -141,7 +142,6 @@ require (
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	google.golang.org/api v0.274.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260414002931-afd174a4e478 // indirect

--- a/core/pkg/actioninbox/actioninbox_test.go
+++ b/core/pkg/actioninbox/actioninbox_test.go
@@ -13,10 +13,10 @@ import (
 func newTestItem(id, managerID string) *actioninbox.InboxItem {
 	return &actioninbox.InboxItem{
 		ItemID:     id,
-		ProposalID: "prop-" + id,
+		ProposalID: "prop-1",
 		EmployeeID: "emp-1",
 		ManagerID:  managerID,
-		Title:      "Test action " + id,
+		Title:      "Test action",
 		Summary:    "Needs approval",
 		RiskClass:  "R2",
 		Status:     actioninbox.StatusPending,

--- a/core/pkg/actioninbox/deny_feedback.go
+++ b/core/pkg/actioninbox/deny_feedback.go
@@ -1,0 +1,176 @@
+package actioninbox
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DenyFeedbackSchemaVersion versions the structured denial feedback payload.
+// The schema is additive: new fields may be added with omitempty; existing
+// field names and meanings must never change without a version bump.
+const DenyFeedbackSchemaVersion = "deny_feedback.v1"
+
+// Denial reason codes for the actioninbox / hook UX layer. These are
+// model-actionable steering codes; they are deliberately namespaced (INBOX_*)
+// so they cannot be confused with workstation policy/receipt reason codes.
+// They carry no authority: they explain and steer, they never permit.
+const (
+	// ReasonHumanRejected is a plain human rejection of an inbox item.
+	ReasonHumanRejected = "INBOX_HUMAN_REJECTED"
+	// ReasonCascadeRejected marks an item denied because an identical
+	// same-session pending ask was rejected (cascade-reject).
+	ReasonCascadeRejected = "INBOX_CASCADE_REJECTED"
+	// ReasonDoomLoopDetected marks a denial forced by the doom-loop
+	// circuit breaker after N identical settled/attempted tool calls.
+	ReasonDoomLoopDetected = "INBOX_DOOM_LOOP_DETECTED"
+	// ReasonSignerUnavailable marks a fail-closed denial emitted when the
+	// local receipt signer cannot be loaded.
+	ReasonSignerUnavailable = "INBOX_SIGNER_UNAVAILABLE"
+	// ReasonReceiptPersistence marks a fail-closed denial emitted when the
+	// decision receipt cannot be persisted.
+	ReasonReceiptPersistence = "INBOX_RECEIPT_PERSISTENCE_UNAVAILABLE"
+	// ReasonKernelPolicyDeny is the generic wrapper when a Kernel verdict
+	// reason code has no specific steering entry.
+	ReasonKernelPolicyDeny = "INBOX_KERNEL_POLICY_DENY"
+)
+
+// DenialRecord is the structured, model-actionable denial payload attached
+// to an inbox item or rendered into a PreToolUse hook deny response. It is
+// data, not authority: it explains a denial that already happened and steers
+// the requesting agent toward self-correction or escalation.
+type DenialRecord struct {
+	SchemaVersion string    `json:"schema_version"`
+	ReasonCode    string    `json:"reason_code"`
+	Explanation   string    `json:"explanation"`
+	Remediation   string    `json:"remediation,omitempty"`
+	Escalation    string    `json:"escalation_route,omitempty"`
+	Feedback      string    `json:"feedback,omitempty"`
+	CascadedFrom  string    `json:"cascaded_from,omitempty"`
+	KernelCode    string    `json:"kernel_reason_code,omitempty"`
+	PrincipalID   string    `json:"principal_id,omitempty"`
+	DecidedAt     time.Time `json:"decided_at"`
+}
+
+// kernelDenyGuidance maps canonical Kernel verdict reason codes to
+// agent-actionable explanation, remediation, and escalation text. Unknown
+// codes fall through to a fail-closed generic entry in DenyFeedbackFor.
+var kernelDenyGuidance = map[string]struct {
+	Explanation string
+	Remediation string
+	Escalation  string
+}{
+	"OPERATE_PERMISSIONS_EMPTY": {
+		Explanation: "No operate-class permissions are granted in the active workstation policy profile, so this effect cannot be authorized.",
+		Remediation: "Do not retry the same call. Rework the approach to use observe/draft-class effects (read-only commands, in-workspace drafts), or ask the operator to grant the required operate permission in the policy profile.",
+		Escalation:  "Ask the human operator to update the workstation policy profile (operate.permissions) and re-run; the denial receipt is the audit anchor.",
+	},
+	"OPERATE_PERMISSION_NOT_GRANTED": {
+		Explanation: "The active workstation policy profile does not grant the specific operate permission this effect requires.",
+		Remediation: "Switch to an approach that needs only already-granted permissions, or request the specific missing permission from the operator instead of retrying.",
+		Escalation:  "Ask the human operator to grant the specific permission named in the decision receipt.",
+	},
+	"EGRESS_ALLOWLIST_EMPTY": {
+		Explanation: "The workstation egress allowlist is empty, so all network egress fails closed.",
+		Remediation: "Do not retry network calls. Work offline from local state, or ask the operator to add the destination to the egress allowlist.",
+		Escalation:  "Ask the human operator to add the destination host/protocol to the workstation egress allowlist.",
+	},
+	"EGRESS_DESTINATION_NOT_ALLOWED": {
+		Explanation: "The destination is outside the workstation egress allowlist.",
+		Remediation: "Use an allowlisted destination or fetch the needed data through an already-approved channel; do not probe alternate routes to the same host.",
+		Escalation:  "Ask the human operator to allowlist this destination if the egress is genuinely required.",
+	},
+	"DRAFT_TARGET_OUTSIDE_WORKSPACE_SCOPE": {
+		Explanation: "The write target is outside the configured workspace roots; drafts are confined to the workspace scope.",
+		Remediation: "Retarget the write to a path inside the configured workspace roots.",
+		Escalation:  "Ask the human operator to widen draft workspace roots only if the out-of-scope write is intended.",
+	},
+	"TAINTED_CONTEXT_REQUIRES_DENY": {
+		Explanation: "The run context is tainted, and tainted context cannot authorize operate-class effects.",
+		Remediation: "Stop attempting operate-class effects in this run. Request a fresh, untainted session for the operation.",
+		Escalation:  "Escalate to the human operator; taint clearance is a principal decision, not an agent decision.",
+	},
+	"MEMORY_CLASS_DISALLOWED": {
+		Explanation: "The memory class is not allowed by the workstation memory policy.",
+		Remediation: "Write the information to an allowed memory class or keep it out of durable memory.",
+		Escalation:  "Ask the human operator to permit the memory class in policy if retention is required.",
+	},
+	"MEMORY_TTL_EXCEEDS_POLICY": {
+		Explanation: "The requested memory TTL exceeds the workstation policy maximum.",
+		Remediation: "Retry with a TTL at or below the policy maximum.",
+		Escalation:  "Ask the human operator to raise the memory TTL cap if longer retention is justified.",
+	},
+	"RECURRING_LOOP_MISSING_SCHEDULE": {
+		Explanation: "The recurring loop registration is missing a schedule.",
+		Remediation: "Re-register the loop with an explicit schedule.",
+		Escalation:  "Ask the human operator if loop policy should change.",
+	},
+	"RECURRING_LOOP_MISSING_MAX_RUNTIME": {
+		Explanation: "The recurring loop registration is missing a max runtime bound.",
+		Remediation: "Re-register the loop with an explicit max runtime.",
+		Escalation:  "Ask the human operator if loop policy should change.",
+	},
+	"RECURRING_LOOP_MISSING_TOOL_SCOPE": {
+		Explanation: "The recurring loop registration is missing a tool scope.",
+		Remediation: "Re-register the loop with an explicit, minimal tool scope.",
+		Escalation:  "Ask the human operator if loop policy should change.",
+	},
+	"RECURRING_LOOP_MISSING_EXPIRATION": {
+		Explanation: "The recurring loop registration is missing an expiration.",
+		Remediation: "Re-register the loop with an explicit expiration time.",
+		Escalation:  "Ask the human operator if loop policy should change.",
+	},
+}
+
+// DenyFeedbackFor builds a model-actionable DenialRecord for a denial that
+// carries the given Kernel verdict reason code. Unknown or empty codes are
+// mapped to a generic fail-closed record: the agent is told not to retry and
+// to escalate, never to probe.
+func DenyFeedbackFor(kernelReasonCode string, decidedAt time.Time) DenialRecord {
+	code := strings.TrimSpace(kernelReasonCode)
+	if g, ok := kernelDenyGuidance[code]; ok {
+		return DenialRecord{
+			SchemaVersion: DenyFeedbackSchemaVersion,
+			ReasonCode:    ReasonKernelPolicyDeny,
+			KernelCode:    code,
+			Explanation:   g.Explanation,
+			Remediation:   g.Remediation,
+			Escalation:    g.Escalation,
+			DecidedAt:     decidedAt,
+		}
+	}
+	return DenialRecord{
+		SchemaVersion: DenyFeedbackSchemaVersion,
+		ReasonCode:    ReasonKernelPolicyDeny,
+		KernelCode:    code,
+		Explanation:   "HELM denied this effect under the active policy; the specific reason code has no steering guidance.",
+		Remediation:   "Do not retry the same call unchanged. Change the approach or stop.",
+		Escalation:    "Escalate to the human operator with the decision receipt if you believe this denial is wrong.",
+		DecidedAt:     decidedAt,
+	}
+}
+
+// RenderSteeringText renders a DenialRecord as the single-string reason a
+// PreToolUse hook can hand back to the agent. The format keeps the machine-
+// readable code first, then explanation, remediation, and escalation, so the
+// model can self-correct instead of retrying blind.
+func RenderSteeringText(d DenialRecord) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s]", d.ReasonCode)
+	if d.KernelCode != "" {
+		fmt.Fprintf(&b, " kernel=%s", d.KernelCode)
+	}
+	if d.Explanation != "" {
+		fmt.Fprintf(&b, " %s", d.Explanation)
+	}
+	if d.Feedback != "" {
+		fmt.Fprintf(&b, " Operator feedback: %s", strings.Join(strings.Fields(d.Feedback), " "))
+	}
+	if d.Remediation != "" {
+		fmt.Fprintf(&b, " Remediation: %s", d.Remediation)
+	}
+	if d.Escalation != "" {
+		fmt.Fprintf(&b, " Escalation: %s", d.Escalation)
+	}
+	return b.String()
+}

--- a/core/pkg/actioninbox/deny_feedback.go
+++ b/core/pkg/actioninbox/deny_feedback.go
@@ -27,6 +27,9 @@ const (
 	// ReasonSignerUnavailable marks a fail-closed denial emitted when the
 	// local receipt signer cannot be loaded.
 	ReasonSignerUnavailable = "INBOX_SIGNER_UNAVAILABLE"
+	// ReasonPolicyProfileUnavailable marks a fail-closed denial emitted when
+	// the selected workstation policy profile cannot be loaded or verified.
+	ReasonPolicyProfileUnavailable = "INBOX_POLICY_PROFILE_UNAVAILABLE"
 	// ReasonReceiptPersistence marks a fail-closed denial emitted when the
 	// decision receipt cannot be persisted.
 	ReasonReceiptPersistence = "INBOX_RECEIPT_PERSISTENCE_UNAVAILABLE"

--- a/core/pkg/actioninbox/deny_feedback_test.go
+++ b/core/pkg/actioninbox/deny_feedback_test.go
@@ -1,0 +1,689 @@
+package actioninbox_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/actioninbox"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDenyFeedbackFor_KnownKernelCodes checks the curated workstation reason
+// codes that currently have specific model-actionable steering guidance.
+func TestDenyFeedbackFor_KnownKernelCodes(t *testing.T) {
+	knownCodes := []string{
+		"OPERATE_PERMISSIONS_EMPTY",
+		"OPERATE_PERMISSION_NOT_GRANTED",
+		"EGRESS_ALLOWLIST_EMPTY",
+		"EGRESS_DESTINATION_NOT_ALLOWED",
+		"DRAFT_TARGET_OUTSIDE_WORKSPACE_SCOPE",
+		"TAINTED_CONTEXT_REQUIRES_DENY",
+		"MEMORY_CLASS_DISALLOWED",
+		"MEMORY_TTL_EXCEEDS_POLICY",
+		"RECURRING_LOOP_MISSING_SCHEDULE",
+		"RECURRING_LOOP_MISSING_MAX_RUNTIME",
+		"RECURRING_LOOP_MISSING_TOOL_SCOPE",
+		"RECURRING_LOOP_MISSING_EXPIRATION",
+	}
+	now := time.Unix(0, 0).UTC()
+	for _, code := range knownCodes {
+		t.Run(code, func(t *testing.T) {
+			d := actioninbox.DenyFeedbackFor(code, now)
+			assert.Equal(t, actioninbox.DenyFeedbackSchemaVersion, d.SchemaVersion)
+			assert.Equal(t, actioninbox.ReasonKernelPolicyDeny, d.ReasonCode)
+			assert.Equal(t, code, d.KernelCode)
+			assert.NotEmpty(t, d.Explanation, "explanation required")
+			assert.NotEmpty(t, d.Remediation, "remediation required")
+			assert.NotEmpty(t, d.Escalation, "escalation route required")
+			assert.Equal(t, now, d.DecidedAt)
+		})
+	}
+}
+
+// TestDenyFeedbackFor_UnknownCodeFailsClosed verifies that an unrecognized
+// Kernel code still yields safe steering: never "retry", always "change or
+// escalate".
+func TestDenyFeedbackFor_UnknownCodeFailsClosed(t *testing.T) {
+	for _, code := range []string{"", "TOTALLY_UNKNOWN_CODE", "  "} {
+		d := actioninbox.DenyFeedbackFor(code, time.Now().UTC())
+		assert.Equal(t, actioninbox.ReasonKernelPolicyDeny, d.ReasonCode)
+		assert.Contains(t, d.Remediation, "Do not retry")
+		assert.NotEmpty(t, d.Escalation)
+	}
+}
+
+func TestRenderSteeringText_ContainsActionableFields(t *testing.T) {
+	d := actioninbox.DenyFeedbackFor("OPERATE_PERMISSIONS_EMPTY", time.Now().UTC())
+	d.Feedback = "use the staging workspace instead"
+	text := actioninbox.RenderSteeringText(d)
+	assert.Contains(t, text, "["+actioninbox.ReasonKernelPolicyDeny+"]")
+	assert.Contains(t, text, "kernel=OPERATE_PERMISSIONS_EMPTY")
+	assert.Contains(t, text, "Operator feedback: use the staging workspace instead")
+	assert.Contains(t, text, "Remediation:")
+	assert.Contains(t, text, "Escalation:")
+}
+
+func TestRenderSteeringText_NormalizesOperatorFeedback(t *testing.T) {
+	d := actioninbox.DenyFeedbackFor("OPERATE_PERMISSIONS_EMPTY", time.Now().UTC())
+	d.Feedback = "use staging\n  then retry\twith approval"
+	assert.NotContains(t, actioninbox.RenderSteeringText(d), "\n")
+	assert.Contains(t, actioninbox.RenderSteeringText(d), "use staging then retry with approval")
+}
+
+func TestDeny_StoresStructuredFeedback(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Enqueue(ctx, newTestItem("item-1", "mgr-1")))
+	require.NoError(t, store.Deny(ctx, "item-1", "too risky, narrow the scope", "principal-1"))
+
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusDenied, got.Status)
+	require.NotNil(t, got.Denial, "denial record must be attached")
+	assert.Equal(t, actioninbox.DenyFeedbackSchemaVersion, got.Denial.SchemaVersion)
+	assert.Equal(t, actioninbox.ReasonHumanRejected, got.Denial.ReasonCode)
+	assert.Equal(t, "too risky, narrow the scope", got.Denial.Feedback)
+	assert.Equal(t, "principal-1", got.Denial.PrincipalID)
+	assert.NotEmpty(t, got.Denial.Remediation)
+	assert.NotEmpty(t, got.Denial.Escalation)
+	assert.False(t, got.Denial.DecidedAt.IsZero())
+}
+
+func TestDenyWithFeedback_CustomReasonCode(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Enqueue(ctx, newTestItem("item-1", "mgr-1")))
+	require.NoError(t, store.DenyWithFeedback(ctx, "item-1", "try a smaller diff", "  "+actioninbox.ReasonHumanRejected+"  ", "principal-1"))
+
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	require.NotNil(t, got.Denial)
+	assert.Equal(t, "try a smaller diff", got.Denial.Feedback)
+	assert.Equal(t, actioninbox.ReasonHumanRejected, got.Denial.ReasonCode)
+}
+
+func TestDenyCascade_RejectsIdenticalSameSessionAsks(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	withHash := func(item *actioninbox.InboxItem, hash, session string) *actioninbox.InboxItem {
+		item.ContentHash = hash
+		item.Context = map[string]any{actioninbox.SessionContextKey: session}
+		return item
+	}
+
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("target", "mgr-1"), "hash-A", "sess-1")))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("dup-1", "mgr-1"), "hash-A", "sess-1")))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("dup-2", "mgr-1"), "hash-A", "sess-1")))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("other-session", "mgr-1"), "hash-A", "sess-2")))
+	otherContent := withHash(newTestItem("other-hash", "mgr-1"), "hash-B", "sess-1")
+	otherContent.Summary = "different request content"
+	require.NoError(t, store.Enqueue(ctx, otherContent))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("already-approved", "mgr-1"), "hash-A", "sess-1")))
+	require.NoError(t, store.Approve(ctx, "already-approved", "approver-1"))
+
+	cascaded, err := store.DenyCascade(ctx, "target", "rejected: too broad", "principal-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dup-1", "dup-2"}, cascaded)
+
+	target, err := store.Get(ctx, "target")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusDenied, target.Status)
+	require.NotNil(t, target.Denial)
+	assert.Equal(t, actioninbox.ReasonHumanRejected, target.Denial.ReasonCode)
+	assert.Equal(t, "rejected: too broad", target.Denial.Feedback)
+	assert.Empty(t, target.Denial.CascadedFrom)
+
+	for _, id := range []string{"dup-1", "dup-2"} {
+		got, err := store.Get(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, actioninbox.StatusDenied, got.Status, id)
+		require.NotNil(t, got.Denial, id)
+		assert.Equal(t, actioninbox.ReasonCascadeRejected, got.Denial.ReasonCode, id)
+		assert.Equal(t, "target", got.Denial.CascadedFrom, id)
+		assert.Equal(t, "rejected: too broad", got.Denial.Feedback, id)
+	}
+
+	// Fail-closed scoping: different session, different hash, and settled
+	// items are untouched.
+	for _, id := range []string{"other-session", "other-hash"} {
+		got, err := store.Get(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, actioninbox.StatusPending, got.Status, id)
+		assert.Nil(t, got.Denial, id)
+	}
+	settled, err := store.Get(ctx, "already-approved")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusApproved, settled.Status)
+}
+
+func TestDenyCascade_WithoutContentHashDoesNotGuess(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	// No ContentHash and no session: identity of "identical ask" is
+	// unprovable, so the cascade must refuse to guess.
+	require.NoError(t, store.Enqueue(ctx, newTestItem("target", "mgr-1")))
+	require.NoError(t, store.Enqueue(ctx, newTestItem("lookalike", "mgr-1")))
+
+	cascaded, err := store.DenyCascade(ctx, "target", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Empty(t, cascaded)
+
+	got, err := store.Get(ctx, "lookalike")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusPending, got.Status)
+}
+
+func TestDenyCascade_DerivesIdentityWithoutCallerHash(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	for _, id := range []string{"target", "duplicate"} {
+		item := newTestItem(id, "mgr-1")
+		item.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+		require.NoError(t, store.Enqueue(ctx, item))
+	}
+
+	cascaded, err := store.DenyCascade(ctx, "target", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"duplicate"}, cascaded)
+}
+
+func TestDenyCascade_ContentIdentityIncludesTitleAndProposal(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	target := newTestItem("target", "mgr-1")
+	target.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	require.NoError(t, store.Enqueue(ctx, target))
+
+	otherTitle := newTestItem("other-title", "mgr-1")
+	otherTitle.Title = "A different governed action"
+	otherTitle.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	require.NoError(t, store.Enqueue(ctx, otherTitle))
+
+	otherProposal := newTestItem("other-proposal", "mgr-1")
+	otherProposal.ProposalID = "proposal-other"
+	otherProposal.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	require.NoError(t, store.Enqueue(ctx, otherProposal))
+
+	cascaded, err := store.DenyCascade(ctx, "target", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Empty(t, cascaded)
+}
+
+func TestEnqueue_RejectsUnhashableContentIdentity(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	item := newTestItem("cyclic", "mgr-1")
+	cycle := map[string]any{}
+	cycle["self"] = cycle
+	item.Context = cycle
+
+	err := store.Enqueue(context.Background(), item)
+	require.ErrorContains(t, err, "canonicalize content identity")
+}
+
+func TestDenyCascade_CallerSuppliedIdentityCannotForgeDuplicate(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	target := newTestItem("target", "mgr-1")
+	target.ContentHash = "caller-claimed-hash"
+	target.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	target.Summary = "deploy the reviewed release"
+	require.NoError(t, store.Enqueue(ctx, target))
+
+	forged := newTestItem("forged", "mgr-1")
+	forged.ContentHash = target.ContentHash
+	forged.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	forged.Summary = "delete unrelated production data"
+	require.NoError(t, store.Enqueue(ctx, forged))
+
+	storedTarget, err := store.Get(ctx, "target")
+	require.NoError(t, err)
+	storedForged, err := store.Get(ctx, "forged")
+	require.NoError(t, err)
+	assert.Equal(t, "caller-claimed-hash", storedTarget.ContentHash)
+	assert.Equal(t, target.ContentHash, storedForged.ContentHash)
+
+	cascaded, err := store.DenyCascade(ctx, "target", "reject deployment", "principal-1")
+	require.NoError(t, err)
+	assert.Empty(t, cascaded)
+
+	got, err := store.Get(ctx, "forged")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusPending, got.Status)
+	assert.Nil(t, got.Denial)
+}
+
+func TestDenialRecord_GetReturnsDeepCopy(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Enqueue(ctx, newTestItem("item-1", "mgr-1")))
+	require.NoError(t, store.Deny(ctx, "item-1", "original feedback", "principal-1"))
+
+	// Mutating the record returned by Get must not corrupt stored denial
+	// evidence (aliasing regression).
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	require.NotNil(t, got.Denial)
+	got.Denial.Feedback = "tampered"
+	got.Denial.ReasonCode = "tampered-code"
+
+	again, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	assert.Equal(t, "original feedback", again.Denial.Feedback)
+	assert.Equal(t, actioninbox.ReasonHumanRejected, again.Denial.ReasonCode)
+}
+
+func TestCopyItem_DeepCopiesAllMutableFields(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	item := newTestItem("item-1", "mgr-1")
+	item.EffectTypes = []string{"shell", "write"}
+	item.Escalation = &actioninbox.EscalationReason{Code: "TIMEOUT", Urgency: "high"}
+	item.Context = map[string]any{
+		actioninbox.SessionContextKey: "sess-1",
+		"nested":                      map[string]any{"k": "v"},
+		"list":                        []any{"a", "b"},
+	}
+	require.NoError(t, store.Enqueue(ctx, item))
+
+	// Mutate every mutable field through the caller's original reference.
+	item.EffectTypes[0] = "tampered"
+	item.Escalation.Code = "tampered"
+	item.Context["nested"].(map[string]any)["k"] = "tampered"
+	item.Context["list"].([]any)[0] = "tampered"
+
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shell", "write"}, got.EffectTypes)
+	assert.Equal(t, "TIMEOUT", got.Escalation.Code)
+	assert.Equal(t, "v", got.Context["nested"].(map[string]any)["k"])
+	assert.Equal(t, "a", got.Context["list"].([]any)[0])
+
+	// Mutating the returned copy must not corrupt the store either.
+	got.EffectTypes[0] = "tampered"
+	got.Escalation.Code = "tampered"
+	got.Context["nested"].(map[string]any)["k"] = "tampered"
+
+	again, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"shell", "write"}, again.EffectTypes)
+	assert.Equal(t, "TIMEOUT", again.Escalation.Code)
+	assert.Equal(t, "v", again.Context["nested"].(map[string]any)["k"])
+}
+
+func TestCopyItem_DeepCopiesTypedContext(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	item := newTestItem("item-1", "mgr-1")
+	item.Context = map[string]any{
+		"map":   map[string]int{"count": 1},
+		"slice": []int{1, 2},
+		"bytes": []byte("ok"),
+	}
+	require.NoError(t, store.Enqueue(ctx, item))
+
+	item.Context["map"].(map[string]int)["count"] = 9
+	item.Context["slice"].([]int)[0] = 9
+	item.Context["bytes"].([]byte)[0] = 'x'
+
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	assert.Equal(t, 1, got.Context["map"].(map[string]int)["count"])
+	assert.Equal(t, []int{1, 2}, got.Context["slice"])
+	assert.Equal(t, []byte("ok"), got.Context["bytes"])
+}
+
+func TestCopyItem_DeepCopiesPointerStructArrayAndOverlappingSlices(t *testing.T) {
+	type nestedContext struct {
+		Values []int
+	}
+
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+	pointer := &nestedContext{Values: []int{1}}
+	array := [1][]int{{2}}
+	backing := []int{3, 4}
+	short := backing[:1:1]
+	long := backing[:2:2]
+	item := newTestItem("item-1", "mgr-1")
+	item.Context = map[string]any{
+		"pointer": pointer,
+		"array":   array,
+		"short":   short,
+		"long":    long,
+	}
+	require.NoError(t, store.Enqueue(ctx, item))
+
+	pointer.Values[0] = 9
+	array[0][0] = 9
+	backing[0] = 9
+
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	assert.Equal(t, []int{1}, got.Context["pointer"].(*nestedContext).Values)
+	assert.Equal(t, []int{2}, got.Context["array"].([1][]int)[0])
+	assert.Equal(t, []int{3}, got.Context["short"])
+	assert.Equal(t, []int{3, 4}, got.Context["long"])
+}
+
+func TestEnqueue_StripsCallerSuppliedDenial(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	// A caller-supplied denial record on a freshly enqueued (pending)
+	// item is forged evidence; Enqueue must strip it.
+	item := newTestItem("item-1", "mgr-1")
+	item.Denial = &actioninbox.DenialRecord{Feedback: "forged denial"}
+	require.NoError(t, store.Enqueue(ctx, item))
+
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusPending, got.Status)
+	assert.Nil(t, got.Denial, "pending items must never carry caller-supplied denial records")
+}
+
+func TestContext_GetAndEnqueueReturnDeepCopy(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	item := newTestItem("item-1", "mgr-1")
+	item.ContentHash = "hash-A"
+	item.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	require.NoError(t, store.Enqueue(ctx, item))
+
+	// Mutating the caller's context after Enqueue must not rewrite the
+	// stored session identity (cascade-scoping regression).
+	item.Context[actioninbox.SessionContextKey] = "sess-tampered"
+
+	other := newTestItem("item-2", "mgr-1")
+	other.ContentHash = "hash-A"
+	other.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	require.NoError(t, store.Enqueue(ctx, other))
+
+	// Mutating the context returned by Get must not corrupt the store
+	// either.
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	got.Context[actioninbox.SessionContextKey] = "sess-tampered"
+
+	cascaded, err := store.DenyCascade(ctx, "item-1", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"item-2"}, cascaded,
+		"cascade scoping must use the stored session_id, not caller-mutated aliases")
+}
+
+func TestDenyCascade_EmptySessionNeverCollides(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	withHash := func(item *actioninbox.InboxItem, hash, session string) *actioninbox.InboxItem {
+		item.ContentHash = hash
+		if session != "" {
+			item.Context = map[string]any{actioninbox.SessionContextKey: session}
+		}
+		return item
+	}
+
+	// Same content hash, but NEITHER item has a session ID: empty session
+	// IDs must not compare equal, so unrelated unknown-session asks are
+	// never cascade-denied together.
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("target-nosess", "mgr-1"), "hash-A", "")))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("other-nosess", "mgr-1"), "hash-A", "")))
+
+	cascaded, err := store.DenyCascade(ctx, "target-nosess", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Empty(t, cascaded, "empty session must disable cascading")
+
+	got, err := store.Get(ctx, "other-nosess")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusPending, got.Status)
+
+	// Mixed: target HAS a session, lookalike has none — still no cascade.
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("target-sess", "mgr-1"), "hash-B", "sess-1")))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("other-nosess-2", "mgr-1"), "hash-B", "")))
+
+	cascaded, err = store.DenyCascade(ctx, "target-sess", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Empty(t, cascaded, "non-empty session must not cascade into empty-session items")
+
+	got, err = store.Get(ctx, "other-nosess-2")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusPending, got.Status)
+}
+
+func TestDenyCascade_SkipsExpiredDuplicates(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	withHash := func(item *actioninbox.InboxItem, hash, session string) *actioninbox.InboxItem {
+		item.ContentHash = hash
+		item.Context = map[string]any{actioninbox.SessionContextKey: session}
+		return item
+	}
+
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("target", "mgr-1"), "hash-A", "sess-1")))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("live-dup", "mgr-1"), "hash-A", "sess-1")))
+	// Same hash + session but already logically expired: it must remain an
+	// expired audit record, never a cascade-denied one.
+	expired := withHash(newTestItem("expired-dup", "mgr-1"), "hash-A", "sess-1")
+	expired.CreatedAt = time.Now().UTC().Add(-2 * time.Hour)
+	expired.ExpiresAt = time.Now().UTC().Add(-1 * time.Hour)
+	require.NoError(t, store.Enqueue(ctx, expired))
+
+	cascaded, err := store.DenyCascade(ctx, "target", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"live-dup"}, cascaded, "expired duplicates must not be cascaded")
+
+	got, err := store.Get(ctx, "expired-dup")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusExpired, got.Status, "expired item must read as EXPIRED, not DENIED")
+	assert.Nil(t, got.Denial, "expired item must not carry a denial record")
+}
+
+func TestDenyCascade_ExpiredTargetDoesNotCascade(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	withHash := func(item *actioninbox.InboxItem, hash, session string) *actioninbox.InboxItem {
+		item.ContentHash = hash
+		item.Context = map[string]any{actioninbox.SessionContextKey: session}
+		return item
+	}
+
+	// Logically expired TARGET plus a live matching request: the expired
+	// target must not be denied and must not cascade into the live item.
+	expiredTarget := withHash(newTestItem("expired-target", "mgr-1"), "hash-A", "sess-1")
+	expiredTarget.CreatedAt = time.Now().UTC().Add(-2 * time.Hour)
+	expiredTarget.ExpiresAt = time.Now().UTC().Add(-1 * time.Hour)
+	require.NoError(t, store.Enqueue(ctx, expiredTarget))
+	require.NoError(t, store.Enqueue(ctx, withHash(newTestItem("live-dup", "mgr-1"), "hash-A", "sess-1")))
+
+	_, err := store.DenyCascade(ctx, "expired-target", "no", "principal-1")
+	require.Error(t, err, "expired target must reject the cascade")
+	assert.Contains(t, err.Error(), "expired")
+
+	target, err := store.Get(ctx, "expired-target")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusExpired, target.Status, "expired target must read as EXPIRED, not DENIED")
+	assert.Nil(t, target.Denial, "expired target must not carry a denial record")
+
+	live, err := store.Get(ctx, "live-dup")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusPending, live.Status, "live matching request must be unaffected")
+	assert.Nil(t, live.Denial)
+}
+
+func TestRouteSlices_GetAndEnqueueReturnDeepCopy(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	item := newTestItem("item-1", "mgr-1")
+	item.ContentHash = "hash-A"
+	item.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	item.Route = actioninbox.ApprovalRoute{
+		RouteType:   "single_human",
+		ApproverIDs: []string{"approver-1"},
+		Quorum:      1,
+		TimeoutSecs: 3600,
+		OnTimeout:   "deny",
+	}
+	require.NoError(t, store.Enqueue(ctx, item))
+
+	// Mutating the caller's route slices after Enqueue must not rewrite
+	// the stored route (SameApprovalDomain forgery regression).
+	item.Route.ApproverIDs[0] = "approver-forged"
+
+	// Mutating the route slices returned by Get must not corrupt the
+	// store either.
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	got.Route.ApproverIDs[0] = "approver-forged"
+
+	other := newTestItem("item-2", "mgr-1")
+	other.ContentHash = "hash-A"
+	other.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+	other.Route = actioninbox.ApprovalRoute{
+		RouteType:   "single_human",
+		ApproverIDs: []string{"approver-1"},
+		Quorum:      1,
+		TimeoutSecs: 3600,
+		OnTimeout:   "deny",
+	}
+	require.NoError(t, store.Enqueue(ctx, other))
+
+	cascaded, err := store.DenyCascade(ctx, "item-1", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"item-2"}, cascaded,
+		"stored route must be immune to caller mutation of aliased slices")
+
+	again, err := store.Get(ctx, "item-2")
+	require.NoError(t, err)
+	require.NotNil(t, again.Denial)
+	assert.Equal(t, []string{"approver-1"}, again.Route.ApproverIDs,
+		"denied item's stored route must retain original approvers")
+}
+
+func TestDenyCascade_NeverCrossesApprovalDomains(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	base := func(id string) *actioninbox.InboxItem {
+		item := newTestItem(id, "mgr-1")
+		item.ContentHash = "hash-A"
+		item.Context = map[string]any{actioninbox.SessionContextKey: "sess-1"}
+		return item
+	}
+
+	require.NoError(t, store.Enqueue(ctx, base("target")))
+
+	// Same hash + session, but each in a DIFFERENT approval domain.
+	otherManager := base("other-manager")
+	otherManager.ManagerID = "mgr-2"
+	require.NoError(t, store.Enqueue(ctx, otherManager))
+
+	otherEmployee := base("other-employee")
+	otherEmployee.EmployeeID = "emp-2"
+	require.NoError(t, store.Enqueue(ctx, otherEmployee))
+
+	otherRoute := base("other-route")
+	otherRoute.Route = actioninbox.ApprovalRoute{RouteType: "dual_control", Quorum: 2, TimeoutSecs: 7200, OnTimeout: "escalate"}
+	require.NoError(t, store.Enqueue(ctx, otherRoute))
+
+	// Identical domain: this one MUST cascade.
+	sameDomain := base("same-domain")
+	require.NoError(t, store.Enqueue(ctx, sameDomain))
+
+	cascaded, err := store.DenyCascade(ctx, "target", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"same-domain"}, cascaded,
+		"cascade must stay inside the target's approval domain")
+
+	for _, id := range []string{"other-manager", "other-employee", "other-route"} {
+		got, err := store.Get(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, actioninbox.StatusPending, got.Status, id)
+		assert.Nil(t, got.Denial, id)
+	}
+	got, err := store.Get(ctx, "same-domain")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusDenied, got.Status)
+	require.NotNil(t, got.Denial)
+	assert.Equal(t, actioninbox.ReasonCascadeRejected, got.Denial.ReasonCode)
+}
+
+func TestDenyCascade_TargetWithoutDomainFieldsDoesNotCascade(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	// Target lacks domain-defining fields (no ManagerID/EmployeeID): not
+	// comparable, so fail-closed — nothing cascades even to lookalikes.
+	target := &actioninbox.InboxItem{
+		ItemID:      "target",
+		Title:       "domainless",
+		ContentHash: "hash-A",
+		Context:     map[string]any{actioninbox.SessionContextKey: "sess-1"},
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}
+	require.NoError(t, store.Enqueue(ctx, target))
+
+	lookalike := &actioninbox.InboxItem{
+		ItemID:      "lookalike",
+		Title:       "domainless-2",
+		ContentHash: "hash-A",
+		Context:     map[string]any{actioninbox.SessionContextKey: "sess-1"},
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   time.Now().UTC().Add(time.Hour),
+	}
+	require.NoError(t, store.Enqueue(ctx, lookalike))
+
+	cascaded, err := store.DenyCascade(ctx, "target", "no", "principal-1")
+	require.NoError(t, err)
+	assert.Empty(t, cascaded, "items without comparable domain fields must not cascade")
+
+	got, err := store.Get(ctx, "lookalike")
+	require.NoError(t, err)
+	assert.Equal(t, actioninbox.StatusPending, got.Status)
+}
+
+func TestDenyCascade_NonPendingTargetFails(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Enqueue(ctx, newTestItem("item-1", "mgr-1")))
+	require.NoError(t, store.Deny(ctx, "item-1", "no", "principal-1"))
+
+	_, err := store.DenyCascade(ctx, "item-1", "no", "principal-1")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not pending")
+}
+
+func TestDenialRecord_JSONRoundTripIsAdditive(t *testing.T) {
+	store := actioninbox.NewInMemoryInboxStore()
+	ctx := context.Background()
+
+	require.NoError(t, store.Enqueue(ctx, newTestItem("item-1", "mgr-1")))
+	require.NoError(t, store.Deny(ctx, "item-1", "feedback text", "principal-1"))
+
+	got, err := store.Get(ctx, "item-1")
+	require.NoError(t, err)
+	// The denial record renders as structured JSON alongside the legacy
+	// item shape (additive omitempty field, no schema break).
+	raw, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"denial"`)
+	assert.Contains(t, string(raw), `"schema_version":"`+actioninbox.DenyFeedbackSchemaVersion+`"`)
+	assert.Contains(t, string(raw), `"reason_code":"`+actioninbox.ReasonHumanRejected+`"`)
+}

--- a/core/pkg/actioninbox/doom_loop.go
+++ b/core/pkg/actioninbox/doom_loop.go
@@ -1,0 +1,110 @@
+package actioninbox
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+)
+
+// DefaultDoomLoopThreshold matches the opencode DOOM_LOOP_THRESHOLD: three
+// identical settled tool calls in a row is treated as a doom loop.
+const DefaultDoomLoopThreshold = 3
+
+// DefaultDoomLoopMaxTripped bounds the latch map so a long-lived process
+// cannot grow breaker memory without bound via distinct tripped calls.
+// Eviction is deterministic (lexicographically smallest signature); an
+// evicted signature simply re-trips after another threshold run.
+const DefaultDoomLoopMaxTripped = 64
+
+// DoomLoopBreaker is a circuit breaker against agents retrying an identical
+// call forever. After threshold consecutive identical signatures, it trips
+// and stays tripped for that signature until Reset. Observing a different
+// signature only starts a new consecutive run. Tripping only ever forces an
+// ask/escalation; it never authorizes anything, so the breaker is fail-closed
+// by construction. The latch map is bounded (DefaultDoomLoopMaxTripped,
+// deterministic eviction).
+//
+// The zero value is unusable; construct via NewDoomLoopBreaker.
+type DoomLoopBreaker struct {
+	mu         sync.Mutex
+	threshold  int
+	maxTripped int
+	// tail holds the most recent consecutive identical-signature run.
+	lastSignature string
+	runLength     int
+	tripped       map[string]bool
+}
+
+// NewDoomLoopBreaker creates a breaker that trips after threshold consecutive
+// identical signatures. A threshold < 1 is clamped to DefaultDoomLoopThreshold
+// so invalid configuration cannot silently disable the breaker.
+func NewDoomLoopBreaker(threshold int) *DoomLoopBreaker {
+	if threshold < 1 {
+		threshold = DefaultDoomLoopThreshold
+	}
+	return &DoomLoopBreaker{
+		threshold:  threshold,
+		maxTripped: DefaultDoomLoopMaxTripped,
+		tripped:    make(map[string]bool),
+	}
+}
+
+// SignatureFor builds a stable signature for a tool call. Callers should
+// pass the normalized tool identity, action, and target; the signature binds
+// all three so "identical call" means identical in everything that matters.
+func SignatureFor(toolID, action, target string) string {
+	sum := sha256.Sum256([]byte(toolID + "\x00" + action + "\x00" + target))
+	return hex.EncodeToString(sum[:])
+}
+
+// Record observes one settled (or attempted, for pre-tool hooks) call with
+// the given signature and reports whether the breaker is now tripped for it.
+// Once tripped for a signature, Record keeps returning true for that
+// signature until a different signature is recorded, which clears the
+// consecutive run but leaves prior trips latched.
+func (b *DoomLoopBreaker) Record(signature string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if signature == b.lastSignature {
+		b.runLength++
+	} else {
+		b.lastSignature = signature
+		b.runLength = 1
+	}
+	if b.runLength >= b.threshold {
+		if !b.tripped[signature] && len(b.tripped) >= b.maxTripped {
+			// Bounded latch: evict the deterministic victim (smallest
+			// key); an evicted signature re-trips after another
+			// threshold run.
+			victim := ""
+			for k := range b.tripped {
+				if victim == "" || k < victim {
+					victim = k
+				}
+			}
+			delete(b.tripped, victim)
+		}
+		b.tripped[signature] = true
+	}
+	return b.tripped[signature]
+}
+
+// Tripped reports whether the breaker has latched for the given signature,
+// without recording a new observation.
+func (b *DoomLoopBreaker) Tripped(signature string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.tripped[signature]
+}
+
+// Reset clears all latched trips and the consecutive-run state. Intended for
+// explicit human/operator intervention (e.g. after an escalation is
+// resolved), not for routine agent use.
+func (b *DoomLoopBreaker) Reset() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.lastSignature = ""
+	b.runLength = 0
+	b.tripped = make(map[string]bool)
+}

--- a/core/pkg/actioninbox/doom_loop_test.go
+++ b/core/pkg/actioninbox/doom_loop_test.go
@@ -1,0 +1,100 @@
+package actioninbox_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/actioninbox"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoomLoopBreaker_TripsAtThreshold(t *testing.T) {
+	b := actioninbox.NewDoomLoopBreaker(3)
+	sig := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/x")
+
+	assert.False(t, b.Record(sig), "first attempt must not trip")
+	assert.False(t, b.Record(sig), "second attempt must not trip")
+	assert.True(t, b.Record(sig), "third identical attempt must trip")
+	assert.True(t, b.Tripped(sig))
+}
+
+func TestDoomLoopBreaker_DifferentSignatureResetsRun(t *testing.T) {
+	b := actioninbox.NewDoomLoopBreaker(3)
+	sigA := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/a")
+	sigB := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/b")
+
+	assert.False(t, b.Record(sigA))
+	assert.False(t, b.Record(sigA))
+	assert.False(t, b.Record(sigB), "different signature breaks the run")
+	assert.False(t, b.Record(sigA), "run restarts at 1 after a different signature")
+}
+
+func TestDoomLoopBreaker_TripLatchesUntilReset(t *testing.T) {
+	b := actioninbox.NewDoomLoopBreaker(3)
+	sigA := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/a")
+	sigB := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/b")
+
+	for i := 0; i < 3; i++ {
+		b.Record(sigA)
+	}
+	assert.True(t, b.Tripped(sigA))
+
+	// A different signature clears the consecutive run but the latch for
+	// sigA stays: the agent cannot evade the breaker by interleaving one
+	// different call.
+	b.Record(sigB)
+	assert.True(t, b.Record(sigA), "latched trip must survive interleaved calls")
+
+	b.Reset()
+	assert.False(t, b.Tripped(sigA))
+	assert.False(t, b.Record(sigA), "after reset the run starts fresh")
+}
+
+func TestDoomLoopBreaker_ThresholdClampedToDefault(t *testing.T) {
+	b := actioninbox.NewDoomLoopBreaker(0)
+	sig := actioninbox.SignatureFor("t", "a", "x")
+	for i := 0; i < actioninbox.DefaultDoomLoopThreshold-1; i++ {
+		assert.False(t, b.Record(sig))
+	}
+	assert.True(t, b.Record(sig), "clamped threshold must match the default")
+}
+
+func TestDoomLoopBreaker_NeverUpgradesToAllow(t *testing.T) {
+	// Conformance guard: the breaker's only outputs are tripped/not-tripped;
+	// a not-tripped result is not an authorization. This test pins the
+	// contract that Record returns a boolean about looping only.
+	b := actioninbox.NewDoomLoopBreaker(1) // threshold 1: trips immediately
+	sig := actioninbox.SignatureFor("mcp", "mcp_tool_call", "mcp__x__y")
+	assert.True(t, b.Record(sig), "threshold 1 trips on first observation")
+}
+
+func TestDoomLoopBreaker_LatchMapIsBounded(t *testing.T) {
+	b := actioninbox.NewDoomLoopBreaker(3)
+	total := actioninbox.DefaultDoomLoopMaxTripped + 10
+	for i := 0; i < total; i++ {
+		sig := actioninbox.SignatureFor("shell", "shell_operate", fmt.Sprintf("target-%d", i))
+		for j := 0; j < 3; j++ {
+			b.Record(sig)
+		}
+	}
+	// Distinct tripped signatures beyond the cap must not grow the latch
+	// without bound; evicted signatures simply re-trip on a fresh run.
+	// (The cap is an internal invariant; behavioral proof: recording many
+	// distinct tripped signatures completes and the newest still trips.)
+	newest := actioninbox.SignatureFor("shell", "shell_operate", fmt.Sprintf("target-%d", total-1))
+	if !b.Tripped(newest) {
+		t.Fatal("newest tripped signature must be latched")
+	}
+}
+
+func TestSignatureFor_DeterministicAndDiscriminating(t *testing.T) {
+	a1 := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/a")
+	a2 := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/a")
+	b := actioninbox.SignatureFor("shell", "shell_operate", "rm -rf /tmp/b")
+	c := actioninbox.SignatureFor("Write", "file_write", ".env")
+
+	assert.Equal(t, a1, a2, "same inputs must give the same signature")
+	assert.NotEqual(t, a1, b, "different target must change the signature")
+	assert.NotEqual(t, a1, c, "different tool/action must change the signature")
+	assert.Len(t, a1, 64, "sha256 hex signature")
+}

--- a/core/pkg/actioninbox/store.go
+++ b/core/pkg/actioninbox/store.go
@@ -3,22 +3,203 @@ package actioninbox
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"slices"
+	"sort"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
 )
 
 // InMemoryInboxStore implements Inbox using an in-memory map.
 // Thread-safe via RWMutex.
 type InMemoryInboxStore struct {
-	mu    sync.RWMutex
-	items map[string]*InboxItem
+	mu                sync.RWMutex
+	items             map[string]*InboxItem
+	cascadeIdentities map[string]string
 }
 
 // NewInMemoryInboxStore creates a new in-memory inbox store.
 func NewInMemoryInboxStore() *InMemoryInboxStore {
 	return &InMemoryInboxStore{
-		items: make(map[string]*InboxItem),
+		items:             make(map[string]*InboxItem),
+		cascadeIdentities: make(map[string]string),
 	}
+}
+
+func canonicalContentHash(item *InboxItem) (string, error) {
+	if item == nil {
+		return "", fmt.Errorf("actioninbox: item must not be nil")
+	}
+	contextWithoutSession := make(map[string]any, len(item.Context))
+	for key, value := range item.Context {
+		if key != SessionContextKey {
+			contextWithoutSession[key] = value
+		}
+	}
+	identity, err := canonicalize.CanonicalHash(struct {
+		ProposalID  string         `json:"proposal_id"`
+		Title       string         `json:"title"`
+		Summary     string         `json:"summary"`
+		RiskClass   string         `json:"risk_class"`
+		EffectTypes []string       `json:"effect_types"`
+		Context     map[string]any `json:"context"`
+	}{
+		ProposalID:  item.ProposalID,
+		Title:       item.Title,
+		Summary:     item.Summary,
+		RiskClass:   item.RiskClass,
+		EffectTypes: item.EffectTypes,
+		Context:     contextWithoutSession,
+	})
+	if err != nil {
+		return "", fmt.Errorf("actioninbox: canonicalize content identity: %w", err)
+	}
+	return identity, nil
+}
+
+func cascadeIdentity(item *InboxItem, contentIdentity string) string {
+	if item == nil || contentIdentity == "" || item.SessionID() == "" || !item.HasApprovalDomain() {
+		return ""
+	}
+	identity, err := canonicalize.CanonicalHash(struct {
+		ContentHash string        `json:"content_hash"`
+		SessionID   string        `json:"session_id"`
+		EmployeeID  string        `json:"employee_id"`
+		ManagerID   string        `json:"manager_id"`
+		Route       ApprovalRoute `json:"route"`
+	}{
+		ContentHash: contentIdentity,
+		SessionID:   item.SessionID(),
+		EmployeeID:  item.EmployeeID,
+		ManagerID:   item.ManagerID,
+		Route:       item.Route,
+	})
+	if err != nil {
+		return ""
+	}
+	return identity
+}
+
+// copyItem deep-copies an inbox item: the structured denial record, the
+// context map (including nested map/slice values), the approval-route
+// approver slices, the effect-type slice, and the escalation record.
+// Anything less would let callers mutate stored approval evidence —
+// denial records, session scoping, approver lists, or escalation data —
+// through aliased references obtained via Enqueue arguments or Get /
+// ListPending results.
+func copyItem(item *InboxItem) *InboxItem {
+	val := *item
+	if item.Denial != nil {
+		d := *item.Denial
+		val.Denial = &d
+	}
+	if item.Escalation != nil {
+		e := *item.Escalation
+		val.Escalation = &e
+	}
+	if item.Context != nil {
+		val.Context = copyContextValue(item.Context).(map[string]any)
+	}
+	val.Route.ApproverIDs = slices.Clone(item.Route.ApproverIDs)
+	val.Route.ApproverRoles = slices.Clone(item.Route.ApproverRoles)
+	val.EffectTypes = slices.Clone(item.EffectTypes)
+	return &val
+}
+
+// copyContextValue recursively copies mutable context containers while
+// preserving cycles. Context accepts typed containers, not just
+// map[string]any and []any.
+func copyContextValue(v any) any {
+	type visit struct {
+		typ reflect.Type
+		ptr uintptr
+		len int
+		cap int
+	}
+	seen := make(map[visit]reflect.Value)
+
+	var clone func(reflect.Value) reflect.Value
+	clone = func(src reflect.Value) reflect.Value {
+		if !src.IsValid() {
+			return src
+		}
+		if src.Kind() == reflect.Interface {
+			if src.IsNil() {
+				return reflect.Zero(src.Type())
+			}
+			dst := reflect.New(src.Type()).Elem()
+			dst.Set(clone(src.Elem()))
+			return dst
+		}
+
+		switch src.Kind() {
+		case reflect.Map:
+			if src.IsNil() {
+				return reflect.Zero(src.Type())
+			}
+			key := visit{typ: src.Type(), ptr: src.Pointer()}
+			if dst, ok := seen[key]; ok {
+				return dst
+			}
+			dst := reflect.MakeMapWithSize(src.Type(), src.Len())
+			seen[key] = dst
+			iter := src.MapRange()
+			for iter.Next() {
+				dst.SetMapIndex(clone(iter.Key()), clone(iter.Value()))
+			}
+			return dst
+		case reflect.Slice:
+			if src.IsNil() {
+				return reflect.Zero(src.Type())
+			}
+			key := visit{typ: src.Type(), ptr: src.Pointer(), len: src.Len(), cap: src.Cap()}
+			if dst, ok := seen[key]; ok {
+				return dst
+			}
+			dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+			seen[key] = dst
+			for i := range src.Len() {
+				dst.Index(i).Set(clone(src.Index(i)))
+			}
+			return dst
+		case reflect.Pointer:
+			if src.IsNil() {
+				return reflect.Zero(src.Type())
+			}
+			key := visit{typ: src.Type(), ptr: src.Pointer()}
+			if dst, ok := seen[key]; ok {
+				return dst
+			}
+			dst := reflect.New(src.Type().Elem())
+			seen[key] = dst
+			dst.Elem().Set(clone(src.Elem()))
+			return dst
+		case reflect.Array:
+			dst := reflect.New(src.Type()).Elem()
+			for i := range src.Len() {
+				dst.Index(i).Set(clone(src.Index(i)))
+			}
+			return dst
+		case reflect.Struct:
+			// Preserve unexported value fields, then replace every exported
+			// field with its recursively cloned value.
+			dst := reflect.New(src.Type()).Elem()
+			dst.Set(src)
+			for i := range src.NumField() {
+				if src.Type().Field(i).PkgPath == "" {
+					dst.Field(i).Set(clone(src.Field(i)))
+				}
+			}
+			return dst
+		default:
+			return src
+		}
+	}
+
+	return clone(reflect.ValueOf(v)).Interface()
 }
 
 func (s *InMemoryInboxStore) Enqueue(ctx context.Context, item *InboxItem) error {
@@ -36,16 +217,24 @@ func (s *InMemoryInboxStore) Enqueue(ctx context.Context, item *InboxItem) error
 		return fmt.Errorf("actioninbox: item %q already exists", item.ItemID)
 	}
 
-	// Store a copy to prevent external mutation.
-	val := *item
+	// Store a copy to prevent external mutation. A freshly enqueued item
+	// is PENDING: strip any caller-supplied denial record so forged
+	// denial evidence can never ride in on a pending item.
+	val := copyItem(item)
 	val.Status = StatusPending
-	s.items[item.ItemID] = &val
+	val.Denial = nil
+	contentIdentity, err := canonicalContentHash(val)
+	if err != nil {
+		return err
+	}
+	s.items[item.ItemID] = val
+	s.cascadeIdentities[item.ItemID] = cascadeIdentity(val, contentIdentity)
 	return nil
 }
 
 func (s *InMemoryInboxStore) Get(ctx context.Context, itemID string) (*InboxItem, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	item, ok := s.items[itemID]
 	if !ok {
@@ -54,16 +243,10 @@ func (s *InMemoryInboxStore) Get(ctx context.Context, itemID string) (*InboxItem
 
 	// Check expiry on read.
 	if item.Status == StatusPending && !item.ExpiresAt.IsZero() && time.Now().After(item.ExpiresAt) {
-		// Mark expired (upgrade to write lock).
-		s.mu.RUnlock()
-		s.mu.Lock()
 		item.Status = StatusExpired
-		s.mu.Unlock()
-		s.mu.RLock()
 	}
 
-	val := *item
-	return &val, nil
+	return copyItem(item), nil
 }
 
 func (s *InMemoryInboxStore) ListPending(ctx context.Context, managerID string, limit int) ([]*InboxItem, error) {
@@ -77,8 +260,7 @@ func (s *InMemoryInboxStore) ListPending(ctx context.Context, managerID string, 
 			if !item.ExpiresAt.IsZero() && time.Now().After(item.ExpiresAt) {
 				continue
 			}
-			val := *item
-			result = append(result, &val)
+			result = append(result, copyItem(item))
 			if limit > 0 && len(result) >= limit {
 				break
 			}
@@ -104,6 +286,14 @@ func (s *InMemoryInboxStore) Approve(ctx context.Context, itemID string, approve
 }
 
 func (s *InMemoryInboxStore) Deny(ctx context.Context, itemID string, reason string, principalID string) error {
+	return s.DenyWithFeedback(ctx, itemID, reason, ReasonHumanRejected, principalID)
+}
+
+// DenyWithFeedback marks an item as denied and attaches a structured,
+// model-actionable denial record (reject-with-feedback): the human's
+// steering text is preserved on the item so the requesting agent can
+// retrieve it and self-correct instead of retrying blind.
+func (s *InMemoryInboxStore) DenyWithFeedback(ctx context.Context, itemID string, feedback string, reasonCode string, principalID string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -114,9 +304,109 @@ func (s *InMemoryInboxStore) Deny(ctx context.Context, itemID string, reason str
 	if item.Status != StatusPending {
 		return fmt.Errorf("actioninbox: item %q is not pending (status=%s)", itemID, item.Status)
 	}
+	if strings.TrimSpace(reasonCode) == "" {
+		reasonCode = ReasonHumanRejected
+	}
+	reasonCode = strings.TrimSpace(reasonCode)
 
 	item.Status = StatusDenied
+	item.Denial = newHumanDenialRecord(feedback, reasonCode, principalID, time.Now().UTC())
 	return nil
+}
+
+func newHumanDenialRecord(feedback, reasonCode, principalID string, decidedAt time.Time) *DenialRecord {
+	return &DenialRecord{
+		SchemaVersion: DenyFeedbackSchemaVersion,
+		ReasonCode:    reasonCode,
+		Explanation:   "The requested action was reviewed and rejected by the approving principal.",
+		Feedback:      feedback,
+		Remediation:   "Do not retry the identical request. Adjust the proposal according to the feedback, or abandon it.",
+		Escalation:    "If the rejection seems mistaken, escalate to the approving principal with this item's receipt and content hash.",
+		PrincipalID:   principalID,
+		DecidedAt:     decidedAt,
+	}
+}
+
+// DenyCascade marks an item as denied with feedback, then cascade-rejects
+// every other still-pending item that is an identical same-session ask in
+// the same approval domain: same non-empty ContentHash, same non-empty
+// session ID, and SameApprovalDomain (same requester, approval authority,
+// and route). A logically expired target is rejected (error) and never
+// cascades; logically expired duplicates are skipped, not denied; items
+// lacking comparable domain fields are never cascaded to (fail-closed).
+// Cascaded items are denied, never approved — the cascade only ever
+// narrows, preserving fail-closed semantics. It returns the IDs of the
+// cascaded items (excluding itemID).
+func (s *InMemoryInboxStore) DenyCascade(ctx context.Context, itemID string, feedback string, principalID string) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	item, ok := s.items[itemID]
+	if !ok {
+		return nil, fmt.Errorf("actioninbox: item %q not found", itemID)
+	}
+	if item.Status != StatusPending {
+		return nil, fmt.Errorf("actioninbox: item %q is not pending (status=%s)", itemID, item.Status)
+	}
+	now := time.Now().UTC()
+	if !item.ExpiresAt.IsZero() && now.After(item.ExpiresAt) {
+		// A logically expired target is an expired audit record (lazy
+		// expiry marks it EXPIRED on read), not a deniable ask: it must
+		// not be denied and must not cascade rejection into live matching
+		// requests.
+		return nil, fmt.Errorf("actioninbox: item %q is expired and cannot be cascade-denied", itemID)
+	}
+
+	item.Status = StatusDenied
+	item.Denial = newHumanDenialRecord(feedback, ReasonHumanRejected, principalID, now)
+
+	var cascaded []string
+	identity := s.cascadeIdentities[itemID]
+	if identity == "" {
+		// Without a store-derived identity there is no safe proof of an
+		// identical ask. This includes missing domain/session fields and
+		// context shapes that cannot be canonically hashed.
+		return cascaded, nil
+	}
+	for _, other := range s.items {
+		if other.ItemID == itemID || other.Status != StatusPending {
+			continue
+		}
+		// Skip logically expired items: they are expired audit records
+		// (lazy expiry marks them EXPIRED on read), not deniable asks —
+		// a cascade must never rewrite them as DENIED.
+		if !other.ExpiresAt.IsZero() && now.After(other.ExpiresAt) {
+			continue
+		}
+		// Caller-supplied hash/session/domain strings are not authority.
+		// Compare the private canonical identity computed at Enqueue.
+		if s.cascadeIdentities[other.ItemID] != identity {
+			continue
+		}
+		// Cascade only within the target's approval domain: same
+		// requester, same approval authority, same route. A principal
+		// denying one ask must never settle asks owned by another
+		// manager, employee, or route; items without comparable domain
+		// fields are skipped (fail-closed).
+		if !item.SameApprovalDomain(other) {
+			continue
+		}
+		other.Status = StatusDenied
+		other.Denial = &DenialRecord{
+			SchemaVersion: DenyFeedbackSchemaVersion,
+			ReasonCode:    ReasonCascadeRejected,
+			Explanation:   "An identical pending request in the same session was rejected; this duplicate was cascade-rejected.",
+			Feedback:      feedback,
+			CascadedFrom:  itemID,
+			Remediation:   "Do not re-enqueue the identical request in this session. Adjust the proposal according to the feedback first.",
+			Escalation:    "Escalate to the approving principal with the originating item's receipt if the cascade seems mistaken.",
+			PrincipalID:   principalID,
+			DecidedAt:     now,
+		}
+		cascaded = append(cascaded, other.ItemID)
+	}
+	sort.Strings(cascaded)
+	return cascaded, nil
 }
 
 func (s *InMemoryInboxStore) Defer(ctx context.Context, itemID string, until time.Time) error {

--- a/core/pkg/actioninbox/types.go
+++ b/core/pkg/actioninbox/types.go
@@ -4,7 +4,10 @@
 // proceed.
 package actioninbox
 
-import "time"
+import (
+	"slices"
+	"time"
+)
 
 // InboxItemStatus represents the lifecycle state of an inbox item.
 type InboxItemStatus string
@@ -32,9 +35,66 @@ type InboxItem struct {
 	Status      InboxItemStatus   `json:"status"`
 	Route       ApprovalRoute     `json:"route"`
 	Escalation  *EscalationReason `json:"escalation,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	ExpiresAt   time.Time         `json:"expires_at"`
-	ContentHash string            `json:"content_hash"`
+	// Denial is the structured, model-actionable denial record, present
+	// once the item has been denied. Additive (omitempty): older items and
+	// non-denied items are unaffected.
+	Denial      *DenialRecord `json:"denial,omitempty"`
+	CreatedAt   time.Time     `json:"created_at"`
+	ExpiresAt   time.Time     `json:"expires_at"`
+	ContentHash string        `json:"content_hash"`
+}
+
+// SessionContextKey is the InboxItem.Context key carrying the agent session
+// identifier. Cascade-reject only propagates within one session.
+const SessionContextKey = "session_id"
+
+// SessionID returns the session identifier recorded on the item, or "".
+func (i *InboxItem) SessionID() string {
+	if i == nil || i.Context == nil {
+		return ""
+	}
+	if s, ok := i.Context[SessionContextKey].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// HasApprovalDomain reports whether the item carries the domain-defining
+// fields a cascade decision can compare: a requester (EmployeeID) and an
+// approval authority (ManagerID). Items lacking them are not comparable —
+// fail-closed callers must refuse to cascade to or from them.
+func (i *InboxItem) HasApprovalDomain() bool {
+	return i != nil && i.EmployeeID != "" && i.ManagerID != ""
+}
+
+// SameApprovalDomain reports whether two items belong to the same approval
+// domain: identical requester, identical approval authority, and identical
+// approval route (who must approve and how). A denial ceremony for one item
+// may only cascade within its own domain; denying across managers,
+// employees, or routes would let one principal settle asks they are not
+// authorized for.
+func (i *InboxItem) SameApprovalDomain(other *InboxItem) bool {
+	if !i.HasApprovalDomain() || !other.HasApprovalDomain() {
+		return false
+	}
+	if i.EmployeeID != other.EmployeeID || i.ManagerID != other.ManagerID {
+		return false
+	}
+	return i.Route.SameRoute(&other.Route)
+}
+
+// SameRoute reports whether two approval routes are identical in every
+// field that defines the approval authority and ceremony.
+func (r *ApprovalRoute) SameRoute(other *ApprovalRoute) bool {
+	if r == nil || other == nil {
+		return r == other
+	}
+	return r.RouteType == other.RouteType &&
+		slices.Equal(r.ApproverIDs, other.ApproverIDs) &&
+		slices.Equal(r.ApproverRoles, other.ApproverRoles) &&
+		r.Quorum == other.Quorum &&
+		r.TimeoutSecs == other.TimeoutSecs &&
+		r.OnTimeout == other.OnTimeout
 }
 
 // ApprovalRoute defines how an item must be approved.

--- a/docs/INTEGRATIONS/claude-code.md
+++ b/docs/INTEGRATIONS/claude-code.md
@@ -35,9 +35,10 @@ helm-ai-kernel setup claude-code --dry-run --json
 The JSON summary includes the binary path, client config path, hook config path,
 data dir, Kernel URL, draft policy path, and uninstall command.
 
-## Verify A Denial
+## Verify a Hook Decision
 
-Denied hook decisions write signed receipts under:
+Every classified PreToolUse decision, whether allowed or denied, writes a
+signed receipt under:
 
 ```text
 ~/.helm-ai-kernel/receipts/hooks/
@@ -83,7 +84,8 @@ HELM denied <class>: <KERNEL_REASON_CODE> (receipt: <path>) [INBOX_KERNEL_POLICY
   boundary. Payloads without a session ID are not tracked, so unrelated
   sessionless invocations can never false-trip each other.
 - Fail-closed infrastructure denials carry their own codes:
-  `[INBOX_SIGNER_UNAVAILABLE]`, `[INBOX_RECEIPT_PERSISTENCE_UNAVAILABLE]`.
+  `[INBOX_SIGNER_UNAVAILABLE]`, `[INBOX_POLICY_PROFILE_UNAVAILABLE]`,
+  `[INBOX_RECEIPT_PERSISTENCE_UNAVAILABLE]`.
 
 ## MCP Configuration
 

--- a/docs/INTEGRATIONS/claude-code.md
+++ b/docs/INTEGRATIONS/claude-code.md
@@ -58,6 +58,33 @@ copied receipts — see
 [local signer and trusted verification](../reference/workstation-governance.md#local-signer-and-trusted-verification).
 Receipts signed with pre-v0.7.3 derivable seeds remain untrusted.
 
+## Deny Feedback Format
+
+Every PreToolUse denial returns model-actionable steering text in
+`hookSpecificOutput.permissionDecisionReason`, not just "denied":
+
+```text
+HELM denied <class>: <KERNEL_REASON_CODE> (receipt: <path>) [INBOX_KERNEL_POLICY_DENY] kernel=<CODE> <explanation> Remediation: <what to do instead> Escalation: <who can unblock>
+```
+
+- `[INBOX_*]` is the machine-readable steering code (namespaced so it cannot
+  be confused with canonical Kernel verdict reason codes).
+- `Remediation` tells the agent how to self-correct; `Escalation` names the
+  human route. Agents should not retry an identical denied call.
+- After 3 consecutive identical denied hook outcomes in one session, the
+  doom-loop circuit breaker appends `[INBOX_DOOM_LOOP_DETECTED]` escalation
+  guidance to the denial. The latch is per call signature: a changed
+  approach is evaluated fresh. Policy denials and fail-closed infrastructure
+  denials count; allowed calls never trip the breaker and reset the run.
+  Breaker state lives under `<data-dir>/state/hook-doomloop.json` (bounded,
+  lock-serialized); it is advisory
+  steering on top of the authoritative policy path — the session ID is
+  client-supplied and unauthenticated, so the breaker is not a security
+  boundary. Payloads without a session ID are not tracked, so unrelated
+  sessionless invocations can never false-trip each other.
+- Fail-closed infrastructure denials carry their own codes:
+  `[INBOX_SIGNER_UNAVAILABLE]`, `[INBOX_RECEIPT_PERSISTENCE_UNAVAILABLE]`.
+
 ## MCP Configuration
 
 For lower-level MCP configuration, install the Claude Code MCP server:


### PR DESCRIPTION
## Summary

Wave 1 / W5 of the opencode→HELM supremacy campaign: denials now return **steering text, not just 'denied'**, so agents can self-correct against the firewall instead of thrashing.

1. **Structured, model-actionable deny reasons** — new versioned `deny_feedback.v1` `DenialRecord` in `core/pkg/actioninbox`: machine-readable `INBOX_*` steering codes (namespaced away from canonical Kernel verdict codes), human/agent-readable explanation, suggested remediation, and escalation route. Known Kernel verdict reason codes (`OPERATE_PERMISSIONS_EMPTY`, `EGRESS_ALLOWLIST_EMPTY`, `TAINTED_CONTEXT_REQUIRES_DENY`, etc.) map to specific guidance; unknown codes fall back to a fail-closed generic ("do not retry; change approach or escalate").
2. **Reject-with-feedback** — `Deny`/`DenyWithFeedback` attach the structured record (including the principal's own words) to the inbox item, retrievable via `Get`. Additive `omitempty` field; no schema break.
3. **Cascade-reject** — `DenyCascade` rejects all identical same-session pending asks (same non-empty `ContentHash` + session). Refuses to guess identity without a content hash; only ever narrows (deny), never approves.
4. **Doom-loop circuit breaker** — `DoomLoopBreaker` (threshold 3, matching opencode's `DOOM_LOOP_THRESHOLD`) trips on N consecutive identical call signatures and latches until reset. Wired into the pre-tool hook with per-session persisted state under the data dir (atomic 0600 writes; disabled when no data dir exists). The hook always completes policy evaluation and persists the decision receipt first; after three identical denied outcomes the breaker appends `[INBOX_DOOM_LOOP_DETECTED]` escalation steering without changing the authoritative verdict.
5. **Hook surfacing** — the Claude/Codex PreToolUse deny JSON's `permissionDecisionReason` now carries the full steering text; fail-closed infrastructure denials keep their operator-facing prefixes and gain `[INBOX_SIGNER_UNAVAILABLE]` / `[INBOX_RECEIPT_PERSISTENCE_UNAVAILABLE]` codes. Format documented in `docs/INTEGRATIONS/claude-code.md`.

## Evidence base

- `research/opencode-study/05-core-agents-permissions.md` — reject-with-feedback (`CorrectedError`), cascade-reject, doom-loop breaker (`processor.ts:331-381`), and the HELM gap analysis (§4: "no interactive per-call ask UI with once/always/reject-with-feedback… no doom-loop/circuit-breaker ask").
- `research/opencode-study/03-core-tools.md` — structured, model-actionable deny reasons reduce agent thrash ("adapting structured, model-actionable reason text into denial outputs would reduce agent thrash against the firewall").

## Test evidence

Baseline before changes: `go test ./pkg/actioninbox/...` and `go test ./cmd/helm-ai-kernel/ -run TestHookPreTool` both green.

After changes (all from `core/`):
- `go test ./pkg/actioninbox/... -count=1` → **ok** (24 tests, incl. new curated workstation deny-code guidance table, cascade scoping, breaker latch semantics)
- `go test ./cmd/helm-ai-kernel/ -count=1` → **ok** (full CLI package, incl. 4 new hook tests: actionable feedback content, fail-closed steering codes, doom-loop steering + per-session isolation + receipt preservation on tripped attempts)
- `go test ./pkg/workstation/... -count=1` → **ok** (adjacent decision path, untouched)
- `go vet ./...` → clean; `gofmt -l .` → clean; `golangci-lint run ./pkg/actioninbox/...` → 0 issues (cmd package has only pre-existing findings in untouched files)
- `scripts/check_documentation_truth.py` + `check_documentation_coverage.py` → pass

## Risk notes / deviations

- **Attempts vs settlements:** the pre-tool hook observes call *attempts*, not settled results (opencode counts settled tool parts). Counting attempts is strictly more conservative and stays fail-closed. The pure `DoomLoopBreaker` supports settled-call semantics for control-plane use.
- **Breaker persistence is best-effort:** unreadable/missing state starts fresh; state-write failures log to stderr and continue. The base policy decision path is unchanged and remains fail-closed on its own — the breaker is additive defense-in-depth only.
- **No verdict/receipt schema changes:** signed `WorkstationPolicyDecisionReceipt` is untouched (hash/signature conformance preserved). All new surface area is the additive `deny_feedback.v1` record and hook output text.
- No new network calls, no credential-handling changes, no permit/receipt semantic weakening. INBOX_* codes carry zero authority (steering data only).

## Linear

Tracked in Linear as **HELM-420**.

## Gates

This PR does **not** self-authorize merge. It still requires the repo's normal source-owned deterministic gates, distinct-provider 2-of-2 permit, and exact-head approval-only App interlock. `/review`, labels, and commit trailers carry zero authorization weight. I will not merge.

## Rebase note (repair pass)

Rebased onto `origin/main` @ `71b7e73a` (v0.7.5 prep, #669/#670, x/text bump #647, release-permit #668) with `--signoff`; both commits now carry `Signed-off-by` trailers (DCO gate green). Only conflict: `docs/INTEGRATIONS/claude-code.md` — #669 added the receipt integrity-vs-trust paragraph at the same anchor as the new "Deny Feedback Format" section. Resolved by keeping **both** (main's paragraph first, then the deny-format section). Main did not change `hook_cmd.go` or actioninbox semantics, so no code adaptation was required. Post-rebase gates: `go test ./pkg/actioninbox/... ./cmd/helm-ai-kernel/ ./pkg/workstation/... -count=1` all ok; `go vet ./...` clean; gofmt clean; docs-truth/coverage pass. PR is MERGEABLE again (mergeStateStatus BLOCKED = pending source-owned gates, as expected).
