### PR TITLE
chore(launch): clean-install gate defaults to v0.7.5 release run (HELM-224)

### DIFF
--- a/scripts/launch/clean_install_gate.sh
+++ b/scripts/launch/clean_install_gate.sh
@@ -19,7 +19,7 @@ Usage: scripts/launch/clean_install_gate.sh [options]
 
 Options:
   --release-tag <tag>       Release tag to validate (default: v0.7.5)
-  --artifact-run-id <id>    Launchpad artifact workflow run (default: 26198407296)
+  --artifact-run-id <id>    Launchpad artifact workflow run (default: 30031231555)
   --host-kind <kind>        developer_macos or github_macos_runner
   --output <path>           Redacted JSON report path
   --transcript-dir <path>   Directory for redacted command output and audit inputs

--- a/scripts/launch/clean_install_gate.sh
+++ b/scripts/launch/clean_install_gate.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPO="${HELM_LAUNCHPAD_GITHUB_REPO:-Mindburn-Labs/helm-ai-kernel}"
 RELEASE_TAG="v0.7.5"
-ARTIFACT_RUN_ID="26198407296"
+ARTIFACT_RUN_ID="30031231555"
 HOST_KIND="developer_macos"
 OUTPUT="$ROOT/docs/launchpad/clean_install_report.json"
 TRANSCRIPT_DIR="${TMPDIR:-/tmp}/helm-launchpad-clean-install"

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -46,7 +46,7 @@ func TestLaunchpadClaimsReflectContractFirstSupportLevels(t *testing.T) {
 	requireContains(t, cleanGate, "VERIFY_ONLY_APPS=(opencode kilocode)")
 	requireContains(t, cleanGate, "--include-candidates")
 	requireContains(t, cleanGate, `RELEASE_TAG="`+releaseTag+`"`)
-	requireContains(t, cleanGate, `ARTIFACT_RUN_ID="26198407296"`)
+	requireContains(t, cleanGate, `ARTIFACT_RUN_ID="30031231555"`)
 	requireContains(t, cleanGate, "output, status, commands_path")
 	requireNotContains(t, cleanGate, "status = sys.stdin.read()", "scripts/launch/clean_install_gate.sh")
 	requireContains(t, cleanGate, `"supported_apps": ["openclaw", "hermes"]`)


### PR DESCRIPTION
One-line follow-up promised in PR #670's review thread: `clean_install_gate.sh` default `ARTIFACT_RUN_ID` now points at the v0.7.5 Release run (`30031231555`, published 2026-07-23) instead of the stale historical run, matching the bumped `RELEASE_TAG`.

Refs HELM-224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Vxjnf9PNiaTN1ceqDF9zt