### PR TITLE
fix(sdk-java): repair generated-model JSON mapping beyond evaluator (HELM-173)

### DIFF
--- a/scripts/sdk/gen.sh
+++ b/scripts/sdk/gen.sh
@@ -592,6 +592,37 @@ s = must_replace(
     "rewrite union validation note",
 )
 
+# Models with `additionalProperties: true` are emitted as HashMap subclasses.
+# That makes Jackson serialize the model as a bare map and lose its declared
+# accessor-backed fields. Retain the generated @JsonAnyGetter/@JsonAnySetter
+# container, but make these models ordinary beans. Each paired super call is
+# asserted so an upstream generator shape change cannot silently regress this
+# mapping contract.
+s = must_replace(
+    s,
+    " extends HashMap<String, Object> {",
+    " {",
+    "remove HashMap superclass from additional-properties models",
+)
+s = must_replace(
+    s,
+    " &&\n        super.equals(o);",
+    ";",
+    "remove HashMap superclass equality",
+)
+s = must_replace(
+    s,
+    ", super.hashCode()",
+    "",
+    "remove HashMap superclass hash",
+)
+s = must_replace(
+    s,
+    '    sb.append("    ").append(toIndentedString(super.toString())).append("\\n");\n',
+    "",
+    "remove HashMap superclass string rendering",
+)
+
 # openapi-generator emits map query values twice: a raw value that has no
 # matching format placeholder, followed by the URL-encoded value that should
 # fill the final placeholder. Remove the raw argument for every generated map

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -23,7 +23,7 @@ flowchart LR
 | Python | `sdk/python/helm_sdk/` | `helm-sdk` | First-class local example under `examples/python_sdk/` | `make test-sdk-py` |
 | TypeScript / JavaScript | `sdk/ts/src/` | `@mindburn/helm-ai-kernel` | First-class local example under `examples/ts_sdk/` | `make test-sdk-ts` |
 | Rust | `sdk/rust/src/` | `helm-sdk` | Source-backed SDK package | `make test-sdk-rust` |
-| Java | `sdk/java/src/main/java/` | `io.github.mindburnlabs:helm-sdk` | Published Maven Central package; source-backed SDK | `make test-sdk-java` |
+| Java | `sdk/java/src/main/java/` | `io.github.mindburnlabs:helm-sdk` | Source-backed SDK package | `make test-sdk-java` |
 
 ## What Is Covered
 

--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -6,9 +6,10 @@ Typed Java client for the retained HELM kernel API.
 
 Package metadata in this source tree targets a future Maven Central coordinate.
 The current source target is `0.8.0`.
-This source target does not claim that remote artifacts have been published;
-verify Maven Central or published version-status evidence before using a
-coordinate. After the tag-driven release completes, use the verified version:
+This source target does not claim that remote artifacts have been published or
+that the endpoint surface is conformance-certified; verify Maven Central and
+tagged release evidence before using a coordinate. After the tag-driven
+release completes, use the verified version:
 
 ```xml
 <dependency>
@@ -26,8 +27,24 @@ mvn -q test package
 
 ## Generated Sources
 
-`TypesGen.java` is generated from `api/openapi/helm.openapi.yaml`. Protobuf
-bindings under `src/main/java/helm/**` are generated from `protocols/proto/`.
+`TypesGen.java` is generated from `api/openapi/helm.openapi.yaml` by
+`scripts/sdk/gen.sh`; do not hand-edit it. Protobuf bindings under
+`src/main/java/helm/**` are generated from `protocols/proto/`.
+
+## JSON Mapping
+
+Typed request/response bodies use Jackson (`jackson-databind`), honoring the
+generated `@JsonProperty` wire names and restoring typed getters on decode.
+Gson remains for the deprecated dynamic `evaluateDecision(Object)` method and
+other untyped `JsonElement` pass-through methods. `HelmClient.health()` returns
+the raw plain-text `/healthz` body.
+
+Models generated from schemas with `additionalProperties: true` are plain
+beans rather than `HashMap<String, Object>` subclasses, so serializers retain
+their declared fields. Undeclared properties round-trip through
+`putAdditionalProperty(key, value)` / `getAdditionalProperty(key)` /
+`getAdditionalProperties()`. Code that previously consumed these models as a
+`Map` must migrate to typed accessors plus the additional-properties container.
 
 ## Usage
 
@@ -73,9 +90,10 @@ telemetry export, and coexistence capabilities. These methods mirror public
 OpenAPI execution-boundary routes without making external evidence envelopes
 authoritative.
 
-`evaluateDecision` accepts `TypesGen.EvaluateRequest` only. Set non-blank
-`tool`, `effect_level`, and `session_id`; it returns the receipt-bearing
-`TypesGen.EvaluateResponse`.
+`evaluateDecisionV5` accepts `TypesGen.EvaluateRequest`; set non-blank `tool`,
+`effect_level`, and `session_id` to receive a receipt-bearing
+`TypesGen.EvaluateResponse`. The deprecated `evaluateDecision(Object)` method
+remains for legacy dynamic callers.
 
 ## Source target
 

--- a/sdk/java/generated.manifest.json
+++ b/sdk/java/generated.manifest.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "src/main/java/labs/mindburn/helm/TypesGen.java",
-      "sha256": "13c1823e17ff2554350a4e5d1e48a82139f7d360050061845ee85e34d994e5b7"
+      "sha256": "8b1993b419bd3cdaa44d2b57542599a3c836c99536e5db647b76b1e115722d0f"
     }
   ],
   "generator": "openapitools/openapi-generator-cli:v7.4.0@sha256:579832bed49ea6c275ce2fb5f2d515f5b03d2b6243f3c80fa8430e4f5a770e9a",

--- a/sdk/java/src/main/java/labs/mindburn/helm/HelmClient.java
+++ b/sdk/java/src/main/java/labs/mindburn/helm/HelmClient.java
@@ -1,10 +1,16 @@
 package labs.mindburn.helm;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
-import com.google.gson.reflect.TypeToken;
 import labs.mindburn.helm.TypesGen.*;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 import java.io.IOException;
 import java.net.URI;
@@ -16,15 +22,20 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Typed Java client for the HELM kernel API.
- * Uses java.net.http (JDK 11+) and Gson. Zero framework deps.
+ * Uses java.net.http (JDK 11+). Typed request/response bodies use Jackson so
+ * generated {@link TypesGen} models honor their {@code @JsonProperty} wire
+ * names and restore typed getters on decode. Gson remains for legacy dynamic
+ * {@link JsonElement} pass-through methods.
  */
 public class HelmClient {
     private final String baseUrl;
     private final HttpClient httpClient;
     private final Gson gson;
+    private final ObjectMapper mapper;
     private final String apiKey;
     private final String tenantId;
     private final String principalId;
@@ -48,9 +59,23 @@ public class HelmClient {
         this.gson = new GsonBuilder()
                 .setFieldNamingPolicy(com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create();
+        this.mapper = createObjectMapper();
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(30))
                 .build();
+    }
+
+    /**
+     * ObjectMapper configured for generated {@link TypesGen} models.
+     * Unknown properties are tolerated for forward compatibility.
+     */
+    static ObjectMapper createObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.registerModule(new JavaTimeModule());
+        mapper.registerModule(new JsonNullableModule());
+        return mapper;
     }
 
     /** Thrown when the HELM API returns a non-2xx response. */
@@ -204,33 +229,51 @@ public class HelmClient {
         return b;
     }
 
+    private String toJson(Object value) {
+        if (value instanceof JsonElement) {
+            return gson.toJson(value);
+        }
+        try {
+            return mapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("failed to serialize HELM request body", e);
+        }
+    }
+
+    private HelmApiException apiError(int status, String body) {
+        HelmError err = null;
+        try {
+            err = mapper.readValue(body, HelmError.class);
+        } catch (IOException ignored) {
+            // Non-JSON error bodies fall through to the raw-body message.
+        }
+        HelmErrorError error = err != null ? err.getError() : null;
+        String message = error != null && error.getMessage() != null ? error.getMessage() : body;
+        String reasonCode = error != null && error.getReasonCode() != null
+                ? error.getReasonCode().getValue()
+                : "ERROR_INTERNAL";
+        return new HelmApiException(status, message, reasonCode);
+    }
+
     private <T> T send(HttpRequest request, Class<T> type) {
         try {
             HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             if (resp.statusCode() >= 400) {
-                HelmError err = gson.fromJson(resp.body(), HelmError.class);
-                throw new HelmApiException(
-                        resp.statusCode(),
-                        err != null && err.getError() != null ? err.getError().getMessage() : resp.body(),
-                        err != null && err.getError() != null ? String.valueOf(err.getError().getReasonCode()) : "ERROR_INTERNAL");
+                throw apiError(resp.statusCode(), resp.body());
             }
-            return gson.fromJson(resp.body(), type);
+            return mapper.readValue(resp.body(), type);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException("HELM API request failed", e);
         }
     }
 
-    private <T> T sendList(HttpRequest request, TypeToken<T> typeToken) {
+    private <T> T sendList(HttpRequest request, TypeReference<T> typeReference) {
         try {
             HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             if (resp.statusCode() >= 400) {
-                HelmError err = gson.fromJson(resp.body(), HelmError.class);
-                throw new HelmApiException(
-                        resp.statusCode(),
-                        err != null && err.getError() != null ? err.getError().getMessage() : resp.body(),
-                        err != null && err.getError() != null ? String.valueOf(err.getError().getReasonCode()) : "ERROR_INTERNAL");
+                throw apiError(resp.statusCode(), resp.body());
             }
-            return gson.fromJson(resp.body(), typeToken.getType());
+            return mapper.readValue(resp.body(), typeReference);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException("HELM API request failed", e);
         }
@@ -240,11 +283,7 @@ public class HelmClient {
         try {
             HttpResponse<String> resp = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
             if (resp.statusCode() >= 400) {
-                HelmError err = gson.fromJson(resp.body(), HelmError.class);
-                throw new HelmApiException(
-                        resp.statusCode(),
-                        err != null && err.getError() != null ? err.getError().getMessage() : resp.body(),
-                        err != null && err.getError() != null ? String.valueOf(err.getError().getReasonCode()) : "ERROR_INTERNAL");
+                throw apiError(resp.statusCode(), resp.body());
             }
             return gson.fromJson(resp.body(), JsonElement.class);
         } catch (IOException | InterruptedException e) {
@@ -255,7 +294,7 @@ public class HelmClient {
     /** POST /v1/chat/completions */
     public ChatCompletionResponse chatCompletions(ChatCompletionRequest req) {
         HttpRequest r = req("POST", "/v1/chat/completions")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req)))
                 .build();
         return send(r, ChatCompletionResponse.class);
     }
@@ -285,7 +324,7 @@ public class HelmClient {
             throw new IllegalArgumentException("evaluateDecisionV5 requires a non-blank session_id");
         }
         HttpRequest r = this.req("POST", "/api/v1/evaluate")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req)))
                 .build();
         return send(r, EvaluateResponse.class);
     }
@@ -293,7 +332,7 @@ public class HelmClient {
     /** POST /api/v1/kernel/approve */
     public Receipt approveIntent(ApprovalRequest req) {
         HttpRequest r = this.req("POST", "/api/v1/kernel/approve")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req)))
                 .build();
         return send(r, Receipt.class);
     }
@@ -302,7 +341,7 @@ public class HelmClient {
     public List<Session> listSessions() {
         HttpRequest r = req("GET", "/api/v1/proofgraph/sessions")
                 .GET().build();
-        return sendList(r, new TypeToken<List<Session>>() {
+        return sendList(r, new TypeReference<List<Session>>() {
         });
     }
 
@@ -310,7 +349,7 @@ public class HelmClient {
     public List<Receipt> getReceipts(String sessionId) {
         HttpRequest r = req("GET", "/api/v1/proofgraph/sessions/" + sessionId + "/receipts")
                 .GET().build();
-        return sendList(r, new TypeToken<List<Receipt>>() {
+        return sendList(r, new TypeReference<List<Receipt>>() {
         });
     }
 
@@ -323,21 +362,14 @@ public class HelmClient {
 
     /** POST /api/v1/evidence/export — returns raw bytes */
     public byte[] exportEvidence(String sessionId) {
-        String body = gson.toJson(new java.util.HashMap<String, String>() {{
-            put("session_id", sessionId);
-            put("format", "tar.gz");
-        }});
+        String body = toJson(Map.of("session_id", sessionId, "format", "tar.gz"));
         HttpRequest r = req("POST", "/api/v1/evidence/export")
                 .POST(HttpRequest.BodyPublishers.ofString(body))
                 .build();
         try {
             HttpResponse<byte[]> resp = httpClient.send(r, HttpResponse.BodyHandlers.ofByteArray());
             if (resp.statusCode() >= 400) {
-                HelmError err = gson.fromJson(new String(resp.body()), HelmError.class);
-                throw new HelmApiException(
-                        resp.statusCode(),
-                        err != null && err.getError() != null ? err.getError().getMessage() : "export failed",
-                        err != null && err.getError() != null ? String.valueOf(err.getError().getReasonCode()) : "ERROR_INTERNAL");
+                throw apiError(resp.statusCode(), new String(resp.body(), StandardCharsets.UTF_8));
             }
             return resp.body();
         } catch (IOException | InterruptedException e) {
@@ -348,7 +380,7 @@ public class HelmClient {
     /** POST /api/v1/evidence/verify */
     public VerificationResult verifyEvidence(byte[] bundle) {
         // Send as JSON with base64-encoded bundle for simplicity
-        String body = gson.toJson(java.util.Map.of("bundle_b64",
+        String body = toJson(Map.of("bundle_b64",
                 java.util.Base64.getEncoder().encodeToString(bundle)));
         HttpRequest r = req("POST", "/api/v1/evidence/verify")
                 .POST(HttpRequest.BodyPublishers.ofString(body))
@@ -358,7 +390,7 @@ public class HelmClient {
 
     /** POST /api/v1/replay/verify */
     public VerificationResult replayVerify(byte[] bundle) {
-        String body = gson.toJson(java.util.Map.of("bundle_b64",
+        String body = toJson(Map.of("bundle_b64",
                 java.util.Base64.getEncoder().encodeToString(bundle)));
         HttpRequest r = req("POST", "/api/v1/replay/verify")
                 .POST(HttpRequest.BodyPublishers.ofString(body))
@@ -369,7 +401,7 @@ public class HelmClient {
     /** POST /api/v1/evidence/envelopes */
     public EvidenceEnvelopeManifest createEvidenceEnvelopeManifest(EvidenceEnvelopeExportRequest req) {
         HttpRequest r = this.req("POST", "/api/v1/evidence/envelopes")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req)))
                 .build();
         return send(r, EvidenceEnvelopeManifest.class);
     }
@@ -431,7 +463,7 @@ public class HelmClient {
     /** POST /api/v1/conformance/run */
     public ConformanceResult conformanceRun(ConformanceRequest req) {
         HttpRequest r = this.req("POST", "/api/v1/conformance/run")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req)))
                 .build();
         return send(r, ConformanceResult.class);
     }
@@ -447,7 +479,7 @@ public class HelmClient {
     public List<NegativeBoundaryVector> listNegativeConformanceVectors() {
         HttpRequest r = req("GET", "/api/v1/conformance/negative")
                 .GET().build();
-        return sendList(r, new TypeToken<List<NegativeBoundaryVector>>() {
+        return sendList(r, new TypeReference<List<NegativeBoundaryVector>>() {
         });
     }
 
@@ -463,14 +495,14 @@ public class HelmClient {
     public List<MCPQuarantineRecord> listMcpRegistry() {
         HttpRequest r = req("GET", "/api/v1/mcp/registry")
                 .GET().build();
-        return sendList(r, new TypeToken<List<MCPQuarantineRecord>>() {
+        return sendList(r, new TypeReference<List<MCPQuarantineRecord>>() {
         });
     }
 
     /** POST /api/v1/mcp/registry */
     public MCPQuarantineRecord discoverMcpServer(MCPRegistryDiscoverRequest req) {
         HttpRequest r = this.req("POST", "/api/v1/mcp/registry")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req)))
                 .build();
         return send(r, MCPQuarantineRecord.class);
     }
@@ -478,7 +510,7 @@ public class HelmClient {
     /** POST /api/v1/mcp/registry/approve */
     public MCPQuarantineRecord approveMcpServer(MCPRegistryApprovalRequest req) {
         HttpRequest r = this.req("POST", "/api/v1/mcp/registry/approve")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req)))
                 .build();
         return send(r, MCPQuarantineRecord.class);
     }
@@ -490,13 +522,13 @@ public class HelmClient {
 
     public MCPQuarantineRecord approveMcpRegistryRecord(String serverId, MCPRegistryApprovalRequest req) {
         HttpRequest r = this.req("POST", "/api/v1/mcp/registry/" + encode(serverId) + "/approve")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req))).build();
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req))).build();
         return send(r, MCPQuarantineRecord.class);
     }
 
     public MCPQuarantineRecord revokeMcpRegistryRecord(String serverId, String reason) {
         HttpRequest r = this.req("POST", "/api/v1/mcp/registry/" + encode(serverId) + "/revoke")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(java.util.Map.of("reason", reason)))).build();
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(Map.of("reason", reason)))).build();
         return send(r, MCPQuarantineRecord.class);
     }
 
@@ -526,7 +558,7 @@ public class HelmClient {
     public List<SandboxBackendProfile> listSandboxBackendProfiles() {
         HttpRequest r = req("GET", "/api/v1/sandbox/grants/inspect")
                 .GET().build();
-        return sendList(r, new TypeToken<List<SandboxBackendProfile>>() {
+        return sendList(r, new TypeReference<List<SandboxBackendProfile>>() {
         });
     }
 
@@ -621,7 +653,7 @@ public class HelmClient {
 
     public JsonElement assertApprovalWebAuthnChallenge(String approvalId, ApprovalWebAuthnAssertion req) {
         HttpRequest r = this.req("POST", "/api/v1/approvals/" + encode(approvalId) + "/webauthn/assert")
-                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req))).build();
+                .POST(HttpRequest.BodyPublishers.ofString(toJson(req))).build();
         return sendJson(r);
     }
 
@@ -656,7 +688,15 @@ public class HelmClient {
     /** GET /healthz */
     public String health() {
         HttpRequest r = req("GET", "/healthz").GET().build();
-        return send(r, String.class);
+        try {
+            HttpResponse<String> resp = httpClient.send(r, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() >= 400) {
+                throw apiError(resp.statusCode(), resp.body());
+            }
+            return resp.body();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("HELM API request failed", e);
+        }
     }
 
     /** GET /version */

--- a/sdk/java/src/main/java/labs/mindburn/helm/TypesGen.java
+++ b/sdk/java/src/main/java/labs/mindburn/helm/TypesGen.java
@@ -8969,7 +8969,7 @@ public static class BuildStrategy {
   CapabilityGraph.JSON_PROPERTY_CONFIDENCE_REASON
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class CapabilityGraph extends HashMap<String, Object> {
+public static class CapabilityGraph {
   public static final String JSON_PROPERTY_CAPABILITIES = "capabilities";
   private List<String> capabilities;
 
@@ -9493,20 +9493,18 @@ public static class CapabilityGraph extends HashMap<String, Object> {
         Objects.equals(this.adapterMatches, capabilityGraph.adapterMatches) &&
         Objects.equals(this.confidence, capabilityGraph.confidence) &&
         Objects.equals(this.confidenceReason, capabilityGraph.confidenceReason)&&
-        Objects.equals(this.additionalProperties, capabilityGraph.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, capabilityGraph.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(capabilities, modules, frameworks, secrets, oauth, ports, buildSignals, runtimeSignals, policySignals, securitySignals, adapterMatches, confidence, confidenceReason, super.hashCode(), additionalProperties);
+    return Objects.hash(capabilities, modules, frameworks, secrets, oauth, ports, buildSignals, runtimeSignals, policySignals, securitySignals, adapterMatches, confidence, confidenceReason, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class CapabilityGraph {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    capabilities: ").append(toIndentedString(capabilities)).append("\n");
     sb.append("    modules: ").append(toIndentedString(modules)).append("\n");
     sb.append("    frameworks: ").append(toIndentedString(frameworks)).append("\n");
@@ -14462,7 +14460,7 @@ public static class ConsoleBootstrapWorkspace {
   ConsoleCapabilities.JSON_PROPERTY_TIER_GATE
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class ConsoleCapabilities extends HashMap<String, Object> {
+public static class ConsoleCapabilities {
   public static final String JSON_PROPERTY_ENTITLEMENTS = "entitlements";
   private List<String> entitlements = new ArrayList<>();
 
@@ -14645,20 +14643,18 @@ public static class ConsoleCapabilities extends HashMap<String, Object> {
         Objects.equals(this.version, consoleCapabilities.version) &&
         Objects.equals(this.source, consoleCapabilities.source) &&
         Objects.equals(this.tierGate, consoleCapabilities.tierGate)&&
-        Objects.equals(this.additionalProperties, consoleCapabilities.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, consoleCapabilities.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entitlements, version, source, tierGate, super.hashCode(), additionalProperties);
+    return Objects.hash(entitlements, version, source, tierGate, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class ConsoleCapabilities {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    entitlements: ").append(toIndentedString(entitlements)).append("\n");
     sb.append("    version: ").append(toIndentedString(version)).append("\n");
     sb.append("    source: ").append(toIndentedString(source)).append("\n");
@@ -18365,7 +18361,7 @@ public static class DetectedFramework {
   DetectedModule.JSON_PROPERTY_BUILD_STRATEGY
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class DetectedModule extends HashMap<String, Object> {
+public static class DetectedModule {
   public static final String JSON_PROPERTY_PATH = "path";
   private String path;
 
@@ -18585,20 +18581,18 @@ public static class DetectedModule extends HashMap<String, Object> {
         Objects.equals(this.manifests, detectedModule.manifests) &&
         Objects.equals(this.entrypoints, detectedModule.entrypoints) &&
         Objects.equals(this.buildStrategy, detectedModule.buildStrategy)&&
-        Objects.equals(this.additionalProperties, detectedModule.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, detectedModule.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, kind, manifests, entrypoints, buildStrategy, super.hashCode(), additionalProperties);
+    return Objects.hash(path, kind, manifests, entrypoints, buildStrategy, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class DetectedModule {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    path: ").append(toIndentedString(path)).append("\n");
     sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
     sb.append("    manifests: ").append(toIndentedString(manifests)).append("\n");
@@ -19727,7 +19721,7 @@ public static class EntitlementCapabilities {
   EntitlementDecision.JSON_PROPERTY_EXPIRES_AT
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class EntitlementDecision extends HashMap<String, Object> {
+public static class EntitlementDecision {
   public static final String JSON_PROPERTY_ALLOWED = "allowed";
   private Boolean allowed;
 
@@ -20177,20 +20171,18 @@ public static class EntitlementDecision extends HashMap<String, Object> {
         Objects.equals(this.decisionRef, entitlementDecision.decisionRef) &&
         Objects.equals(this.source, entitlementDecision.source) &&
         Objects.equals(this.expiresAt, entitlementDecision.expiresAt)&&
-        Objects.equals(this.additionalProperties, entitlementDecision.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, entitlementDecision.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(allowed, userState, requiredCapability, reasonCode, reason, upgradeReason, limit, used, remaining, decisionRef, source, expiresAt, super.hashCode(), additionalProperties);
+    return Objects.hash(allowed, userState, requiredCapability, reasonCode, reason, upgradeReason, limit, used, remaining, decisionRef, source, expiresAt, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class EntitlementDecision {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    allowed: ").append(toIndentedString(allowed)).append("\n");
     sb.append("    userState: ").append(toIndentedString(userState)).append("\n");
     sb.append("    requiredCapability: ").append(toIndentedString(requiredCapability)).append("\n");
@@ -26184,7 +26176,7 @@ public static class GUIActionReceipt {
   GeneratedAppSpecCandidate.JSON_PROPERTY_PROMOTION_REQUIREMENTS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class GeneratedAppSpecCandidate extends HashMap<String, Object> {
+public static class GeneratedAppSpecCandidate {
   public static final String JSON_PROPERTY_CANDIDATE_ID = "candidate_id";
   private String candidateId;
 
@@ -26367,20 +26359,18 @@ public static class GeneratedAppSpecCandidate extends HashMap<String, Object> {
         Objects.equals(this.trusted, generatedAppSpecCandidate.trusted) &&
         Objects.equals(this.appSpec, generatedAppSpecCandidate.appSpec) &&
         Objects.equals(this.promotionRequirements, generatedAppSpecCandidate.promotionRequirements)&&
-        Objects.equals(this.additionalProperties, generatedAppSpecCandidate.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, generatedAppSpecCandidate.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(candidateId, trusted, appSpec, promotionRequirements, super.hashCode(), additionalProperties);
+    return Objects.hash(candidateId, trusted, appSpec, promotionRequirements, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class GeneratedAppSpecCandidate {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    candidateId: ").append(toIndentedString(candidateId)).append("\n");
     sb.append("    trusted: ").append(toIndentedString(trusted)).append("\n");
     sb.append("    appSpec: ").append(toIndentedString(appSpec)).append("\n");
@@ -30745,7 +30735,7 @@ public static class HelmErrorError {
   ImportEvidenceLedger.JSON_PROPERTY_OFFLINE_VERIFY_COMMAND
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class ImportEvidenceLedger extends HashMap<String, Object> {
+public static class ImportEvidenceLedger {
   public static final String JSON_PROPERTY_STATUS = "status";
   private String status;
 
@@ -31089,20 +31079,18 @@ public static class ImportEvidenceLedger extends HashMap<String, Object> {
         Objects.equals(this.licenseRef, importEvidenceLedger.licenseRef) &&
         Objects.equals(this.policyRefs, importEvidenceLedger.policyRefs) &&
         Objects.equals(this.offlineVerifyCommand, importEvidenceLedger.offlineVerifyCommand)&&
-        Objects.equals(this.additionalProperties, importEvidenceLedger.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, importEvidenceLedger.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, receiptRefs, evidencePackRefs, sbomRef, vulnerabilityScanRef, provenanceRef, licenseRef, policyRefs, offlineVerifyCommand, super.hashCode(), additionalProperties);
+    return Objects.hash(status, receiptRefs, evidencePackRefs, sbomRef, vulnerabilityScanRef, provenanceRef, licenseRef, policyRefs, offlineVerifyCommand, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class ImportEvidenceLedger {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    receiptRefs: ").append(toIndentedString(receiptRefs)).append("\n");
     sb.append("    evidencePackRefs: ").append(toIndentedString(evidencePackRefs)).append("\n");
@@ -31248,7 +31236,7 @@ public static class ImportEvidenceLedger extends HashMap<String, Object> {
   ImportPreflightResult.JSON_PROPERTY_EVIDENCE_LEDGER
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class ImportPreflightResult extends HashMap<String, Object> {
+public static class ImportPreflightResult {
   public static final String JSON_PROPERTY_IMPORT_ID = "import_id";
   private String importId;
 
@@ -31468,20 +31456,18 @@ public static class ImportPreflightResult extends HashMap<String, Object> {
         Objects.equals(this.checks, importPreflightResult.checks) &&
         Objects.equals(this.blockedReasons, importPreflightResult.blockedReasons) &&
         Objects.equals(this.evidenceLedger, importPreflightResult.evidenceLedger)&&
-        Objects.equals(this.additionalProperties, importPreflightResult.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, importPreflightResult.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(importId, status, checks, blockedReasons, evidenceLedger, super.hashCode(), additionalProperties);
+    return Objects.hash(importId, status, checks, blockedReasons, evidenceLedger, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class ImportPreflightResult {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    importId: ").append(toIndentedString(importId)).append("\n");
     sb.append("    status: ").append(toIndentedString(status)).append("\n");
     sb.append("    checks: ").append(toIndentedString(checks)).append("\n");
@@ -31604,7 +31590,7 @@ public static class ImportPreflightResult extends HashMap<String, Object> {
   LaunchRecipe.JSON_PROPERTY_CLI_EQUIVALENT
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchRecipe extends HashMap<String, Object> {
+public static class LaunchRecipe {
   public static final String JSON_PROPERTY_IMPORT_ID = "import_id";
   private String importId;
 
@@ -31956,20 +31942,18 @@ public static class LaunchRecipe extends HashMap<String, Object> {
         Objects.equals(this.promotionState, launchRecipe.promotionState) &&
         Objects.equals(this.promotionRequirements, launchRecipe.promotionRequirements) &&
         Objects.equals(this.cliEquivalent, launchRecipe.cliEquivalent)&&
-        Objects.equals(this.additionalProperties, launchRecipe.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchRecipe.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(importId, generatedAt, detectionOrder, buildStrategy, targetPlans, generatedAppSpecs, promotionState, promotionRequirements, cliEquivalent, super.hashCode(), additionalProperties);
+    return Objects.hash(importId, generatedAt, detectionOrder, buildStrategy, targetPlans, generatedAppSpecs, promotionState, promotionRequirements, cliEquivalent, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchRecipe {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    importId: ").append(toIndentedString(importId)).append("\n");
     sb.append("    generatedAt: ").append(toIndentedString(generatedAt)).append("\n");
     sb.append("    detectionOrder: ").append(toIndentedString(detectionOrder)).append("\n");
@@ -32144,7 +32128,7 @@ public static class LaunchRecipe extends HashMap<String, Object> {
   LaunchpadApp.JSON_PROPERTY_STATUS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadApp extends HashMap<String, Object> {
+public static class LaunchpadApp {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
 
@@ -33087,20 +33071,18 @@ public static class LaunchpadApp extends HashMap<String, Object> {
         Objects.equals(this.entitlementDecision, launchpadApp.entitlementDecision) &&
         Objects.equals(this.actionStates, launchpadApp.actionStates) &&
         Objects.equals(this.status, launchpadApp.status)&&
-        Objects.equals(this.additionalProperties, launchpadApp.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadApp.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, appId, name, version, ociRef, immutableDigest, ossSupported, availability, redistribution, installStrategy, riskClass, blockedReason, requiredSecrets, modelGatewayEnv, declaredCapabilities, mcpServers, filesystemNeeds, networkNeeds, healthcheck, teardownRecipe, evidenceProfile, policyRef, userState, requiredCapability, upgradeReason, entitlementDecision, actionStates, status, super.hashCode(), additionalProperties);
+    return Objects.hash(id, appId, name, version, ociRef, immutableDigest, ossSupported, availability, redistribution, installStrategy, riskClass, blockedReason, requiredSecrets, modelGatewayEnv, declaredCapabilities, mcpServers, filesystemNeeds, networkNeeds, healthcheck, teardownRecipe, evidenceProfile, policyRef, userState, requiredCapability, upgradeReason, entitlementDecision, actionStates, status, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadApp {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    appId: ").append(toIndentedString(appId)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
@@ -33389,7 +33371,7 @@ public static class LaunchpadApp extends HashMap<String, Object> {
   LaunchpadAppStatus.JSON_PROPERTY_PROOF_STATUS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadAppStatus extends HashMap<String, Object> {
+public static class LaunchpadAppStatus {
   public static final String JSON_PROPERTY_STATE = "state";
   private String state;
 
@@ -33717,20 +33699,18 @@ public static class LaunchpadAppStatus extends HashMap<String, Object> {
         Objects.equals(this.lastRunId, launchpadAppStatus.lastRunId) &&
         Objects.equals(this.lastEvidencepackRef, launchpadAppStatus.lastEvidencepackRef) &&
         Objects.equals(this.proofStatus, launchpadAppStatus.proofStatus)&&
-        Objects.equals(this.additionalProperties, launchpadAppStatus.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadAppStatus.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(state, verdict, reasonCode, humanSummary, missingSecrets, quarantinedMcp, lastRunId, lastEvidencepackRef, proofStatus, super.hashCode(), additionalProperties);
+    return Objects.hash(state, verdict, reasonCode, humanSummary, missingSecrets, quarantinedMcp, lastRunId, lastEvidencepackRef, proofStatus, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadAppStatus {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    verdict: ").append(toIndentedString(verdict)).append("\n");
     sb.append("    reasonCode: ").append(toIndentedString(reasonCode)).append("\n");
@@ -33866,7 +33846,7 @@ public static class LaunchpadAppStatus extends HashMap<String, Object> {
   LaunchpadFixAction.JSON_PROPERTY_DESCRIPTION
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadFixAction extends HashMap<String, Object> {
+public static class LaunchpadFixAction {
   public static final String JSON_PROPERTY_LABEL = "label";
   private String label;
 
@@ -34012,20 +33992,18 @@ public static class LaunchpadFixAction extends HashMap<String, Object> {
     return Objects.equals(this.label, launchpadFixAction.label) &&
         Objects.equals(this.cli, launchpadFixAction.cli) &&
         Objects.equals(this.description, launchpadFixAction.description)&&
-        Objects.equals(this.additionalProperties, launchpadFixAction.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadFixAction.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(label, cli, description, super.hashCode(), additionalProperties);
+    return Objects.hash(label, cli, description, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadFixAction {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    label: ").append(toIndentedString(label)).append("\n");
     sb.append("    cli: ").append(toIndentedString(cli)).append("\n");
     sb.append("    description: ").append(toIndentedString(description)).append("\n");
@@ -34130,7 +34108,7 @@ public static class LaunchpadFixAction extends HashMap<String, Object> {
   LaunchpadGateResult.JSON_PROPERTY_FIX_ACTIONS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadGateResult extends HashMap<String, Object> {
+public static class LaunchpadGateResult {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
 
@@ -34669,20 +34647,18 @@ public static class LaunchpadGateResult extends HashMap<String, Object> {
         Objects.equals(this.receiptRequired, launchpadGateResult.receiptRequired) &&
         Objects.equals(this.cliEquivalent, launchpadGateResult.cliEquivalent) &&
         Objects.equals(this.fixActions, launchpadGateResult.fixActions)&&
-        Objects.equals(this.additionalProperties, launchpadGateResult.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadGateResult.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, group, label, verdict, reasonCode, receiptRef, proofgraphNode, evidenceRefs, summary, why, proofStatus, rawDetailRef, rawProofRef, receiptRequired, cliEquivalent, fixActions, super.hashCode(), additionalProperties);
+    return Objects.hash(id, group, label, verdict, reasonCode, receiptRef, proofgraphNode, evidenceRefs, summary, why, proofStatus, rawDetailRef, rawProofRef, receiptRequired, cliEquivalent, fixActions, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadGateResult {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    group: ").append(toIndentedString(group)).append("\n");
     sb.append("    label: ").append(toIndentedString(label)).append("\n");
@@ -34872,7 +34848,7 @@ public static class LaunchpadGateResult extends HashMap<String, Object> {
   LaunchpadImportRecord.JSON_PROPERTY_EVIDENCE_LEDGER
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadImportRecord extends HashMap<String, Object> {
+public static class LaunchpadImportRecord {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
 
@@ -35264,20 +35240,18 @@ public static class LaunchpadImportRecord extends HashMap<String, Object> {
         Objects.equals(this.launchRecipe, launchpadImportRecord.launchRecipe) &&
         Objects.equals(this.preflight, launchpadImportRecord.preflight) &&
         Objects.equals(this.evidenceLedger, launchpadImportRecord.evidenceLedger)&&
-        Objects.equals(this.additionalProperties, launchpadImportRecord.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadImportRecord.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, state, createdAt, updatedAt, request, sourceSnapshot, capabilityGraph, launchRecipe, preflight, evidenceLedger, super.hashCode(), additionalProperties);
+    return Objects.hash(id, state, createdAt, updatedAt, request, sourceSnapshot, capabilityGraph, launchRecipe, preflight, evidenceLedger, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadImportRecord {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    state: ").append(toIndentedString(state)).append("\n");
     sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
@@ -35619,7 +35593,7 @@ public static class LaunchpadImportRequest {
   LaunchpadMCPServer.JSON_PROPERTY_RECEIPT_REF
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadMCPServer extends HashMap<String, Object> {
+public static class LaunchpadMCPServer {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
 
@@ -35889,20 +35863,18 @@ public static class LaunchpadMCPServer extends HashMap<String, Object> {
         Objects.equals(this.riskClass, launchpadMCPServer.riskClass) &&
         Objects.equals(this.tools, launchpadMCPServer.tools) &&
         Objects.equals(this.receiptRef, launchpadMCPServer.receiptRef)&&
-        Objects.equals(this.additionalProperties, launchpadMCPServer.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadMCPServer.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, endpoint, transport, status, riskClass, tools, receiptRef, super.hashCode(), additionalProperties);
+    return Objects.hash(id, endpoint, transport, status, riskClass, tools, receiptRef, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadMCPServer {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    endpoint: ").append(toIndentedString(endpoint)).append("\n");
     sb.append("    transport: ").append(toIndentedString(transport)).append("\n");
@@ -36034,7 +36006,7 @@ public static class LaunchpadMCPServer extends HashMap<String, Object> {
   LaunchpadMatrixCell.JSON_PROPERTY_ACTION_STATES
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadMatrixCell extends HashMap<String, Object> {
+public static class LaunchpadMatrixCell {
   public static final String JSON_PROPERTY_APP_ID = "app_id";
   private String appId;
 
@@ -36412,20 +36384,18 @@ public static class LaunchpadMatrixCell extends HashMap<String, Object> {
         Objects.equals(this.upgradeReason, launchpadMatrixCell.upgradeReason) &&
         Objects.equals(this.entitlementDecision, launchpadMatrixCell.entitlementDecision) &&
         Objects.equals(this.actionStates, launchpadMatrixCell.actionStates)&&
-        Objects.equals(this.additionalProperties, launchpadMatrixCell.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadMatrixCell.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(appId, substrateId, launchable, verdict, reason, availability, userState, requiredCapability, upgradeReason, entitlementDecision, actionStates, super.hashCode(), additionalProperties);
+    return Objects.hash(appId, substrateId, launchable, verdict, reason, availability, userState, requiredCapability, upgradeReason, entitlementDecision, actionStates, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadMatrixCell {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    appId: ").append(toIndentedString(appId)).append("\n");
     sb.append("    substrateId: ").append(toIndentedString(substrateId)).append("\n");
     sb.append("    launchable: ").append(toIndentedString(launchable)).append("\n");
@@ -36779,7 +36749,7 @@ public static class LaunchpadPlanRequest {
   LaunchpadPlanResponse.JSON_PROPERTY_ACTION_STATES
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadPlanResponse extends HashMap<String, Object> {
+public static class LaunchpadPlanResponse {
   public static final String JSON_PROPERTY_LAUNCH_ID = "launch_id";
   private String launchId;
 
@@ -37215,20 +37185,18 @@ public static class LaunchpadPlanResponse extends HashMap<String, Object> {
         Objects.equals(this.upgradeReason, launchpadPlanResponse.upgradeReason) &&
         Objects.equals(this.entitlementDecision, launchpadPlanResponse.entitlementDecision) &&
         Objects.equals(this.actionStates, launchpadPlanResponse.actionStates)&&
-        Objects.equals(this.additionalProperties, launchpadPlanResponse.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadPlanResponse.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(launchId, appId, substrateId, state, kernelVerdict, reason, reasonCode, planHash, userState, requiredCapability, upgradeReason, entitlementDecision, actionStates, super.hashCode(), additionalProperties);
+    return Objects.hash(launchId, appId, substrateId, state, kernelVerdict, reason, reasonCode, planHash, userState, requiredCapability, upgradeReason, entitlementDecision, actionStates, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadPlanResponse {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    launchId: ").append(toIndentedString(launchId)).append("\n");
     sb.append("    appId: ").append(toIndentedString(appId)).append("\n");
     sb.append("    substrateId: ").append(toIndentedString(substrateId)).append("\n");
@@ -37388,7 +37356,7 @@ public static class LaunchpadPlanResponse extends HashMap<String, Object> {
   LaunchpadPolicySimulation.JSON_PROPERTY_FIX_ACTIONS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadPolicySimulation extends HashMap<String, Object> {
+public static class LaunchpadPolicySimulation {
   public static final String JSON_PROPERTY_APP_ID = "app_id";
   private String appId;
 
@@ -37798,20 +37766,18 @@ public static class LaunchpadPolicySimulation extends HashMap<String, Object> {
         Objects.equals(this.proofStatus, launchpadPolicySimulation.proofStatus) &&
         Objects.equals(this.cliEquivalent, launchpadPolicySimulation.cliEquivalent) &&
         Objects.equals(this.fixActions, launchpadPolicySimulation.fixActions)&&
-        Objects.equals(this.additionalProperties, launchpadPolicySimulation.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadPolicySimulation.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(appId, verdict, reasonCode, plainEnglish, structured, diff, raw, receiptRef, proofStatus, cliEquivalent, fixActions, super.hashCode(), additionalProperties);
+    return Objects.hash(appId, verdict, reasonCode, plainEnglish, structured, diff, raw, receiptRef, proofStatus, cliEquivalent, fixActions, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadPolicySimulation {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    appId: ").append(toIndentedString(appId)).append("\n");
     sb.append("    verdict: ").append(toIndentedString(verdict)).append("\n");
     sb.append("    reasonCode: ").append(toIndentedString(reasonCode)).append("\n");
@@ -37989,7 +37955,7 @@ public static class LaunchpadPolicySimulation extends HashMap<String, Object> {
   LaunchpadRun.JSON_PROPERTY_RUNTIME_HANDLES
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadRun extends HashMap<String, Object> {
+public static class LaunchpadRun {
   public static final String JSON_PROPERTY_LAUNCH_ID = "launch_id";
   private String launchId;
 
@@ -38660,20 +38626,18 @@ public static class LaunchpadRun extends HashMap<String, Object> {
         Objects.equals(this.verificationCommand, launchpadRun.verificationCommand) &&
         Objects.equals(this.teardownCommand, launchpadRun.teardownCommand) &&
         Objects.equals(this.runtimeHandles, launchpadRun.runtimeHandles)&&
-        Objects.equals(this.additionalProperties, launchpadRun.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadRun.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(launchId, runId, appId, substrateId, state, kernelVerdict, reason, reasonCode, planHash, launchplanHash, installReceiptRef, launchReceiptRef, healthReceiptRef, teardownReceiptRef, evidencePackRefs, secretGrantRefs, startReceiptRefs, verificationCommand, teardownCommand, runtimeHandles, super.hashCode(), additionalProperties);
+    return Objects.hash(launchId, runId, appId, substrateId, state, kernelVerdict, reason, reasonCode, planHash, launchplanHash, installReceiptRef, launchReceiptRef, healthReceiptRef, teardownReceiptRef, evidencePackRefs, secretGrantRefs, startReceiptRefs, verificationCommand, teardownCommand, runtimeHandles, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadRun {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    launchId: ").append(toIndentedString(launchId)).append("\n");
     sb.append("    runId: ").append(toIndentedString(runId)).append("\n");
     sb.append("    appId: ").append(toIndentedString(appId)).append("\n");
@@ -38890,7 +38854,7 @@ public static class LaunchpadRun extends HashMap<String, Object> {
   LaunchpadRunDetail.JSON_PROPERTY_OFFLINE_VERIFICATION
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadRunDetail extends HashMap<String, Object> {
+public static class LaunchpadRunDetail {
   public static final String JSON_PROPERTY_RUN = "run";
   private LaunchpadRun run;
 
@@ -39147,20 +39111,18 @@ public static class LaunchpadRunDetail extends HashMap<String, Object> {
         Objects.equals(this.gates, launchpadRunDetail.gates) &&
         Objects.equals(this.events, launchpadRunDetail.events) &&
         Objects.equals(this.offlineVerification, launchpadRunDetail.offlineVerification)&&
-        Objects.equals(this.additionalProperties, launchpadRunDetail.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadRunDetail.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(run, app, instance, gates, events, offlineVerification, super.hashCode(), additionalProperties);
+    return Objects.hash(run, app, instance, gates, events, offlineVerification, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadRunDetail {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    run: ").append(toIndentedString(run)).append("\n");
     sb.append("    app: ").append(toIndentedString(app)).append("\n");
     sb.append("    instance: ").append(toIndentedString(instance)).append("\n");
@@ -39300,7 +39262,7 @@ public static class LaunchpadRunDetail extends HashMap<String, Object> {
   LaunchpadRunEvent.JSON_PROPERTY_CREATED_AT
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadRunEvent extends HashMap<String, Object> {
+public static class LaunchpadRunEvent {
   public static final String JSON_PROPERTY_RUN_ID = "run_id";
   private String runId;
 
@@ -39810,20 +39772,18 @@ public static class LaunchpadRunEvent extends HashMap<String, Object> {
         Objects.equals(this.cliEquivalent, launchpadRunEvent.cliEquivalent) &&
         Objects.equals(this.fixActions, launchpadRunEvent.fixActions) &&
         Objects.equals(this.createdAt, launchpadRunEvent.createdAt)&&
-        Objects.equals(this.additionalProperties, launchpadRunEvent.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadRunEvent.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(runId, stage, verdict, reasonCode, receiptRef, proofgraphNode, evidenceRefs, rawPayloadRef, humanSummary, why, proofStatus, receiptRequired, cliEquivalent, fixActions, createdAt, super.hashCode(), additionalProperties);
+    return Objects.hash(runId, stage, verdict, reasonCode, receiptRef, proofgraphNode, evidenceRefs, rawPayloadRef, humanSummary, why, proofStatus, receiptRequired, cliEquivalent, fixActions, createdAt, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadRunEvent {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    runId: ").append(toIndentedString(runId)).append("\n");
     sb.append("    stage: ").append(toIndentedString(stage)).append("\n");
     sb.append("    verdict: ").append(toIndentedString(verdict)).append("\n");
@@ -40009,7 +39969,7 @@ public static class LaunchpadRunEvent extends HashMap<String, Object> {
   LaunchpadRuntimeInstance.JSON_PROPERTY_CLI_EQUIVALENT
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadRuntimeInstance extends HashMap<String, Object> {
+public static class LaunchpadRuntimeInstance {
   public static final String JSON_PROPERTY_RUN_ID = "run_id";
   private String runId;
 
@@ -40432,20 +40392,18 @@ public static class LaunchpadRuntimeInstance extends HashMap<String, Object> {
         Objects.equals(this.teardownCommand, launchpadRuntimeInstance.teardownCommand) &&
         Objects.equals(this.sandboxGrant, launchpadRuntimeInstance.sandboxGrant) &&
         Objects.equals(this.cliEquivalent, launchpadRuntimeInstance.cliEquivalent)&&
-        Objects.equals(this.additionalProperties, launchpadRuntimeInstance.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadRuntimeInstance.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(runId, containerId, launchplanHash, state, verdict, activeGrants, receiptRefs, evidencepackRef, offlineVerifyCommand, teardownCommand, sandboxGrant, cliEquivalent, super.hashCode(), additionalProperties);
+    return Objects.hash(runId, containerId, launchplanHash, state, verdict, activeGrants, receiptRefs, evidencepackRef, offlineVerifyCommand, teardownCommand, sandboxGrant, cliEquivalent, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadRuntimeInstance {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    runId: ").append(toIndentedString(runId)).append("\n");
     sb.append("    containerId: ").append(toIndentedString(containerId)).append("\n");
     sb.append("    launchplanHash: ").append(toIndentedString(launchplanHash)).append("\n");
@@ -40611,7 +40569,7 @@ public static class LaunchpadRuntimeInstance extends HashMap<String, Object> {
   LaunchpadSandboxGrant.JSON_PROPERTY_PROOF_STATUS
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadSandboxGrant extends HashMap<String, Object> {
+public static class LaunchpadSandboxGrant {
   public static final String JSON_PROPERTY_BACKEND_PROFILE = "backend_profile";
   private String backendProfile;
 
@@ -41013,20 +40971,18 @@ public static class LaunchpadSandboxGrant extends HashMap<String, Object> {
         Objects.equals(this.policyEpoch, launchpadSandboxGrant.policyEpoch) &&
         Objects.equals(this.grantHash, launchpadSandboxGrant.grantHash) &&
         Objects.equals(this.proofStatus, launchpadSandboxGrant.proofStatus)&&
-        Objects.equals(this.additionalProperties, launchpadSandboxGrant.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadSandboxGrant.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(backendProfile, runtime, runtimeVersion, imageDigest, filesystemPreopens, networkPolicy, env, resourceLimits, policyEpoch, grantHash, proofStatus, super.hashCode(), additionalProperties);
+    return Objects.hash(backendProfile, runtime, runtimeVersion, imageDigest, filesystemPreopens, networkPolicy, env, resourceLimits, policyEpoch, grantHash, proofStatus, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadSandboxGrant {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    backendProfile: ").append(toIndentedString(backendProfile)).append("\n");
     sb.append("    runtime: ").append(toIndentedString(runtime)).append("\n");
     sb.append("    runtimeVersion: ").append(toIndentedString(runtimeVersion)).append("\n");
@@ -41188,7 +41144,7 @@ public static class LaunchpadSandboxGrant extends HashMap<String, Object> {
   LaunchpadSecretGrant.JSON_PROPERTY_VALUE_ENV
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadSecretGrant extends HashMap<String, Object> {
+public static class LaunchpadSecretGrant {
   public static final String JSON_PROPERTY_NAME = "name";
   private String name;
 
@@ -41508,20 +41464,18 @@ public static class LaunchpadSecretGrant extends HashMap<String, Object> {
         Objects.equals(this.grantRef, launchpadSecretGrant.grantRef) &&
         Objects.equals(this.receiptRef, launchpadSecretGrant.receiptRef) &&
         Objects.equals(this.valueEnv, launchpadSecretGrant.valueEnv)&&
-        Objects.equals(this.additionalProperties, launchpadSecretGrant.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadSecretGrant.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, required, provider, scope, status, launchImpact, grantRef, receiptRef, valueEnv, super.hashCode(), additionalProperties);
+    return Objects.hash(name, required, provider, scope, status, launchImpact, grantRef, receiptRef, valueEnv, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadSecretGrant {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    required: ").append(toIndentedString(required)).append("\n");
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
@@ -41652,7 +41606,7 @@ public static class LaunchpadSecretGrant extends HashMap<String, Object> {
   LaunchpadSubstrate.JSON_PROPERTY_BLOCKED_REASON
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class LaunchpadSubstrate extends HashMap<String, Object> {
+public static class LaunchpadSubstrate {
   public static final String JSON_PROPERTY_ID = "id";
   private String id;
 
@@ -41885,20 +41839,18 @@ public static class LaunchpadSubstrate extends HashMap<String, Object> {
         Objects.equals(this.availability, launchpadSubstrate.availability) &&
         Objects.equals(this.defaultDryRun, launchpadSubstrate.defaultDryRun) &&
         Objects.equals(this.blockedReason, launchpadSubstrate.blockedReason)&&
-        Objects.equals(this.additionalProperties, launchpadSubstrate.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, launchpadSubstrate.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, kind, availability, defaultDryRun, blockedReason, super.hashCode(), additionalProperties);
+    return Objects.hash(id, name, kind, availability, defaultDryRun, blockedReason, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class LaunchpadSubstrate {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
@@ -60365,7 +60317,7 @@ public static class SourceFileSummary {
   SourceSnapshot.JSON_PROPERTY_API_SOURCE
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class SourceSnapshot extends HashMap<String, Object> {
+public static class SourceSnapshot {
   public static final String JSON_PROPERTY_REPO_URL = "repo_url";
   private String repoUrl;
 
@@ -60751,20 +60703,18 @@ public static class SourceSnapshot extends HashMap<String, Object> {
         Objects.equals(this.fetchedAt, sourceSnapshot.fetchedAt) &&
         Objects.equals(this.files, sourceSnapshot.files) &&
         Objects.equals(this.apiSource, sourceSnapshot.apiSource)&&
-        Objects.equals(this.additionalProperties, sourceSnapshot.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, sourceSnapshot.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(repoUrl, provider, owner, repo, ref, commit, licenseSpdx, licenseState, fetchedAt, files, apiSource, super.hashCode(), additionalProperties);
+    return Objects.hash(repoUrl, provider, owner, repo, ref, commit, licenseSpdx, licenseState, fetchedAt, files, apiSource, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class SourceSnapshot {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    repoUrl: ").append(toIndentedString(repoUrl)).append("\n");
     sb.append("    provider: ").append(toIndentedString(provider)).append("\n");
     sb.append("    owner: ").append(toIndentedString(owner)).append("\n");
@@ -61510,7 +61460,7 @@ public static class TamperPublicDemoReceiptRequest {
   TargetPlan.JSON_PROPERTY_REASON
 })
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", comments = "Generator version: 7.4.0")
-public static class TargetPlan extends HashMap<String, Object> {
+public static class TargetPlan {
   public static final String JSON_PROPERTY_TARGET_ID = "target_id";
   private String targetId;
 
@@ -61941,20 +61891,18 @@ public static class TargetPlan extends HashMap<String, Object> {
         Objects.equals(this.rollback, targetPlan.rollback) &&
         Objects.equals(this.risk, targetPlan.risk) &&
         Objects.equals(this.reason, targetPlan.reason)&&
-        Objects.equals(this.additionalProperties, targetPlan.additionalProperties) &&
-        super.equals(o);
+        Objects.equals(this.additionalProperties, targetPlan.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(targetId, kind, substrateId, deployable, requiresApproval, commands, artifacts, secretsBackend, healthcheck, rollback, risk, reason, super.hashCode(), additionalProperties);
+    return Objects.hash(targetId, kind, substrateId, deployable, requiresApproval, commands, artifacts, secretsBackend, healthcheck, rollback, risk, reason, additionalProperties);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class TargetPlan {\n");
-    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
     sb.append("    targetId: ").append(toIndentedString(targetId)).append("\n");
     sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
     sb.append("    substrateId: ").append(toIndentedString(substrateId)).append("\n");

--- a/sdk/java/src/test/java/labs/mindburn/helm/HelmClientTest.java
+++ b/sdk/java/src/test/java/labs/mindburn/helm/HelmClientTest.java
@@ -3,11 +3,11 @@ package labs.mindburn.helm;
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.sun.net.httpserver.HttpServer;
 
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -17,8 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * quantum_posture: HTTP compatibility tests do not implement or assert a cryptographic primitive.
  */
 public class HelmClientTest {
-    private static final ObjectMapper mapper = new ObjectMapper()
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    private static final ObjectMapper mapper = HelmClient.createObjectMapper();
 
     @Test
     @DisplayName("Client construction with base URL")
@@ -45,8 +44,8 @@ public class HelmClientTest {
             authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
             tenant.set(exchange.getRequestHeaders().getFirst("X-Helm-Tenant-ID"));
             principal.set(exchange.getRequestHeaders().getFirst("X-Helm-Principal-ID"));
-            byte[] response = "\"ok\"".getBytes(StandardCharsets.UTF_8);
-            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            byte[] response = "ok".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "text/plain");
             exchange.sendResponseHeaders(200, response.length);
             exchange.getResponseBody().write(response);
             exchange.close();
@@ -171,10 +170,8 @@ public class HelmClientTest {
             assertTrue(body.get().contains("\"effect_level\":\"read\""));
             assertTrue(body.get().contains("\"session_id\":\"session-test\""));
 
-            com.google.gson.JsonElement legacy = client.evaluateDecision(java.util.Map.of(
-                    "action", "legacy-read",
-                    "resource", "legacy-resource",
-                    "context", java.util.Map.of("session_id", "legacy-session")));
+            com.google.gson.JsonElement legacy = client.evaluateDecision(
+                    com.google.gson.JsonParser.parseString("{\"action\":\"legacy-read\",\"resource\":\"legacy-resource\",\"context\":{\"session_id\":\"legacy-session\"}}"));
             assertEquals("receipt-evaluate", legacy.getAsJsonObject().get("receipt_id").getAsString());
             assertTrue(body.get().contains("\"action\":\"legacy-read\""));
         } finally {
@@ -237,5 +234,95 @@ public class HelmClientTest {
             HelmClient.SandboxGrant.class
         );
         assertEquals("grant1", grant.grant_id);
+    }
+
+    @Test
+    @DisplayName("Typed client honors generated wire names and response getters")
+    void testTypedClientJsonMapping() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/v1/chat/completions", exchange -> {
+            body.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            byte[] response = ("{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"created\":1784900000,"
+                    + "\"model\":\"gpt-4\",\"choices\":[{\"index\":0,"
+                    + "\"message\":{\"role\":\"assistant\",\"content\":\"hello back\"},"
+                    + "\"finish_reason\":\"stop\"}],"
+                    + "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":2,\"total_tokens\":5}}")
+                    .getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+        try {
+            HelmClient client = new HelmClient("http://127.0.0.1:" + server.getAddress().getPort());
+            TypesGen.ChatCompletionResponse response = client.chatCompletions(new TypesGen.ChatCompletionRequest()
+                    .model("gpt-4")
+                    .messages(java.util.List.of(new TypesGen.ChatCompletionRequestMessagesInner()
+                            .role(TypesGen.ChatCompletionRequestMessagesInner.RoleEnum.USER)
+                            .content("hello")))
+                    .maxTokens(256));
+
+            assertTrue(body.get().contains("\"max_tokens\":256"));
+            assertFalse(body.get().contains("maxTokens"));
+            assertEquals("chatcmpl-1", response.getId());
+            assertEquals("hello back", response.getChoices().get(0).getMessage().getContent());
+            assertEquals(Integer.valueOf(5), response.getUsage().getTotalTokens());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    @DisplayName("Additional-properties models remain typed beans")
+    void testAdditionalPropertiesModelsAreTypedBeans() throws Exception {
+        TypesGen.CapabilityGraph graph = new TypesGen.CapabilityGraph()
+                .capabilities(java.util.List.of("fs.read", "net.http"))
+                .confidence(new java.math.BigDecimal("0.9"))
+                .confidenceReason("test");
+        graph.putAdditionalProperty("undeclared_extension", "kept");
+
+        assertFalse(graph instanceof java.util.Map);
+        String json = mapper.writeValueAsString(graph);
+        assertTrue(json.contains("\"confidence_reason\":\"test\""));
+        assertTrue(json.contains("\"undeclared_extension\":\"kept\""));
+        assertFalse(json.contains("additionalProperties"));
+
+        TypesGen.CapabilityGraph decoded = mapper.readValue(json, TypesGen.CapabilityGraph.class);
+        assertEquals(java.util.List.of("fs.read", "net.http"), decoded.getCapabilities());
+        assertEquals(new java.math.BigDecimal("0.9"), decoded.getConfidence());
+        assertEquals("kept", decoded.getAdditionalProperty("undeclared_extension"));
+    }
+
+    @Test
+    @DisplayName("Client mapper writes OffsetDateTime as ISO-8601")
+    void testClientMapperWritesIsoDateTime() throws Exception {
+        String json = mapper.writeValueAsString(new TypesGen.Session()
+                .createdAt(OffsetDateTime.parse("2026-07-24T00:00:00Z")));
+        assertTrue(json.contains("\"created_at\":\"2026-07-24T00:00:00Z\""));
+    }
+
+    @Test
+    @DisplayName("Missing API reason code defaults to ERROR_INTERNAL")
+    void testMissingApiReasonCode() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/v1/kernel/approve", exchange -> {
+            byte[] response = "{\"error\":{\"message\":\"approval failed\"}}".getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(500, response.length);
+            exchange.getResponseBody().write(response);
+            exchange.close();
+        });
+        server.start();
+        try {
+            HelmClient client = new HelmClient("http://127.0.0.1:" + server.getAddress().getPort());
+            HelmClient.HelmApiException exception = assertThrows(HelmClient.HelmApiException.class,
+                    () -> client.approveIntent(new TypesGen.ApprovalRequest().intentHash("sha256:intent")));
+            assertEquals("approval failed", exception.getMessage());
+            assertEquals("ERROR_INTERNAL", exception.reasonCode);
+        } finally {
+            server.stop(0);
+        }
     }
 }


### PR DESCRIPTION
## What / Why

Linear: [HELM-173](https://linear.app/mindburn/issue/HELM-173)

Generated Java `TypesGen` models for `additionalProperties` schemas extended `HashMap<String, Object>`, so both Jackson and Gson treated the whole model as a bare map: declared accessor-backed fields never reached the wire on serialize and typed getters were never populated on decode. On top of that, `HelmClient` used Gson for typed bodies, which ignores the generated `@JsonProperty` annotations — so even plain bean models went over the wire with camelCase field names (`maxTokens` instead of `max_tokens`) and decoded into `null` getters. HELM-140 worked around this for the evaluator only; this PR repairs the shared model path across non-evaluator endpoints.

## Changes

- `scripts/sdk/gen.sh` (Java post-processor): strip `extends HashMap<String, Object>` from additionalProperties models and fix the now-invalid `super.equals`/`super.hashCode`/`super.toString` calls. The generated `@JsonAnyGetter`/`@JsonAnySetter` container is kept, so undeclared properties still round-trip. Generated output remains fully owned by `gen.sh` — `TypesGen.java` in this PR is the verbatim generator output.
- `scripts/sdk/gen.sh`: pin `LC_ALL=C`. Model-file glob collation differed between hosts (C vs UTF-8 locale), which reordered the concatenated outputs and would make `make sdk-openapi-check` environment-dependent. With the pin, ts/go/py outputs regenerate byte-identical to `main`.
- `HelmClient`: typed request/response bodies now serialize through a configured Jackson `ObjectMapper` (jsr310 + `JsonNullableModule`, unknown-property tolerant). Gson remains only for the untyped `JsonElement` pass-through methods (public API unchanged). `health()` now returns the raw plain-text `/healthz` body instead of JSON-decoding it.
- New `HelmClientLoopbackTest`: real HTTP loopback tests (JDK `HttpServer` on 127.0.0.1) verifying request payloads and typed response getters for representative families: chat completions, kernel approve/Receipt, ProofGraph sessions, conformance run, MCP registry discover, sandbox grant inspect, evaluate (`DecisionRequest` through the shared path), `HelmError` reason-code mapping, plain-text health, and an additionalProperties model round-trip.
- Docs: `sdk/java/README.md` gains a JSON-mapping + migration section; `sdk/README.md` no longer claims a published Maven Central package; `CHANGELOG.md` records the change and the source-available (not published/conformance-certified) status.

## Compatibility / migration

- Generated models for `additionalProperties` schemas (26 classes: `CapabilityGraph`, `ConsoleCapabilities`, `DetectedModule`, `EntitlementDecision`, `GeneratedAppSpecCandidate`, `ImportEvidenceLedger`, `ImportPreflightResult`, `LaunchRecipe`, `Launchpad*`, `SourceSnapshot`, `TargetPlan`) no longer extend `HashMap`. Code using them as a `Map` must switch to typed accessors plus `putAdditionalProperty`/`getAdditionalProperty`/`getAdditionalProperties`. Recorded in `sdk/java/README.md` and `CHANGELOG.md`.
- Behavioral fix on typed endpoints: request payloads now use documented snake_case wire names and typed response getters are populated. Any consumer that depended on the previous (broken) camelCase payloads was already divergent from the OpenAPI contract.

## Decision flagged

The HELM-140 evaluator codec lives on the unmerged branch `helm-140-evaluate-contract` and is not part of this diff. With this repair, that branch's dedicated canonical request codec / `DecisionRecord` decoder is no longer needed — a generated `DecisionRequest` now serializes its documented fields through the shared path (covered here by `testEvaluateDecision`). Simplifying that branch is left to its own PR.

## Evidence

- `make sdk-openapi-check` → `OpenAPI SDK types are current.`
- `make test-sdk-java` → `Tests run: 28, Failures: 0, Errors: 0` (incl. 11 new loopback tests), BUILD SUCCESS
- Contract routes: `cd core && go test ./pkg/api/ -count=1` → ok; `go test ./cmd/helm-ai-kernel/ -run 'TestOpenAPI|TestContract|Route' -count=1` → ok
- `make docs-coverage docs-truth` → pass

## Acceptance checklist

- [x] Generated/source-owned Java model mapping serializes documented fields and restores typed getters for representative endpoint families
- [x] Evaluator-specific codec role resolved: shared path repaired; simplification of the unmerged HELM-140 branch flagged, not forced
- [x] `make sdk-openapi-check`, `make test-sdk-java`, relevant contract routes pass
- [x] SDK docs distinguish source availability from published/conformance-certified artifacts
