### PR TITLE
docs: pin partner guide to v0.7.5 and register it with the drift gate (HELM-197)

### DIFF
--- a/docs/guides/implementation-partner.md
+++ b/docs/guides/implementation-partner.md
@@ -5,7 +5,7 @@ last_reviewed: 2026-07-15
 
 # Implementation Partner Handoff
 
-This guide packages the local, self-hosted HELM AI Kernel v0.7.2 surface for an
+This guide packages the local, self-hosted HELM AI Kernel v0.7.5 surface for an
 implementation partner. It does not describe a hosted HELM API.
 
 NavigoTech Innovation is an official HELM implementation partner.
@@ -22,9 +22,9 @@ brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel --version
 ```
 
-The expected release for this packet is `0.7.2`. If the registry or local cache
+The expected release for this packet is `0.7.5`. If the registry or local cache
 does not return that release, stop and use the signed asset from the
-[v0.7.2 release](https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.2).
+[v0.7.5 release](https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.7.5).
 
 ## 2. Run A Clean Local Proof
 
@@ -82,7 +82,7 @@ If the selected SDK cannot send a required identity header, stop and use direct
 HTTP or a client generated from `/openapi.yaml`. Never remove a required scope
 merely to make an example run.
 
-At v0.7.2, the handwritten TypeScript and Python clients cannot set the
+At v0.7.5, the handwritten TypeScript and Python clients cannot set the
 principal header, and the Go client cannot set the optional workspace header.
 Use those convenience clients only for routes covered by their helpers. For a
 protected evaluate call, direct HTTP or a generated OpenAPI client is the

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -382,11 +382,11 @@
       "replacement": "<version>{version}</version>"
     },
     {
-      "id": "implementation-partner-guide-version-tag",
+      "id": "implementation-partner-guide-packaged-surface",
       "path": "docs/guides/implementation-partner.md",
       "kind": "regex",
-      "pattern": "v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
-      "replacement": "v{version}"
+      "pattern": "HELM AI Kernel v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+) surface",
+      "replacement": "HELM AI Kernel v{version} surface"
     },
     {
       "id": "implementation-partner-guide-expected-release",
@@ -394,6 +394,27 @@
       "kind": "regex",
       "pattern": "The expected release for this packet is `(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)`",
       "replacement": "The expected release for this packet is `{version}`"
+    },
+    {
+      "id": "implementation-partner-guide-release-link-text",
+      "path": "docs/guides/implementation-partner.md",
+      "kind": "regex",
+      "pattern": "\\[v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+) release\\]",
+      "replacement": "[v{version} release]"
+    },
+    {
+      "id": "implementation-partner-guide-release-url",
+      "path": "docs/guides/implementation-partner.md",
+      "kind": "regex",
+      "pattern": "releases/tag/v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "replacement": "releases/tag/v{version}"
+    },
+    {
+      "id": "implementation-partner-guide-sdk-header-claim",
+      "path": "docs/guides/implementation-partner.md",
+      "kind": "regex",
+      "pattern": "At v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+), the handwritten",
+      "replacement": "At v{version}, the handwritten"
     },
     {
       "id": "examples-java-coordinate",

--- a/release/version-surfaces.yaml
+++ b/release/version-surfaces.yaml
@@ -382,6 +382,20 @@
       "replacement": "<version>{version}</version>"
     },
     {
+      "id": "implementation-partner-guide-version-tag",
+      "path": "docs/guides/implementation-partner.md",
+      "kind": "regex",
+      "pattern": "v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)",
+      "replacement": "v{version}"
+    },
+    {
+      "id": "implementation-partner-guide-expected-release",
+      "path": "docs/guides/implementation-partner.md",
+      "kind": "regex",
+      "pattern": "The expected release for this packet is `(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+)`",
+      "replacement": "The expected release for this packet is `{version}`"
+    },
+    {
       "id": "examples-java-coordinate",
       "path": "docs/EXAMPLES.md",
       "kind": "regex",


### PR DESCRIPTION
## What

The live implementation-partner guide — [helm.docs.mindburn.org/guides/implementation-partner/](https://helm.docs.mindburn.org/guides/implementation-partner/), the page our official partner NavigoTech is pointed at ([HELM-197](https://linear.app/mindburn/issue/HELM-197)) — still packaged **v0.7.2** and instructed partners to install that pinned CLI. That is three releases stale and materially wrong for this audience: v0.7.3–v0.7.5 carry the security fixes a partner integration most needs — **HELM-225** (fail-closed production receipt signing, replacing a derivable/forgeable signer seed) and **HELM-354** (x/text `GO-2026-5970`).

## Root cause (the part worth reviewing)

`docs/guides/implementation-partner.md` was **never registered in `release/version-surfaces.yaml`**. All 77 other version surfaces — README, PUBLISHING, VERIFICATION, DEVELOPER_JOURNEY, `docs/sdks/00_INDEX.md`, QUICKSTART, RELEASE_SECURITY, every SDK manifest — are pinned to `VERSION`, so `make version-drift` guards them and `make prepare-version` bumps them each release. The one page an *external* reader consumes was the only one that could rot silently, and it did.

It is now registered as **five blocking surfaces**, each anchored to the exact sentence it guards (packaged-surface line, expected-release backtick, release link text, release URL, SDK header-claim line), so:
- `version-drift` fails whenever the guide's pin diverges from `VERSION`, and
- `prepare-version` bumps it automatically on every future release.

Anchored rather than a single broad `v<semver>` pattern (permit P3): this is an install-oriented page, so a broad pattern would let `prepare-version` rewrite a future third-party version such as `Docker v24.0.1` into the kernel version.

## Verification

- `make version-drift` → **86 OK / 0 FAIL**; all five new surfaces report `OK … expected='0.7.5' actual=['0.7.5']`.
- **Drift is caught** (guard is not tautological): reintroducing the `0.7.2` pin makes all five report `FAIL … [blocking]`.
- **Third-party versions are immune**: appending `Docker v24.0.1 and Node v22.11.0` leaves `version-drift` green, and no anchored pattern matches either string (asserted programmatically).
- **A reword fails loudly rather than going dead**: rewording an anchored sentence yields `FAIL … actual=None [blocking]`, so whoever rewords must update the contract in lockstep — chosen deliberately over `blocking: false`, since an advisory surface would let this partner-facing pin rot silently again, which is the bug being fixed here.
- `make docs-truth` and `make docs-coverage` green (683 rows / 409 surfaces).
- The guide's substantive SDK claim was **re-verified against current main, not blind-bumped**: the handwritten TypeScript and Python clients still set no principal header, and the Go client still has no workspace header (`sdk/go/client/client.go` principal=6, workspace=0). The sentence holds at v0.7.5 — only the version was wrong.

Follow-on for HELM-197: this change regenerates into `app-helm-docs` so the public URL serves the corrected pin; the remaining acceptance items (partner's first governed client loop, commercial terms) are unaffected by this PR.

Refs HELM-197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Vxjnf9PNiaTN1ceqDF9zt