### PR TITLE
docs(conformance): state that CI runs the module on every PR (HELM-376)

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -17,9 +17,9 @@ cd tests/conformance
 GOWORK=off go test ./...
 ```
 
-`GOWORK=off` is not optional: the repo has a `go.work`, and without it the
-module resolves against the workspace build list rather than its own `go.mod`,
-so a local pass need not mean a CI pass.
+`GOWORK=off` is not optional: the repo has a `go.work`, and without that flag
+the module resolves against the workspace build list rather than its own
+`go.mod`, so a local pass need not mean a CI pass.
 
 This is the same command CI runs. `scripts/ci/go_module_tests.sh` discovers
 every tracked `go.mod` and runs `GOWORK=off go test ./...` in each. It is wired

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -17,6 +17,12 @@ cd tests/conformance
 go test ./...
 ```
 
+This is a local convenience, not the gate. CI already runs this module on every
+PR through the `Independent Go module tests` step of the `kernel` job
+(`scripts/ci/go_module_tests.sh`), which discovers every tracked `go.mod` and
+runs `GOWORK=off go test ./...` in each. A new package added under this
+directory is covered the moment it lands — no workflow edit required.
+
 Then run:
 
 ```bash

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -18,10 +18,11 @@ go test ./...
 ```
 
 This is a local convenience, not the gate. CI already runs this module on every
-PR through the `Independent Go module tests` step of the `kernel` job
-(`scripts/ci/go_module_tests.sh`), which discovers every tracked `go.mod` and
-runs `GOWORK=off go test ./...` in each. A new package added under this
-directory is covered the moment it lands — no workflow edit required.
+PR: `scripts/ci/go_module_tests.sh` discovers every tracked `go.mod` and runs
+`GOWORK=off go test ./...` in each. It is wired into `.github/workflows/ci.yml`
+as the `Independent Go module tests` step of the `kernel` job. A new package
+added under this directory is covered the moment it lands — no workflow edit
+required.
 
 Then run:
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -20,9 +20,11 @@ go test ./...
 This is a local convenience, not the gate. CI already runs this module on every
 PR: `scripts/ci/go_module_tests.sh` discovers every tracked `go.mod` and runs
 `GOWORK=off go test ./...` in each. It is wired into `.github/workflows/ci.yml`
-as the `Independent Go module tests` step of the `kernel` job. A new package
-added under this directory is covered the moment it lands — no workflow edit
-required.
+as the `Independent Go module tests` step of the `kernel` job, which is a
+required status check for merging to `main` — see
+[`.github/TEST_MATRIX.md`](../../.github/TEST_MATRIX.md) for the canonical CI
+baseline. A new package added under this directory is covered the moment it
+lands — no workflow edit required.
 
 Then run:
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -20,11 +20,12 @@ go test ./...
 This is a local convenience, not the gate. CI already runs this module on every
 PR: `scripts/ci/go_module_tests.sh` discovers every tracked `go.mod` and runs
 `GOWORK=off go test ./...` in each. It is wired into `.github/workflows/ci.yml`
-as the `Independent Go module tests` step of the `kernel` job, which is a
-required status check for merging to `main` — see
-[`.github/TEST_MATRIX.md`](../../.github/TEST_MATRIX.md) for the canonical CI
-baseline. A new package added under this directory is covered the moment it
-lands — no workflow edit required.
+as the `Independent Go module tests` step of the `kernel` job, which the active
+`main protection` ruleset lists among the status checks required to merge into
+`main` — so a red conformance package blocks the merge. See
+[`.github/TEST_MATRIX.md`](../../.github/TEST_MATRIX.md) for the CI baseline
+that job belongs to. A new package added under this directory is covered the
+moment it lands — no workflow edit required.
 
 Then run:
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -14,15 +14,19 @@ Run:
 
 ```bash
 cd tests/conformance
-go test ./...
+GOWORK=off go test ./...
 ```
 
-This is a local convenience, not the gate. CI already runs this module on every
-PR: `scripts/ci/go_module_tests.sh` discovers every tracked `go.mod` and runs
-`GOWORK=off go test ./...` in each. It is wired into `.github/workflows/ci.yml`
-as the `Independent Go module tests` step of the `kernel` job, which the active
-`main protection` ruleset lists among the status checks required to merge into
-`main` — so a red conformance package blocks the merge. See
+`GOWORK=off` is not optional: the repo has a `go.work`, and without it the
+module resolves against the workspace build list rather than its own `go.mod`,
+so a local pass need not mean a CI pass.
+
+This is the same command CI runs. `scripts/ci/go_module_tests.sh` discovers
+every tracked `go.mod` and runs `GOWORK=off go test ./...` in each. It is wired
+into `.github/workflows/ci.yml` as the `Independent Go module tests` step of the
+`kernel` job, which the active `main protection` ruleset lists among the status
+checks required to merge into `main` — so a red conformance package blocks the
+merge. See
 [`.github/TEST_MATRIX.md`](../../.github/TEST_MATRIX.md) for the CI baseline
 that job belongs to. A new package added under this directory is covered the
 moment it lands — no workflow edit required.


### PR DESCRIPTION
## Summary

`tests/conformance/README.md` documented only the manual invocation, which reads
as "this suite is manual-only". It is not — CI runs the whole module on every PR.

Auditing CI coverage by grepping workflows for `tests/conformance` surfaces only
the CodeQL *compile* reference (`codeql.yml:53-59`), so the suite reads as
unguarded. That misreading nearly landed a redundant conformance job — a second
~2 min run per PR for zero new coverage. This names the real gate in the README
so the next audit terminates there.

The actual coverage path, verified on `main` @ `4209cc34`:

- `.github/workflows/ci.yml:146-147` — job `kernel`, step `Independent Go module
  tests` → `bash scripts/ci/go_module_tests.sh`. No `if:`, no `continue-on-error`.
- `scripts/ci/go_module_tests.sh:4` — `git ls-files '**/go.mod' 'go.mod'`
  enumerates every tracked Go module; `tests/conformance` is in the resolved set.
- `scripts/ci/go_module_tests.sh:8` — `(cd "${module}" && GOWORK=off go test ./...)`
  under `set -euo pipefail`, so a conformance failure fails the step and the job.
- No build tags, `t.Skip`, or `testing.Short()` under `tests/conformance/**/*.go`
  — the coverage is real, not a no-op.

Docs-only. No workflow, Makefile, contract, or claim changes.

Deliberately **not** included, and recorded as such in HELM-376:

- No new CI job — coverage already exists.
- No change to `release-readiness` (`Makefile:144`) — it already carries
  `conformance-release-gate`.
- No change to `make test-all` (`Makefile:114`) — local parity would pull in
  every module including all of `core`, broader than `make test`'s `./pkg/...`.

## Validation

```bash
make verify-presentation
```

```bash
cd tests/conformance && GOWORK=off go test ./...
```

12/12 packages ok (~2 min) — the same invocation CI performs. `make quality-pr`
was not run locally; CI runs it and this change touches no code, contract, or
version surface.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes. — no behavior change
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. — not touched
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path.
- [x] Release version surfaces are lockstep (`make version-drift`) when touching `VERSION`, release workflows, chart metadata, SDK manifests, OpenAPI, or publishing docs. — none touched
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`. — none
- [x] Advisory quality warnings are acknowledged or tracked when relevant.

Closes HELM-376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)