### PR TITLE
docs: align CI docs with the enforced gate and the real command (HELM-381)

### DIFF
--- a/.github/TEST_MATRIX.md
+++ b/.github/TEST_MATRIX.md
@@ -27,15 +27,31 @@ Systems that contribute to HELM AI Kernel execution truth must enforce:
 
 ## CI Branch Protection Baseline
 
-The following jobs should pass before merging to `main` unless a tracked
-Advisory suppression explicitly explains the risk:
+The `main protection` ruleset is the enforcing source. This section describes
+it; it does not define it. Read the live list rather than trusting this copy:
 
-1. `quality-pr` / `make quality-pr`
-2. `hygiene`
-3. `kernel`
-4. `contract-drift`
-5. `deployment-smoke` and `release-smoke`
-6. `codeql` and `scorecard`
+```bash
+gh api /repos/Mindburn-Labs/helm-ai-kernel/rulesets/16024605 \
+  --jq '.rules[] | select(.type=="required_status_checks")
+        | [.parameters.required_status_checks[].context]'
+```
+
+As inspected on 2026-07-25 the ruleset is `active` on `refs/heads/main`,
+requires a pull request and linear history, blocks deletion and
+non-fast-forward pushes, and requires these 18 status checks in strict mode, so
+a branch must also be up to date with `main` before it can merge:
+
+`Quality PR profile`, `hygiene`, `kernel`, `contract-drift`, `python-sdk`,
+`ts-sdk`, `rust-sdk`, `java-sdk`, `deployment-smoke`, `kind-smoke`,
+`release-smoke`, `Coverage and truth`, `OpenSSF Scorecard`, `CodeQL (go)`,
+`CodeQL (javascript-typescript)`, `CodeQL (python)`, `CodeQL (java-kotlin)`,
+`Rust audit`.
+
+These are not waivable. The ruleset's `bypass_actors` list is empty, so no
+role — maintainer, admin, or app — can merge past a red required check.
+Advisory suppression operates inside the quality profiles, on individual checks
+that have not been promoted to blocking; it is not a route around the contexts
+above.
 
 Nightly runs `make quality-nightly`. New noisy gates remain Advisory until
 their baselines are clean or `QUALITY_STRICT=1` promotes them to blocking.

--- a/docs/execution-boundary-oss-response.md
+++ b/docs/execution-boundary-oss-response.md
@@ -42,7 +42,7 @@ Targeted verification for this boundary slice:
 
 ```sh
 go test ./core/pkg/contracts ./core/pkg/boundary ./core/cmd/helm-ai-kernel
-cd tests/conformance && go test ./...
+cd tests/conformance && GOWORK=off go test ./...
 cd sdk/go && GOWORK=off CGO_ENABLED=0 go test ./client
 cd sdk/python && python -m pytest -q
 cd sdk/ts && npm test

--- a/docs/reference/execution-boundary.md
+++ b/docs/reference/execution-boundary.md
@@ -166,7 +166,7 @@ or unsupported roots are reported as not verified.
 cd core
 go test ./pkg/contracts ./pkg/boundary ./cmd/helm-ai-kernel -run 'Test.*Boundary|Test.*Route|Test.*Evidence|Test.*MCP|Test.*Sandbox' -count=1
 cd ../tests/conformance
-go test ./...
+GOWORK=off go test ./...
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Two docs described CI weaker than it is enforced. Both surfaced while reviewing #689.

**1. `.github/TEST_MATRIX.md` understated the merge gate.** It said six jobs
"should pass before merging to `main` unless a tracked Advisory suppression
explicitly explains the risk". The live ruleset:

```
main protection (16024605)   active   refs/heads/main
  rules: pull_request, required_linear_history, required_status_checks, deletion, non_fast_forward
  strict_required_status_checks_policy: true
  bypass_actors: []
  contexts: 18
```

Nothing waives those checks and no role — maintainer, admin, or app — merges
past a red one. Describing a fail-closed gate as advisory is the wrong direction
of error for this repo. The section now names the ruleset as the enforcing
source, lists the 18 contexts, ships the `gh api` command to read the live list,
and says what Advisory suppression actually covers (individual checks inside the
quality profiles, not the required contexts).

**2. Two docs ran a command CI does not run.**
`docs/execution-boundary-oss-response.md` and `docs/reference/execution-boundary.md`
invoked the conformance suite as plain `go test ./...`; CI runs
`GOWORK=off go test ./...`. With a `go.work` present those resolve differently —
377 modules under the workspace vs 369 module-scoped, zero shared dependencies
differing in version today, so the gap is latent rather than active, but it would
surface as a locally-unreproducible CI failure. `execution-boundary-oss-response.md`
already used `GOWORK=off` for the Go SDK line, so conformance was simply missed.

**Known weakness, stated rather than hidden:** listing the 18 contexts creates a
copy that can drift from the ruleset — the same failure this PR corrects, one
level up. Naming the ruleset as authoritative and shipping the live-read command
mitigates that; it does not eliminate it. A generated check would, and is not
proposed here: the list changes rarely and a generator is more machinery than the
problem warrants. Reviewers who disagree should say so.

## Validation

```bash
make docs-coverage && make docs-truth && make verify-presentation
```

All pass. The documented context list was cross-checked against the live ruleset —
18/18 match.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes. — docs-only, no behavior change
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. — not touched
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path.
- [x] Release version surfaces are lockstep (`make version-drift`) when touching `VERSION`, release workflows, chart metadata, SDK manifests, OpenAPI, or publishing docs. — none touched
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`. — none
- [x] Advisory quality warnings are acknowledged or tracked when relevant.

Closes HELM-381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)