### PR TITLE
fix(ci): report published version drift without red runs

### DIFF
--- a/.github/workflows/version-drift.yml
+++ b/.github/workflows/version-drift.yml
@@ -19,21 +19,38 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - id: drift
         name: Check published registry lockstep
-        continue-on-error: true
         run: |
           VERSION="$(cat VERSION)"
           python3 scripts/release/check_version_drift.py \
+            --report \
             --expected-version "$VERSION" \
             --write-status version-status.json \
             published \
             --surface-timeout 15
+      - id: verdict
+        name: Read drift verdict
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+
+          with open("version-status.json", "r", encoding="utf-8") as f:
+              status = json.load(f)
+          if status.get("schema_version") != "mindburn.version_status.v1":
+              raise SystemExit("unrecognised version-status schema")
+          verdict = status.get("status")
+          if verdict not in {"pass", "fail"}:
+              raise SystemExit(f"unrecognised version-status verdict: {verdict!r}")
+          print(f"drift={'true' if verdict == 'fail' else 'false'}")
+          PY
       - name: Upload version status
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: version-status
           path: version-status.json
+          if-no-files-found: warn
       - name: Open or update drift issue
-        if: steps.drift.outcome == 'failure'
+        if: steps.verdict.outputs.drift == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -124,7 +141,7 @@ jobs:
               --label release-blocker
           fi
       - name: Close resolved drift issue
-        if: steps.drift.outcome == 'success'
+        if: steps.verdict.outputs.drift == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -572,7 +572,7 @@ def check_published(contract: dict[str, Any], version: str, skip: set[str], only
             continue
         try:
             results.append(checker(surface, version))
-        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, socket.timeout, KeyError, ET.ParseError, json.JSONDecodeError) as exc:
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, socket.timeout, KeyError, ValueError, ET.ParseError, json.JSONDecodeError) as exc:
             results.append(published_error(surface, version, exc))
     return results
 

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -228,6 +228,29 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertEqual(result.expected, "0.5.10")
         self.assertIsNone(result.actual)
 
+    def test_published_value_error_is_reported_as_a_surface_failure(self) -> None:
+        contract = {
+            "published_surfaces": [
+                {"id": "invalid-url", "kind": "example", "url": "https://example.test"},
+            ]
+        }
+        original = drift.PUBLISHED_CHECKS.copy()
+
+        def raise_value_error(_surface, _version):
+            raise ValueError("invalid URL")
+
+        drift.PUBLISHED_CHECKS["example"] = raise_value_error
+        try:
+            results = drift.check_published(contract, "0.5.12", set())
+        finally:
+            drift.PUBLISHED_CHECKS.clear()
+            drift.PUBLISHED_CHECKS.update(original)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, "fail")
+        self.assertTrue(results[0].blocking)
+        self.assertIn("ValueError: invalid URL", results[0].detail or "")
+
     def test_status_payload_emits_timeout_failures_without_blocking_advisory(self) -> None:
         blocking = drift.published_error(
             {


### PR DESCRIPTION
## Why

The scheduled Version Drift Monitor treats expected published-channel drift as a CI failure, then its issue-reporting path can crash when a surface raises `ValueError` before a status file is available. This creates permanent red noise rather than actionable release signal.

## Change

- invoke the checker in its existing `--report` mode, so real drift writes `version-status.json` and updates one tracking issue without failing the cron run;
- remove `continue-on-error`: checker/status-schema failures stay red;
- classify only recognised status schemas/verdicts;
- convert per-surface `ValueError` (including malformed URLs) to a recorded failed surface;
- add a regression test for that error path.

## Validation

- `python3 scripts/release/check_version_drift_test.py` (14 tests)
- `python3 scripts/release/check_version_drift.py --report --write-status <temp> local`
- `actionlint .github/workflows/version-drift.yml`
- `git diff --check`