### PR TITLE
fix(ci): run command tests from core module

### DIFF
--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -287,7 +287,7 @@
     {
       "id": "command-tests",
       "title": "CLI command tests",
-      "command": "go test ./core/cmd/helm-ai-kernel -count=1",
+      "command": "cd core && go test ./cmd/helm-ai-kernel -count=1",
       "timeout_seconds": 900,
       "paths": [
         "core/cmd/**",


### PR DESCRIPTION
## Summary
- run the CLI command gate from the Go module root

## Validation
- `/usr/bin/python3 scripts/ci/quality.py run --gate command-tests`
- `make quality-self-test`
- `make quality-pr`