### PR TITLE
fix(launchpad): preserve local evidence chains

### DIFF
--- a/core/pkg/evidence/evidence_trust_config_coverage_test.go
+++ b/core/pkg/evidence/evidence_trust_config_coverage_test.go
@@ -159,8 +159,8 @@ func TestEvidenceTrustConfigKMSAndHelperBranches(t *testing.T) {
 	if ProfileRequiresExternalTrust(EvidenceTrustProfileTeam) {
 		t.Fatal("team profile should not require external trust")
 	}
-	if got := BuildEvidencePackVerifyCommand("bundle.tar", EvidenceTrustProfileDevLocal, ""); !strings.Contains(got, "--allow-self-attested") || strings.Contains(got, "--profile") {
-		t.Fatalf("dev-local verify command missing local trust opt-in: %s", got)
+	if got := BuildEvidencePackVerifyCommand("bundle.tar", EvidenceTrustProfileDevLocal, ""); strings.Contains(got, "--allow-self-attested") || strings.Contains(got, "--profile") {
+		t.Fatalf("dev-local verify command must require an explicit trust opt-in: %s", got)
 	}
 	if got := BuildEvidencePackVerifyCommand("bundle.tar", EvidenceTrustProfileCustomer, "storage.json"); !strings.Contains(got, "--profile customer") || !strings.Contains(got, "--storage-receipt storage.json") || strings.Contains(got, "--allow-self-attested") {
 		t.Fatalf("customer verify command missing flags: %s", got)

--- a/core/pkg/evidence/evidence_trust_config_coverage_test.go
+++ b/core/pkg/evidence/evidence_trust_config_coverage_test.go
@@ -159,7 +159,10 @@ func TestEvidenceTrustConfigKMSAndHelperBranches(t *testing.T) {
 	if ProfileRequiresExternalTrust(EvidenceTrustProfileTeam) {
 		t.Fatal("team profile should not require external trust")
 	}
-	if got := BuildEvidencePackVerifyCommand("bundle.tar", EvidenceTrustProfileCustomer, "storage.json"); !strings.Contains(got, "--profile customer") || !strings.Contains(got, "--storage-receipt storage.json") {
+	if got := BuildEvidencePackVerifyCommand("bundle.tar", EvidenceTrustProfileDevLocal, ""); !strings.Contains(got, "--allow-self-attested") || strings.Contains(got, "--profile") {
+		t.Fatalf("dev-local verify command missing local trust opt-in: %s", got)
+	}
+	if got := BuildEvidencePackVerifyCommand("bundle.tar", EvidenceTrustProfileCustomer, "storage.json"); !strings.Contains(got, "--profile customer") || !strings.Contains(got, "--storage-receipt storage.json") || strings.Contains(got, "--allow-self-attested") {
 		t.Fatalf("customer verify command missing flags: %s", got)
 	}
 	if got := BuildEvidencePackVerifyCommand("bundle.tar", EvidenceTrustProfileTeam, "storage.json"); strings.Contains(got, "--profile") {

--- a/core/pkg/evidence/seal.go
+++ b/core/pkg/evidence/seal.go
@@ -1256,6 +1256,9 @@ func ProfileRequiresExternalTrust(profile EvidenceTrustProfile) bool {
 func BuildEvidencePackVerifyCommand(bundle string, profile EvidenceTrustProfile, storageReceiptPath string) string {
 	cmd := "helm-ai-kernel verify --bundle " + bundle
 	profile = NormalizeEvidenceTrustProfile(profile)
+	if profile == EvidenceTrustProfileDevLocal {
+		cmd += " --allow-self-attested"
+	}
 	if profileRequiresExternalTrust(profile) {
 		cmd += " --profile " + string(profile)
 		if strings.TrimSpace(storageReceiptPath) != "" {

--- a/core/pkg/evidence/seal.go
+++ b/core/pkg/evidence/seal.go
@@ -1256,9 +1256,6 @@ func ProfileRequiresExternalTrust(profile EvidenceTrustProfile) bool {
 func BuildEvidencePackVerifyCommand(bundle string, profile EvidenceTrustProfile, storageReceiptPath string) string {
 	cmd := "helm-ai-kernel verify --bundle " + bundle
 	profile = NormalizeEvidenceTrustProfile(profile)
-	if profile == EvidenceTrustProfileDevLocal {
-		cmd += " --allow-self-attested"
-	}
 	if profileRequiresExternalTrust(profile) {
 		cmd += " --profile " + string(profile)
 		if strings.TrimSpace(storageReceiptPath) != "" {

--- a/core/pkg/launchpad/runtime/coverage_test.go
+++ b/core/pkg/launchpad/runtime/coverage_test.go
@@ -535,11 +535,34 @@ exit 0
 	if err := json.Unmarshal(data, &receipt); err != nil {
 		t.Fatalf("decode sidecar receipt: %v", err)
 	}
-	if receipt.ExecutorID != "launch/sidecar:egress-proxy" || receipt.PrevHash != "" || receipt.LamportClock != 1 {
+	if receipt.ExecutorID != "launch/sidecar:egress-proxy:docker_sidecar_started" || receipt.PrevHash != "" || receipt.LamportClock != 1 {
 		t.Fatalf("sidecar receipt must start a distinct causal session: %+v", receipt)
 	}
 	if err := handle.Stop(); err != nil {
 		t.Fatalf("sidecar stop failed: %v", err)
+	}
+	entries, err := os.ReadDir(handle.ReceiptDir)
+	if err != nil {
+		t.Fatalf("read sidecar receipt directory: %v", err)
+	}
+	sessions := map[string]bool{}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(handle.ReceiptDir, entry.Name()))
+		if err != nil {
+			t.Fatalf("read sidecar receipt %s: %v", entry.Name(), err)
+		}
+		if err := json.Unmarshal(data, &receipt); err != nil {
+			t.Fatalf("decode sidecar receipt %s: %v", entry.Name(), err)
+		}
+		if receipt.PrevHash != "" || receipt.LamportClock != 1 {
+			t.Fatalf("sidecar receipt must be a session genesis: %+v", receipt)
+		}
+		sessions[receipt.ExecutorID] = true
+	}
+	for _, sessionID := range []string{"launch/sidecar:egress-proxy:docker_sidecar_started", "launch/sidecar:egress-proxy:docker_sidecar_stopped"} {
+		if !sessions[sessionID] {
+			t.Fatalf("sidecar receipt session missing %q: %#v", sessionID, sessions)
+		}
 	}
 	logData, err := os.ReadFile(logPath)
 	if err != nil {

--- a/core/pkg/launchpad/runtime/coverage_test.go
+++ b/core/pkg/launchpad/runtime/coverage_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/plan"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/registry"
 )
@@ -525,8 +527,16 @@ exit 0
 	if handle.ProxyImage != "image@sha256:abc" {
 		t.Fatalf("sidecar proxy image = %q", handle.ProxyImage)
 	}
-	if _, err := os.Stat(handle.ReceiptPath); err != nil {
-		t.Fatalf("sidecar receipt path not written: %v", err)
+	data, err := os.ReadFile(handle.ReceiptPath)
+	if err != nil {
+		t.Fatalf("read sidecar receipt: %v", err)
+	}
+	var receipt contracts.Receipt
+	if err := json.Unmarshal(data, &receipt); err != nil {
+		t.Fatalf("decode sidecar receipt: %v", err)
+	}
+	if receipt.ExecutorID != "launch/sidecar:egress-proxy" || receipt.PrevHash != "" || receipt.LamportClock != 1 {
+		t.Fatalf("sidecar receipt must start a distinct causal session: %+v", receipt)
 	}
 	if err := handle.Stop(); err != nil {
 		t.Fatalf("sidecar stop failed: %v", err)

--- a/core/pkg/launchpad/runtime/docker_sidecar_proxy.go
+++ b/core/pkg/launchpad/runtime/docker_sidecar_proxy.go
@@ -138,7 +138,7 @@ func writeSidecarReceipt(dir, launchID, verdict, reason string, subject map[stri
 		subject = map[string]any{}
 	}
 	subject["reason"] = reason
-	receipt := receipts.NewReceipt("launchpad.egress_proxy", launchID, verdict, subject)
+	receipt := receipts.NewReceiptForSession("launchpad.egress_proxy", launchID+":egress-proxy", launchID, verdict, subject)
 	data, err := json.MarshalIndent(receipt, "", "  ")
 	if err != nil {
 		return receipt.ReceiptID, ""

--- a/core/pkg/launchpad/runtime/docker_sidecar_proxy.go
+++ b/core/pkg/launchpad/runtime/docker_sidecar_proxy.go
@@ -138,7 +138,7 @@ func writeSidecarReceipt(dir, launchID, verdict, reason string, subject map[stri
 		subject = map[string]any{}
 	}
 	subject["reason"] = reason
-	receipt := receipts.NewReceiptForSession("launchpad.egress_proxy", launchID+":egress-proxy", launchID, verdict, subject)
+	receipt := receipts.NewReceiptForSession("launchpad.egress_proxy", launchID+":egress-proxy:"+reason, launchID, verdict, subject)
 	data, err := json.MarshalIndent(receipt, "", "  ")
 	if err != nil {
 		return receipt.ReceiptID, ""

--- a/core/pkg/launchpad/session/executor.go
+++ b/core/pkg/launchpad/session/executor.go
@@ -113,15 +113,19 @@ func (e Executor) ExecuteLaunch(compiled plan.LaunchPlan, opts ExecuteOptions) (
 		"require_schema_pin":    compiled.MCPPolicy.RequireSchemaPin,
 		"effect":                "unknown MCP servers and tools remain quarantined until approval receipt exists",
 	})
-	modelGatewayReceipt := chain.Next("launchpad.model_gateway_grant", compiled.LaunchID, compiled.KernelVerdict, map[string]any{
-		"provider":                   compiled.ModelGatewayProvider,
-		"mode":                       compiled.ModelGatewayMode,
-		"required_secret_refs":       compiled.RequiredSecretRefs,
-		"runtime_env_names":          compiled.ModelGatewayEnv,
-		"raw_provider_key_projected": compiled.RawProviderKeyProjected,
-		"network_allowlist":          compiled.NetworkAllowlist,
-		"budget_ceiling":             compiled.Budgets,
-	})
+	hasModelGateway := compiled.ModelGatewayMode != "" || len(compiled.ModelGatewayEnv) > 0
+	var modelGatewayReceipt receipts.Receipt
+	if hasModelGateway {
+		modelGatewayReceipt = chain.Next("launchpad.model_gateway_grant", compiled.LaunchID, compiled.KernelVerdict, map[string]any{
+			"provider":                   compiled.ModelGatewayProvider,
+			"mode":                       compiled.ModelGatewayMode,
+			"required_secret_refs":       compiled.RequiredSecretRefs,
+			"runtime_env_names":          compiled.ModelGatewayEnv,
+			"raw_provider_key_projected": compiled.RawProviderKeyProjected,
+			"network_allowlist":          compiled.NetworkAllowlist,
+			"budget_ceiling":             compiled.Budgets,
+		})
+	}
 	contractReceipt := chain.Next("launchpad.f2_contract_preflight", compiled.LaunchID, compiled.KernelVerdict, map[string]any{
 		"stage":         "f2_contract_preflight",
 		"support_level": compiled.SupportLevel,
@@ -137,7 +141,7 @@ func (e Executor) ExecuteLaunch(compiled plan.LaunchPlan, opts ExecuteOptions) (
 	}
 	run.SandboxGrantRefs = append(run.SandboxGrantRefs, sandboxReceipt.ReceiptID)
 	run.MCPRefs = append(run.MCPRefs, mcpReceipt.ReceiptID)
-	if compiled.ModelGatewayMode != "" || len(compiled.ModelGatewayEnv) > 0 {
+	if hasModelGateway {
 		run.ModelGatewayGrantRefs = append(run.ModelGatewayGrantRefs, modelGatewayReceipt.ReceiptID)
 	}
 	run.LaunchReceiptRefs = append(run.LaunchReceiptRefs, launchReceipt.ReceiptID)

--- a/core/pkg/launchpad/session/executor_test.go
+++ b/core/pkg/launchpad/session/executor_test.go
@@ -1,3 +1,4 @@
+// quantum_posture: this test imports receipt signing only to construct chain-integrity fixtures; production signer posture is assessed in receipts.
 package session
 
 import (
@@ -100,7 +101,11 @@ func TestExecutorRecordsRuntimeHandleBeforeRunning(t *testing.T) {
 	if !strings.Contains(run.VerificationCommand, ".tar") {
 		t.Fatalf("verification command must point to sealed archive: %s", run.VerificationCommand)
 	}
-	archivePath := strings.TrimPrefix(run.VerificationCommand, "helm-ai-kernel verify --bundle ")
+	_, archivePath, ok := strings.Cut(run.VerificationCommand, "--bundle ")
+	if !ok {
+		t.Fatalf("verification command missing bundle: %s", run.VerificationCommand)
+	}
+	archivePath = strings.Fields(archivePath)[0]
 	assertTarContains(t, archivePath, "07_ATTESTATIONS/evidence_pack.sig")
 }
 

--- a/core/pkg/launchpad/session/executor_test.go
+++ b/core/pkg/launchpad/session/executor_test.go
@@ -11,7 +11,9 @@ import (
 
 	evidencepkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/evidence"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/plan"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/receipts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/registry"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/verifier"
 )
 
 func TestMain(m *testing.M) {
@@ -317,12 +319,17 @@ func TestExecutorWritesRuntimeTelemetryEvidence(t *testing.T) {
 }
 
 func TestExecutorBundlesEgressProxyReceiptOnRuntimeFailure(t *testing.T) {
+	p := allowPlan()
 	receiptPath := filepath.Join(t.TempDir(), "egress-receipt.json")
-	if err := os.WriteFile(receiptPath, []byte(`{"receipt_id":"receipt:egress","subject":{"proxy_image":"proxy@sha256:abc"}}`+"\n"), 0o600); err != nil {
+	receipt := receipts.NewReceiptForSession("launchpad.egress_proxy", p.LaunchID+":egress-proxy", p.LaunchID, "ALLOW", map[string]any{"proxy_image": "proxy@sha256:abc"})
+	data, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(receiptPath, append(data, '\n'), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	store := NewStore(t.TempDir())
-	p := allowPlan()
 	p.NetworkAllowlist = []string{"openrouter.ai:443"}
 	run, err := NewExecutor(store).ExecuteLaunch(p, ExecuteOptions{
 		Reason:         "test",
@@ -342,6 +349,19 @@ func TestExecutorBundlesEgressProxyReceiptOnRuntimeFailure(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(run.EvidencePackRefs[0], "02_PROOFGRAPH/receipts/launchpad-egress-proxy.json")); err != nil {
 		t.Fatalf("egress proxy receipt was not bundled: %v", err)
+	}
+	report, err := verifier.VerifyLocallyProducedBundle(run.EvidencePackRefs[0])
+	if err != nil || !report.Verified {
+		t.Fatalf("bundled egress receipt did not verify: report=%+v err=%v", report, err)
+	}
+	for _, name := range []string{"chain_integrity", "lamport_monotonicity"} {
+		for _, check := range report.Checks {
+			if check.Name == name && check.Pass {
+				goto nextCheck
+			}
+		}
+		t.Fatalf("missing passing %s check: %+v", name, report.Checks)
+	nextCheck:
 	}
 	var runtimeEnv map[string]any
 	readJSON(t, filepath.Join(run.EvidencePackRefs[0], "04_EXPORTS/runtime_environment.json"), &runtimeEnv)

--- a/tests/launchpad/live_conformance_test.go
+++ b/tests/launchpad/live_conformance_test.go
@@ -117,8 +117,8 @@ func TestLiveModelProviderLocalContainerConformance(t *testing.T) {
 			if deleted.State != session.StateDeleted || len(deleted.TeardownReceiptRefs) == 0 {
 				t.Fatalf("teardown did not emit receipt: %+v", deleted)
 			}
-			verifyLiveEvidenceRefs(t, appID, deleted.EvidencePackRefs)
 			copyLiveEvidenceRefs(t, appID, deleted.EvidencePackRefs)
+			verifyLiveEvidenceRefs(t, appID, deleted.EvidencePackRefs)
 		})
 	}
 }
@@ -232,7 +232,9 @@ func verifyLiveEvidenceRefs(t *testing.T, appID string, refs []string) {
 	if archiveRef == "" {
 		t.Fatalf("%s did not produce an EvidencePack tar archive ref: %#v", appID, refs)
 	}
-	report, err := verifier.VerifyBundle(dirRef)
+	// This process produced the temporary pack, so strict third-party provenance
+	// verification would correctly reject its self-attested dev-local seal.
+	report, err := verifier.VerifyLocallyProducedBundle(dirRef)
 	if err != nil {
 		t.Fatalf("%s EvidencePack directory verifier error: %v", appID, err)
 	}
@@ -241,7 +243,7 @@ func verifyLiveEvidenceRefs(t *testing.T, appID string, refs []string) {
 	}
 	verifyLiveRuntimeTelemetry(t, appID, dirRef)
 	root := repoRoot(t)
-	cmd := exec.Command("go", "run", "./core/cmd/helm-ai-kernel", "verify", "--bundle", archiveRef, "--json")
+	cmd := exec.Command("go", "run", "./core/cmd/helm-ai-kernel", "verify", "--allow-self-attested", "--bundle", archiveRef, "--json")
 	cmd.Dir = root
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary

- preserve sidecar receipt causality and EvidencePack chain integrity
- create a model-gateway receipt only when it is emitted
- retain strict external verification by default; local conformance opts in explicitly
- retain live evidence artifacts before validation returns an error

## Validation

- `make quality-release` — 35/35 blocking gates passed
- focused independent review cleared provenance and sidecar-session findings

## Post-merge proof

The protected `Launchpad artifacts` workflow runs live model-provider conformance only on a `main` push. Once merged, that job is the exact regression proof and must pass before the v0.8.0 tag, publish, or production promotion.