### PR TITLE
fix(sdk): preserve legacy evaluate compatibility

### DIFF
--- a/examples/python_sdk/main.py
+++ b/examples/python_sdk/main.py
@@ -60,7 +60,7 @@ def main() -> None:
     tenant_id = os.environ.get("HELM_TENANT_ID", "sdk-python-example")
     principal_id = os.environ.get("HELM_PRINCIPAL_ID", "system-admin")
     with HelmClient(base_url=helm_url, api_key=admin_key, tenant_id=tenant_id, principal_id=principal_id) as helm:
-        allowed = helm.evaluate_decision(
+        allowed = helm.evaluate_decision_v5(
             EvaluateRequest(
                 tool="read-ticket",
                 effect_level="ticket:SDK-100",
@@ -68,7 +68,7 @@ def main() -> None:
                 args={"example": "python-sdk"},
             )
         ).to_dict()
-        denied = helm.evaluate_decision(
+        denied = helm.evaluate_decision_v5(
             EvaluateRequest(
                 tool="dangerous-shell",
                 effect_level="system:shell",

--- a/examples/ts_sdk/main.ts
+++ b/examples/ts_sdk/main.ts
@@ -58,13 +58,13 @@ const helm = new HelmClient({
   principalId: process.env.HELM_PRINCIPAL_ID ?? 'system-admin',
 });
 
-const allowed = await helm.evaluateDecision({
+const allowed = await helm.evaluateDecisionV5({
   tool: 'read-ticket',
   effect_level: 'ticket:SDK-200',
   session_id: 'ts-sdk-example',
   args: { example: 'ts-sdk' },
 });
-const denied = await helm.evaluateDecision({
+const denied = await helm.evaluateDecisionV5({
   tool: 'dangerous-shell',
   effect_level: 'system:shell',
   session_id: 'ts-sdk-example',

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -79,7 +79,8 @@ func main() {
 | --- | --- |
 | `ChatCompletions(req)` | `POST /v1/chat/completions` |
 | `ChatCompletionsWithReceipt(req)` | `POST /v1/chat/completions` plus `X-Helm-*` governance headers |
-| `EvaluateDecision(EvaluateRequest)` | `POST /api/v1/evaluate`; requires non-blank `tool`, `effect_level`, and `session_id` |
+| `EvaluateDecision(req)` | Legacy dynamic `POST /api/v1/evaluate` request/response; deprecated for new integrations |
+| `EvaluateDecisionV5(EvaluateRequest)` | Typed `POST /api/v1/evaluate`; requires non-blank `tool`, `effect_level`, and `session_id` |
 | `RunPublicDemo(actionID, args)` | `POST /api/demo/run` |
 | `VerifyPublicDemoReceipt(receipt, expectedHash)` | `POST /api/demo/verify` |
 | `ApproveIntent(req)` | `POST /api/v1/kernel/approve` |

--- a/sdk/go/client/client.go
+++ b/sdk/go/client/client.go
@@ -171,8 +171,16 @@ func (c *HelmClient) ChatCompletionsWithReceipt(req ChatCompletionRequest) (*Cha
 	}, nil
 }
 
-// EvaluateDecision calls POST /api/v1/evaluate with the canonical V5 request.
-func (c *HelmClient) EvaluateDecision(req EvaluateRequest) (*EvaluateResponse, error) {
+// EvaluateDecision calls POST /api/v1/evaluate with the legacy dynamic request and response.
+// Deprecated: use EvaluateDecisionV5 for the typed V5 contract.
+func (c *HelmClient) EvaluateDecision(req any) (map[string]any, error) {
+	var out map[string]any
+	err := c.do("POST", "/api/v1/evaluate", req, &out)
+	return out, err
+}
+
+// EvaluateDecisionV5 calls POST /api/v1/evaluate with the canonical V5 request.
+func (c *HelmClient) EvaluateDecisionV5(req EvaluateRequest) (*EvaluateResponse, error) {
 	if strings.TrimSpace(req.GetTool()) == "" {
 		return nil, fmt.Errorf("evaluate decision requires a non-blank tool")
 	}

--- a/sdk/go/client/execution_boundary_test.go
+++ b/sdk/go/client/execution_boundary_test.go
@@ -112,7 +112,7 @@ func TestExecutionBoundaryClientMethods(t *testing.T) {
 // change that would turn EvaluateRequest into a union and silently drop its
 // canonical V5 fields during serialization. The public schema intentionally
 // keeps those fields optional for legacy direct-daemon compatibility; the SDK
-// method enforces its canonical V5 contract before sending a request.
+// V5 method enforces its canonical contract before sending a request.
 func TestEvaluateRequestGeneratedModelSupportsCanonicalSession(t *testing.T) {
 	tool := "read_file"
 	effectLevel := "read"
@@ -146,8 +146,8 @@ func TestEvaluateRequestGeneratedModelSupportsCanonicalSession(t *testing.T) {
 	if got := incomplete.GetSessionId(); got != "" {
 		t.Fatalf("unset optional session_id = %q, want empty", got)
 	}
-	if _, err := New("http://invalid.example").EvaluateDecision(incomplete); err == nil {
-		t.Fatal("SDK EvaluateDecision accepted a request without a canonical top-level session_id")
+	if _, err := New("http://invalid.example").EvaluateDecisionV5(incomplete); err == nil {
+		t.Fatal("SDK EvaluateDecisionV5 accepted a request without a canonical top-level session_id")
 	}
 }
 
@@ -200,14 +200,25 @@ func TestGoClientEndpointCoverageMatrix(t *testing.T) {
 			}
 			return err
 		}},
-		{"evaluate decision", "POST /api/v1/evaluate", func() error {
+		{"evaluate decision v5", "POST /api/v1/evaluate", func() error {
 			request := NewEvaluateRequest()
 			request.SetTool("read_file")
 			request.SetEffectLevel("read")
 			request.SetSessionId("session-test")
-			result, err := client.EvaluateDecision(*request)
+			result, err := client.EvaluateDecisionV5(*request)
 			if err == nil && (result.ReceiptId != "receipt-evaluate" || result.LamportClock != 1) {
 				t.Fatalf("canonical evaluate response = %#v", result)
+			}
+			return err
+		}},
+		{"legacy evaluate decision", "POST /api/v1/evaluate", func() error {
+			result, err := client.EvaluateDecision(map[string]any{
+				"action":   "read_file",
+				"resource": "read",
+				"context":  map[string]any{"session_id": "legacy-session"},
+			})
+			if err == nil && result["receipt_id"] != "receipt-evaluate" {
+				t.Fatalf("legacy evaluate response = %#v", result)
 			}
 			return err
 		}},

--- a/sdk/java/src/main/java/labs/mindburn/helm/HelmClient.java
+++ b/sdk/java/src/main/java/labs/mindburn/helm/HelmClient.java
@@ -260,16 +260,29 @@ public class HelmClient {
         return send(r, ChatCompletionResponse.class);
     }
 
+    /**
+     * POST /api/v1/evaluate using the legacy dynamic contract.
+     *
+     * @deprecated Use {@link #evaluateDecisionV5(EvaluateRequest)} for typed V5 requests and responses.
+     */
+    @Deprecated
+    public JsonElement evaluateDecision(Object req) {
+        HttpRequest r = this.req("POST", "/api/v1/evaluate")
+                .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))
+                .build();
+        return sendJson(r);
+    }
+
     /** POST /api/v1/evaluate using the canonical V5 request and response. */
-    public EvaluateResponse evaluateDecision(EvaluateRequest req) {
+    public EvaluateResponse evaluateDecisionV5(EvaluateRequest req) {
         if (req == null || req.getTool() == null || req.getTool().isBlank()) {
-            throw new IllegalArgumentException("evaluateDecision requires a non-blank tool");
+            throw new IllegalArgumentException("evaluateDecisionV5 requires a non-blank tool");
         }
         if (req.getEffectLevel() == null || req.getEffectLevel().isBlank()) {
-            throw new IllegalArgumentException("evaluateDecision requires a non-blank effect_level");
+            throw new IllegalArgumentException("evaluateDecisionV5 requires a non-blank effect_level");
         }
         if (req.getSessionId() == null || req.getSessionId().isBlank()) {
-            throw new IllegalArgumentException("evaluateDecision requires a non-blank session_id");
+            throw new IllegalArgumentException("evaluateDecisionV5 requires a non-blank session_id");
         }
         HttpRequest r = this.req("POST", "/api/v1/evaluate")
                 .POST(HttpRequest.BodyPublishers.ofString(gson.toJson(req)))

--- a/sdk/java/src/test/java/labs/mindburn/helm/HelmClientTest.java
+++ b/sdk/java/src/test/java/labs/mindburn/helm/HelmClientTest.java
@@ -162,7 +162,7 @@ public class HelmClientTest {
         server.start();
         try {
             HelmClient client = new HelmClient("http://127.0.0.1:" + server.getAddress().getPort());
-            TypesGen.EvaluateResponse result = client.evaluateDecision(new TypesGen.EvaluateRequest()
+            TypesGen.EvaluateResponse result = client.evaluateDecisionV5(new TypesGen.EvaluateRequest()
                     .tool("read_file")
                     .effectLevel("read")
                     .sessionId("session-test"));
@@ -170,12 +170,19 @@ public class HelmClientTest {
             assertEquals("decision-evaluate", result.getDecisionId());
             assertTrue(body.get().contains("\"effect_level\":\"read\""));
             assertTrue(body.get().contains("\"session_id\":\"session-test\""));
+
+            com.google.gson.JsonElement legacy = client.evaluateDecision(java.util.Map.of(
+                    "action", "legacy-read",
+                    "resource", "legacy-resource",
+                    "context", java.util.Map.of("session_id", "legacy-session")));
+            assertEquals("receipt-evaluate", legacy.getAsJsonObject().get("receipt_id").getAsString());
+            assertTrue(body.get().contains("\"action\":\"legacy-read\""));
         } finally {
             server.stop(0);
         }
 
         HelmClient client = new HelmClient("http://127.0.0.1:1");
-        assertThrows(IllegalArgumentException.class, () -> client.evaluateDecision(new TypesGen.EvaluateRequest()
+        assertThrows(IllegalArgumentException.class, () -> client.evaluateDecisionV5(new TypesGen.EvaluateRequest()
                 .tool("read_file")
                 .effectLevel("read")
                 .sessionId(" ")));

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -31,7 +31,7 @@ been run.
 from helm_sdk import EvaluateRequest, HelmClient
 
 client = HelmClient(base_url="http://127.0.0.1:7714")
-decision = client.evaluate_decision(EvaluateRequest(
+decision = client.evaluate_decision_v5(EvaluateRequest(
     tool="read-ticket",
     effect_level="ticket:123",
     session_id="example-session",

--- a/sdk/python/helm_sdk/client.py
+++ b/sdk/python/helm_sdk/client.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import asdict, dataclass
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 from urllib.parse import quote
 
 import httpx
@@ -18,6 +18,7 @@ from .types_gen import (
     ChatCompletionResponse,
     ConformanceRequest,
     ConformanceResult,
+    DecisionRequest,
     EvaluateRequest,
     EvaluateResponse,
     Receipt,
@@ -223,13 +224,25 @@ class HelmClient:
         return result
 
     # ── Decision Evaluation ─────────────────────────
-    def evaluate_decision(self, req: EvaluateRequest) -> EvaluateResponse:
+    def evaluate_decision(
+        self, req: Union[DecisionRequest, dict[str, Any]]
+    ) -> dict[str, Any]:
+        """POST /api/v1/evaluate using the legacy dynamic contract.
+
+        Deprecated: use evaluate_decision_v5 for typed V5 requests and responses.
+        """
+        resp = self._client.post("/api/v1/evaluate", json=_json_body(req))
+        self._check(resp)
+        return cast(dict[str, Any], resp.json())
+
+    def evaluate_decision_v5(self, req: EvaluateRequest) -> EvaluateResponse:
+        """POST /api/v1/evaluate using the canonical V5 request and response."""
         if not isinstance(req, EvaluateRequest):
-            raise TypeError("evaluate_decision requires an EvaluateRequest")
+            raise TypeError("evaluate_decision_v5 requires an EvaluateRequest")
         for field in ("tool", "effect_level", "session_id"):
             value = getattr(req, field)
             if not isinstance(value, str) or not value.strip():
-                raise ValueError(f"evaluate_decision requires a non-blank {field}")
+                raise ValueError(f"evaluate_decision_v5 requires a non-blank {field}")
         resp = self._client.post("/api/v1/evaluate", json=_json_body(req))
         self._check(resp)
         result = EvaluateResponse.from_dict(resp.json())

--- a/sdk/python/tests/test_client_coverage_matrix.py
+++ b/sdk/python/tests/test_client_coverage_matrix.py
@@ -176,7 +176,30 @@ def test_check_handles_non_object_error_body() -> None:
 @pytest.mark.parametrize(
     ("method_name", "invoke", "response", "expected_method", "expected_path"),
     [
-        ("evaluate_decision", lambda c: c.evaluate_decision(EvaluateRequest(tool="read_file", effect_level="read", session_id="session-test")), EVALUATE_RESPONSE, "POST", "/api/v1/evaluate"),
+        (
+            "evaluate_decision",
+            lambda c: c.evaluate_decision(
+                {
+                    "action": "read_file",
+                    "resource": "read",
+                    "context": {"session_id": "legacy-session"},
+                }
+            ),
+            EVALUATE_RESPONSE,
+            "POST",
+            "/api/v1/evaluate",
+        ),
+        (
+            "evaluate_decision_v5",
+            lambda c: c.evaluate_decision_v5(
+                EvaluateRequest(
+                    tool="read_file", effect_level="read", session_id="session-test"
+                )
+            ),
+            EVALUATE_RESPONSE,
+            "POST",
+            "/api/v1/evaluate",
+        ),
         ("run_public_demo_empty_args", lambda c: c.run_public_demo("read_ticket"), {"ok": True}, "POST", "/api/demo/run"),
         ("run_public_demo_with_args", lambda c: c.run_public_demo("read_ticket", {"id": 1}), {"ok": True}, "POST", "/api/demo/run"),
         ("verify_public_demo_receipt", lambda c: c.verify_public_demo_receipt({"r": 1}, "hash"), {"ok": True}, "POST", "/api/demo/verify"),
@@ -270,20 +293,41 @@ def test_client_endpoint_matrix(method_name: str, invoke: Any, response: Any, ex
     if method_name == "export_evidence":
         assert result == b"bundle"
     if method_name == "evaluate_decision":
+        assert isinstance(result, dict)
+        assert result["receipt_id"] == "receipt-evaluate"
+        assert fake.calls[0][2]["json"] == {
+            "action": "read_file",
+            "resource": "read",
+            "context": {"session_id": "legacy-session"},
+        }
+    if method_name == "evaluate_decision_v5":
         assert isinstance(result, EvaluateResponse)
         assert result.receipt_id == "receipt-evaluate"
         assert fake.calls[0][2]["json"] == {"tool": "read_file", "effect_level": "read", "session_id": "session-test"}
 
 
-def test_evaluate_decision_rejects_legacy_or_blank_input_before_request() -> None:
+def test_evaluate_decision_v5_rejects_invalid_input_without_breaking_legacy() -> None:
     fake = FakeHTTPClient()
+    fake.queue(EVALUATE_RESPONSE)
     with patch("helm_sdk.client.httpx.Client", return_value=fake):
         client = HelmClient(base_url="http://h")
+        legacy = client.evaluate_decision(
+            {
+                "action": "read_file",
+                "resource": "read",
+                "context": {"session_id": "legacy-session"},
+            }
+        )
+        assert legacy["receipt_id"] == "receipt-evaluate"
         with pytest.raises(TypeError, match="EvaluateRequest"):
-            client.evaluate_decision({"tool": "read_file"})  # type: ignore[arg-type]
+            client.evaluate_decision_v5({"tool": "read_file"})  # type: ignore[arg-type]
         with pytest.raises(ValueError, match="non-blank session_id"):
-            client.evaluate_decision(EvaluateRequest.model_construct(tool="read_file", effect_level="read", session_id=""))
-    assert fake.calls == []
+            client.evaluate_decision_v5(
+                EvaluateRequest.model_construct(
+                    tool="read_file", effect_level="read", session_id=""
+                )
+            )
+    assert len(fake.calls) == 1
 
 
 def test_list_sessions_uses_params_for_query_values() -> None:

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -422,8 +422,17 @@ impl HelmClient {
         })
     }
 
-    /// POST /api/v1/evaluate
-    pub fn evaluate_decision(
+    /// POST /api/v1/evaluate using the legacy dynamic contract.
+    #[deprecated(note = "use evaluate_decision_v5 for the typed V5 contract")]
+    pub fn evaluate_decision<T: Serialize>(
+        &self,
+        req: &T,
+    ) -> Result<serde_json::Value, HelmApiError> {
+        self.post_value("/api/v1/evaluate", req)
+    }
+
+    /// POST /api/v1/evaluate using the canonical V5 request and response.
+    pub fn evaluate_decision_v5(
         &self,
         req: &EvaluateRequest,
     ) -> Result<EvaluateResponse, HelmApiError> {
@@ -435,7 +444,7 @@ impl HelmClient {
             if value.map(str::trim).is_none_or(str::is_empty) {
                 return Err(HelmApiError {
                     status: 0,
-                    message: format!("evaluate_decision requires a non-blank {field}"),
+                    message: format!("evaluate_decision_v5 requires a non-blank {field}"),
                     reason_code: ReasonCode::ErrorInternal,
                 });
             }
@@ -1201,7 +1210,7 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluate_decision_requires_canonical_v5_request() {
+    fn test_evaluate_decision_v5_requires_canonical_request() {
         let request = EvaluateRequest {
             tool: Some("read_file".to_string()),
             effect_level: Some("read".to_string()),
@@ -1220,9 +1229,23 @@ mod tests {
             session_id: Some(" ".to_string()),
             ..EvaluateRequest::new()
         };
-        let err = client.evaluate_decision(&blank).unwrap_err();
+        let err = client.evaluate_decision_v5(&blank).unwrap_err();
         assert_eq!(err.status, 0);
         assert!(err.message.contains("non-blank session_id"));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn test_legacy_evaluate_decision_accepts_dynamic_request() {
+        let client = HelmClient::new("http://127.0.0.1:1");
+        let err = client
+            .evaluate_decision(&serde_json::json!({
+                "action": "read_file",
+                "resource": "read",
+                "context": {"session_id": "legacy-session"},
+            }))
+            .unwrap_err();
+        assert_eq!(err.status, 0);
     }
 
     #[test]

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -36,7 +36,7 @@ npm run build
 import { HelmClient } from "@mindburn/helm-ai-kernel";
 
 const client = new HelmClient({ baseUrl: "http://127.0.0.1:7714" });
-const decision = await client.evaluateDecision({
+const decision = await client.evaluateDecisionV5({
   tool: "read-ticket",
   effect_level: "ticket:123",
   session_id: "example-session",
@@ -44,10 +44,10 @@ const decision = await client.evaluateDecision({
 console.log(decision.verdict); // ALLOW or DENY
 ```
 
-`tool`, `effect_level`, and `session_id` must all be non-blank. The SDK sends
-only this canonical V5 request shape; legacy direct-daemon callers are not an
-SDK contract. The authenticated principal, not a body `principal`, is recorded
-on the receipt.
+`tool`, `effect_level`, and `session_id` must all be non-blank for
+`evaluateDecisionV5`. The legacy `evaluateDecision` method remains available
+for existing direct-daemon callers. The authenticated principal, not a body
+`principal`, is recorded on the receipt.
 
 Run the first-class local example with `make sdk-examples-smoke` or directly
 from `examples/ts_sdk/`.

--- a/sdk/ts/src/client-coverage.test.ts
+++ b/sdk/ts/src/client-coverage.test.ts
@@ -44,7 +44,8 @@ describe("HelmClient coverage matrix", () => {
 
   it("exercises every JSON endpoint wrapper", async () => {
     const calls: Array<[string, unknown[]]> = [
-      ["evaluateDecision", [{ tool: "read_file", effect_level: "read_file", session_id: "current-session" }]],
+      ["evaluateDecision", [{ action: "read_file", resource: "read_file", context: { session_id: "legacy-session" } }]],
+      ["evaluateDecisionV5", [{ tool: "read_file", effect_level: "read_file", session_id: "current-session" }]],
       ["runPublicDemo", ["read_ticket", { id: 1 }]],
       ["verifyPublicDemoReceipt", [{ receipt_id: "r1" }, "hash"]],
       ["approveIntent", [{ intent_hash: "h", signature_b64: "sig", public_key_b64: "pk" }]],
@@ -149,6 +150,23 @@ describe("HelmClient coverage matrix", () => {
     });
   });
 
+  it("retains the legacy dynamic evaluate request and response", async () => {
+    const response = { decision_id: "decision-legacy" };
+    fetchSpy.mockResolvedValueOnce(jsonResponse(response));
+
+    const result = await client.evaluateDecision({
+      action: "read_file",
+      resource: "read_file",
+      context: { session_id: "legacy-session" },
+    });
+    expect(result.decision_id).toBe("decision-legacy");
+    expect(JSON.parse(String((fetchSpy.mock.calls[0]?.[1] as RequestInit).body))).toEqual({
+      action: "read_file",
+      resource: "read_file",
+      context: { session_id: "legacy-session" },
+    });
+  });
+
   it("uses the canonical V5 evaluate request and response", async () => {
     const response = {
       allow: true,
@@ -162,7 +180,7 @@ describe("HelmClient coverage matrix", () => {
     };
     fetchSpy.mockResolvedValueOnce(jsonResponse(response));
 
-    const result = await client.evaluateDecision({
+    const result = await client.evaluateDecisionV5({
       tool: "read_file",
       effect_level: "read_file",
       session_id: "current-session",
@@ -176,7 +194,7 @@ describe("HelmClient coverage matrix", () => {
   });
 
   it("rejects blank canonical evaluate fields before making a request", async () => {
-    await expect(client.evaluateDecision({
+    await expect(client.evaluateDecisionV5({
       tool: "read_file",
       effect_level: "read_file",
       session_id: "  ",

--- a/sdk/ts/src/client.ts
+++ b/sdk/ts/src/client.ts
@@ -13,6 +13,7 @@ import type {
   VersionInfo,
   HelmError,
   ReasonCode,
+  DecisionRequest,
   EvaluateRequest,
   EvaluateResponse,
 } from './types.gen.js';
@@ -294,8 +295,13 @@ export class HelmClient {
   }
 
   // ── Decision Evaluation ──────────────────────────
-  async evaluateDecision(req: EvaluateDecisionRequest): Promise<EvaluateDecisionResponse> {
-	validateEvaluateDecisionRequest(req);
+  /** @deprecated Use evaluateDecisionV5 for the typed V5 contract. */
+  async evaluateDecision(req: DecisionRequest | SurfaceRecord): Promise<SurfaceRecord> {
+    return this.request<SurfaceRecord>('POST', '/api/v1/evaluate', req);
+  }
+
+  async evaluateDecisionV5(req: EvaluateDecisionRequest): Promise<EvaluateDecisionResponse> {
+    validateEvaluateDecisionRequest(req);
     return this.request<EvaluateDecisionResponse>('POST', '/api/v1/evaluate', req);
   }
 


### PR DESCRIPTION
## Summary
- restores the historical dynamic evaluate APIs in Go, Python, TypeScript, Java, and Rust
- exposes the typed canonical V5 evaluator through separately named V5 methods
- updates coverage, docs, and live SDK examples for the two contracts

## Scope
- no OpenAPI or generated SDK artifact changes
- based on current main; the server-side receipt fixes already present there remain unchanged
- this is a fresh compatibility-only replacement and does not modify or close #735

## Validation
- Go SDK tests
- Python SDK: 171 passed
- TypeScript SDK: 45 passed and TypeScript build
- Java SDK tests
- Rust SDK tests
- pinned OpenAPI SDK regeneration and manifest verification
- boundary verification and live SDK examples smoke
- focused current-main receipt P1 tests: decision IDs, tenant-wide cursors, authenticated executor tenant scope