### PR TITLE
fix(release): pin Console workflow and peer admission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,9 +196,23 @@ jobs:
           GH_TOKEN: ${{ secrets.CONSOLE_BUNDLE_TOKEN }}
           CONSOLE_REPOSITORY: ${{ steps.console-pin.outputs.repository }}
           CONSOLE_SOURCE_SHA: ${{ steps.console-pin.outputs.source_sha }}
+          CONSOLE_WORKFLOW_REF: ${{ steps.console-pin.outputs.workflow_ref }}
         run: |
           set -euo pipefail
           command -v gh >/dev/null
+          case "${CONSOLE_WORKFLOW_REF}" in
+            refs/tags/*) ;;
+            *)
+              echo "::error::Console workflow_ref must be an immutable refs/tags/... source pin."
+              exit 1
+              ;;
+          esac
+          workflow_tag="${CONSOLE_WORKFLOW_REF#refs/tags/}"
+          workflow_sha="$(gh api "repos/${CONSOLE_REPOSITORY}/commits/${workflow_tag}" --jq '.sha')"
+          if [ "${workflow_sha}" != "${CONSOLE_SOURCE_SHA}" ]; then
+            echo "::error::Console workflow_ref ${CONSOLE_WORKFLOW_REF} resolves to ${workflow_sha}, not pinned source ${CONSOLE_SOURCE_SHA}. Create a protected immutable tag at the pinned source before releasing."
+            exit 1
+          fi
           prior_runs="${RUNNER_TEMP}/console-local-sidecar-prior-runs.txt"
           gh run list \
             --repo "${CONSOLE_REPOSITORY}" \
@@ -209,7 +223,7 @@ jobs:
             --jq '.[].databaseId' | sort > "${prior_runs}"
           gh workflow run release-local-sidecar.yml \
             --repo "${CONSOLE_REPOSITORY}" \
-            --ref main \
+            --ref "${workflow_tag}" \
             -f source_sha="${CONSOLE_SOURCE_SHA}" \
             -f kernel_release_version="${GITHUB_REF_NAME}"
 

--- a/core/cmd/helm-ai-kernel/local_console.go
+++ b/core/cmd/helm-ai-kernel/local_console.go
@@ -63,8 +63,6 @@ const (
 	localConsoleReadyTimeout                    = 5 * time.Second
 	localConsoleReadyRetry                      = 50 * time.Millisecond
 	localConsoleStopTimeout                     = 3 * time.Second
-	localConsolePeerReplayTTL                   = 10 * time.Minute
-	localConsolePeerReplayLimit                 = 4096
 )
 
 var (
@@ -1025,41 +1023,23 @@ func validLocalConsoleSecret(secret string) bool {
 
 type localConsolePeerProof struct {
 	secret string
-
-	mu   sync.Mutex
-	used map[string]time.Time
 }
 
 func newLocalConsolePeerProof(secret string) (*localConsolePeerProof, error) {
 	if !validLocalConsoleSecret(secret) {
 		return nil, fmt.Errorf("local Console peer secret is invalid")
 	}
-	return &localConsolePeerProof{secret: secret, used: make(map[string]time.Time)}, nil
+	return &localConsolePeerProof{secret: secret}, nil
 }
 
 func (p *localConsolePeerProof) prove(nonce string) (string, bool) {
 	if p == nil || !validLocalConsoleReadyNonce(nonce) {
 		return "", false
 	}
-	now := time.Now().UTC()
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if p.used == nil {
-		p.used = make(map[string]time.Time)
-	}
-	for previousNonce, issuedAt := range p.used {
-		if now.Sub(issuedAt) >= localConsolePeerReplayTTL {
-			delete(p.used, previousNonce)
-		}
-	}
-	if _, seen := p.used[nonce]; seen || len(p.used) >= localConsolePeerReplayLimit {
-		return "", false
-	}
 	proof := localConsolePeerProofValue(p.secret, nonce)
 	if proof == "" {
 		return "", false
 	}
-	p.used[nonce] = now
 	return proof, true
 }
 

--- a/core/cmd/helm-ai-kernel/local_console.go
+++ b/core/cmd/helm-ai-kernel/local_console.go
@@ -49,7 +49,7 @@ const (
 	localConsoleReleaseComponent                = "app-helm-console"
 	localConsoleReleaseRepository               = "Mindburn-Labs/app-helm-console"
 	localConsoleCosignIssuer                    = "https://token.actions.githubusercontent.com"
-	localConsoleCosignIdentity                  = "https://github.com/Mindburn-Labs/app-helm-console/.github/workflows/release-local-sidecar.yml@refs/heads/main"
+	localConsoleCosignIdentityPrefix            = "https://github.com/Mindburn-Labs/app-helm-console/.github/workflows/release-local-sidecar.yml@"
 	localConsoleInventoryMaxBytes               = 16 * 1024 * 1024
 	localConsoleBundleMaxBytes            int64 = 512 * 1024 * 1024
 	localConsoleReadyPath                       = "/api/runtime/local-sidecar-ready"
@@ -280,12 +280,11 @@ func validateLocalConsoleReleaseManifest(manifest localConsoleReleaseManifest, r
 	if !validLocalConsoleSource(manifest.Source) {
 		return localConsoleReleaseTarget{}, fmt.Errorf("local Console release manifest source is invalid")
 	}
-	if manifest.OuterSignature != (localConsoleOuterSignature{
-		SignedFile:          localConsoleReleaseManifestFile,
-		Bundle:              localConsoleReleaseManifestBundleFile,
-		Issuer:              localConsoleCosignIssuer,
-		CertificateIdentity: localConsoleCosignIdentity,
-	}) {
+	outerSignature := manifest.OuterSignature
+	if outerSignature.SignedFile != localConsoleReleaseManifestFile ||
+		outerSignature.Bundle != localConsoleReleaseManifestBundleFile ||
+		outerSignature.Issuer != localConsoleCosignIssuer ||
+		!validLocalConsoleCosignIdentity(outerSignature.CertificateIdentity) {
 		return localConsoleReleaseTarget{}, fmt.Errorf("local Console release manifest outer signature contract is invalid")
 	}
 	expectedTargets := []string{"linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64"}
@@ -362,6 +361,26 @@ func validLocalConsoleSemver(value string) bool {
 func validLocalConsoleSource(source localConsoleSource) bool {
 	return validLowerHex(source.Commit, 20) && validLowerHex(source.Tree, 20) &&
 		validLocalConsoleSemver(source.Version) && validLowerHex(source.PackageLockSHA256, sha256.Size)
+}
+
+func validLocalConsoleCosignIdentity(value string) bool {
+	workflowRef, ok := strings.CutPrefix(value, localConsoleCosignIdentityPrefix)
+	return ok && validLocalConsoleWorkflowRef(workflowRef)
+}
+
+func validLocalConsoleWorkflowRef(value string) bool {
+	const prefix = "refs/tags/"
+	tag, ok := strings.CutPrefix(value, prefix)
+	if !ok || tag == "" {
+		return false
+	}
+	for index, character := range tag {
+		if (index == 0 && !((character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9'))) ||
+			!((character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z') || (character >= '0' && character <= '9') || character == '-' || character == '.' || character == '_' || character == '/' || character == '+') {
+			return false
+		}
+	}
+	return true
 }
 
 func validateLocalConsoleReleaseLayout(consoleRoot string, manifest localConsoleReleaseManifest) error {

--- a/core/cmd/helm-ai-kernel/local_console_test.go
+++ b/core/cmd/helm-ai-kernel/local_console_test.go
@@ -385,7 +385,7 @@ func TestLocalConsoleReadinessRequiresHMACWithoutCredentialsOnWire(t *testing.T)
 	}
 }
 
-func TestLocalConsolePeerProofRouteRequiresFreshLoopbackNonceWithoutBearer(t *testing.T) {
+func TestLocalConsolePeerProofRouteRequiresValidLoopbackNonceWithoutBearer(t *testing.T) {
 	secret := strings.Repeat("a", 64)
 	peer, err := newLocalConsolePeerProof(secret)
 	if err != nil {
@@ -424,12 +424,17 @@ func TestLocalConsolePeerProofRouteRequiresFreshLoopbackNonceWithoutBearer(t *te
 		t.Fatalf("peer proof = %q, want %q", got, wantProof)
 	}
 
-	// A proof nonce is one-time: replayed proof requests fail closed instead of
-	// becoming a reusable peer-authentication oracle.
+	// The Console verifier owns CSPRNG nonce freshness and validates the shared
+	// secret HMAC. The Kernel must not reserve unauthenticated nonce slots.
 	replay := httptest.NewRecorder()
 	mux.ServeHTTP(replay, request)
-	if replay.Code != http.StatusNotFound || replay.Header().Get(localConsolePeerProofHeader) != "" {
+	if replay.Code != http.StatusOK || !hmac.Equal([]byte(replay.Header().Get(localConsolePeerProofHeader)), []byte(wantProof)) {
 		t.Fatalf("replayed peer proof = status %d headers %#v", replay.Code, replay.Header())
+	}
+	for i := 0; i <= 4096; i++ {
+		if _, ok := peer.prove(fmt.Sprintf("%064x", i)); !ok {
+			t.Fatalf("valid peer nonce %d was rejected", i)
+		}
 	}
 
 	head := httptest.NewRequest(http.MethodHead, localConsolePeerProofPath, nil)

--- a/core/cmd/helm-ai-kernel/local_console_test.go
+++ b/core/cmd/helm-ai-kernel/local_console_test.go
@@ -476,6 +476,23 @@ func TestLocalConsolePeerProofRouteRequiresValidLoopbackNonceWithoutBearer(t *te
 	}
 }
 
+func TestLocalConsoleCosignIdentityRequiresImmutableConsoleWorkflowTag(t *testing.T) {
+	valid := localConsoleCosignIdentityPrefix + "refs/tags/helm-console-sidecar-v0.8.0"
+	if !validLocalConsoleCosignIdentity(valid) {
+		t.Fatalf("valid Console workflow identity rejected: %q", valid)
+	}
+	for _, identity := range []string{
+		localConsoleCosignIdentityPrefix + "main",
+		localConsoleCosignIdentityPrefix + "refs/heads/main",
+		localConsoleCosignIdentityPrefix + "refs/tags/.mutable",
+		"https://github.com/Mindburn-Labs/other/.github/workflows/release-local-sidecar.yml@refs/tags/helm-console-sidecar-v0.8.0",
+	} {
+		if validLocalConsoleCosignIdentity(identity) {
+			t.Fatalf("mutable or foreign Console workflow identity accepted: %q", identity)
+		}
+	}
+}
+
 func TestLocalConsolePeerProofRouteIsAbsentOutsideConsoleMode(t *testing.T) {
 	peer, err := newLocalConsolePeerProof(strings.Repeat("a", 64))
 	if err != nil {
@@ -1175,7 +1192,7 @@ func writeTrustedLocalConsoleRelease(t *testing.T, executable, runtimeTarget str
 			SignedFile:          localConsoleReleaseManifestFile,
 			Bundle:              localConsoleReleaseManifestBundleFile,
 			Issuer:              localConsoleCosignIssuer,
-			CertificateIdentity: localConsoleCosignIdentity,
+			CertificateIdentity: localConsoleCosignIdentityPrefix + "refs/tags/test-console-source",
 		},
 	}
 	var selected localConsoleBundle

--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -1,9 +1,10 @@
 {
-  "schema": "helm.console.local-sidecar.source-pins.v1",
+  "schema": "helm.console.local-sidecar.source-pins.v2",
   "pins": [
     {
       "kernel_release_version": "v0.8.0",
       "source_repository": "Mindburn-Labs/app-helm-console",
+      "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
         "commit": "f9583f9a218cd557c82c79e853b6d2dfbbd86906",
         "tree": "4a5cfca92bfab2eab6008cd703a023b009df9c83",

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -132,6 +132,17 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertRegex(post_release, r"- name: Check full published version status\n\s+if: always\(\)")
         self.assertRegex(post_release, r"- name: Replace release version status with full post-release status\n\s+if: always\(\)")
 
+    def test_console_dispatch_uses_an_immutable_ref_bound_to_the_source_pin(self) -> None:
+        console_sidecar = self.job("console-local-sidecar")
+        self.assertIn("CONSOLE_WORKFLOW_REF: ${{ steps.console-pin.outputs.workflow_ref }}", console_sidecar)
+        self.assertIn('case "${CONSOLE_WORKFLOW_REF}" in', console_sidecar)
+        self.assertIn('refs/tags/*) ;;', console_sidecar)
+        self.assertIn('workflow_tag="${CONSOLE_WORKFLOW_REF#refs/tags/}"', console_sidecar)
+        self.assertIn('gh api "repos/${CONSOLE_REPOSITORY}/commits/${workflow_tag}" --jq \'.sha\'', console_sidecar)
+        self.assertIn('[ "${workflow_sha}" != "${CONSOLE_SOURCE_SHA}" ]', console_sidecar)
+        self.assertIn('--ref "${workflow_tag}"', console_sidecar)
+        self.assertNotIn("--ref main", console_sidecar)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/release/console_local_sidecar.py
+++ b/scripts/release/console_local_sidecar.py
@@ -23,7 +23,7 @@ from typing import Any
 
 
 MANIFEST_SCHEMA = "helm.console.local-sidecar.release-manifest.v1"
-PINS_SCHEMA = "helm.console.local-sidecar.source-pins.v1"
+PINS_SCHEMA = "helm.console.local-sidecar.source-pins.v2"
 COMPONENT = "app-helm-console"
 CONSOLE_REPOSITORY = "Mindburn-Labs/app-helm-console"
 MANIFEST_NAME = "helm-console-local-sidecar-release-manifest.json"
@@ -39,6 +39,7 @@ KERNEL_BINARY_NAMES = {target: f"helm-ai-kernel-{target}" for target in TARGETS}
 HEX_64 = re.compile(r"^[0-9a-f]{64}$")
 SHA_40 = re.compile(r"^[0-9a-f]{40}$")
 SAFE_FILE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+IMMUTABLE_WORKFLOW_REF = re.compile(r"^refs/tags/[0-9A-Za-z][-0-9A-Za-z._/+]*$")
 INNER_PROVENANCE_SCHEMA = "helm.console.local-sidecar.provenance.v1"
 UNSIGNED_INNER_SIGNATURE = "none; this unsigned local artifact has no release authority"
 BUNDLE_MAX_BYTES = 512 * 1024 * 1024
@@ -92,6 +93,12 @@ def require_sha(value: Any, label: str) -> str:
 def require_safe_file_name(value: Any, label: str) -> str:
     if not isinstance(value, str) or not SAFE_FILE_NAME.fullmatch(value):
         reject(f"{label} must be a safe basename")
+    return value
+
+
+def require_immutable_workflow_ref(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not IMMUTABLE_WORKFLOW_REF.fullmatch(value):
+        reject(f"{label} must be an immutable refs/tags/... reference")
     return value
 
 
@@ -536,7 +543,7 @@ def load_pins(path: Path) -> list[dict[str, Any]]:
 def resolve_pin(pins_path: Path, kernel_release: str) -> dict[str, Any]:
     matches: list[dict[str, Any]] = []
     for value in load_pins(pins_path):
-        pin = require_exact_keys(value, {"kernel_release_version", "source_repository", "source"}, "source pin")
+        pin = require_exact_keys(value, {"kernel_release_version", "source_repository", "source", "workflow_ref"}, "source pin")
         if pin["kernel_release_version"] == kernel_release:
             matches.append(pin)
     if len(matches) != 1:
@@ -545,7 +552,13 @@ def resolve_pin(pins_path: Path, kernel_release: str) -> dict[str, Any]:
     if pin["source_repository"] != CONSOLE_REPOSITORY:
         reject("Console source pin names an unexpected repository")
     source = require_source(pin["source"], "source pin.source")
-    return {"kernel_release_version": kernel_release, "source_repository": CONSOLE_REPOSITORY, "source": source}
+    workflow_ref = require_immutable_workflow_ref(pin["workflow_ref"], "source pin.workflow_ref")
+    return {
+        "kernel_release_version": kernel_release,
+        "source_repository": CONSOLE_REPOSITORY,
+        "source": source,
+        "workflow_ref": workflow_ref,
+    }
 
 
 def verify_cosign(manifest: Path, bundle: Path) -> None:
@@ -842,6 +855,7 @@ def write_github_output(pin: dict[str, Any]) -> None:
     with Path(output).open("a", encoding="utf-8") as handle:
         handle.write(f"repository={pin['source_repository']}\n")
         handle.write(f"source_sha={pin['source']['commit']}\n")
+        handle.write(f"workflow_ref={pin['workflow_ref']}\n")
 
 
 def write_github_manifest_output(manifest_sha256: str) -> None:

--- a/scripts/release/console_local_sidecar.py
+++ b/scripts/release/console_local_sidecar.py
@@ -30,9 +30,9 @@ MANIFEST_NAME = "helm-console-local-sidecar-release-manifest.json"
 MANIFEST_BUNDLE_NAME = f"{MANIFEST_NAME}.cosign.bundle"
 KERNEL_MANIFEST_BUNDLE_NAME = f"{MANIFEST_NAME}.kernel.cosign.bundle"
 COSIGN_ISSUER = "https://token.actions.githubusercontent.com"
-COSIGN_IDENTITY = (
+COSIGN_IDENTITY_PREFIX = (
     "https://github.com/Mindburn-Labs/app-helm-console/"
-    ".github/workflows/release-local-sidecar.yml@refs/heads/main"
+    ".github/workflows/release-local-sidecar.yml@"
 )
 TARGETS = ("linux-amd64", "linux-arm64", "darwin-amd64", "darwin-arm64")
 KERNEL_BINARY_NAMES = {target: f"helm-ai-kernel-{target}" for target in TARGETS}
@@ -100,6 +100,10 @@ def require_immutable_workflow_ref(value: Any, label: str) -> str:
     if not isinstance(value, str) or not IMMUTABLE_WORKFLOW_REF.fullmatch(value):
         reject(f"{label} must be an immutable refs/tags/... reference")
     return value
+
+
+def console_cosign_identity(workflow_ref: str) -> str:
+    return COSIGN_IDENTITY_PREFIX + require_immutable_workflow_ref(workflow_ref, "Console workflow ref")
 
 
 def require_nonempty_string(value: Any, label: str) -> str:
@@ -561,7 +565,8 @@ def resolve_pin(pins_path: Path, kernel_release: str) -> dict[str, Any]:
     }
 
 
-def verify_cosign(manifest: Path, bundle: Path) -> None:
+def verify_cosign(manifest: Path, bundle: Path, workflow_ref: str) -> None:
+    identity = console_cosign_identity(workflow_ref)
     try:
         subprocess.run(
             [
@@ -570,7 +575,7 @@ def verify_cosign(manifest: Path, bundle: Path) -> None:
                 "--bundle",
                 str(bundle),
                 "--certificate-identity",
-                COSIGN_IDENTITY,
+                identity,
                 "--certificate-oidc-issuer",
                 COSIGN_ISSUER,
                 str(manifest),
@@ -622,6 +627,7 @@ def verify_release(
     expected_manifest_sha256: str | None = None,
 ) -> list[Path]:
     pin = resolve_pin(pins_path, kernel_release)
+    expected_identity = console_cosign_identity(pin["workflow_ref"])
     manifest = locate_unique(root, MANIFEST_NAME, "Console aggregate release manifest")
     bundle = locate_unique(root, MANIFEST_BUNDLE_NAME, "Console aggregate manifest cosign bundle")
     manifest_sha256 = sha256_path(manifest)
@@ -651,11 +657,11 @@ def verify_release(
         "signed_file": MANIFEST_NAME,
         "bundle": MANIFEST_BUNDLE_NAME,
         "issuer": COSIGN_ISSUER,
-        "certificate_identity": COSIGN_IDENTITY,
+        "certificate_identity": expected_identity,
     }:
         reject("Console aggregate release manifest has an unexpected outer signature contract")
     if require_cosign:
-        verify_cosign(manifest, bundle)
+        verify_cosign(manifest, bundle, pin["workflow_ref"])
 
     if not isinstance(payload["targets"], list):
         reject("Console aggregate release manifest targets must be a list")

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -33,6 +33,7 @@ RELEASE_SOURCE_PIN = {
     "version": "0.2.1",
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }
+RELEASE_WORKFLOW_REF = "refs/tags/helm-console-sidecar-v0.8.0"
 
 
 def digest(data: bytes) -> str:
@@ -182,6 +183,7 @@ def build_release(root: Path, *, target_mutators: dict[str, dict[str, object]] |
             "kernel_release_version": "v0.8.0",
             "source_repository": sidecar.CONSOLE_REPOSITORY,
             "source": SOURCE,
+            "workflow_ref": "refs/tags/test-console-source",
         }],
     }), encoding="utf-8")
     return root, pins
@@ -469,6 +471,22 @@ class ConsoleLocalSidecarTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "exactly one Console source pin"):
                 sidecar.verify_release(root, pins, "v0.8.0", require_cosign=False)
 
+    def test_release_rejects_missing_or_mutable_workflow_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root, pins = build_release(Path(directory))
+            payload = json.loads(pins.read_text(encoding="utf-8"))
+            for label, workflow_ref in (("missing", None), ("main", "main"), ("branch", "refs/heads/main")):
+                with self.subTest(label=label):
+                    candidate = json.loads(json.dumps(payload))
+                    pin = candidate["pins"][0]
+                    if workflow_ref is None:
+                        del pin["workflow_ref"]
+                    else:
+                        pin["workflow_ref"] = workflow_ref
+                    pins.write_text(json.dumps(candidate), encoding="utf-8")
+                    with self.assertRaisesRegex(ValueError, "workflow_ref|invalid fields"):
+                        sidecar.resolve_pin(pins, "v0.8.0")
+
     def test_release_rejects_checksum_descriptor_that_does_not_bind_archive(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root, pins = build_release(Path(directory))
@@ -532,13 +550,14 @@ class ConsoleLocalSidecarTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "ordered exactly"):
                 sidecar.verify_release(root, pins, "v0.8.0", require_cosign=False)
 
-    def test_v080_source_pin_matches_the_authenticated_console_main_tuple(self) -> None:
+    def test_v080_source_pin_matches_the_exact_console_release_contract(self) -> None:
         pin = sidecar.resolve_pin(
             REPOSITORY_ROOT / "release/console-local-sidecar-pins.json",
             "v0.8.0",
         )
         self.assertEqual(pin["source_repository"], sidecar.CONSOLE_REPOSITORY)
         self.assertEqual(pin["source"], RELEASE_SOURCE_PIN)
+        self.assertEqual(pin["workflow_ref"], RELEASE_WORKFLOW_REF)
 
     def test_manifest_digest_flows_into_normal_and_reproducible_linker_flags(self) -> None:
         expected_digest = "d" * 64

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -34,6 +34,7 @@ RELEASE_SOURCE_PIN = {
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }
 RELEASE_WORKFLOW_REF = "refs/tags/helm-console-sidecar-v0.8.0"
+TEST_WORKFLOW_REF = "refs/tags/test-console-source"
 
 
 def digest(data: bytes) -> str:
@@ -168,7 +169,7 @@ def build_release(root: Path, *, target_mutators: dict[str, dict[str, object]] |
             "signed_file": sidecar.MANIFEST_NAME,
             "bundle": sidecar.MANIFEST_BUNDLE_NAME,
             "issuer": sidecar.COSIGN_ISSUER,
-            "certificate_identity": sidecar.COSIGN_IDENTITY,
+            "certificate_identity": sidecar.console_cosign_identity(TEST_WORKFLOW_REF),
         },
     }
     manifest_dir = root / "aggregate"
@@ -183,7 +184,7 @@ def build_release(root: Path, *, target_mutators: dict[str, dict[str, object]] |
             "kernel_release_version": "v0.8.0",
             "source_repository": sidecar.CONSOLE_REPOSITORY,
             "source": SOURCE,
-            "workflow_ref": "refs/tags/test-console-source",
+            "workflow_ref": TEST_WORKFLOW_REF,
         }],
     }), encoding="utf-8")
     return root, pins
@@ -487,6 +488,18 @@ class ConsoleLocalSidecarTests(unittest.TestCase):
                     with self.assertRaisesRegex(ValueError, "workflow_ref|invalid fields"):
                         sidecar.resolve_pin(pins, "v0.8.0")
 
+    def test_release_rejects_outer_signature_not_bound_to_pinned_workflow_ref(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root, pins = build_release(Path(directory))
+            manifest = next(root.rglob(sidecar.MANIFEST_NAME))
+            payload = json.loads(manifest.read_text(encoding="utf-8"))
+            payload["outer_signature"]["certificate_identity"] = sidecar.console_cosign_identity(
+                "refs/tags/other-console-source"
+            )
+            manifest.write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "unexpected outer signature contract"):
+                sidecar.verify_release(root, pins, "v0.8.0", require_cosign=False)
+
     def test_release_rejects_checksum_descriptor_that_does_not_bind_archive(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root, pins = build_release(Path(directory))
@@ -593,7 +606,7 @@ class ConsoleLocalSidecarTests(unittest.TestCase):
                 "#!/usr/bin/env bash\n"
                 "case \" $* \" in\n"
                 "  *\" --certificate-identity https://github.com/Mindburn-Labs/helm-ai-kernel/.github/workflows/release.yml@refs/tags/v0.8.0 \"*) exit 0 ;;\n"
-                "  *\" --certificate-identity https://github.com/Mindburn-Labs/app-helm-console/.github/workflows/release-local-sidecar.yml@refs/heads/main \"*) exit 0 ;;\n"
+                "  *\" --certificate-identity https://github.com/Mindburn-Labs/app-helm-console/.github/workflows/release-local-sidecar.yml@refs/tags/helm-console-sidecar-v0.8.0 \"*) exit 0 ;;\n"
                 "  *) exit 23 ;;\n"
                 "esac\n",
                 encoding="utf-8",

--- a/scripts/release/verify_cosign.sh
+++ b/scripts/release/verify_cosign.sh
@@ -13,6 +13,7 @@
 # Caller: Makefile target `verify-cosign`. Documented in docs/VERIFICATION.md.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DIR="${1:-dist}"
 DEFAULT_IDENTITY_REGEX='^https://github\.com/Mindburn-Labs/helm-ai-kernel/\.github/workflows/release\.yml@refs/(heads/main|tags/v[0-9]+\.[0-9]+\.[0-9]+.*)$'
 IDENTITY_REGEX="${COSIGN_IDENTITY_REGEX:-$DEFAULT_IDENTITY_REGEX}"
@@ -20,7 +21,7 @@ ISSUER="${COSIGN_OIDC_ISSUER:-https://token.actions.githubusercontent.com}"
 CONSOLE_MANIFEST="helm-console-local-sidecar-release-manifest.json"
 CONSOLE_PRODUCER_BUNDLE="${CONSOLE_MANIFEST}.cosign.bundle"
 KERNEL_MANIFEST_BUNDLE="helm-console-local-sidecar-release-manifest.json.kernel.cosign.bundle"
-CONSOLE_PRODUCER_IDENTITY="https://github.com/Mindburn-Labs/app-helm-console/.github/workflows/release-local-sidecar.yml@refs/heads/main"
+CONSOLE_PRODUCER_IDENTITY=""
 KERNEL_RELEASE_IDENTITY=""
 
 if ! printf '%s' "$IDENTITY_REGEX" | grep -Eq '^\^https://github\\?\.com/Mindburn-Labs/helm-ai-kernel/\\?\.github/workflows/[A-Za-z0-9_.-]+\\?\.ya?ml@refs/'; then
@@ -74,6 +75,16 @@ PY
         exit 1
     fi
     KERNEL_RELEASE_IDENTITY="https://github.com/Mindburn-Labs/helm-ai-kernel/.github/workflows/release.yml@refs/tags/${kernel_release_tag}"
+    if ! console_workflow_ref="$(
+        python3 "$ROOT/scripts/release/console_local_sidecar.py" pin \
+            --pins "$ROOT/release/console-local-sidecar-pins.json" \
+            --kernel-release "$kernel_release_tag" | \
+            python3 -c 'import json, sys; print(json.load(sys.stdin)["workflow_ref"])'
+    )"; then
+        echo "::error::Console release verification requires an immutable workflow_ref in the checked-in source pin"
+        exit 1
+    fi
+    CONSOLE_PRODUCER_IDENTITY="https://github.com/Mindburn-Labs/app-helm-console/.github/workflows/release-local-sidecar.yml@${console_workflow_ref}"
 fi
 
 ok=0
@@ -81,8 +92,8 @@ fail=0
 while IFS= read -r bundle; do
     case "$(basename "$bundle")" in
         "$CONSOLE_PRODUCER_BUNDLE")
-            # The Console source tuple is immutable, while its producer
-            # workflow is protected-main trust. The tag-bound Kernel bundle
+            # The Console source tuple and its producer workflow ref are
+            # both checked-in immutable pins. The tag-bound Kernel bundle
             # below is the public-release binding for this manifest.
             if [ -z "$KERNEL_RELEASE_IDENTITY" ]; then
                 echo "::error::Console producer bundle requires an exact Kernel release identity"


### PR DESCRIPTION
## Summary

- Require an explicit `workflow_ref` in the Console source pin, accept only `refs/tags/...`, resolve it through GitHub, and require it to equal the pinned Console source SHA before dispatching the Console sidecar workflow.
- Bind the Console manifest Cosign certificate identity to that same checked-in `workflow_ref` in the release verifier and post-release verifier; local bundled validation accepts only the fixed Console workflow at an immutable tag, while the compiled manifest SHA binds its exact identity.
- Remove the unauthenticated global peer-nonce replay reservation that allowed a loopback caller to exhaust 4,096 slots; retain strict nonce validation, loopback-only routing, bearer suppression, and shared-secret HMAC proof.
- Add contract, negative, mismatch, and exhaustion regressions.

## Validation

- `python3 scripts/release/console_local_sidecar_test.py` (28 tests)
- `python3 scripts/ci/release_workflow_contract_test.py` (5 tests)
- `go test ./cmd/helm-ai-kernel -count=1`
- `make version-drift`
- `git diff --check`

## Explicit owner gate

This intentionally fails closed until `refs/tags/helm-console-sidecar-v0.8.0` is an owner-created protected immutable Console tag that resolves exactly to `f9583f9a218cd557c82c79e853b6d2dfbbd86906`. The Console sidecar workflow must first be made tag-runnable, emit the matching tag certificate identity, and assert its own checked-out SHA before that tag is created. No mutable `main` fallback is present.