### PR TITLE
fix(release): advance Console sidecar source pin

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,8 +6,8 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
-        "commit": "f9583f9a218cd557c82c79e853b6d2dfbbd86906",
-        "tree": "4a5cfca92bfab2eab6008cd703a023b009df9c83",
+        "commit": "8a8677661209a3a0d1317bca1cd161e0174b412f",
+        "tree": "5ae87328e148174661e771053bb1370c6f81da51",
         "version": "0.2.1",
         "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076"
       }

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,8 +28,8 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "f9583f9a218cd557c82c79e853b6d2dfbbd86906",
-    "tree": "4a5cfca92bfab2eab6008cd703a023b009df9c83",
+    "commit": "8a8677661209a3a0d1317bca1cd161e0174b412f",
+    "tree": "5ae87328e148174661e771053bb1370c6f81da51",
     "version": "0.2.1",
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }


### PR DESCRIPTION
## Summary

- advance the v0.8.0 Console source commit and tree to the merged #113 tag-run/OIDC repair
- retain the planned immutable workflow ref `refs/tags/helm-console-sidecar-v0.8.0`
- keep the source lock digest and version re-derived from the same merged Console commit

## Validation

- canonical `console_local_sidecar.py pin` resolver
- `console_local_sidecar_test.py` (28 tests)
- `release_workflow_contract_test.py` (5 tests)
- `TestLocalConsole` Kernel boundary tests
- `make test`

## Owner-only activation gate

No Console tag, release, workflow dispatch, artifact publication, secret change, or deployment was performed. After this pin is merged, an authorized owner must protect and create `helm-console-sidecar-v0.8.0` at exactly `8a8677661209a3a0d1317bca1cd161e0174b412f`; never repoint an existing tag.