### PR TITLE
feat(cli): guide first local Console journey

### DIFF
--- a/core/cmd/helm-ai-kernel/cli_support.go
+++ b/core/cmd/helm-ai-kernel/cli_support.go
@@ -30,21 +30,44 @@ func supportMatrix() cliSupportMatrix {
 
 func printFrontDoor(out io.Writer) {
 	fmt.Fprintf(out, "%s %s (%s)\n\n", terminalTitle(out, "HELM AI Kernel"), displayVersion(), displayCommit())
-	fmt.Fprintln(out, "Start:")
-	fmt.Fprintln(out, "  helm-ai-kernel quickstart")
-	fmt.Fprintln(out, "  helm-ai-kernel setup claude-code --yes")
-	fmt.Fprintln(out, "  helm-ai-kernel setup codex --yes")
-	fmt.Fprintln(out, "")
-	fmt.Fprintln(out, "Inspect:")
-	fmt.Fprintln(out, "  helm-ai-kernel scan --path . --preview out.md")
-	fmt.Fprintln(out, "  helm-ai-kernel receipts tail --agent <id>")
-	fmt.Fprintln(out, "")
-	fmt.Fprintln(out, "Operate:")
-	fmt.Fprintln(out, "  helm-ai-kernel mcp authorize-call --server-id <id> --tool-name <tool>")
-	fmt.Fprintln(out, "")
-	fmt.Fprintln(out, "More:")
-	fmt.Fprintln(out, "  helm-ai-kernel help --all")
-	fmt.Fprintln(out, "  helm-ai-kernel help --json")
+	renderer := ui.NewRenderer(out, frontDoorCapabilities(out))
+	renderer.WriteTimeline("Your first governed-agent run", []ui.Step{
+		{
+			Status: ui.StatusWait,
+			Title:  "Launch local Kernel and browser Console",
+			Detail: "helm-ai-kernel quickstart --console (requires a Console-including package; it stays loopback-only).",
+		},
+		{
+			Status: ui.StatusWait,
+			Title:  "Connect the coding agent you use",
+			Detail: "helm-ai-kernel setup codex or helm-ai-kernel setup claude-code. Interactive terminals show the scoped change before confirmation.",
+		},
+		{
+			Status: ui.StatusWait,
+			Title:  "Review live decisions when they need you",
+			Detail: "helm-ai-kernel watch. Approve or deny only after the complete server-derived ceremony is shown.",
+		},
+	})
+	renderer.WriteCompletion(ui.CompletionCard{
+		Title: "Useful next commands",
+		Fields: []ui.KeyValue{
+			{Key: "Inspect", Value: "helm-ai-kernel scan --path . --preview out.md"},
+			{Key: "Receipts", Value: "helm-ai-kernel receipts tail --agent <id>"},
+			{Key: "Automation", Value: "helm-ai-kernel help --json"},
+		},
+		NextAction: "Run helm-ai-kernel help --all for every command.",
+	})
+}
+
+func frontDoorCapabilities(out io.Writer) ui.Capabilities {
+	file, ok := out.(*os.File)
+	if !ok {
+		return ui.Capabilities{Width: ui.DefaultTerminalWidth}
+	}
+	return ui.DetectCapabilities(os.Stdin, file, ui.TerminalOptions{
+		Format: ui.FormatText,
+		Color:  ui.ColorAuto,
+	})
 }
 
 func printSupportMatrix(out io.Writer) {

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -50,9 +50,9 @@ func TestRun_Help(t *testing.T) {
 	exitCode := Run(args, &stdout, &stderr)
 
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout.String(), "Start:")
-	assert.Contains(t, stdout.String(), "Inspect:")
-	assert.Contains(t, stdout.String(), "Operate:")
+	assert.Contains(t, stdout.String(), "Your first governed-agent run")
+	assert.Contains(t, stdout.String(), "Launch local Kernel and browser Console")
+	assert.Contains(t, stdout.String(), "Review live decisions when they need you")
 	assert.Contains(t, stdout.String(), "helm-ai-kernel help --all")
 }
 
@@ -61,10 +61,12 @@ func TestRunNoArgsPrintsFrontDoor(t *testing.T) {
 	exitCode := Run([]string{"helm"}, &stdout, &stderr)
 
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout.String(), "helm-ai-kernel quickstart")
-	assert.Contains(t, stdout.String(), "helm-ai-kernel setup claude-code --yes")
-	assert.Contains(t, stdout.String(), "helm-ai-kernel mcp authorize-call")
-	assert.NotContains(t, stdout.String(), "watch")
+	assert.Contains(t, stdout.String(), "helm-ai-kernel quickstart --console")
+	assert.Contains(t, stdout.String(), "requires a Console-including package")
+	assert.Contains(t, stdout.String(), "helm-ai-kernel setup claude-code")
+	assert.Contains(t, stdout.String(), "helm-ai-kernel setup codex")
+	assert.Contains(t, stdout.String(), "helm-ai-kernel watch")
+	assert.Contains(t, stdout.String(), "helm-ai-kernel help --json")
 	assert.Empty(t, stderr.String())
 }
 


### PR DESCRIPTION
## Why

The existing CLI renderer and guarded approval flow were already present but the no-argument front door hid the local browser Console and the reviewed approval path behind a long command catalog.

## Change

- replace the static command taxonomy with a three-step local journey: loopback Console, Codex/Claude Code setup, and reviewed approvals;
- reuse the existing safe renderer so TTY output is compact and visual while pipes remain plain;
- state the Console package requirement explicitly and keep JSON/help behavior unchanged.

## Validation

- `GOWORK=off go test ./cmd/helm-ai-kernel -count=1`
- terminal smoke with `TERM=xterm-256color COLUMNS=100 GOWORK=off go run ./cmd/helm-ai-kernel`

No approval action, machine-readable output, or release behavior changed.