### PR TITLE
docs(launchpad): correct catalog refresh review flow

### DIFF
--- a/docs/launchpad/MODEL_PROVIDER_CATALOG.md
+++ b/docs/launchpad/MODEL_PROVIDER_CATALOG.md
@@ -4,7 +4,7 @@ Launchpad BYO model egress is governed by `core/pkg/launchpad/modelproviders/cat
 
 The catalog records the provider id, jurisdiction region, API protocol, runtime env names, required env groups, HTTPS base URLs, dynamic base URL envs, egress host suffixes, and official source URLs for primary US, EU, and China LLM API providers. Local-container egress preflight rejects model-provider destinations that are not in this catalog.
 
-The scheduled `Launchpad Model Provider Catalog` workflow runs `scripts/launch/update_model_provider_catalog.py` daily. It normalizes the catalog, checks official source URLs, and opens a PR if the canonical catalog changes.
+The scheduled `Launchpad Model Provider Catalog` workflow runs `scripts/launch/update_model_provider_catalog.py` daily. Scheduled runs produce review evidence only: when a refresh changes the catalog, the workflow captures a reviewable patch and changed-paths artifact; it never creates a branch, commit, or pull request. A human can download the candidate from a manually dispatched run, apply it in an owned branch, and review it through the normal pull-request workflow.
 When run with `--network --write`, the updater also regenerates
 `core/pkg/launchpad/modelproviders/source_fingerprints.json`. That file stores
 stable SHA-256 fingerprints for the official provider docs listed in

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -132,6 +132,16 @@ func TestLaunchpadAutomationDoesNotCreateRefsOrPullRequests(t *testing.T) {
 	requireContains(t, catalogWorkflow, "reviewable catalog refresh candidate")
 	requireContains(t, catalogWorkflow, "Upload catalog refresh candidate")
 
+	catalogDoc := readDoc(t, root, "docs/launchpad/MODEL_PROVIDER_CATALOG.md")
+	requireNotContains(t, catalogDoc, "opens a PR if the canonical catalog changes", "docs/launchpad/MODEL_PROVIDER_CATALOG.md")
+	for _, want := range []string{
+		"Scheduled runs produce review evidence only",
+		"it never creates a branch, commit, or pull request",
+		"A human can download the candidate from a manually dispatched run",
+	} {
+		requireContains(t, catalogDoc, want)
+	}
+
 	artifactWorkflow := readDoc(t, root, ".github/workflows/launchpad-artifacts.yml")
 	for _, forbidden := range []string{
 		"git push",


### PR DESCRIPTION
## Summary

- correct the model-provider catalog documentation to describe evidence/patch capture rather than automatic branch or PR creation
- extend the existing Launchpad claims-truth regression to keep the documentation aligned with the workflow

## Validation

- `go test ./tests/launchpad -run '^TestLaunchpadAutomationDoesNotCreateRefsOrPullRequests$' -count=1`\n- `make docs-coverage docs-truth`