### PR TITLE
fix(release): pin Console sidecar to c90

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,8 +6,8 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
-        "commit": "8a8677661209a3a0d1317bca1cd161e0174b412f",
-        "tree": "5ae87328e148174661e771053bb1370c6f81da51",
+        "commit": "c90f783e12cc626563d1d8c071b865b5488e666f",
+        "tree": "892a8bd469bb9a266fce50420758af8df4ed2855",
         "version": "0.2.1",
         "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076"
       }

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,8 +28,8 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "8a8677661209a3a0d1317bca1cd161e0174b412f",
-    "tree": "5ae87328e148174661e771053bb1370c6f81da51",
+    "commit": "c90f783e12cc626563d1d8c071b865b5488e666f",
+    "tree": "892a8bd469bb9a266fce50420758af8df4ed2855",
     "version": "0.2.1",
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }


### PR DESCRIPTION
## Summary
- Advances the v0.8.0 checked-in Console source tuple to `c90f783e12cc626563d1d8c071b865b5488e666f` / `892a8bd469bb9a266fce50420758af8df4ed2855`.
- Keeps the existing release version, package-lock digest, and immutable workflow ref unchanged.
- Updates the exact-pin contract expectation alongside the source pin.

## Validation
- `python3 scripts/release/console_local_sidecar_test.py`
- `python3 scripts/ci/release_workflow_contract_test.py`
- `make release-smoke`

## Release gate
`refs/tags/helm-console-sidecar-v0.8.0` is intentionally not created here. A human must create the protected immutable Console tag at the pinned `c90f...` commit before the later Kernel tag release can dispatch and verify the sidecar build. This PR performs no tag, dispatch, publish, or deployment.