### PR TITLE
fix(release): pin Console sidecar to 03e3

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,8 +6,8 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
-        "commit": "c90f783e12cc626563d1d8c071b865b5488e666f",
-        "tree": "892a8bd469bb9a266fce50420758af8df4ed2855",
+        "commit": "03e3c2ea56cee3a50f9ea3cb72e031bf9c586d72",
+        "tree": "126aae475aec529441bb8b4edc3068f5464c33ab",
         "version": "0.2.1",
         "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076"
       }

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,8 +28,8 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "c90f783e12cc626563d1d8c071b865b5488e666f",
-    "tree": "892a8bd469bb9a266fce50420758af8df4ed2855",
+    "commit": "03e3c2ea56cee3a50f9ea3cb72e031bf9c586d72",
+    "tree": "126aae475aec529441bb8b4edc3068f5464c33ab",
     "version": "0.2.1",
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }


### PR DESCRIPTION
## Summary
- Retargets the v0.8 Console local-sidecar source pin from `c90f783e…` / `892a8bd…` to current Console `main` commit `03e3c2ea…` / tree `126aae475…`.
- Updates the focused source-pin contract test to the same immutable tuple.
- Keeps the workflow tag reference, Console version (`0.2.1`), and `package-lock.json` SHA-256 unchanged after verification.

## Evidence
Current Console `main` was verified at:
- commit: `03e3c2ea56cee3a50f9ea3cb72e031bf9c586d72`
- tree: `126aae475aec529441bb8b4edc3068f5464c33ab`
- version: `0.2.1`
- lock SHA-256: `1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076`

## Validation
- `python3 scripts/release/console_local_sidecar_test.py` (28 tests)
- Exact JSON tuple assertion for commit, tree, version, and lock digest

## Out of scope
No tag, dispatch workflow, release artifact, image publication, deployment, or version/lockfile update.