### PR TITLE
fix(ci): fail closed contract-breaking gates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,8 +22,10 @@ surface for the `helm-ai-kernel` project.
 - `make openapi-breaking` / `make proto-breaking` run the contract
   breaking-change gate (HELM-151 GATE 1) against the PR base branch —
   `oasdiff` for the OpenAPI surfaces, `buf breaking` for the policy-schema
-  protos. Both now run in the `pr` profile; a major-version bump or the
-  `contract:breaking-approved` PR label is the explicit override.
+  protos. The PR profile has no mutable label or environment override;
+  only a source-controlled major-version bump permits a break. The release
+  profile runs `make contract-breaking-release` against the commit resolved
+  from the immutable prior version tag, never current `origin/main`.
 
 ## Active Quality Workflows
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,16 @@ jobs:
           # GOTOOLCHAIN=local on Go 1.25, so `go install` cannot build it.
           ver=1.23.0
           tmp="$(mktemp -d)"
-          curl -fsSL "https://github.com/oasdiff/oasdiff/releases/download/v${ver}/oasdiff_${ver}_linux_amd64.tar.gz" \
-            | tar -xz -C "$tmp"
+          archive="$tmp/oasdiff_${ver}_linux_amd64.tar.gz"
+          sha256='972b10535c3db4366b9dc3ebc11ca021279af3095267c3cffdca854a3a3c4f89'
+          curl -fsSL -o "$archive" "https://github.com/oasdiff/oasdiff/releases/download/v${ver}/oasdiff_${ver}_linux_amd64.tar.gz"
+          printf '%s  %s\n' "$sha256" "$archive" | sha256sum --check --strict -
+          tar -xzf "$archive" -C "$tmp"
           mkdir -p "$HOME/.local/bin"
           install -m 0755 "$tmp/oasdiff" "$HOME/.local/bin/oasdiff"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           "$HOME/.local/bin/oasdiff" --version
       - name: Run Make-first PR quality profile
-        env:
-          # `contract:breaking-approved` label downgrades a contract break to a
-          # visible warning (HELM-151 GATE 1 override).
-          CONTRACT_BREAKING_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'contract:breaking-approved') && '1' || '0' }}
         run: make quality-pr
 
   hygiene:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,8 @@ jobs:
     needs: release-preflight
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          fetch-depth: 0
       - name: Install presentation hygiene dependency
         run: |
           set -euo pipefail
@@ -102,13 +104,20 @@ jobs:
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ github.token }}
-      - name: Fetch main ref for proto compatibility checks
+      - name: Install oasdiff (prior-release contract breaking-change gate)
         run: |
-          if [ "$(git symbolic-ref --short -q HEAD || true)" = "main" ]; then
-            echo "On main; local refs/heads/main is already HEAD — nothing to fetch."
-          else
-            git fetch origin main:refs/heads/main --force
-          fi
+          set -euo pipefail
+          ver=1.23.0
+          tmp="$(mktemp -d)"
+          archive="$tmp/oasdiff_${ver}_linux_amd64.tar.gz"
+          sha256='972b10535c3db4366b9dc3ebc11ca021279af3095267c3cffdca854a3a3c4f89'
+          curl -fsSL -o "$archive" "https://github.com/oasdiff/oasdiff/releases/download/v${ver}/oasdiff_${ver}_linux_amd64.tar.gz"
+          printf '%s  %s\n' "$sha256" "$archive" | sha256sum --check --strict -
+          tar -xzf "$archive" -C "$tmp"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$tmp/oasdiff" "$HOME/.local/bin/oasdiff"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/oasdiff" --version
       - name: Install codegen tools
         run: |
           python -m pip install --require-hashes -r .github/codegen-requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: build test test-cli test-race test-approval-ceremony test-approval-ceremony-postgres test-receipt-store-postgres-migration test-connector-release-authority-postgres test-effect-reservation-postgres verify-approval-ceremony-vectors verify-generated-spec-approval-ceremony-vectors verify-connector-release-authority-vectors verify-effect-close-vectors verify-effect-disposition-vectors verify-boundary-profile-vectors verify-update-bundle-vectors test-sdk-go-standalone test-sdk-ts test-platform test-sdk-py test-sdk-rust test-sdk-java sdk-openapi-check sdk-gen-check sdk-manifest-verify test-sdk-manifest sdk-examples-smoke verify-fixtures verify-presentation tee-collateral-verify test-all bench bench-report lint proto-lint proto-breaking openapi-breaking docker-verify release-readiness crucible proxy docker docker-up docker-smoke compose-smoke helm-chart-smoke kind-smoke deployment-smoke release-smoke version-drift version-drift-report version-drift-published version-status prepare-version sbom vex provenance onboard demo-cli mcp-pack mcp-install release-binaries release-binaries-reproducible release-assets build-release release-all verify-boundary verify-cosign bench-pin codegen codegen-go codegen-python codegen-ts codegen-java codegen-rust codegen-check quality-pr quality-merge quality-release quality-nightly quality-list quality-explain quality-self-test quality-typecheck quality-contracts quality-security quality-runbooks quality-mutation quality-flake quality-impact clean docs-coverage docs-truth launch-record-assets real-use-assets launch-release-dry-run launch-ready conformance-release-report conformance-release-gate
 .PHONY: test-generated-spec-approval-ceremony-postgres
+.PHONY: contract-breaking-release test-contract-breaking
 
 # VERSION is source-controlled release truth. Tag-triggered workflows must
 # check that GITHUB_REF_NAME equals v$(VERSION) before any publish step.
@@ -182,6 +183,13 @@ proto-breaking:
 openapi-breaking:
 	bash scripts/ci/contract_breaking.sh openapi
 
+contract-breaking-release:
+	bash scripts/ci/contract_breaking.sh openapi release
+	bash scripts/ci/contract_breaking.sh proto release
+
+test-contract-breaking:
+	bash scripts/ci/test_contract_breaking.sh
+
 docker-verify:
 	docker build -f Dockerfile -t helm-ai-kernel:verify-root .
 	docker build -f Dockerfile.slim -t helm-ai-kernel:verify-slim .
@@ -189,7 +197,7 @@ docker-verify:
 	docker build -f core/Dockerfile.api -t helm-ai-kernel:verify-core-api .
 	docker build -f oss-fuzz/Dockerfile -t helm-ai-kernel:verify-oss-fuzz oss-fuzz
 
-release-readiness: version-drift verify-boundary docs-truth test-sdk-go-standalone sdk-examples-smoke proto-lint proto-breaking docker-verify conformance-release-gate deployment-smoke release-smoke
+release-readiness: version-drift verify-boundary docs-truth test-sdk-go-standalone sdk-examples-smoke proto-lint contract-breaking-release docker-verify conformance-release-gate deployment-smoke release-smoke
 	@echo "✅ Release readiness gate passed"
 
 crucible: build

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -39,7 +39,7 @@ make quality-impact
 | --- | --- | --- |
 | PR | `make quality-pr` | Fast documentation, hygiene, Go, TCB, boundary, fixture, and impacted SDK/UI checks. |
 | Merge | `make quality-merge` | Full retained-surface gate with race tests, SDKs, contracts, deployment smoke, and release smoke. |
-| Release | `make quality-release` | Release-readiness gate plus reproducible binaries, SBOM, VEX, Cosign bundle verification when available, and release smoke. |
+| Release | `make quality-release` | Release-readiness gate plus prior-release OpenAPI and Proto compatibility checks, reproducible binaries, SBOM, VEX, Cosign bundle verification when available, and release smoke. |
 | Nightly | `make quality-nightly` | Advisory mutation, flake, vulnerability, runbook, migration, dependency hygiene, schema, and benchmark checks. |
 
 `make quality-pr` runs path-scoped package gates only when changed files impact

--- a/scripts/ci/contract_breaking.sh
+++ b/scripts/ci/contract_breaking.sh
@@ -1,49 +1,116 @@
 #!/usr/bin/env bash
 # HELM-151 / GATE 1 — contract breaking-change gate.
 #
-# Diffs an API contract surface against the PR's base branch and fails on a
-# backward-incompatible change, so a break cannot merge silently while the
-# version number claims compatibility. Two escapes, both explicit and visible:
-#   * major bump   — if the contract's major version was raised, the break is
-#                    intended and signalled by the version, so the gate passes.
-#   * label override — CONTRACT_BREAKING_APPROVED=1 (set by CI from the
-#                    `contract:breaking-approved` PR label) downgrades a failure
-#                    to a warning for deliberate pre-1.0 / pre-GA churn.
+# Diffs an API contract surface against its required baseline and fails on a
+# backward-incompatible change, so a break cannot merge or release silently
+# while the version number claims compatibility. A source-controlled
+# major-version bump remains the only compatibility escape; mutable PR labels
+# and environment variables never downgrade this gate.
 #
-# Usage: contract_breaking.sh <openapi|proto>
-# Base ref comes from GITHUB_BASE_REF (default: main). Runs locally and in CI.
+# Usage: contract_breaking.sh <openapi|proto> [base|release]
+# "base" (default) compares against the exact remote PR base named by
+# GITHUB_BASE_REF (default: main). "release" compares against the commit
+# resolved from the nearest prior version tag, never current origin/main.
 set -euo pipefail
 
 kind="${1:?usage: contract_breaking.sh <openapi|proto>}"
+baseline_mode="${2:-base}"
 base_ref="${GITHUB_BASE_REF:-main}"
-approved="${CONTRACT_BREAKING_APPROVED:-0}"
 
-# Resolve the base to something git can read (prefer the remote-tracking ref).
-git fetch --quiet origin "$base_ref" 2>/dev/null || true
-base="origin/${base_ref}"
-git rev-parse --verify --quiet "${base}^{commit}" >/dev/null 2>&1 || base="$base_ref"
+case "$kind" in
+openapi | proto) ;;
+*)
+  echo "unknown kind: ${kind} (expected: openapi | proto)" >&2
+  exit 2
+  ;;
+esac
+
+case "$baseline_mode" in
+base | release) ;;
+*)
+  echo "unknown contract-gate baseline mode: ${baseline_mode} (expected: base | release)" >&2
+  exit 2
+  ;;
+esac
+
+resolve_pr_base() {
+  if ! git check-ref-format --branch "$base_ref" >/dev/null 2>&1; then
+    echo "::error::invalid contract-gate base ref: ${base_ref}" >&2
+    exit 2
+  fi
+
+  base="origin/${base_ref}"
+  if ! git fetch --quiet --no-tags origin "refs/heads/${base_ref}:refs/remotes/origin/${base_ref}"; then
+    echo "::error::unable to resolve contract-gate base ref origin/${base_ref}" >&2
+    exit 2
+  fi
+  if ! git rev-parse --verify --quiet "${base}^{commit}" >/dev/null 2>&1; then
+    echo "::error::resolved contract-gate base ref is not a commit: ${base}" >&2
+    exit 2
+  fi
+  base_label="$base"
+}
+
+resolve_release_base() {
+  if ! head="$(git rev-parse --verify 'HEAD^{commit}')"; then
+    echo "::error::unable to resolve release contract-gate HEAD" >&2
+    exit 2
+  fi
+  if ! current_version="$(tr -d '[:space:]' < VERSION)"; then
+    echo "::error::missing VERSION for release contract-gate baseline" >&2
+    exit 2
+  fi
+
+  current_tag="v${current_version}"
+  start="$head"
+  if current_tag_commit="$(git rev-parse --verify --quiet "${current_tag}^{commit}")"; then
+    if [ "$current_tag_commit" = "$head" ]; then
+      if ! start="$(git rev-parse --verify "${head}^")"; then
+        echo "::error::release contract-gate has no commit before ${current_tag}" >&2
+        exit 2
+      fi
+    fi
+  fi
+  if ! prior_tag="$(git describe --tags --abbrev=0 --match 'v[0-9]*' "$start" 2>/dev/null)"; then
+    echo "::error::unable to resolve an immutable prior release tag for contract-gate" >&2
+    exit 2
+  fi
+  if ! base="$(git rev-parse --verify --quiet "${prior_tag}^{commit}")"; then
+    echo "::error::prior release tag ${prior_tag} does not resolve to a commit" >&2
+    exit 2
+  fi
+  base_label="${prior_tag} (${base})"
+  echo "contract release baseline: ${base_label}"
+}
+
+case "$baseline_mode" in
+base) resolve_pr_base ;;
+release) resolve_release_base ;;
+esac
 
 major() { printf '%s' "${1%%.*}"; }              # "1.4.0" -> "1"
 
-is_approved() {                                  # portable lower-case (macOS bash 3.2 has no ${x,,})
-  case "$(printf '%s' "$approved" | tr '[:upper:]' '[:lower:]')" in
-  1 | true | yes | on) return 0 ;;
-  *) return 1 ;;
-  esac
-}
-
-# $1 = surface label, $2 = differ output. Blocks unless the label override is set.
+# $1 = surface label, $2 = differ output. Approval must be represented by
+# source-controlled compatibility/versioning policy, not mutable PR data.
 report_break() {
-  if is_approved; then
-    printf '::warning::%s: backward-incompatible change present, overridden by the contract:breaking-approved label\n' "$1"
-    printf '%s\n' "$2"
-    return 0
-  fi
   printf '::error::%s: backward-incompatible contract change without a major bump\n' "$1"
   printf '%s\n' "$2"
-  # shellcheck disable=SC2016  # backticks are literal markdown, not a shell expansion
-  printf 'Fix it, bump the major version, or add the `contract:breaking-approved` label to override.\n'
+  printf 'Fix it or make an intentional, source-controlled major-version bump.\n'
   return 1
+}
+
+# $1 = surface label, $2 = tool exit status, $3 = tool output.
+report_tool_error() {
+  printf '::error::%s failed with exit %s; refusing to treat a tool failure as a contract break\n' "$1" "$2"
+  printf '%s\n' "$3"
+}
+
+# Buf emits exit 100 for file-annotation findings, including blocking
+# compatibility results. Normalize that class to the same gate exit as an
+# OpenAPI compatibility finding; all other non-zero exits are tool failures.
+report_buf_finding() {
+  printf '::error::%s reported a blocking contract finding\n' "$1"
+  printf '%s\n' "$2"
 }
 
 openapi_version() {                              # <ref-or-WORKTREE> <spec-path>; "" if absent
@@ -59,10 +126,10 @@ openapi)
     exit 2
   }
   specs=(api/openapi/helm.openapi.yaml protocols/specs/effects/openapi.yaml)
-  broke=1
+  broke=0
   for spec in "${specs[@]}"; do
     if ! git cat-file -e "${base}:${spec}" 2>/dev/null; then
-      echo "openapi ${spec}: new on this branch (no base to diff) — skip"
+      echo "openapi ${spec}: new on this branch (no baseline spec to diff) — skip"
       continue
     fi
     cur_major="$(major "$(openapi_version WORKTREE "$spec")")"
@@ -72,36 +139,59 @@ openapi)
       continue
     fi
     base_file="$(mktemp)"
-    git show "${base}:${spec}" >"$base_file"
-    # oasdiff `breaking` prints changes but exits 0 by default; --fail-on ERR
-    # makes it exit non-zero on an ERR-level (backward-incompatible) change.
-    if out="$(oasdiff breaking "$base_file" "$spec" --fail-on ERR 2>&1)"; then
-      echo "openapi ${spec}: no backward-incompatible changes vs ${base}"
+    if ! git show "${base}:${spec}" >"$base_file"; then
+      rm -f "$base_file"
+      echo "::error::unable to read openapi ${spec} from contract-gate baseline ${base_label}" >&2
+      exit 2
+    fi
+    # oasdiff breaking prints changes but exits 0 by default; --fail-on ERR
+    # exits 1 for an ERR-level compatibility finding. Require that exit 1 to
+    # carry a non-empty JSON finding list; otherwise it is an operational
+    # failure and must not be misreported as a diff.
+    if out="$(oasdiff breaking "$base_file" "$spec" --fail-on ERR --format json 2>&1)"; then
+      echo "openapi ${spec}: no backward-incompatible changes vs ${base_label}"
     else
-      report_break "openapi ${spec}" "$out" || broke=0
+      tool_exit=$?
+      rm -f "$base_file"
+      if [ "$tool_exit" -eq 1 ] && printf '%s' "$out" | python3 -c 'import json, sys; report = json.load(sys.stdin); raise SystemExit(0 if isinstance(report, list) and report else 1)' >/dev/null 2>&1; then
+        report_break "openapi ${spec}" "$out" || broke=1
+        continue
+      fi
+      report_tool_error "oasdiff for openapi ${spec}" "$tool_exit" "$out"
+      exit 2
     fi
     rm -f "$base_file"
   done
-  [ "$broke" -eq 0 ] && exit 1
+  [ "$broke" -ne 0 ] && exit 1
   echo "GATE 1 (openapi): pass"
   ;;
 proto)
   command -v buf >/dev/null 2>&1 || { echo "::error::buf is required for the proto breaking gate"; exit 2; }
-  cur_major="$(major "$(cat VERSION 2>/dev/null || echo 0)")"
-  base_major="$(major "$(git show "${base}:VERSION" 2>/dev/null || echo "$cur_major")")"
+  if ! current_version="$(cat VERSION 2>/dev/null)"; then
+    echo "::error::missing VERSION in contract-gate worktree" >&2
+    exit 2
+  fi
+  cur_major="$(major "$current_version")"
+  if ! base_version="$(git show "${base}:VERSION" 2>/dev/null)"; then
+    echo "::error::missing VERSION in contract-gate baseline ${base_label}" >&2
+    exit 2
+  fi
+  base_major="$(major "$base_version")"
   if [[ "$cur_major" =~ ^[0-9]+$ && "$base_major" =~ ^[0-9]+$ && "$cur_major" -gt "$base_major" ]]; then
     echo "proto: major ${base_major} -> ${cur_major} — break allowed by version bump"
     exit 0
   fi
   against=".git#ref=${base},subdir=protocols/policy-schema"
   if out="$(buf breaking protocols/policy-schema --against "$against" 2>&1)"; then
-    echo "GATE 1 (proto): pass — no backward-incompatible changes vs ${base}"
+    echo "GATE 1 (proto): pass — no backward-incompatible changes vs ${base_label}"
   else
-    report_break "proto (protocols/policy-schema)" "$out"
+    tool_exit=$?
+    if [ "$tool_exit" -eq 100 ]; then
+      report_buf_finding "buf breaking for protocols/policy-schema" "$out"
+      exit 1
+    fi
+    report_tool_error "buf breaking for protocols/policy-schema" "$tool_exit" "$out"
+    exit 2
   fi
-  ;;
-*)
-  echo "unknown kind: ${kind} (expected: openapi | proto)" >&2
-  exit 2
   ;;
 esac

--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -27,6 +27,7 @@
         "rust-sdk",
         "java-sdk",
         "json-schemas",
+        "contract-breaking-self-test",
         "proto-breaking",
         "openapi-breaking"
       ]
@@ -62,6 +63,7 @@
         "sdk-openapi-check",
         "codegen-drift",
         "proto-lint",
+        "contract-breaking-self-test",
         "proto-breaking",
         "deployment-smoke",
         "release-smoke"
@@ -97,7 +99,8 @@
         "sdk-openapi-check",
         "codegen-drift",
         "proto-lint",
-        "proto-breaking",
+        "contract-breaking-self-test",
+        "contract-breaking-release",
         "benchmark-report",
         "release-readiness",
         "reproducible-binaries",
@@ -507,6 +510,38 @@
       "paths": [
         "protocols/policy-schema/**",
         "buf.yaml",
+        "Makefile"
+      ]
+    },
+    {
+      "id": "contract-breaking-self-test",
+      "title": "Contract-breaking gate regression test",
+      "description": "Proves unavailable bases and differ execution failures fail closed, while mutable label-style input cannot override a break.",
+      "command": "make test-contract-breaking",
+      "timeout_seconds": 120,
+      "paths": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/release.yml",
+        "scripts/ci/contract_breaking.sh",
+        "scripts/ci/test_contract_breaking.sh",
+        "scripts/ci/quality-gates.json",
+        "scripts/ci/quality.py",
+        "Makefile"
+      ]
+    },
+    {
+      "id": "contract-breaking-release",
+      "title": "Prior-release contract-breaking check",
+      "description": "Diffs OpenAPI and policy-schema contracts against the commit resolved from the immutable prior release tag.",
+      "command": "make contract-breaking-release",
+      "timeout_seconds": 600,
+      "paths": [
+        ".github/workflows/release.yml",
+        "api/openapi/**",
+        "protocols/specs/effects/openapi.yaml",
+        "protocols/policy-schema/**",
+        "VERSION",
+        "scripts/ci/contract_breaking.sh",
         "Makefile"
       ]
     },

--- a/scripts/ci/quality.py
+++ b/scripts/ci/quality.py
@@ -26,6 +26,8 @@ EXPECTED_GATE_IDS = {
     "boundary-manifest",
     "quantum-crypto-inventory",
     "codegen-drift",
+    "contract-breaking-self-test",
+    "contract-breaking-release",
     "proto-breaking",
     "json-schemas",
     "sdk-openapi-check",

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -45,6 +45,14 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertIn("needs: release-preflight", self.job("validate"))
         self.assertIn("release-preflight", self.job("github-release"))
 
+    def test_release_validation_has_the_prior_release_contract_toolchain(self) -> None:
+        validate = self.job("validate")
+        self.assertIn("fetch-depth: 0", validate)
+        self.assertIn("Install oasdiff (prior-release contract breaking-change gate)", validate)
+        self.assertIn("sha256sum --check --strict", validate)
+        self.assertIn("make quality-release", validate)
+        self.assertNotIn("Fetch main ref for proto compatibility checks", validate)
+
     def test_release_never_creates_a_catalog_pr_or_bypasses_tap_policy(self) -> None:
         self.assertNotIn("downstream-fanout:", self.workflow)
         homebrew = self.job("homebrew")

--- a/scripts/ci/test_contract_breaking.sh
+++ b/scripts/ci/test_contract_breaking.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Hermetic regression coverage for HELM-151 contract-breaking gate behavior.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+fail() {
+  printf 'contract-breaking self-test failed: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_status() {
+  [ "$actual_status" -eq "$1" ] || fail "expected exit $1, got $actual_status for $case_name"
+}
+
+assert_contains() {
+  grep -Fq "$1" "$case_output" || fail "expected $case_name output to contain: $1"
+}
+
+assert_not_contains() {
+  if grep -Fq "$1" "$case_output"; then
+    fail "expected $case_name output not to contain: $1"
+  fi
+}
+
+assert_oasdiff_invocations() {
+  actual_invocations="$(wc -l < "$oasdiff_log" | tr -d '[:space:]')"
+  [ "$actual_invocations" = "$1" ] || fail "expected $1 oasdiff invocation(s), got $actual_invocations for $case_name"
+}
+
+assert_buf_invocations() {
+  actual_invocations="$(wc -l < "$buf_log" | tr -d '[:space:]')"
+  [ "$actual_invocations" = "$1" ] || fail "expected $1 buf invocation(s), got $actual_invocations for $case_name"
+}
+
+assert_buf_log_contains() {
+  grep -Fq "$1" "$buf_log" || fail "expected $case_name buf invocation to contain: $1"
+}
+
+write_openapi() {
+  mkdir -p "$(dirname "$1")"
+  printf '%s\n' \
+    'openapi: 3.0.3' \
+    'info:' \
+    '  title: contract gate fixture' \
+    '  version: 1.0.0' \
+    'paths: {}' > "$1"
+}
+
+origin="$work/origin.git"
+seed="$work/seed"
+feature="$work/feature"
+fake_bin="$work/fake-bin"
+oasdiff_log="$work/oasdiff.log"
+buf_log="$work/buf.log"
+
+git init --bare "$origin" >/dev/null
+git clone "$origin" "$seed" >/dev/null
+(
+  cd "$seed"
+  git config user.name 'HELM contract gate test'
+  git config user.email 'contract-gate-test@example.invalid'
+  write_openapi api/openapi/helm.openapi.yaml
+  write_openapi protocols/specs/effects/openapi.yaml
+  mkdir -p protocols/policy-schema
+  printf '%s\n' '1.0.0' > VERSION
+  git add VERSION api/openapi/helm.openapi.yaml protocols/specs/effects/openapi.yaml protocols/policy-schema
+  git commit -m 'test: seed contract base' >/dev/null
+  git branch -M main
+  git tag v1.0.0
+  git push origin main >/dev/null
+  git push origin v1.0.0 >/dev/null
+)
+git clone --branch main "$origin" "$feature" >/dev/null
+(
+  cd "$feature"
+  git config user.name 'HELM contract gate test'
+  git config user.email 'contract-gate-test@example.invalid'
+  printf '%s\n' '1.0.1' > VERSION
+  git add VERSION
+  git commit -m 'test: release candidate' >/dev/null
+)
+release_base="$(git -C "$feature" rev-parse 'v1.0.0^{commit}')"
+
+mkdir -p "$fake_bin"
+# shellcheck disable=SC2016 # Intentional literal expansion in the generated fake executable.
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "%s\n" "$*" >> "$OASDIFF_LOG"' \
+  'if [ "${FAKE_OASDIFF_BREAKING:-0}" = 1 ]; then printf "%s\n" "[{\"level\":3}]"; else printf "%s\n" "${FAKE_OASDIFF_OUTPUT:-}"; fi' \
+  'exit "${FAKE_OASDIFF_EXIT:-0}"' > "$fake_bin/oasdiff"
+chmod 0755 "$fake_bin/oasdiff"
+# shellcheck disable=SC2016 # Intentional literal expansion in the generated fake executable.
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'set -euo pipefail' \
+  'printf "%s\n" "$*" >> "$BUF_LOG"' \
+  'exit "${FAKE_BUF_EXIT:-0}"' > "$fake_bin/buf"
+chmod 0755 "$fake_bin/buf"
+
+run_openapi() {
+  case_name="$1"
+  base_ref="$2"
+  fake_exit="$3"
+  baseline_mode="${4:-base}"
+  fake_breaking="${5:-0}"
+  case_output="$work/${case_name}.out"
+  : > "$oasdiff_log"
+  set +e
+  (
+    cd "$feature"
+    PATH="$fake_bin:$PATH" \
+      OASDIFF_LOG="$oasdiff_log" \
+      FAKE_OASDIFF_EXIT="$fake_exit" \
+      FAKE_OASDIFF_BREAKING="$fake_breaking" \
+      GITHUB_BASE_REF="$base_ref" \
+      CONTRACT_BREAKING_APPROVED=1 \
+      bash "$root/scripts/ci/contract_breaking.sh" openapi "$baseline_mode"
+  ) > "$case_output" 2>&1
+  actual_status=$?
+  set -e
+}
+
+run_proto() {
+  case_name="$1"
+  fake_exit="$2"
+  baseline_mode="${3:-base}"
+  base_ref="${4:-main}"
+  case_output="$work/${case_name}.out"
+  : > "$buf_log"
+  set +e
+  (
+    cd "$feature"
+    PATH="$fake_bin:$PATH" \
+      BUF_LOG="$buf_log" \
+      FAKE_BUF_EXIT="$fake_exit" \
+      GITHUB_BASE_REF="$base_ref" \
+      CONTRACT_BREAKING_APPROVED=1 \
+      bash "$root/scripts/ci/contract_breaking.sh" proto "$baseline_mode"
+  ) > "$case_output" 2>&1
+  actual_status=$?
+  set -e
+}
+
+run_openapi pass main 0
+assert_status 0
+assert_contains 'GATE 1 (openapi): pass'
+assert_oasdiff_invocations 2
+
+run_openapi compatibility_break main 1 base 1
+assert_status 1
+assert_contains 'backward-incompatible contract change without a major bump'
+assert_not_contains 'overridden by the contract:breaking-approved label'
+assert_oasdiff_invocations 2
+
+run_openapi tool_error_exit_one main 1
+assert_status 2
+assert_contains 'oasdiff for openapi api/openapi/helm.openapi.yaml failed with exit 1'
+assert_not_contains 'backward-incompatible contract change without a major bump'
+assert_oasdiff_invocations 1
+
+run_openapi tool_error main 2
+assert_status 2
+assert_contains 'oasdiff for openapi'
+assert_not_contains 'backward-incompatible contract change without a major bump'
+assert_oasdiff_invocations 1
+
+run_openapi missing_base missing-base 0
+assert_status 2
+assert_contains 'unable to resolve contract-gate base ref origin/missing-base'
+assert_oasdiff_invocations 0
+
+run_proto buf_finding 100
+assert_status 1
+assert_contains 'reported a blocking contract finding'
+assert_not_contains 'refusing to treat a tool failure'
+assert_buf_invocations 1
+
+run_proto buf_tool_error 2
+assert_status 2
+assert_contains 'buf breaking for protocols/policy-schema failed with exit 2'
+assert_not_contains 'reported a blocking contract finding'
+assert_buf_invocations 1
+
+run_openapi release_baseline missing-base 0 release
+assert_status 0
+assert_contains "contract release baseline: v1.0.0 ($release_base)"
+assert_oasdiff_invocations 2
+
+run_proto release_buf_finding 100 release missing-base
+assert_status 1
+assert_contains "contract release baseline: v1.0.0 ($release_base)"
+assert_buf_invocations 1
+assert_buf_log_contains "ref=$release_base"
+
+printf 'contract-breaking self-test passed\n'


### PR DESCRIPTION
## Summary

- Replaces the contract-gate hardening intent of stale PR #581 on current `main`; do not merge the legacy PR.
- Makes base-ref resolution fail closed and returns a distinct operational-error exit for unavailable bases or differ failures.
- Treats only verified OpenAPI findings and Buf's documented finding status as compatibility failures; tool errors cannot masquerade as valid diffs.
- Removes mutable PR-label and environment overrides. A source-controlled major-version bump is the only remaining compatibility escape.
- Changes release validation to compare OpenAPI and Proto contracts with the commit resolved from the prior version tag, not current `origin/main`; the workflow fetches full tag history and installs checksum-verified `oasdiff`.
- Adds hermetic regression coverage for base-fetch failure, operational failures, genuine findings, ignored label-style input, and prior-release baselines.

## Validation

- `MISE_TRUSTED_CONFIG_PATHS=/Users/ivan/Code/Mindburn-Labs/helm-ai-kernel-wt-contract-breaking-successor make quality-pr` ✅
- `make test-contract-breaking` ✅
- `python3 scripts/ci/release_workflow_contract_test.py` ✅ (6 tests)
- `python3 scripts/ci/quality.py self-test` ✅ (48 gates / 11 profiles)
- `bash -n` and `shellcheck` for the changed shell scripts ✅
- `actionlint` reports only four pre-existing `release.yml` shellcheck warnings also present on current `main`.

## Explicit release blocker

The new strict release comparator correctly blocks the current `VERSION=0.8.0` source against immutable `v0.7.5`:

1. New required request property `expected_ceremony_hash` for `transitionApprovalCeremony`.
2. `session_id` minimum length changes from `0` to `1`.
3. `session_id` gains a pattern constraint.

The Proto comparison passes. No label or environment waiver was added. A source-owned compatibility or versioning decision is required before a v0.8 tag-release can pass.