### PR TITLE
fix(release): update Console v0.8 source pin

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,8 +6,8 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
-        "commit": "03e3c2ea56cee3a50f9ea3cb72e031bf9c586d72",
-        "tree": "126aae475aec529441bb8b4edc3068f5464c33ab",
+        "commit": "0502ad6af6fdef06b6d9a0f155feae99658c52b7",
+        "tree": "789770c1ea428b1c1ffd5fa5fae57041b51a9365",
         "version": "0.2.1",
         "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076"
       }

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,8 +28,8 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "03e3c2ea56cee3a50f9ea3cb72e031bf9c586d72",
-    "tree": "126aae475aec529441bb8b4edc3068f5464c33ab",
+    "commit": "0502ad6af6fdef06b6d9a0f155feae99658c52b7",
+    "tree": "789770c1ea428b1c1ffd5fa5fae57041b51a9365",
     "version": "0.2.1",
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }


### PR DESCRIPTION
## Scope

Retargets the v0.8 Console local-sidecar source pin to the merged Console successor, without changing release authority or dispatching anything.

- Console commit: `03e3c2ea56cee3a50f9ea3cb72e031bf9c586d72` → `0502ad6af6fdef06b6d9a0f155feae99658c52b7`
- Console tree: `126aae475aec529441bb8b4edc3068f5464c33ab` → `789770c1ea428b1c1ffd5fa5fae57041b51a9365`
- Console `package.json` version remains `0.2.1`; its blob is unchanged.
- Console `package-lock.json` blob and SHA-256 remain `1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076`.
- The immutable workflow tag reference remains unchanged.

## Boundary

This is a release-freeze candidate only. It changes exactly the pin JSON and its exact-contract test; no Kernel execution code, release tag, artifact publish, workflow dispatch, or external effect is included.

## Validation

- `python3 scripts/release/console_local_sidecar_test.py` — 28 passed
- `make lint`
- `make test`
- `make verify-fixtures`
- `make release-smoke`

Based on Kernel `main` `925732d9def648177f96324fe18d2abca9ed76d9`; rebased/check-confirmed immediately before push.