### PR TITLE
fix(release): refresh v0.8 Console source pin

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,8 +6,8 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
-        "commit": "0502ad6af6fdef06b6d9a0f155feae99658c52b7",
-        "tree": "789770c1ea428b1c1ffd5fa5fae57041b51a9365",
+        "commit": "8965520b71f4d23c0974b176f0e1cbb3877d5c33",
+        "tree": "fa89304740e04f079d28bb507c86b6a1716484da",
         "version": "0.2.1",
         "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076"
       }

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,8 +28,8 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "0502ad6af6fdef06b6d9a0f155feae99658c52b7",
-    "tree": "789770c1ea428b1c1ffd5fa5fae57041b51a9365",
+    "commit": "8965520b71f4d23c0974b176f0e1cbb3877d5c33",
+    "tree": "fa89304740e04f079d28bb507c86b6a1716484da",
     "version": "0.2.1",
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }


### PR DESCRIPTION
## Summary

- Repin the v0.8 Console local-sidecar source provenance to merged Console main `8965520b71f4d23c0974b176f0e1cbb3877d5c33` / tree `fa89304740e04f079d28bb507c86b6a1716484da`.
- Preserve the verified Console version `0.2.1` and package-lock SHA-256 `1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076`.
- Keep the deterministic release-contract assertion aligned with the pin.

## Validation

- `python3 scripts/release/console_local_sidecar_test.py` — 28 passing
- `make release-smoke` — passing
- Exact four-field tuple check against the requested, merged Console commit — passing

## Scope boundary

This changes source provenance only. It does not create a release artifact, alter tag/workflow behavior, or establish runtime/release readiness.