### PR TITLE
fix(release): pin Console sidecar to real-mode safety

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,8 +6,8 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
-        "commit": "8965520b71f4d23c0974b176f0e1cbb3877d5c33",
-        "tree": "fa89304740e04f079d28bb507c86b6a1716484da",
+        "commit": "d5382a39af34652d4c04cf17b24133c762ee9ce7",
+        "tree": "f18cd7367be0f2a9452e1081f23112c3ec9c0348",
         "version": "0.2.1",
         "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076"
       }

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,8 +28,8 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "8965520b71f4d23c0974b176f0e1cbb3877d5c33",
-    "tree": "fa89304740e04f079d28bb507c86b6a1716484da",
+    "commit": "d5382a39af34652d4c04cf17b24133c762ee9ce7",
+    "tree": "f18cd7367be0f2a9452e1081f23112c3ec9c0348",
     "version": "0.2.1",
     "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
 }


### PR DESCRIPTION
## Scope

Pins the v0.8 Console local-sidecar source contract to merged Console safety PR #118:

- commit: `d5382a39af34652d4c04cf17b24133c762ee9ce7`
- tree: `f18cd7367be0f2a9452e1081f23112c3ec9c0348`
- package version: `0.2.1`
- package-lock SHA-256: `1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076`

The deterministic sidecar contract test is updated to assert the same exact tuple. This is based on Kernel `705a69ee7b347989d59aebe685707800bdb2148f` (#759), including its public-docs API-contract attestation.

## Validation

- `python3 scripts/release/console_local_sidecar_test.py` — 28 passed
- `make docs-truth`
- `make docs-openapi-parity`
- `make release-smoke` — passed; no Cosign bundles were present, so optional bundle verification was not exercised

No tag, release, deployment, or merge was performed.