### PR TITLE
feat(events): EventMeta v2 + the eight lifecycle event types (HELM-375)

### DIFF
--- a/core/pkg/events/catalog.go
+++ b/core/pkg/events/catalog.go
@@ -33,11 +33,47 @@ const (
 	ConnectorReleaseRevoked   = "helm.connector.release.revoked.v1"
 )
 
+// EventSchemaVersion is the current envelope version (§4). v2 added the
+// identity and data-class fields below; every field it introduced is optional,
+// so a v1 producer keeps emitting valid events.
+const EventSchemaVersion = 2
+
+// Data classes for EventMeta.Env (§7). Retention and placement are cut by this
+// value rather than by which stand produced the event, so a pilot event
+// carries its class wherever it is copied.
+const (
+	EnvSynthetic      = "synthetic"
+	EnvPilot          = "pilot"
+	EnvCustomerHosted = "customer-hosted"
+)
+
 // EventMeta is common metadata for all events.
+//
+// v2 fields are additive and omitempty: they carry the identity that turns a
+// pile of events into one request's story (§2, §3). correlation_id is the join
+// key and survives sampling; trace_id/span_id link the story to its trace and
+// may not.
 type EventMeta struct {
 	EventID     string `json:"event_id"`
 	EventType   string `json:"event_type"`
 	TenantID    string `json:"tenant_id"`
 	TimestampMs int64  `json:"timestamp_ms"`
 	SourceRef   string `json:"source_ref,omitempty"`
+
+	// --- v2 ---
+
+	// CorrelationID is the product request identity (§2). It is the stable
+	// join key across events, receipts and evidence.
+	CorrelationID string `json:"correlation_id,omitempty"`
+	// RunID identifies a multi-request run when one exists.
+	RunID string `json:"run_id,omitempty"`
+	// TraceID and SpanID are copied from the active span for trace
+	// correlation (§3). Deliberately distinct from CorrelationID: sampling
+	// may drop the trace while the product identity survives.
+	TraceID string `json:"trace_id,omitempty"`
+	SpanID  string `json:"span_id,omitempty"`
+	// Env is the data class (§7), one of the Env* constants above.
+	Env string `json:"env,omitempty"`
+	// SchemaVersion is the envelope version; absent means v1.
+	SchemaVersion int `json:"schema_version,omitempty"`
 }

--- a/core/pkg/events/lifecycle.go
+++ b/core/pkg/events/lifecycle.go
@@ -107,14 +107,28 @@ func NewDecisionMade(meta EventMeta, decision contracts.DecisionRecord) Lifecycl
 	})
 }
 
-// NewEscalationTriggered projects #5 from an ESCALATE verdict.
-func NewEscalationTriggered(meta EventMeta, decision contracts.DecisionRecord) LifecycleEvent {
+// ErrNotEscalation reports a decision that cannot be projected into #5.
+var ErrNotEscalation = errors.New("decision verdict is not ESCALATE")
+
+// NewEscalationTriggered projects #5 from an ESCALATE verdict. Alone among the
+// eight it has a precondition its argument can violate: the others project
+// whatever the struct holds and so cannot be wrong, but an escalation event
+// built from an ALLOW asserts a human approval step that never happened. That
+// is the one way a projection could still disagree with the decision it
+// explains, so it returns an error rather than emitting the wrong event.
+func NewEscalationTriggered(meta EventMeta, decision contracts.DecisionRecord) (LifecycleEvent, error) {
+	if decision.Verdict != string(contracts.VerdictEscalate) {
+		return LifecycleEvent{}, fmt.Errorf(
+			"%w: decision %s has verdict %q", ErrNotEscalation, decision.ID, decision.Verdict,
+		)
+	}
+
 	return newEvent(meta, EscalationTriggered, map[string]any{
 		"decision_id": decision.ID,
 		"reason_code": decision.ReasonCode,
 		"action":      decision.Action,
 		"resource":    decision.Resource,
-	})
+	}), nil
 }
 
 // NewDispatchCompleted projects #6 from the receipt the PEP wrote.
@@ -128,9 +142,15 @@ func NewDispatchCompleted(meta EventMeta, receipt contracts.Receipt, intentHash 
 
 // NewRequestFailed projects #7 from a denied or failed attempt. It is one of
 // the two terminal events.
-func NewRequestFailed(meta EventMeta, reason, reasonCode string, retryNumber int) LifecycleEvent {
+//
+// It takes no free-text reason on purpose. §6 prohibits prose in exported
+// events alongside the request-scoped values it keeps out of metric labels:
+// this stream is retained and shipped off-box, and prose is where customer data
+// rides along. reasonCode is the registry code every consumer keys on anyway —
+// the same swap HELM-303 made in the signing preimage. Prose describing one
+// failure belongs in the evidence pack, which is not exported.
+func NewRequestFailed(meta EventMeta, reasonCode string, retryNumber int) LifecycleEvent {
 	return newEvent(meta, RequestFailed, map[string]any{
-		"reason":       reason,
 		"reason_code":  reasonCode,
 		"retry_number": retryNumber,
 	})
@@ -163,8 +183,10 @@ func NewRequestCompleted(meta EventMeta, execution contracts.EvidencePackExecuti
 // request — rather than silence. A monitor that only counts emitted events
 // cannot tell "nothing went wrong" from "the process died mid-request".
 //
-// All events must also share one correlation_id; a sequence spanning two would
-// silently merge two requests into one story.
+// All events must also share one non-empty correlation_id; a sequence spanning
+// two would silently merge two requests into one story, and an empty one is
+// worse: it joins nothing, so every such sequence collides with every other.
+// Checking the anchor is enough — the others are required to equal it.
 func ValidateRequestSequence(sequence []LifecycleEvent) error {
 	if len(sequence) == 0 {
 		return errors.New("empty sequence: a request must emit at least received and one terminal event")
@@ -179,6 +201,9 @@ func ValidateRequestSequence(sequence []LifecycleEvent) error {
 	for i, event := range sequence {
 		if i == 0 {
 			correlationID = event.Meta.CorrelationID
+			if correlationID == "" {
+				return errors.New("sequence has an empty correlation id: an unjoinable sequence is not a request story")
+			}
 		} else if event.Meta.CorrelationID != correlationID {
 			return fmt.Errorf(
 				"sequence spans correlation ids %q and %q: these are two requests, not one",

--- a/core/pkg/events/lifecycle.go
+++ b/core/pkg/events/lifecycle.go
@@ -1,0 +1,208 @@
+package events
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+// The eight lifecycle event types of the pilot business-telemetry contract
+// (§5). Together they let one governed request be explained end to end by
+// querying events joined on correlation_id — the operator flow is an
+// aggregate panel drilling into an event query, never a per-request metric
+// label (§6.1).
+//
+// Only the first two are written from scratch. The rest are projections of
+// structs the kernel already produces, so the event stream cannot disagree
+// with the receipts and decisions it exists to explain.
+const (
+	RequestReceived     = "helm.request.received.v1"
+	RequestClassified   = "helm.request.classified.v1"
+	PolicyApplied       = "helm.policy.applied.v1"
+	DecisionMade        = "helm.decision.made.v1"
+	EscalationTriggered = "helm.escalation.triggered.v1"
+	DispatchCompleted   = "helm.dispatch.completed.v1"
+	RequestFailed       = "helm.request.failed.v1"
+	RequestCompleted    = "helm.request.completed.v1"
+)
+
+// LifecycleEventTypes returns the eight types in lifecycle order.
+func LifecycleEventTypes() []string {
+	return []string{
+		RequestReceived,
+		RequestClassified,
+		PolicyApplied,
+		DecisionMade,
+		EscalationTriggered,
+		DispatchCompleted,
+		RequestFailed,
+		RequestCompleted,
+	}
+}
+
+// terminalEventTypes are the two ways a request can end (§5.1).
+func isTerminal(eventType string) bool {
+	return eventType == RequestFailed || eventType == RequestCompleted
+}
+
+// LifecycleEvent is one envelope plus the key fields of its type. Fields are a
+// projection of existing structs, never a second source of truth.
+type LifecycleEvent struct {
+	Meta   EventMeta      `json:"meta"`
+	Fields map[string]any `json:"fields,omitempty"`
+}
+
+func newEvent(meta EventMeta, eventType string, fields map[string]any) LifecycleEvent {
+	meta.EventType = eventType
+	if meta.SchemaVersion == 0 {
+		meta.SchemaVersion = EventSchemaVersion
+	}
+	return LifecycleEvent{Meta: meta, Fields: fields}
+}
+
+// NewRequestReceived emits #1 at ingress. Every request must produce exactly
+// one of these; it is what makes a missing terminal event detectable.
+func NewRequestReceived(meta EventMeta, action, resource string) LifecycleEvent {
+	return newEvent(meta, RequestReceived, map[string]any{
+		"action":   action,
+		"resource": resource,
+	})
+}
+
+// NewRequestClassified emits #2 once the PEP has classified the request's
+// effect. Written from scratch: no existing struct records the classification
+// as a distinct step.
+func NewRequestClassified(meta EventMeta, effectClass, riskTier string) LifecycleEvent {
+	return newEvent(meta, RequestClassified, map[string]any{
+		"effect_class": effectClass,
+		"risk_tier":    riskTier,
+	})
+}
+
+// NewPolicyApplied projects #3 from the policy identity already bound into the
+// decision, plus the rules the evidence recorded as fired.
+func NewPolicyApplied(meta EventMeta, decision contracts.DecisionRecord, rulesFired []string) LifecycleEvent {
+	return newEvent(meta, PolicyApplied, map[string]any{
+		"decision_id":         decision.ID,
+		"policy_version":      decision.PolicyVersion,
+		"policy_content_hash": decision.PolicyContentHash,
+		"policy_epoch":        decision.PolicyEpoch,
+		"rules_fired":         rulesFired,
+	})
+}
+
+// NewDecisionMade projects #4 from the signed decision. The verdict here is
+// the decision's verdict — inventing one would let the event stream disagree
+// with the receipt it explains.
+func NewDecisionMade(meta EventMeta, decision contracts.DecisionRecord) LifecycleEvent {
+	return newEvent(meta, DecisionMade, map[string]any{
+		"decision_id":          decision.ID,
+		"verdict":              decision.Verdict,
+		"reason_code":          decision.ReasonCode,
+		"action":               decision.Action,
+		"resource":             decision.Resource,
+		"subject_id":           decision.SubjectID,
+		"policy_decision_hash": decision.PolicyDecisionHash,
+	})
+}
+
+// NewEscalationTriggered projects #5 from an ESCALATE verdict.
+func NewEscalationTriggered(meta EventMeta, decision contracts.DecisionRecord) LifecycleEvent {
+	return newEvent(meta, EscalationTriggered, map[string]any{
+		"decision_id": decision.ID,
+		"reason_code": decision.ReasonCode,
+		"action":      decision.Action,
+		"resource":    decision.Resource,
+	})
+}
+
+// NewDispatchCompleted projects #6 from the receipt the PEP wrote.
+func NewDispatchCompleted(meta EventMeta, receipt contracts.Receipt, intentHash string) LifecycleEvent {
+	return newEvent(meta, DispatchCompleted, map[string]any{
+		"receipt_id":  receipt.ID,
+		"status":      receipt.Status,
+		"intent_hash": intentHash,
+	})
+}
+
+// NewRequestFailed projects #7 from a denied or failed attempt. It is one of
+// the two terminal events.
+func NewRequestFailed(meta EventMeta, reason, reasonCode string, retryNumber int) LifecycleEvent {
+	return newEvent(meta, RequestFailed, map[string]any{
+		"reason":       reason,
+		"reason_code":  reasonCode,
+		"retry_number": retryNumber,
+	})
+}
+
+// NewRequestCompleted projects #8 from the execution record, summing the PAL
+// receipts' token counts so per-request cost is answerable without reading
+// every receipt. The other terminal event.
+func NewRequestCompleted(meta EventMeta, execution contracts.EvidencePackExecution, palReceipts []contracts.PALReceiptRef) LifecycleEvent {
+	tokensIn, tokensOut := 0, 0
+	for _, receipt := range palReceipts {
+		tokensIn += receipt.TokensIn
+		tokensOut += receipt.TokensOut
+	}
+
+	return newEvent(meta, RequestCompleted, map[string]any{
+		"execution_id": execution.ExecutionID,
+		"status":       execution.Status,
+		"retry_count":  execution.RetryCount,
+		"duration_ms":  execution.DurationMs,
+		"tokens_in":    tokensIn,
+		"tokens_out":   tokensOut,
+	})
+}
+
+// ValidateRequestSequence enforces the completeness invariant (§5.1): every
+// request emits helm.request.received.v1 and exactly one terminal event.
+//
+// The point is that a missing terminal is itself a signal — an unclosed
+// request — rather than silence. A monitor that only counts emitted events
+// cannot tell "nothing went wrong" from "the process died mid-request".
+//
+// All events must also share one correlation_id; a sequence spanning two would
+// silently merge two requests into one story.
+func ValidateRequestSequence(sequence []LifecycleEvent) error {
+	if len(sequence) == 0 {
+		return errors.New("empty sequence: a request must emit at least received and one terminal event")
+	}
+
+	var (
+		correlationID string
+		received      int
+		terminals     int
+	)
+
+	for i, event := range sequence {
+		if i == 0 {
+			correlationID = event.Meta.CorrelationID
+		} else if event.Meta.CorrelationID != correlationID {
+			return fmt.Errorf(
+				"sequence spans correlation ids %q and %q: these are two requests, not one",
+				correlationID, event.Meta.CorrelationID,
+			)
+		}
+
+		switch {
+		case event.Meta.EventType == RequestReceived:
+			received++
+		case isTerminal(event.Meta.EventType):
+			terminals++
+		}
+	}
+
+	if received != 1 {
+		return fmt.Errorf("sequence has %d %s events, want exactly 1", received, RequestReceived)
+	}
+	if terminals != 1 {
+		return fmt.Errorf(
+			"sequence has %d terminal events (%s / %s), want exactly 1; an unclosed request is a signal, not silence",
+			terminals, RequestCompleted, RequestFailed,
+		)
+	}
+
+	return nil
+}

--- a/core/pkg/events/lifecycle_test.go
+++ b/core/pkg/events/lifecycle_test.go
@@ -1,0 +1,329 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func testMeta(correlationID string) EventMeta {
+	return EventMeta{
+		EventID:       "evt_1",
+		TenantID:      "tenant_1",
+		TimestampMs:   1754251200000,
+		CorrelationID: correlationID,
+		TraceID:       "4bf92f3577b34da6a3ce929d0e0e4736",
+		SpanID:        "00f067aa0ba902b7",
+		Env:           EnvSynthetic,
+	}
+}
+
+// TestEventMetaV2CarriesIdentity covers the envelope half of §4. Without these
+// fields an event can be read but not joined: correlation_id is what turns a
+// pile of events into one request's story, and trace_id/span_id are what link
+// that story to the trace.
+func TestEventMetaV2CarriesIdentity(t *testing.T) {
+	meta := testMeta("3f2504e0-4f89-41d3-9a0c-0305e82c3301")
+	meta.EventType = RequestReceived
+	meta.RunID = "run_7"
+	meta.SchemaVersion = EventSchemaVersion
+
+	encoded, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for key, want := range map[string]any{
+		"correlation_id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		"run_id":         "run_7",
+		"trace_id":       "4bf92f3577b34da6a3ce929d0e0e4736",
+		"span_id":        "00f067aa0ba902b7",
+		"env":            EnvSynthetic,
+		"schema_version": float64(EventSchemaVersion),
+	} {
+		if got := decoded[key]; got != want {
+			t.Errorf("meta[%q] = %v, want %v", key, got, want)
+		}
+	}
+}
+
+// The v1 fields are load-bearing for existing producers; v2 is additive only.
+func TestEventMetaOmitsAbsentOptionalFields(t *testing.T) {
+	encoded, err := json.Marshal(EventMeta{
+		EventID:     "evt_1",
+		EventType:   RequestReceived,
+		TenantID:    "tenant_1",
+		TimestampMs: 1754251200000,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, key := range []string{"correlation_id", "run_id", "trace_id", "span_id", "env", "source_ref"} {
+		if _, present := decoded[key]; present {
+			t.Errorf("optional field %q emitted when unset; v2 must be additive and omitempty", key)
+		}
+	}
+	for _, key := range []string{"event_id", "event_type", "tenant_id", "timestamp_ms"} {
+		if _, present := decoded[key]; !present {
+			t.Errorf("required v1 field %q missing", key)
+		}
+	}
+}
+
+// TestLifecycleCatalogRegistersEightTypes pins §5. A missing type is a hole in
+// the request story that only shows up when an operator queries for it.
+func TestLifecycleCatalogRegistersEightTypes(t *testing.T) {
+	want := []string{
+		"helm.request.received.v1",
+		"helm.request.classified.v1",
+		"helm.policy.applied.v1",
+		"helm.decision.made.v1",
+		"helm.escalation.triggered.v1",
+		"helm.dispatch.completed.v1",
+		"helm.request.failed.v1",
+		"helm.request.completed.v1",
+	}
+
+	got := LifecycleEventTypes()
+	if len(got) != len(want) {
+		t.Fatalf("catalog has %d lifecycle types, want %d: %v", len(got), len(want), got)
+	}
+
+	registered := make(map[string]bool, len(got))
+	for _, eventType := range got {
+		registered[eventType] = true
+	}
+	for _, eventType := range want {
+		if !registered[eventType] {
+			t.Errorf("lifecycle type %q not registered", eventType)
+		}
+	}
+}
+
+// TestDecisionMadeProjectsFromDecisionRecord: #4 must be a projection of the
+// signed decision, not a parallel record. If it invented its own verdict the
+// event stream could disagree with the receipt it is supposed to explain.
+func TestDecisionMadeProjectsFromDecisionRecord(t *testing.T) {
+	decision := contracts.DecisionRecord{
+		ID:                 "dec_1",
+		CorrelationID:      "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		SubjectID:          "did:helm:operator:ops",
+		Action:             "payments.refund",
+		Resource:           "orders/42",
+		Verdict:            string(contracts.VerdictDeny),
+		Reason:             "over limit",
+		ReasonCode:         "SPEND_LIMIT_EXCEEDED",
+		PolicyVersion:      "v3",
+		PolicyContentHash:  "sha256:policy",
+		PolicyEpoch:        "epoch_9",
+		PolicyDecisionHash: "sha256:decision",
+	}
+
+	event := NewDecisionMade(testMeta(decision.CorrelationID), decision)
+
+	if event.Meta.EventType != DecisionMade {
+		t.Errorf("event_type = %q, want %q", event.Meta.EventType, DecisionMade)
+	}
+	for key, want := range map[string]any{
+		"decision_id": "dec_1",
+		"verdict":     "DENY",
+		"reason_code": "SPEND_LIMIT_EXCEEDED",
+		"action":      "payments.refund",
+		"resource":    "orders/42",
+	} {
+		if got := event.Fields[key]; got != want {
+			t.Errorf("fields[%q] = %v, want %v", key, got, want)
+		}
+	}
+}
+
+// #3 is a projection of the policy identity already bound into the decision,
+// plus the rules the evidence recorded as fired.
+func TestPolicyAppliedProjectsPolicyIdentity(t *testing.T) {
+	decision := contracts.DecisionRecord{
+		ID:                "dec_1",
+		CorrelationID:     "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+		PolicyVersion:     "v3",
+		PolicyContentHash: "sha256:policy",
+		PolicyEpoch:       "epoch_9",
+	}
+
+	event := NewPolicyApplied(testMeta(decision.CorrelationID), decision, []string{"rule.spend.cap", "rule.egress"})
+
+	if event.Meta.EventType != PolicyApplied {
+		t.Errorf("event_type = %q, want %q", event.Meta.EventType, PolicyApplied)
+	}
+	if got := event.Fields["policy_content_hash"]; got != "sha256:policy" {
+		t.Errorf("policy_content_hash = %v, want the decision's bound hash", got)
+	}
+	rules, ok := event.Fields["rules_fired"].([]string)
+	if !ok || len(rules) != 2 {
+		t.Errorf("rules_fired = %v, want the two fired rules", event.Fields["rules_fired"])
+	}
+}
+
+// #8 carries the cost of the request. TokensIn/TokensOut are the anchor the
+// spec names; summing them here is what makes a per-request cost query
+// possible without reading every PAL receipt.
+func TestRequestCompletedProjectsExecutionAndTokens(t *testing.T) {
+	execution := contracts.EvidencePackExecution{
+		ExecutionID: "exec_1",
+		Status:      "success",
+		RetryCount:  1,
+		DurationMs:  1234,
+	}
+	receipts := []contracts.PALReceiptRef{
+		{ReceiptID: "pal_1", TokensIn: 100, TokensOut: 20, CompletedAt: time.Unix(0, 0)},
+		{ReceiptID: "pal_2", TokensIn: 5, TokensOut: 3, CompletedAt: time.Unix(0, 0)},
+	}
+
+	event := NewRequestCompleted(testMeta("3f2504e0-4f89-41d3-9a0c-0305e82c3301"), execution, receipts)
+
+	if event.Meta.EventType != RequestCompleted {
+		t.Errorf("event_type = %q, want %q", event.Meta.EventType, RequestCompleted)
+	}
+	if got := event.Fields["tokens_in"]; got != 105 {
+		t.Errorf("tokens_in = %v, want 105 (summed across PAL receipts)", got)
+	}
+	if got := event.Fields["tokens_out"]; got != 23 {
+		t.Errorf("tokens_out = %v, want 23", got)
+	}
+	if got := event.Fields["status"]; got != "success" {
+		t.Errorf("status = %v, want the execution status", got)
+	}
+}
+
+// TestCompletenessInvariant is §5.1 and the reason the catalog is worth having:
+// a request that never closed must be detectable. Silent loss is the failure
+// mode an event stream is supposed to rule out.
+func TestCompletenessInvariant(t *testing.T) {
+	const correlationID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+	received := LifecycleEvent{Meta: EventMeta{EventType: RequestReceived, CorrelationID: correlationID}}
+	completed := LifecycleEvent{Meta: EventMeta{EventType: RequestCompleted, CorrelationID: correlationID}}
+	failed := LifecycleEvent{Meta: EventMeta{EventType: RequestFailed, CorrelationID: correlationID}}
+	decided := LifecycleEvent{Meta: EventMeta{EventType: DecisionMade, CorrelationID: correlationID}}
+
+	tests := []struct {
+		name    string
+		events  []LifecycleEvent
+		wantErr bool
+	}{
+		{"allow path closes with completed", []LifecycleEvent{received, decided, completed}, false},
+		{"failure path closes with failed", []LifecycleEvent{received, decided, failed}, false},
+		{"unclosed request is a signal, not silence", []LifecycleEvent{received, decided}, true},
+		{"two terminal events", []LifecycleEvent{received, completed, failed}, true},
+		{"terminal without a received", []LifecycleEvent{completed}, true},
+		{"empty sequence", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateRequestSequence(tt.events)
+			if tt.wantErr && err == nil {
+				t.Error("ValidateRequestSequence accepted an invalid sequence")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("ValidateRequestSequence rejected a valid sequence: %v", err)
+			}
+		})
+	}
+}
+
+// Every event of one request must join on correlation_id — the §11 check that
+// was unrunnable until this issue.
+func TestSequenceRejectsMixedCorrelationIDs(t *testing.T) {
+	events := []LifecycleEvent{
+		{Meta: EventMeta{EventType: RequestReceived, CorrelationID: "3f2504e0-4f89-41d3-9a0c-0305e82c3301"}},
+		{Meta: EventMeta{EventType: RequestCompleted, CorrelationID: "9c5b94b1-35ad-49bb-b118-8e8fc24abf80"}},
+	}
+
+	if err := ValidateRequestSequence(events); err == nil {
+		t.Error("accepted a sequence spanning two correlation ids; the join would silently merge two requests")
+	}
+}
+
+// TestSyntheticRequestSequences walks the five shapes a governed request can
+// take, built with the real constructors rather than hand-written envelopes.
+// This is the half of HELM-290 §11 that had no build owner and could not be
+// run: every shape emits #1 plus exactly one terminal, and every event of one
+// request joins on correlation_id.
+func TestSyntheticRequestSequences(t *testing.T) {
+	const correlationID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+
+	base := func() EventMeta { return testMeta(correlationID) }
+	decision := func(verdict contracts.Verdict) contracts.DecisionRecord {
+		return contracts.DecisionRecord{
+			ID:            "dec_1",
+			CorrelationID: correlationID,
+			Action:        "payments.refund",
+			Resource:      "orders/42",
+			Verdict:       string(verdict),
+			PolicyVersion: "v3",
+		}
+	}
+	execution := contracts.EvidencePackExecution{ExecutionID: "exec_1", Status: "success"}
+
+	sequences := map[string][]LifecycleEvent{
+		"ALLOW dispatched and completed": {
+			NewRequestReceived(base(), "payments.refund", "orders/42"),
+			NewRequestClassified(base(), "financial.write", "high"),
+			NewPolicyApplied(base(), decision(contracts.VerdictAllow), []string{"rule.spend.cap"}),
+			NewDecisionMade(base(), decision(contracts.VerdictAllow)),
+			NewDispatchCompleted(base(), contracts.Receipt{ID: "rec_1", Status: "applied"}, "sha256:intent"),
+			NewRequestCompleted(base(), execution, nil),
+		},
+		"DENY closes as failed": {
+			NewRequestReceived(base(), "payments.refund", "orders/42"),
+			NewRequestClassified(base(), "financial.write", "high"),
+			NewPolicyApplied(base(), decision(contracts.VerdictDeny), []string{"rule.spend.cap"}),
+			NewDecisionMade(base(), decision(contracts.VerdictDeny)),
+			NewRequestFailed(base(), "over limit", "SPEND_LIMIT_EXCEEDED", 0),
+		},
+		"ESCALATE then approved and completed": {
+			NewRequestReceived(base(), "payments.refund", "orders/42"),
+			NewDecisionMade(base(), decision(contracts.VerdictEscalate)),
+			NewEscalationTriggered(base(), decision(contracts.VerdictEscalate)),
+			NewDispatchCompleted(base(), contracts.Receipt{ID: "rec_1", Status: "applied"}, "sha256:intent"),
+			NewRequestCompleted(base(), execution, nil),
+		},
+		"execution failure": {
+			NewRequestReceived(base(), "payments.refund", "orders/42"),
+			NewDecisionMade(base(), decision(contracts.VerdictAllow)),
+			NewRequestFailed(base(), "upstream timeout", "EXECUTION_FAILED", 2),
+		},
+		"read-only request completes without dispatch": {
+			NewRequestReceived(base(), "receipts.list", "receipts"),
+			NewRequestCompleted(base(), execution, nil),
+		},
+	}
+
+	for name, sequence := range sequences {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateRequestSequence(sequence); err != nil {
+				t.Errorf("valid %s sequence rejected: %v", name, err)
+			}
+			for _, event := range sequence {
+				if event.Meta.CorrelationID != correlationID {
+					t.Errorf("event %s does not join on correlation_id", event.Meta.EventType)
+				}
+				if event.Meta.SchemaVersion != EventSchemaVersion {
+					t.Errorf("event %s has schema_version %d, want %d",
+						event.Meta.EventType, event.Meta.SchemaVersion, EventSchemaVersion)
+				}
+			}
+		})
+	}
+}

--- a/core/pkg/events/lifecycle_test.go
+++ b/core/pkg/events/lifecycle_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -206,6 +207,90 @@ func TestRequestCompletedProjectsExecutionAndTokens(t *testing.T) {
 	}
 }
 
+// #5 is the one projection whose argument can contradict it. An escalation
+// event built from an ALLOW asserts a human approval step that never happened —
+// the event stream would then disagree with the decision it exists to explain,
+// which is exactly what projecting rather than re-deriving is meant to prevent.
+func TestEscalationTriggeredRejectsNonEscalateVerdict(t *testing.T) {
+	const correlationID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+
+	for _, verdict := range []contracts.Verdict{contracts.VerdictAllow, contracts.VerdictDeny} {
+		t.Run(string(verdict), func(t *testing.T) {
+			decision := contracts.DecisionRecord{
+				ID:            "dec_1",
+				CorrelationID: correlationID,
+				Action:        "payments.refund",
+				Resource:      "orders/42",
+				Verdict:       string(verdict),
+			}
+
+			event, err := NewEscalationTriggered(testMeta(correlationID), decision)
+			if err == nil {
+				t.Fatalf("projected a %s decision into an escalation event: %v", verdict, event.Fields)
+			}
+			if !errors.Is(err, ErrNotEscalation) {
+				t.Errorf("err = %v, want ErrNotEscalation so callers can branch on it", err)
+			}
+			if event.Meta.EventType != "" {
+				t.Errorf("emitted event_type %q alongside the error; a rejected projection must emit nothing",
+					event.Meta.EventType)
+			}
+		})
+	}
+
+	escalate := contracts.DecisionRecord{
+		ID:            "dec_1",
+		CorrelationID: correlationID,
+		Action:        "payments.refund",
+		Resource:      "orders/42",
+		Verdict:       string(contracts.VerdictEscalate),
+		ReasonCode:    string(contracts.ReasonApprovalRequired),
+	}
+
+	event, err := NewEscalationTriggered(testMeta(correlationID), escalate)
+	if err != nil {
+		t.Fatalf("rejected a genuine ESCALATE decision: %v", err)
+	}
+	if event.Meta.EventType != EscalationTriggered {
+		t.Errorf("event_type = %q, want %q", event.Meta.EventType, EscalationTriggered)
+	}
+	if got := event.Fields["reason_code"]; got != string(contracts.ReasonApprovalRequired) {
+		t.Errorf("reason_code = %v, want the decision's registry code", got)
+	}
+}
+
+// #7 is the event a failing request always emits, so it is the one most likely
+// to be handed prose describing what went wrong. §6 prohibits free text in
+// exported events for the same reason it keeps request-scoped values out of
+// metric labels: the stream is retained and shipped off-box, and prose is where
+// customer data rides along. reason_code is the registry code downstream keys
+// on — the same swap HELM-303 made in the signing preimage.
+func TestRequestFailedOmitsFreeTextReason(t *testing.T) {
+	event := NewRequestFailed(
+		testMeta("3f2504e0-4f89-41d3-9a0c-0305e82c3301"),
+		string(contracts.ReasonBudgetExceeded),
+		2,
+	)
+
+	if event.Meta.EventType != RequestFailed {
+		t.Errorf("event_type = %q, want %q", event.Meta.EventType, RequestFailed)
+	}
+	if got := event.Fields["reason_code"]; got != string(contracts.ReasonBudgetExceeded) {
+		t.Errorf("reason_code = %v, want the machine-readable registry code", got)
+	}
+	if got := event.Fields["retry_number"]; got != 2 {
+		t.Errorf("retry_number = %v, want 2", got)
+	}
+
+	// Named prose carriers, not just "reason": renaming the field would move
+	// the leak rather than close it.
+	for _, key := range []string{"reason", "message", "detail", "error", "failure_reason"} {
+		if value, present := event.Fields[key]; present {
+			t.Errorf("field %q exported (%v); §6 prohibits free-text prose in the event stream", key, value)
+		}
+	}
+}
+
 // TestCompletenessInvariant is §5.1 and the reason the catalog is worth having:
 // a request that never closed must be detectable. Silent loss is the failure
 // mode an event stream is supposed to rule out.
@@ -255,6 +340,21 @@ func TestSequenceRejectsMixedCorrelationIDs(t *testing.T) {
 	}
 }
 
+// An empty correlation_id joins nothing: every such sequence collides with
+// every other one. Accepting it looks like a valid single request while
+// actually asserting no identity at all — worse than the mixed-id case above,
+// which at least fails loudly.
+func TestSequenceRejectsEmptyCorrelationID(t *testing.T) {
+	events := []LifecycleEvent{
+		{Meta: EventMeta{EventType: RequestReceived}},
+		{Meta: EventMeta{EventType: RequestCompleted}},
+	}
+
+	if err := ValidateRequestSequence(events); err == nil {
+		t.Error("accepted a sequence with an empty correlation id; an unjoinable sequence is not a request story")
+	}
+}
+
 // TestSyntheticRequestSequences walks the five shapes a governed request can
 // take, built with the real constructors rather than hand-written envelopes.
 // This is the half of HELM-290 §11 that had no build owner and could not be
@@ -275,6 +375,16 @@ func TestSyntheticRequestSequences(t *testing.T) {
 		}
 	}
 	execution := contracts.EvidencePackExecution{ExecutionID: "exec_1", Status: "success"}
+	// #5 is the only fallible constructor, so it cannot be called inline in the
+	// literal below; the walk still uses the real one rather than a stand-in.
+	escalation := func(decision contracts.DecisionRecord) LifecycleEvent {
+		t.Helper()
+		event, err := NewEscalationTriggered(base(), decision)
+		if err != nil {
+			t.Fatalf("escalation projection rejected a genuine ESCALATE decision: %v", err)
+		}
+		return event
+	}
 
 	sequences := map[string][]LifecycleEvent{
 		"ALLOW dispatched and completed": {
@@ -290,19 +400,19 @@ func TestSyntheticRequestSequences(t *testing.T) {
 			NewRequestClassified(base(), "financial.write", "high"),
 			NewPolicyApplied(base(), decision(contracts.VerdictDeny), []string{"rule.spend.cap"}),
 			NewDecisionMade(base(), decision(contracts.VerdictDeny)),
-			NewRequestFailed(base(), "over limit", "SPEND_LIMIT_EXCEEDED", 0),
+			NewRequestFailed(base(), string(contracts.ReasonBudgetExceeded), 0),
 		},
 		"ESCALATE then approved and completed": {
 			NewRequestReceived(base(), "payments.refund", "orders/42"),
 			NewDecisionMade(base(), decision(contracts.VerdictEscalate)),
-			NewEscalationTriggered(base(), decision(contracts.VerdictEscalate)),
+			escalation(decision(contracts.VerdictEscalate)),
 			NewDispatchCompleted(base(), contracts.Receipt{ID: "rec_1", Status: "applied"}, "sha256:intent"),
 			NewRequestCompleted(base(), execution, nil),
 		},
 		"execution failure": {
 			NewRequestReceived(base(), "payments.refund", "orders/42"),
 			NewDecisionMade(base(), decision(contracts.VerdictAllow)),
-			NewRequestFailed(base(), "upstream timeout", "EXECUTION_FAILED", 2),
+			NewRequestFailed(base(), string(contracts.ReasonComputeTimeExhausted), 2),
 		},
 		"read-only request completes without dispatch": {
 			NewRequestReceived(base(), "receipts.list", "receipts"),


### PR DESCRIPTION
Closes HELM-375 — the event-catalog half of the pilot business-telemetry contract (§4, §5, §5.1). HELM-325 delivered the identity half and HELM-333/334 the trace/log correlation, but the events themselves had no build owner, so §4/§5 stayed unimplemented.

## EventMeta v2

Adds `correlation_id`, `run_id`, `trace_id`, `span_id`, `env`, `schema_version`. Every new field is optional and `omitempty` — **strictly additive**, a v1 producer keeps emitting valid events. `EventMeta` had zero consumers in the tree, so there is no migration.

`correlation_id` and the trace ids are kept deliberately distinct (§3): the product identity survives sampling, the trace ids may not.

## The eight types

Registered with their key fields. Only `helm.request.received.v1` and `helm.request.classified.v1` are written from scratch — **the other six are projections of structs the kernel already produces**, so the event stream cannot disagree with the receipts and decisions it exists to explain:

| Event | Projected from |
|---|---|
| `policy.applied` | `PolicyVersion` / `PolicyContentHash` / `PolicyEpoch` + rules fired |
| `decision.made` | `DecisionRecord` — verdict taken from the signed decision, not re-derived |
| `escalation.triggered` | `VerdictEscalate` |
| `dispatch.completed` | `Receipt.Status` + intent hash |
| `request.failed` | denied/failed attempt |
| `request.completed` | `EvidencePackExecution` + `PALReceiptRef` tokens |

`NewRequestCompleted` sums `TokensIn`/`TokensOut` across PAL receipts, so per-request cost is answerable without reading every receipt.

I re-verified every anchor the issue names still exists on current `main` (`e9de2d31`) rather than trusting the table, which was written against `9a28f6d1`. All eleven resolve.

## The completeness invariant (§5.1)

`ValidateRequestSequence` requires exactly one `received` and exactly one terminal from {`failed`, `completed`}. The point is that **a missing terminal is itself a signal** — an unclosed request — rather than silence: a monitor that only counts emitted events cannot tell "nothing went wrong" from "the process died mid-request".

It also rejects a sequence spanning two `correlation_id`s, which would silently merge two requests into one story.

## HELM-290 §11 becomes runnable

Includes the five synthetic sequences — ALLOW, DENY, ESCALATE, execution failure, and a read-only request that completes without dispatch — built from the **real constructors**, not hand-written envelopes. Each asserts §1 + exactly one terminal and that every event joins on `correlation_id`. That walk is the half of §11 that previously had no way to run.

## Verification

- `go test ./...` from `core/` — **275 packages, 0 failures**
- §6 prohibited-label scan (`TestNoProhibitedMetricLabels`) still green — none of the new fields may become a metric label
- `make verify-boundary` — 1098 entries, manifest matches the tree (re-run with the new files tracked, since an untracked file wouldn't be seen)
- `go vet` + `gofmt` clean; 9 new tests

## Scope

This is the schema and the projections. **Wiring the emit points into the live request path is not in this PR** — the issue flags the `#1`/`#2` emit sites as wanting human review, and placing them touches the ingress and PEP paths. Happy to follow up once the shape here is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183cb9Kvzswa7VKjhoqVbdi