### PR TITLE
fix(release): pin Console v0.8 sidecar source

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,10 +6,10 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
       "source": {
-        "commit": "d5382a39af34652d4c04cf17b24133c762ee9ce7",
-        "tree": "f18cd7367be0f2a9452e1081f23112c3ec9c0348",
+        "commit": "943726863b9a28bf75945c4db1d2a0f659595000",
+        "tree": "6f98cf7567f0ca8ad6d841422df1a6a79e358f2f",
         "version": "0.2.1",
-        "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076"
+        "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9"
       }
     }
   ]

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,10 +28,10 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "d5382a39af34652d4c04cf17b24133c762ee9ce7",
-    "tree": "f18cd7367be0f2a9452e1081f23112c3ec9c0348",
+    "commit": "943726863b9a28bf75945c4db1d2a0f659595000",
+    "tree": "6f98cf7567f0ca8ad6d841422df1a6a79e358f2f",
     "version": "0.2.1",
-    "package_lock_sha256": "1028990307789189333657942de79d11e6889ef47dc539f77e0a9c94c26a2076",
+    "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9",
 }
 RELEASE_WORKFLOW_REF = "refs/tags/helm-console-sidecar-v0.8.0"
 TEST_WORKFLOW_REF = "refs/tags/test-console-source"


### PR DESCRIPTION
Updates the checked-in v0.8.0 Console sidecar source tuple to the merged Console contract source. The immutable workflow tag reference is unchanged.\n\nValidation:\n- python3 scripts/release/console_local_sidecar.py pin --pins release/console-local-sidecar-pins.json --kernel-release v0.8.0\n- python3 scripts/release/console_local_sidecar_test.py\n- git diff --check