### PR TITLE
docs(correlation): one package comment, not two contradictory ones (HELM-460)

### DIFF
--- a/core/pkg/correlation/correlation.go
+++ b/core/pkg/correlation/correlation.go
@@ -1,16 +1,3 @@
-// Package correlation carries the product request identity of the pilot
-// business-telemetry contract (§2.2): one opaque ID that joins a request
-// across services, receipts and evidence.
-//
-// It deliberately depends on nothing but the standard library and a UUID
-// implementation. Reading an ID out of a context is not a tracing concern, and
-// the packages that do it — the policy engine, the executor — should not
-// inherit an OpenTelemetry SDK and an OTLP exporter to do it.
-//
-// The contract keeps this identity separate from the OTel identity (§3):
-// correlation_id survives sampling and is stamped onto receipts, while
-// trace_id/span_id are infrastructure identity that may be dropped. Anything
-// needing the latter belongs in pkg/tracing, not here.
 package correlation
 
 import (

--- a/core/pkg/correlation/doc.go
+++ b/core/pkg/correlation/doc.go
@@ -1,2 +1,19 @@
-// Package correlation groups HELM authority-to-evidence correlation engines.
+// Package correlation carries the product request identity of the pilot
+// business-telemetry contract (§2.2): one opaque ID that joins a request
+// across services, receipts and evidence.
+//
+// It deliberately depends on nothing but the standard library and a UUID
+// implementation. Reading an ID out of a context is not a tracing concern, and
+// the packages that do it — the policy engine, the executor — should not
+// inherit an OpenTelemetry SDK and an OTLP exporter to do it (HELM-460).
+//
+// The contract keeps this identity separate from the OTel identity (§3):
+// correlation_id survives sampling and is stamped onto receipts, while
+// trace_id/span_id are infrastructure identity that may be dropped. Anything
+// needing the latter belongs in pkg/tracing, not here.
+//
+// Subpackages group the authority-to-evidence correlation engines, which
+// correlate observed host activity back to governed decisions — a different
+// sense of "correlation" than the request identity above, and deliberately
+// kept out of this package's dependency-free root.
 package correlation


### PR DESCRIPTION
Follow-up to #767, fixing something that PR introduced.

`pkg/correlation` **already existed** — added long before as a namespace whose `doc.go` described it as grouping *"HELM authority-to-evidence correlation engines"*, with the real content in the `hostaction/` subpackage and **no code at the root**.

#767 added the request-identity code to that root and brought its own package comment along, so the package ended up with two package comments describing two different things. Nothing broke — Go permits it and every gate passed — but a reader landing on `correlation.ID` found a package doc about host-activity correlation engines, which is a different sense of the word entirely.

`doc.go` is now the single package comment and states both roles and how they differ. `correlation.go` starts at its package clause.

I found this while verifying that the merged branches had actually landed on `main`, not from a failing check — no gate looks for a duplicate package comment.

## Verification

`make quality-pr` — 0 blocking failures. `gofmt` clean, `go build` clean, `pkg/correlation` and `pkg/tracing` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0183cb9Kvzswa7VKjhoqVbdi