### PR TITLE
feat(approval): durable GeneratedSpec ceremony runtime

### DIFF
--- a/core/cmd/helm-ai-kernel/generated_spec_approval_routes.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_routes.go
@@ -1,0 +1,316 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/api"
+	helmauth "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/auth"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapproval"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapprovalceremony"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+)
+
+const (
+	generatedSpecApprovalBeginPath      = "/internal/v1/generated-spec-approvals/begin"
+	generatedSpecApprovalGetPath        = "/internal/v1/generated-spec-approvals/get"
+	generatedSpecApprovalChallengePath  = "/internal/v1/generated-spec-approvals/challenge"
+	generatedSpecApprovalSubmitPath     = "/internal/v1/generated-spec-approvals/submit"
+	generatedSpecApprovalConsumePath    = "/internal/v1/generated-spec-approvals/consume"
+	generatedSpecApprovalRecoverPath    = "/internal/v1/generated-spec-approvals/recover"
+	generatedSpecApprovalMaxBody        = 256 << 10
+	generatedSpecApprovalContractStatus = "generated_spec_approval.v1"
+)
+
+type generatedSpecApprovalIdentityContextKey struct{}
+
+type generatedSpecApprovalRouteIdentity struct {
+	Subject     string
+	TenantID    string
+	WorkspaceID string
+	Audience    string
+}
+
+type generatedSpecApprovalContextIdentityProvider struct{}
+
+func (generatedSpecApprovalContextIdentityProvider) LoadControlIdentity(ctx context.Context) (generatedspecapprovalceremony.ControlIdentity, error) {
+	identity, ok := ctx.Value(generatedSpecApprovalIdentityContextKey{}).(generatedSpecApprovalRouteIdentity)
+	if !ok || !validWorkloadClaim(identity.Subject) || !validWorkloadClaim(identity.TenantID) || !validWorkloadClaim(identity.WorkspaceID) {
+		return generatedspecapprovalceremony.ControlIdentity{}, generatedspecapprovalceremony.ErrControlUnavailable
+	}
+	return generatedspecapprovalceremony.ControlIdentity{Subject: identity.Subject, TenantID: identity.TenantID, WorkspaceID: identity.WorkspaceID}, nil
+}
+
+func (generatedSpecApprovalContextIdentityProvider) LoadConsumerIdentity(ctx context.Context) (generatedspecapprovalceremony.ConsumerIdentity, error) {
+	identity, ok := ctx.Value(generatedSpecApprovalIdentityContextKey{}).(generatedSpecApprovalRouteIdentity)
+	if !ok || !validWorkloadClaim(identity.Subject) || !validWorkloadClaim(identity.TenantID) ||
+		!validWorkloadClaim(identity.WorkspaceID) || identity.Audience != contracts.GeneratedSpecApprovalAudienceV1 {
+		return generatedspecapprovalceremony.ConsumerIdentity{}, generatedspecapprovalceremony.ErrConsumerUnavailable
+	}
+	return generatedspecapprovalceremony.ConsumerIdentity{
+		Subject: identity.Subject, TenantID: identity.TenantID, WorkspaceID: identity.WorkspaceID, Audience: identity.Audience,
+	}, nil
+}
+
+type generatedSpecApprovalIDRequest struct {
+	ApprovalID string `json:"approval_id"`
+}
+
+type generatedSpecApprovalBeginRequest struct {
+	BindingRef string `json:"binding_ref"`
+}
+
+type generatedSpecApprovalSubmitRequest struct {
+	ApprovalID string                                     `json:"approval_id"`
+	Assertions []contracts.GeneratedSpecApprovalAssertion `json:"assertions"`
+}
+
+type generatedSpecApprovalConsumeRequest struct {
+	ApprovalID string `json:"approval_id"`
+	GrantID    string `json:"grant_id"`
+	GrantHash  string `json:"grant_hash"`
+	Nonce      string `json:"nonce"`
+}
+
+type generatedSpecApprovalRecordResponse struct {
+	State         generatedspecapprovalceremony.State       `json:"state"`
+	ApprovalID    string                                    `json:"approval_id"`
+	TenantID      string                                    `json:"tenant_id"`
+	WorkspaceID   string                                    `json:"workspace_id"`
+	Challenge     *contracts.GeneratedSpecApprovalChallenge `json:"challenge,omitempty"`
+	Grant         *generatedspecapproval.SignedGrant        `json:"grant,omitempty"`
+	Consumption   *generatedspecapproval.SignedConsumption  `json:"consumption,omitempty"`
+	HoldStartedAt time.Time                                 `json:"hold_started_at"`
+	ExpiresAt     *time.Time                                `json:"expires_at,omitempty"`
+	ConsumedAt    *time.Time                                `json:"consumed_at,omitempty"`
+	ConsumedBy    string                                    `json:"consumed_by,omitempty"`
+	Version       int64                                     `json:"version"`
+}
+
+func registerGeneratedSpecApprovalRoutes(mux *http.ServeMux, runtime *generatedSpecApprovalRuntime) {
+	if mux == nil || runtime == nil {
+		return
+	}
+	mux.HandleFunc(generatedSpecApprovalBeginPath, runtime.protectControl(runtime.handleBegin))
+	mux.HandleFunc(generatedSpecApprovalGetPath, runtime.protectControl(runtime.handleGet))
+	mux.HandleFunc(generatedSpecApprovalChallengePath, runtime.protectControl(runtime.handleChallenge))
+	mux.HandleFunc(generatedSpecApprovalSubmitPath, runtime.protectControl(runtime.handleSubmit))
+	mux.HandleFunc(generatedSpecApprovalConsumePath, runtime.protectConsumer(runtime.handleConsume(false)))
+	mux.HandleFunc(generatedSpecApprovalRecoverPath, runtime.protectConsumer(runtime.handleConsume(true)))
+}
+
+func (runtime *generatedSpecApprovalRuntime) protectControl(next http.HandlerFunc) http.HandlerFunc {
+	return runtime.protect(runtime.controlValidator, "helm-generated-spec-approval-control", "generated-spec-approval-controller", "control", next)
+}
+
+func (runtime *generatedSpecApprovalRuntime) protectConsumer(next http.HandlerFunc) http.HandlerFunc {
+	return runtime.protect(runtime.consumerValidator, "helm-generated-spec-approval-consumer", "generated-spec-approval-consumer", "consume", next)
+}
+
+func (runtime *generatedSpecApprovalRuntime) protect(validator approvalConsumerTokenValidator, realm, role, capability string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		if runtime == nil || runtime.service == nil || validator == nil || runtime.audience != contracts.GeneratedSpecApprovalAudienceV1 || runtime.maxTokenTTL <= 0 {
+			api.WriteError(w, http.StatusServiceUnavailable, "GeneratedSpec approval unavailable", "workload authentication is not configured")
+			return
+		}
+		token, detail, ok := helmauth.BearerToken(r)
+		if !ok {
+			writeApprovalWorkloadUnauthorized(w, realm, detail)
+			return
+		}
+		claims, err := validator.ValidateAuthorization(token)
+		if err != nil {
+			var validationErr *mcppkg.JWKSValidationError
+			if errors.As(err, &validationErr) && validationErr.Kind == mcppkg.JWKSErrMissingScope {
+				w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer realm="%s", error="insufficient_scope"`, realm))
+				api.WriteForbidden(w, "Workload token is missing the GeneratedSpec approval "+capability+" scope")
+				return
+			}
+			writeApprovalWorkloadUnauthorized(w, realm, "Invalid or expired workload token")
+			return
+		}
+		if claims == nil || !validWorkloadClaim(claims.RegisteredClaims.Subject) ||
+			!validWorkloadClaim(claims.TenantID) || !validWorkloadClaim(claims.WorkspaceID) {
+			writeApprovalWorkloadUnauthorized(w, realm, "Workload token subject, tenant, and workspace are required")
+			return
+		}
+		issuedAt, expiresAt := claims.RegisteredClaims.IssuedAt, claims.RegisteredClaims.ExpiresAt
+		if issuedAt == nil || expiresAt == nil || !expiresAt.After(issuedAt.Time) || expiresAt.Sub(issuedAt.Time) > runtime.maxTokenTTL {
+			writeApprovalWorkloadUnauthorized(w, realm, "Workload token lifetime is invalid")
+			return
+		}
+		identity := generatedSpecApprovalRouteIdentity{
+			Subject: claims.RegisteredClaims.Subject, TenantID: claims.TenantID,
+			WorkspaceID: claims.WorkspaceID, Audience: runtime.audience,
+		}
+		ctx := context.WithValue(r.Context(), generatedSpecApprovalIdentityContextKey{}, identity)
+		ctx = helmauth.WithPrincipal(ctx, &helmauth.BasePrincipal{ID: identity.Subject, TenantID: identity.TenantID, Roles: []string{role}})
+		next(w, r.WithContext(ctx))
+	}
+}
+
+func (runtime *generatedSpecApprovalRuntime) handleBegin(w http.ResponseWriter, r *http.Request) {
+	if !requireGeneratedSpecApprovalPOST(w, r) {
+		return
+	}
+	var request generatedSpecApprovalBeginRequest
+	if decodeGeneratedSpecApprovalRequest(w, r, &request) != nil || !validWorkloadClaim(request.BindingRef) {
+		api.WriteBadRequest(w, "Invalid GeneratedSpec approval binding reference")
+		return
+	}
+	record, err := runtime.service.BeginHold(r.Context(), request.BindingRef)
+	writeGeneratedSpecApprovalResult(w, record, err)
+}
+
+func (runtime *generatedSpecApprovalRuntime) handleGet(w http.ResponseWriter, r *http.Request) {
+	if !requireGeneratedSpecApprovalPOST(w, r) {
+		return
+	}
+	var request generatedSpecApprovalIDRequest
+	if decodeGeneratedSpecApprovalRequest(w, r, &request) != nil || !validWorkloadClaim(request.ApprovalID) {
+		api.WriteBadRequest(w, "Invalid GeneratedSpec approval id")
+		return
+	}
+	record, err := runtime.service.Get(r.Context(), request.ApprovalID)
+	writeGeneratedSpecApprovalResult(w, record, err)
+}
+
+func (runtime *generatedSpecApprovalRuntime) handleChallenge(w http.ResponseWriter, r *http.Request) {
+	if !requireGeneratedSpecApprovalPOST(w, r) {
+		return
+	}
+	var request generatedSpecApprovalIDRequest
+	if decodeGeneratedSpecApprovalRequest(w, r, &request) != nil || !validWorkloadClaim(request.ApprovalID) {
+		api.WriteBadRequest(w, "Invalid GeneratedSpec approval id")
+		return
+	}
+	record, err := runtime.service.IssueChallenge(r.Context(), request.ApprovalID)
+	writeGeneratedSpecApprovalResult(w, record, err)
+}
+
+func (runtime *generatedSpecApprovalRuntime) handleSubmit(w http.ResponseWriter, r *http.Request) {
+	if !requireGeneratedSpecApprovalPOST(w, r) {
+		return
+	}
+	var request generatedSpecApprovalSubmitRequest
+	if decodeGeneratedSpecApprovalRequest(w, r, &request) != nil || !validWorkloadClaim(request.ApprovalID) || len(request.Assertions) == 0 {
+		api.WriteBadRequest(w, "Invalid GeneratedSpec approval assertions")
+		return
+	}
+	record, err := runtime.service.Get(r.Context(), request.ApprovalID)
+	if err == nil && record.State == generatedspecapprovalceremony.StateChallengeIssued {
+		record, err = runtime.service.VerifyQuorum(r.Context(), request.ApprovalID, request.Assertions)
+	}
+	if err == nil && record.State == generatedspecapprovalceremony.StateQuorumVerified {
+		record, err = runtime.service.IssueGrant(r.Context(), request.ApprovalID)
+	}
+	if err == nil && record.State != generatedspecapprovalceremony.StateGrantIssued && record.State != generatedspecapprovalceremony.StateConsumed {
+		err = generatedspecapprovalceremony.ErrTransitionConflict
+	}
+	writeGeneratedSpecApprovalResult(w, record, err)
+}
+
+func (runtime *generatedSpecApprovalRuntime) handleConsume(recoverOnly bool) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !requireGeneratedSpecApprovalPOST(w, r) {
+			return
+		}
+		var request generatedSpecApprovalConsumeRequest
+		if decodeGeneratedSpecApprovalRequest(w, r, &request) != nil || !validWorkloadClaim(request.ApprovalID) ||
+			!validWorkloadClaim(request.GrantID) || !validSHA256Reference(request.GrantHash) || !validLowerHex(request.Nonce, 32) {
+			api.WriteBadRequest(w, "Invalid GeneratedSpec approval grant tuple")
+			return
+		}
+		var record generatedspecapprovalceremony.Record
+		var err error
+		if recoverOnly {
+			record, err = runtime.service.RecoverGrantConsumption(r.Context(), request.ApprovalID, request.GrantID, request.GrantHash, request.Nonce)
+		} else {
+			record, err = runtime.service.ConsumeGrant(r.Context(), request.ApprovalID, request.GrantID, request.GrantHash, request.Nonce)
+		}
+		writeGeneratedSpecApprovalResult(w, record, err)
+	}
+}
+
+func requireGeneratedSpecApprovalPOST(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != http.MethodPost {
+		api.WriteMethodNotAllowed(w)
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		api.WriteError(w, http.StatusUnsupportedMediaType, "Unsupported media type", "Content-Type must be application/json")
+		return false
+	}
+	return true
+}
+
+func decodeGeneratedSpecApprovalRequest(w http.ResponseWriter, r *http.Request, target any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, generatedSpecApprovalMaxBody)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("request must contain exactly one JSON object")
+	}
+	return nil
+}
+
+func writeGeneratedSpecApprovalResult(w http.ResponseWriter, record generatedspecapprovalceremony.Record, err error) {
+	if err != nil {
+		writeGeneratedSpecApprovalError(w, err)
+		return
+	}
+	response := generatedSpecApprovalRecordResponse{
+		State: record.State, ApprovalID: record.ApprovalID, TenantID: record.TenantID, WorkspaceID: record.WorkspaceID,
+		Challenge: record.Challenge, Grant: record.SignedGrant, Consumption: record.SignedConsumption,
+		HoldStartedAt: record.HoldStartedAt, ExpiresAt: record.ExpiresAt, ConsumedAt: record.ConsumedAt,
+		ConsumedBy: record.ConsumedBy, Version: record.Version,
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Helm-Contract-Status", generatedSpecApprovalContractStatus)
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+func writeGeneratedSpecApprovalError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, generatedspecapprovalceremony.ErrInvalidRecord):
+		api.WriteBadRequest(w, "Invalid GeneratedSpec approval request")
+	case errors.Is(err, generatedspecapprovalceremony.ErrNotFound):
+		api.WriteError(w, http.StatusNotFound, "GeneratedSpec approval not found", "no matching ceremony exists in this workload scope")
+	case errors.Is(err, generatedspecapprovalceremony.ErrHoldPending), errors.Is(err, generatedspecapprovalceremony.ErrTransitionConflict):
+		api.WriteConflict(w, "GeneratedSpec approval conflicts with current ceremony state")
+	case errors.Is(err, generatedspecapprovalceremony.ErrExpired):
+		api.WriteError(w, http.StatusGone, "GeneratedSpec approval expired", "the challenge or grant is no longer active")
+	case errors.Is(err, approvalverify.ErrVerificationFailed), errors.Is(err, generatedspecapproval.ErrVerificationFailed):
+		api.WriteBadRequest(w, "GeneratedSpec approval verification failed")
+	case errors.Is(err, approvalverify.ErrDuplicateSigner), errors.Is(err, approvalverify.ErrQuorumNotMet),
+		errors.Is(err, generatedspecapproval.ErrDuplicateSigner), errors.Is(err, generatedspecapproval.ErrQuorumNotMet):
+		api.WriteConflict(w, "GeneratedSpec approval quorum is not satisfied")
+	case errors.Is(err, generatedspecapprovalceremony.ErrControlUnavailable), errors.Is(err, generatedspecapprovalceremony.ErrConsumerUnavailable),
+		errors.Is(err, approvalverify.ErrAuthorityRejected), errors.Is(err, generatedspecapproval.ErrAuthorityRejected),
+		errors.Is(err, approvalverify.ErrSignatureRejected), errors.Is(err, generatedspecapproval.ErrAssertionRejected),
+		errors.Is(err, generatedspecapproval.ErrSignatureRejected):
+		api.WriteForbidden(w, "GeneratedSpec approval authority rejected the request")
+	case errors.Is(err, generatedspecapprovalceremony.ErrEmergencyStopFenced):
+		w.Header().Set(approvalConsumptionReasonHeader, approvalConsumptionFencedReason)
+		api.WriteConflict(w, "GeneratedSpec approval is emergency-stop fenced")
+	default:
+		api.WriteError(w, http.StatusServiceUnavailable, "GeneratedSpec approval unavailable", "durable approval authority rejected the operation")
+	}
+}
+
+var _ generatedspecapprovalceremony.ControlIdentityProvider = generatedSpecApprovalContextIdentityProvider{}
+var _ generatedspecapprovalceremony.ConsumerIdentityProvider = generatedSpecApprovalContextIdentityProvider{}

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_routes.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_routes.go
@@ -81,18 +81,19 @@ type generatedSpecApprovalConsumeRequest struct {
 }
 
 type generatedSpecApprovalRecordResponse struct {
-	State         generatedspecapprovalceremony.State       `json:"state"`
-	ApprovalID    string                                    `json:"approval_id"`
-	TenantID      string                                    `json:"tenant_id"`
-	WorkspaceID   string                                    `json:"workspace_id"`
-	Challenge     *contracts.GeneratedSpecApprovalChallenge `json:"challenge,omitempty"`
-	Grant         *generatedspecapproval.SignedGrant        `json:"grant,omitempty"`
-	Consumption   *generatedspecapproval.SignedConsumption  `json:"consumption,omitempty"`
-	HoldStartedAt time.Time                                 `json:"hold_started_at"`
-	ExpiresAt     *time.Time                                `json:"expires_at,omitempty"`
-	ConsumedAt    *time.Time                                `json:"consumed_at,omitempty"`
-	ConsumedBy    string                                    `json:"consumed_by,omitempty"`
-	Version       int64                                     `json:"version"`
+	State           generatedspecapprovalceremony.State       `json:"state"`
+	ApprovalID      string                                    `json:"approval_id"`
+	TenantID        string                                    `json:"tenant_id"`
+	WorkspaceID     string                                    `json:"workspace_id"`
+	GeneratedSpecID string                                    `json:"generated_spec_id"`
+	Challenge       *contracts.GeneratedSpecApprovalChallenge `json:"challenge,omitempty"`
+	Grant           *generatedspecapproval.SignedGrant        `json:"grant,omitempty"`
+	Consumption     *generatedspecapproval.SignedConsumption  `json:"consumption,omitempty"`
+	HoldStartedAt   time.Time                                 `json:"hold_started_at"`
+	ExpiresAt       *time.Time                                `json:"expires_at,omitempty"`
+	ConsumedAt      *time.Time                                `json:"consumed_at,omitempty"`
+	ConsumedBy      string                                    `json:"consumed_by,omitempty"`
+	Version         int64                                     `json:"version"`
 }
 
 func registerGeneratedSpecApprovalRoutes(mux *http.ServeMux, runtime *generatedSpecApprovalRuntime) {
@@ -274,7 +275,8 @@ func writeGeneratedSpecApprovalResult(w http.ResponseWriter, record generatedspe
 	}
 	response := generatedSpecApprovalRecordResponse{
 		State: record.State, ApprovalID: record.ApprovalID, TenantID: record.TenantID, WorkspaceID: record.WorkspaceID,
-		Challenge: record.Challenge, Grant: record.SignedGrant, Consumption: record.SignedConsumption,
+		GeneratedSpecID: record.Binding.GeneratedSpecID,
+		Challenge:       record.Challenge, Grant: record.SignedGrant, Consumption: record.SignedConsumption,
 		HoldStartedAt: record.HoldStartedAt, ExpiresAt: record.ExpiresAt, ConsumedAt: record.ConsumedAt,
 		ConsumedBy: record.ConsumedBy, Version: record.Version,
 	}

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_routes_test.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_routes_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapprovalceremony"
+)
+
+func TestGeneratedSpecApprovalResponseCarriesPendingSpecBinding(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	writeGeneratedSpecApprovalResult(recorder, generatedspecapprovalceremony.Record{
+		State: generatedspecapprovalceremony.StateHoldPending, ApprovalID: "approval-a",
+		TenantID: "tenant-a", WorkspaceID: "workspace-a", HoldStartedAt: time.Now().UTC(), Version: 1,
+		Binding: generatedspecapprovalceremony.Binding{GeneratedSpecID: "generated-spec-a"},
+	}, nil)
+	if recorder.Code != http.StatusOK || recorder.Header().Get("X-Helm-Contract-Status") != generatedSpecApprovalContractStatus {
+		t.Fatalf("status=%d headers=%v body=%s", recorder.Code, recorder.Header(), recorder.Body.String())
+	}
+	var response generatedSpecApprovalRecordResponse
+	if err := json.NewDecoder(recorder.Body).Decode(&response); err != nil {
+		t.Fatal(err)
+	}
+	if response.GeneratedSpecID != "generated-spec-a" {
+		t.Fatalf("generated_spec_id=%q", response.GeneratedSpecID)
+	}
+}

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_runtime.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_runtime.go
@@ -1,0 +1,336 @@
+package main
+
+// quantum_posture: this runtime wires classical Ed25519 approval envelopes,
+// SHA-256 source commitments, TLS, and RS256 workload JWTs. It makes no
+// post-quantum claim.
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapproval"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapprovalceremony"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/kernel"
+	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+)
+
+const (
+	generatedSpecApprovalEnabledEnv               = "HELM_GENERATED_SPEC_APPROVAL_ENABLED"
+	generatedSpecApprovalSourceURLEnv             = "HELM_GENERATED_SPEC_APPROVAL_SOURCE_URL"
+	generatedSpecApprovalSourceTokenEnv           = "HELM_GENERATED_SPEC_APPROVAL_SOURCE_TOKEN"
+	generatedSpecApprovalJWKSURLEnv               = "HELM_GENERATED_SPEC_APPROVAL_JWKS_URL"
+	generatedSpecApprovalIssuerEnv                = "HELM_GENERATED_SPEC_APPROVAL_ISSUER"
+	generatedSpecApprovalAudienceEnv              = "HELM_GENERATED_SPEC_APPROVAL_AUDIENCE"
+	generatedSpecApprovalResourceEnv              = "HELM_GENERATED_SPEC_APPROVAL_RESOURCE"
+	generatedSpecApprovalControlScopeEnv          = "HELM_GENERATED_SPEC_APPROVAL_CONTROL_SCOPE"
+	generatedSpecApprovalConsumerScopeEnv         = "HELM_GENERATED_SPEC_APPROVAL_CONSUMER_SCOPE"
+	generatedSpecApprovalMaxTokenTTLEnv           = "HELM_GENERATED_SPEC_APPROVAL_MAX_TOKEN_TTL"
+	generatedSpecApprovalMinHoldDurationEnv       = "HELM_GENERATED_SPEC_APPROVAL_MIN_HOLD_DURATION"
+	generatedSpecApprovalChallengeTTLEnv          = "HELM_GENERATED_SPEC_APPROVAL_CHALLENGE_TTL"
+	generatedSpecApprovalMaxChallengeLifetimeEnv  = "HELM_GENERATED_SPEC_APPROVAL_MAX_CHALLENGE_LIFETIME"
+	generatedSpecApprovalGrantTTLEnv              = "HELM_GENERATED_SPEC_APPROVAL_GRANT_TTL"
+	generatedSpecApprovalMaxAssertionsEnv         = "HELM_GENERATED_SPEC_APPROVAL_MAX_ASSERTIONS"
+	generatedSpecApprovalServerIdentityEnv        = "HELM_GENERATED_SPEC_APPROVAL_SERVER_IDENTITY"
+	generatedSpecApprovalSigningKeyRefEnv         = "HELM_GENERATED_SPEC_APPROVAL_SIGNING_KEY_REF"
+	generatedSpecApprovalKernelTrustRootIDEnv     = "HELM_GENERATED_SPEC_APPROVAL_KERNEL_TRUST_ROOT_ID"
+	generatedSpecApprovalBindingSourcePath        = "/internal/v1/generated-spec-approval/source/binding"
+	generatedSpecApprovalAuthoritySourcePath      = "/internal/v1/generated-spec-approval/source/authority"
+	defaultGeneratedSpecApprovalControlScope      = "helm.generated-spec.approval.control"
+	defaultGeneratedSpecApprovalConsumerScope     = "helm.generated-spec.approval.consume"
+	defaultGeneratedSpecApprovalMaxTokenTTL       = 5 * time.Minute
+	maximumGeneratedSpecApprovalMaxTokenTTL       = 15 * time.Minute
+	defaultGeneratedSpecApprovalMinHoldDuration   = 5 * time.Second
+	defaultGeneratedSpecApprovalChallengeTTL      = 10 * time.Minute
+	defaultGeneratedSpecApprovalChallengeLifetime = 30 * time.Minute
+	defaultGeneratedSpecApprovalGrantTTL          = 2 * time.Minute
+	defaultGeneratedSpecApprovalMaxAssertions     = 8
+	generatedSpecApprovalMaximumSourceResponse    = 512 << 10
+	generatedSpecApprovalSourceTimeout            = 10 * time.Second
+)
+
+type generatedSpecApprovalRuntimeConfig struct {
+	SourceURL            string
+	SourceToken          string
+	JWKSURL              string
+	Issuer               string
+	Audience             string
+	Resource             string
+	ControlScope         string
+	ConsumerScope        string
+	MaxTokenTTL          time.Duration
+	MinHoldDuration      time.Duration
+	ChallengeTTL         time.Duration
+	MaxChallengeLifetime time.Duration
+	GrantTTL             time.Duration
+	MaxAssertions        int
+	ServerIdentity       string
+	SigningKeyRef        string
+	KernelTrustRootID    string
+}
+
+type generatedSpecApprovalRuntime struct {
+	service           *generatedspecapprovalceremony.Service
+	controlValidator  approvalConsumerTokenValidator
+	consumerValidator approvalConsumerTokenValidator
+	audience          string
+	maxTokenTTL       time.Duration
+}
+
+func generatedSpecApprovalRuntimeConfigFromEnv() (generatedSpecApprovalRuntimeConfig, bool, error) {
+	if !envBool(generatedSpecApprovalEnabledEnv) {
+		return generatedSpecApprovalRuntimeConfig{}, false, nil
+	}
+	cfg := generatedSpecApprovalRuntimeConfig{
+		SourceURL: strings.TrimSpace(os.Getenv(generatedSpecApprovalSourceURLEnv)), SourceToken: strings.TrimSpace(os.Getenv(generatedSpecApprovalSourceTokenEnv)),
+		JWKSURL: strings.TrimSpace(os.Getenv(generatedSpecApprovalJWKSURLEnv)), Issuer: strings.TrimSpace(os.Getenv(generatedSpecApprovalIssuerEnv)),
+		Audience: strings.TrimSpace(os.Getenv(generatedSpecApprovalAudienceEnv)), Resource: strings.TrimSpace(os.Getenv(generatedSpecApprovalResourceEnv)),
+		ControlScope: strings.TrimSpace(os.Getenv(generatedSpecApprovalControlScopeEnv)), ConsumerScope: strings.TrimSpace(os.Getenv(generatedSpecApprovalConsumerScopeEnv)),
+		MaxTokenTTL: defaultGeneratedSpecApprovalMaxTokenTTL, MinHoldDuration: defaultGeneratedSpecApprovalMinHoldDuration,
+		ChallengeTTL: defaultGeneratedSpecApprovalChallengeTTL, MaxChallengeLifetime: defaultGeneratedSpecApprovalChallengeLifetime,
+		GrantTTL: defaultGeneratedSpecApprovalGrantTTL, MaxAssertions: defaultGeneratedSpecApprovalMaxAssertions,
+		ServerIdentity:    strings.TrimSpace(os.Getenv(generatedSpecApprovalServerIdentityEnv)),
+		SigningKeyRef:     strings.TrimSpace(os.Getenv(generatedSpecApprovalSigningKeyRefEnv)),
+		KernelTrustRootID: strings.TrimSpace(os.Getenv(generatedSpecApprovalKernelTrustRootIDEnv)),
+	}
+	if cfg.ControlScope == "" {
+		cfg.ControlScope = defaultGeneratedSpecApprovalControlScope
+	}
+	if cfg.ConsumerScope == "" {
+		cfg.ConsumerScope = defaultGeneratedSpecApprovalConsumerScope
+	}
+	var err error
+	for name, target := range map[string]*time.Duration{
+		generatedSpecApprovalMaxTokenTTLEnv: &cfg.MaxTokenTTL, generatedSpecApprovalMinHoldDurationEnv: &cfg.MinHoldDuration,
+		generatedSpecApprovalChallengeTTLEnv: &cfg.ChallengeTTL, generatedSpecApprovalMaxChallengeLifetimeEnv: &cfg.MaxChallengeLifetime,
+		generatedSpecApprovalGrantTTLEnv: &cfg.GrantTTL,
+	} {
+		if raw := strings.TrimSpace(os.Getenv(name)); raw != "" {
+			*target, err = time.ParseDuration(raw)
+			if err != nil {
+				return generatedSpecApprovalRuntimeConfig{}, true, fmt.Errorf("parse %s: %w", name, err)
+			}
+		}
+	}
+	if raw := strings.TrimSpace(os.Getenv(generatedSpecApprovalMaxAssertionsEnv)); raw != "" {
+		cfg.MaxAssertions = envInt(generatedSpecApprovalMaxAssertionsEnv, -1)
+	}
+	if err := validateGeneratedSpecApprovalRuntimeConfig(cfg, false); err != nil {
+		return generatedSpecApprovalRuntimeConfig{}, true, err
+	}
+	return cfg, true, nil
+}
+
+func validateGeneratedSpecApprovalRuntimeConfig(cfg generatedSpecApprovalRuntimeConfig, allowInsecureSource bool) error {
+	for name, value := range map[string]string{
+		generatedSpecApprovalSourceTokenEnv: cfg.SourceToken, generatedSpecApprovalIssuerEnv: cfg.Issuer,
+		generatedSpecApprovalAudienceEnv: cfg.Audience, generatedSpecApprovalResourceEnv: cfg.Resource,
+		generatedSpecApprovalControlScopeEnv: cfg.ControlScope, generatedSpecApprovalConsumerScopeEnv: cfg.ConsumerScope,
+		generatedSpecApprovalServerIdentityEnv: cfg.ServerIdentity, generatedSpecApprovalSigningKeyRefEnv: cfg.SigningKeyRef,
+		generatedSpecApprovalKernelTrustRootIDEnv: cfg.KernelTrustRootID,
+	} {
+		if !validWorkloadClaim(value) {
+			return fmt.Errorf("%s is required and must be a non-whitespace token", name)
+		}
+	}
+	if cfg.Audience != contracts.GeneratedSpecApprovalAudienceV1 || cfg.ControlScope == cfg.ConsumerScope {
+		return errors.New("generated spec approval audience or workload scopes are invalid")
+	}
+	for name, raw := range map[string]string{generatedSpecApprovalSourceURLEnv: cfg.SourceURL, generatedSpecApprovalJWKSURLEnv: cfg.JWKSURL, generatedSpecApprovalResourceEnv: cfg.Resource} {
+		parsed, err := url.Parse(raw)
+		if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" ||
+			(parsed.Scheme != "https" && !(allowInsecureSource && name == generatedSpecApprovalSourceURLEnv && parsed.Scheme == "http")) {
+			return fmt.Errorf("%s must be an absolute HTTPS URL", name)
+		}
+	}
+	if cfg.MaxTokenTTL <= 0 || cfg.MaxTokenTTL > maximumGeneratedSpecApprovalMaxTokenTTL || cfg.MinHoldDuration <= 0 ||
+		cfg.ChallengeTTL <= 0 || cfg.MaxChallengeLifetime <= cfg.MinHoldDuration ||
+		cfg.ChallengeTTL > cfg.MaxChallengeLifetime-cfg.MinHoldDuration || cfg.GrantTTL <= 0 || cfg.MaxAssertions <= 0 || cfg.MaxAssertions > 64 {
+		return errors.New("generated spec approval runtime limits are invalid")
+	}
+	return nil
+}
+
+func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops kernel.ScopedStopReader) (*generatedSpecApprovalRuntime, error) {
+	cfg, enabled, err := generatedSpecApprovalRuntimeConfigFromEnv()
+	if err != nil || !enabled {
+		return nil, err
+	}
+	if databaseMode != "postgres" || db == nil || stops == nil {
+		return nil, errors.New("generated spec approval requires durable PostgreSQL and emergency-stop scope coordination")
+	}
+	approvalSigner, err := classicalApprovalSigner(signer)
+	if err != nil {
+		return nil, err
+	}
+	verifier, err := generatedspecapproval.NewEd25519Verifier(approvalSigner.PublicKeyBytes(), cfg.SigningKeyRef, cfg.KernelTrustRootID)
+	if err != nil {
+		return nil, fmt.Errorf("initialize generated spec approval verifier: %w", err)
+	}
+	store := generatedspecapprovalceremony.NewPostgresStore(db, verifier)
+	if err := store.Init(ctx); err != nil {
+		return nil, fmt.Errorf("initialize generated spec approval ceremony store: %w", err)
+	}
+	source, err := newGeneratedSpecApprovalSourceClient(cfg.SourceURL, cfg.SourceToken, nil, false)
+	if err != nil {
+		return nil, err
+	}
+	identity := generatedSpecApprovalContextIdentityProvider{}
+	service, err := generatedspecapprovalceremony.NewService(
+		store, source, source, identity, identity, approvalSigner, verifier,
+		generatedspecapprovalceremony.ServiceConfig{
+			MinHoldDuration: cfg.MinHoldDuration, ChallengeTTL: cfg.ChallengeTTL,
+			MaxChallengeLifetime: cfg.MaxChallengeLifetime, GrantTTL: cfg.GrantTTL,
+			MaxAssertions: cfg.MaxAssertions, ServerIdentity: cfg.ServerIdentity,
+			KernelTrustRootID: cfg.KernelTrustRootID, SigningKeyRef: cfg.SigningKeyRef,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("initialize generated spec approval service: %w", err)
+	}
+	validatorConfig := mcppkg.JWKSConfig{JWKSURL: cfg.JWKSURL, Issuer: cfg.Issuer, Audience: cfg.Audience, Resource: cfg.Resource}
+	validatorConfig.Scopes = []string{cfg.ControlScope}
+	controlValidator := mcppkg.NewJWKSValidator(validatorConfig)
+	validatorConfig.Scopes = []string{cfg.ConsumerScope}
+	consumerValidator := mcppkg.NewJWKSValidator(validatorConfig)
+	return &generatedSpecApprovalRuntime{
+		service: service, controlValidator: controlValidator, consumerValidator: consumerValidator,
+		audience: cfg.Audience, maxTokenTTL: cfg.MaxTokenTTL,
+	}, nil
+}
+
+type generatedSpecApprovalSourceClient struct {
+	baseURL    *url.URL
+	token      string
+	httpClient *http.Client
+}
+
+type generatedSpecApprovalBindingSourceRequest struct {
+	TenantID    string `json:"tenant_id"`
+	WorkspaceID string `json:"workspace_id"`
+	BindingRef  string `json:"binding_ref"`
+}
+
+type generatedSpecApprovalAuthoritySourceRequest struct {
+	TenantID              string `json:"tenant_id"`
+	WorkspaceID           string `json:"workspace_id"`
+	AuthoritySource       string `json:"authority_source"`
+	AuthorityVersion      string `json:"authority_version"`
+	AuthoritySnapshotHash string `json:"authority_snapshot_hash"`
+}
+
+func newGeneratedSpecApprovalSourceClient(rawURL, token string, client *http.Client, allowInsecure bool) (*generatedSpecApprovalSourceClient, error) {
+	baseURL, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || baseURL.Host == "" || baseURL.User != nil || baseURL.RawQuery != "" || baseURL.Fragment != "" ||
+		(baseURL.Scheme != "https" && !(allowInsecure && baseURL.Scheme == "http")) {
+		return nil, errors.New("generated spec approval source URL must be absolute HTTPS")
+	}
+	if !validWorkloadClaim(token) {
+		return nil, errors.New("generated spec approval source token is invalid")
+	}
+	baseURL.Path = strings.TrimRight(baseURL.Path, "/")
+	if client == nil {
+		client = &http.Client{Timeout: generatedSpecApprovalSourceTimeout}
+	}
+	copy := *client
+	if copy.Timeout <= 0 {
+		copy.Timeout = generatedSpecApprovalSourceTimeout
+	}
+	if copy.Timeout > 30*time.Second {
+		return nil, errors.New("generated spec approval source timeout must not exceed 30 seconds")
+	}
+	copy.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return &generatedSpecApprovalSourceClient{baseURL: baseURL, token: token, httpClient: &copy}, nil
+}
+
+func (client *generatedSpecApprovalSourceClient) LoadGeneratedSpecApprovalBinding(ctx context.Context, tenantID, workspaceID, bindingRef string) (generatedspecapprovalceremony.Binding, error) {
+	var binding generatedspecapprovalceremony.Binding
+	err := client.post(ctx, generatedSpecApprovalBindingSourcePath, generatedSpecApprovalBindingSourceRequest{
+		TenantID: tenantID, WorkspaceID: workspaceID, BindingRef: bindingRef,
+	}, &binding)
+	if err != nil {
+		return generatedspecapprovalceremony.Binding{}, fmt.Errorf("%w: %v", generatedspecapprovalceremony.ErrBindingUnavailable, err)
+	}
+	if binding.TenantID != tenantID || binding.WorkspaceID != workspaceID || binding.BindingRef != bindingRef || binding.Validate() != nil {
+		return generatedspecapprovalceremony.Binding{}, fmt.Errorf("%w: source binding mismatch", generatedspecapprovalceremony.ErrBindingUnavailable)
+	}
+	return binding, nil
+}
+
+func (client *generatedSpecApprovalSourceClient) LoadGeneratedSpecApprovalAuthority(ctx context.Context, tenantID, workspaceID, source, version, snapshotHash string) (approvalverify.TrustStore, error) {
+	var snapshot generatedspecapprovalceremony.AuthoritySnapshot
+	err := client.post(ctx, generatedSpecApprovalAuthoritySourcePath, generatedSpecApprovalAuthoritySourceRequest{
+		TenantID: tenantID, WorkspaceID: workspaceID, AuthoritySource: source,
+		AuthorityVersion: version, AuthoritySnapshotHash: snapshotHash,
+	}, &snapshot)
+	if err != nil {
+		return approvalverify.TrustStore{}, fmt.Errorf("%w: %v", generatedspecapprovalceremony.ErrAuthorityUnavailable, err)
+	}
+	store, err := snapshot.TrustStore()
+	if err != nil || store.AuthoritySource != source || store.AuthorityVersion != version || store.AuthoritySnapshotHash != snapshotHash {
+		return approvalverify.TrustStore{}, fmt.Errorf("%w: source authority mismatch", generatedspecapprovalceremony.ErrAuthorityUnavailable)
+	}
+	return store, nil
+}
+
+func (client *generatedSpecApprovalSourceClient) post(ctx context.Context, path string, request, response any) error {
+	if client == nil || client.baseURL == nil || client.httpClient == nil {
+		return errors.New("source client is unavailable")
+	}
+	body, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+	endpoint := *client.baseURL
+	endpoint.Path = strings.TrimRight(endpoint.Path, "/") + path
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	httpRequest.Header.Set("Accept", "application/json")
+	httpRequest.Header.Set("Content-Type", "application/json")
+	httpRequest.Header.Set("Authorization", "Bearer "+client.token)
+	httpResponse, err := client.httpClient.Do(httpRequest)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = httpResponse.Body.Close() }()
+	if httpResponse.StatusCode < http.StatusOK || httpResponse.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(httpResponse.Body, 4096))
+		return fmt.Errorf("source returned HTTP %d", httpResponse.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(httpResponse.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return errors.New("source response content type is invalid")
+	}
+	limited := io.LimitReader(httpResponse.Body, generatedSpecApprovalMaximumSourceResponse+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil || len(raw) > generatedSpecApprovalMaximumSourceResponse {
+		return errors.New("source response is unavailable or oversized")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(response); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return errors.New("source response must contain one JSON object")
+	}
+	return nil
+}
+
+var _ generatedspecapprovalceremony.BindingProvider = (*generatedSpecApprovalSourceClient)(nil)
+var _ generatedspecapprovalceremony.AuthorityProvider = (*generatedSpecApprovalSourceClient)(nil)

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_runtime_test.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_runtime_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapproval"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapprovalceremony"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func TestGeneratedSpecApprovalConfigIsExplicitAndFailClosed(t *testing.T) {
+	generatedSpecApprovalTestEnv(t)
+	if _, enabled, err := generatedSpecApprovalRuntimeConfigFromEnv(); err != nil || enabled {
+		t.Fatalf("disabled config enabled=%t err=%v", enabled, err)
+	}
+	t.Setenv(generatedSpecApprovalEnabledEnv, "1")
+	if _, enabled, err := generatedSpecApprovalRuntimeConfigFromEnv(); err == nil || !enabled {
+		t.Fatalf("incomplete config enabled=%t err=%v", enabled, err)
+	}
+	setCompleteGeneratedSpecApprovalEnv(t)
+	cfg, enabled, err := generatedSpecApprovalRuntimeConfigFromEnv()
+	if err != nil || !enabled || cfg.ControlScope != defaultGeneratedSpecApprovalControlScope ||
+		cfg.ConsumerScope != defaultGeneratedSpecApprovalConsumerScope || cfg.MaxTokenTTL != defaultGeneratedSpecApprovalMaxTokenTTL {
+		t.Fatalf("config=%+v enabled=%t err=%v", cfg, enabled, err)
+	}
+	t.Setenv(generatedSpecApprovalMaxTokenTTLEnv, "16m")
+	if _, _, err := generatedSpecApprovalRuntimeConfigFromEnv(); err == nil {
+		t.Fatal("overlong workload token TTL was accepted")
+	}
+	t.Setenv(generatedSpecApprovalMaxTokenTTLEnv, "")
+	t.Setenv(generatedSpecApprovalControlScopeEnv, defaultGeneratedSpecApprovalConsumerScope)
+	if _, _, err := generatedSpecApprovalRuntimeConfigFromEnv(); err == nil {
+		t.Fatal("shared control and consumer scope was accepted")
+	}
+	t.Setenv(generatedSpecApprovalControlScopeEnv, "")
+	t.Setenv(generatedSpecApprovalSourceURLEnv, "http://control.example.test")
+	if _, _, err := generatedSpecApprovalRuntimeConfigFromEnv(); err == nil {
+		t.Fatal("HTTP source URL was accepted")
+	}
+}
+
+func TestGeneratedSpecApprovalSourceClientPinsBindingAndAuthority(t *testing.T) {
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	snapshot, err := generatedspecapprovalceremony.SealAuthoritySnapshot(generatedspecapprovalceremony.AuthoritySnapshot{
+		AuthoritySource: "control-plane-approver-registry", AuthorityVersion: "authority-v1",
+		Keys: []generatedspecapprovalceremony.AuthoritySnapshotKey{{
+			KeyID: "key-a", TenantID: "tenant-a", PrincipalID: "approver-a", CredentialID: "credential-a", DeviceID: "device-a",
+			PublicKey: hex.EncodeToString(make([]byte, 32)), WorkspaceIDs: []string{"workspace-a"}, Roles: []string{"approver"},
+			Actions: []string{contracts.GeneratedSpecApprovalActionV1}, Audiences: []string{contracts.GeneratedSpecApprovalAudienceV1},
+			Enabled: true, NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := generatedspecapprovalceremony.Binding{
+		BindingRef: "binding-a", TenantID: "tenant-a", WorkspaceID: "workspace-a", Audience: contracts.GeneratedSpecApprovalAudienceV1,
+		GeneratedSpecID: "spec-a", GeneratedSpecHash: testGeneratedSpecApprovalHash("1"), ExecutionPlanHash: testGeneratedSpecApprovalHash("2"),
+		PlanTransactionHash: testGeneratedSpecApprovalHash("3"), WriteSetHash: testGeneratedSpecApprovalHash("4"),
+		VerificationScopeHash: testGeneratedSpecApprovalHash("5"), PolicyEnvelopeHash: testGeneratedSpecApprovalHash("6"),
+		PolicyVersion: "policy-v1", PolicyEpoch: "epoch-1", Action: contracts.GeneratedSpecApprovalActionV1,
+		RequestingPrincipalID: "requester-a", AuthoritySource: snapshot.AuthoritySource, AuthorityVersion: snapshot.AuthorityVersion,
+		AuthoritySnapshotHash: snapshot.AuthoritySnapshotHash, RequiredRole: "approver", Quorum: 1, ServerIdentity: "kernel-a",
+	}
+	authorityResponse := snapshot
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.Header.Get("Authorization") != "Bearer source-token" || r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected source request method=%s headers=%v", r.Method, r.Header)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case generatedSpecApprovalBindingSourcePath:
+			_ = json.NewEncoder(w).Encode(binding)
+		case generatedSpecApprovalAuthoritySourcePath:
+			_ = json.NewEncoder(w).Encode(authorityResponse)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	client, err := newGeneratedSpecApprovalSourceClient(server.URL, "source-token", server.Client(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadedBinding, err := client.LoadGeneratedSpecApprovalBinding(t.Context(), "tenant-a", "workspace-a", "binding-a")
+	if err != nil || loadedBinding.GeneratedSpecHash != binding.GeneratedSpecHash {
+		t.Fatalf("binding=%+v err=%v", loadedBinding, err)
+	}
+	store, err := client.LoadGeneratedSpecApprovalAuthority(t.Context(), "tenant-a", "workspace-a", snapshot.AuthoritySource, snapshot.AuthorityVersion, snapshot.AuthoritySnapshotHash)
+	if err != nil || len(store.Keys) != 1 {
+		t.Fatalf("trust store=%+v err=%v", store, err)
+	}
+	authorityResponse.Keys = append([]generatedspecapprovalceremony.AuthoritySnapshotKey(nil), snapshot.Keys...)
+	authorityResponse.Keys[0].Roles = []string{"administrator"}
+	if _, err := client.LoadGeneratedSpecApprovalAuthority(t.Context(), "tenant-a", "workspace-a", snapshot.AuthoritySource, snapshot.AuthorityVersion, snapshot.AuthoritySnapshotHash); !errors.Is(err, generatedspecapprovalceremony.ErrAuthorityUnavailable) {
+		t.Fatalf("tampered authority error=%v", err)
+	}
+}
+
+func TestGeneratedSpecApprovalVerifierErrorsRemainActionable(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+		code int
+	}{
+		{"verification", generatedspecapproval.ErrVerificationFailed, http.StatusBadRequest},
+		{"duplicate", approvalverify.ErrDuplicateSigner, http.StatusConflict},
+		{"quorum", generatedspecapproval.ErrQuorumNotMet, http.StatusConflict},
+		{"signature", generatedspecapproval.ErrAssertionRejected, http.StatusForbidden},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			response := httptest.NewRecorder()
+			writeGeneratedSpecApprovalError(response, test.err)
+			if response.Code != test.code {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func generatedSpecApprovalTestEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		generatedSpecApprovalEnabledEnv, generatedSpecApprovalSourceURLEnv, generatedSpecApprovalSourceTokenEnv,
+		generatedSpecApprovalJWKSURLEnv, generatedSpecApprovalIssuerEnv, generatedSpecApprovalAudienceEnv,
+		generatedSpecApprovalResourceEnv, generatedSpecApprovalControlScopeEnv, generatedSpecApprovalConsumerScopeEnv,
+		generatedSpecApprovalMaxTokenTTLEnv, generatedSpecApprovalMinHoldDurationEnv, generatedSpecApprovalChallengeTTLEnv,
+		generatedSpecApprovalMaxChallengeLifetimeEnv, generatedSpecApprovalGrantTTLEnv, generatedSpecApprovalMaxAssertionsEnv,
+		generatedSpecApprovalServerIdentityEnv, generatedSpecApprovalSigningKeyRefEnv, generatedSpecApprovalKernelTrustRootIDEnv,
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func setCompleteGeneratedSpecApprovalEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(generatedSpecApprovalEnabledEnv, "1")
+	t.Setenv(generatedSpecApprovalSourceURLEnv, "https://control.example.test")
+	t.Setenv(generatedSpecApprovalSourceTokenEnv, "source-token")
+	t.Setenv(generatedSpecApprovalJWKSURLEnv, "https://identity.example.test/.well-known/jwks.json")
+	t.Setenv(generatedSpecApprovalIssuerEnv, "https://identity.example.test")
+	t.Setenv(generatedSpecApprovalAudienceEnv, contracts.GeneratedSpecApprovalAudienceV1)
+	t.Setenv(generatedSpecApprovalResourceEnv, "https://kernel.example.test/internal/v1/generated-spec-approvals")
+	t.Setenv(generatedSpecApprovalServerIdentityEnv, "kernel-a")
+	t.Setenv(generatedSpecApprovalSigningKeyRefEnv, "kernel-generated-spec-key-a")
+	t.Setenv(generatedSpecApprovalKernelTrustRootIDEnv, "kernel-root-a")
+}
+
+func testGeneratedSpecApprovalHash(digit string) string {
+	return "sha256:" + strings.Repeat(digit, 64)
+}

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -508,6 +508,10 @@ func runServerWithOptions(opts serverOptions) error {
 		if err != nil {
 			log.Fatalf("Failed to initialize approval grant consumption runtime: %v", err)
 		}
+		services.GeneratedSpecApproval, err = newGeneratedSpecApprovalRuntime(ctx, db, databaseMode, signer, services.EmergencyStops)
+		if err != nil {
+			log.Fatalf("Failed to initialize GeneratedSpec approval runtime: %v", err)
+		}
 
 		// Receipt transparency log: anchor decision-record receipt hashes at
 		// issuance (see persistDecisionReceipt -> anchorReceiptTransparency). The
@@ -697,7 +701,7 @@ func writeServerReady(opts serverOptions, bindAddr string, port int) error {
 }
 
 func servicesInitFailureIsFatal() bool {
-	return envBool("HELM_PRODUCTION") || emergencyStopFenceEnabled() || envBool(approvalConsumptionEnabledEnv)
+	return envBool("HELM_PRODUCTION") || emergencyStopFenceEnabled() || envBool(approvalConsumptionEnabledEnv) || envBool(generatedSpecApprovalEnabledEnv)
 }
 
 func envBool(key string) bool {

--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -60,13 +60,14 @@ type Services struct {
 	MemoryAPI *api.MemoryService
 
 	// --- Kernel & Execution ---
-	BoundaryEnforcer    *boundary.PerimeterEnforcer
-	BoundarySurfaces    *boundary.SurfaceRegistry
-	MerkleTree          *merkle.MerkleTree
-	Sandbox             sandbox.Sandbox
-	Obligation          *obligation.ObligationEngine
-	EmergencyStops      *kernel.ScopedStopStore
-	ApprovalConsumption *approvalConsumptionRuntime
+	BoundaryEnforcer      *boundary.PerimeterEnforcer
+	BoundarySurfaces      *boundary.SurfaceRegistry
+	MerkleTree            *merkle.MerkleTree
+	Sandbox               sandbox.Sandbox
+	Obligation            *obligation.ObligationEngine
+	EmergencyStops        *kernel.ScopedStopStore
+	ApprovalConsumption   *approvalConsumptionRuntime
+	GeneratedSpecApproval *generatedSpecApprovalRuntime
 
 	// --- Evidence ---
 	Evidence          *evidence.DefaultExporter

--- a/core/cmd/helm-ai-kernel/subsystems.go
+++ b/core/cmd/helm-ai-kernel/subsystems.go
@@ -45,6 +45,7 @@ func RegisterSubsystemRoutes(mux *http.ServeMux, svc *Services) {
 	registerExtAuthzRoutes(mux, svc)
 	registerEmergencyStopFenceRoutes(mux, svc)
 	registerApprovalGrantConsumptionRoutes(mux, svc.ApprovalConsumption)
+	registerGeneratedSpecApprovalRoutes(mux, svc.GeneratedSpecApproval)
 
 	// --- OpenAI-Compatible Proxy (governed inference) ---
 	// Wraps api.HandleOpenAIProxy with Guardian governance enforcement and receipt headers.

--- a/core/pkg/boundary/generatedspecapprovalceremony/migrations/001_generated_spec_approval_ceremonies.sql
+++ b/core/pkg/boundary/generatedspecapprovalceremony/migrations/001_generated_spec_approval_ceremonies.sql
@@ -201,6 +201,9 @@ CREATE INDEX IF NOT EXISTS generated_spec_approval_ceremonies_active_scope_idx
     WHERE state IN ('HOLD_PENDING', 'CHALLENGE_ISSUED', 'QUORUM_VERIFIED', 'GRANT_ISSUED');
 CREATE INDEX IF NOT EXISTS generated_spec_approval_ceremonies_binding_ref_idx
     ON generated_spec_approval_ceremonies (tenant_id, workspace_id, binding_ref);
+CREATE UNIQUE INDEX IF NOT EXISTS generated_spec_approval_ceremonies_active_binding_ref_uq
+    ON generated_spec_approval_ceremonies (tenant_id, workspace_id, binding_ref)
+    WHERE state IN ('HOLD_PENDING', 'CHALLENGE_ISSUED', 'QUORUM_VERIFIED', 'GRANT_ISSUED');
 CREATE UNIQUE INDEX IF NOT EXISTS generated_spec_approval_ceremonies_challenge_id_uq
     ON generated_spec_approval_ceremonies (tenant_id, workspace_id, challenge_id)
     WHERE challenge_id IS NOT NULL;

--- a/core/pkg/boundary/generatedspecapprovalceremony/postgres_store.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/postgres_store.go
@@ -97,7 +97,7 @@ func (s *PostgresStore) CreateHold(ctx context.Context, record Record) (Record, 
 				$22, $23, $24,
 				$25, $26, $27, $28
 			)
-			ON CONFLICT (tenant_id, workspace_id, approval_id) DO NOTHING
+			ON CONFLICT DO NOTHING
 			RETURNING `+generatedSpecApprovalRecordColumns,
 			record.TenantID, record.WorkspaceID, record.ApprovalID, record.State,
 			string(bindingJSON), record.Binding.BindingRef, record.Binding.Audience, record.Binding.GeneratedSpecID,

--- a/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
@@ -62,6 +62,18 @@ func TestPostgresStoreRequiresDatabaseAndVerifier(t *testing.T) {
 	}
 }
 
+func TestPostgresSchemaKeepsOneActiveCeremonyPerBinding(t *testing.T) {
+	for _, required := range []string{
+		"CREATE UNIQUE INDEX IF NOT EXISTS generated_spec_approval_ceremonies_active_binding_ref_uq",
+		"ON generated_spec_approval_ceremonies (tenant_id, workspace_id, binding_ref)",
+		"WHERE state IN ('HOLD_PENDING', 'CHALLENGE_ISSUED', 'QUORUM_VERIFIED', 'GRANT_ISSUED')",
+	} {
+		if !strings.Contains(generatedSpecApprovalPostgresSchema, required) {
+			t.Fatalf("generated spec approval schema missing %q", required)
+		}
+	}
+}
+
 // TestPostgresLifecycleSingleIssueConsumeAndFence is a source-owned real-
 // Postgres proof. It intentionally skips until the caller supplies a database
 // URL; it never falls back to SQLite or a missing emergency-stop table.
@@ -200,6 +212,9 @@ func TestPostgresLifecycleSingleIssueConsumeAndFence(t *testing.T) {
 	pending, err := service.BeginHold(ctx, fixture.binding.BindingRef)
 	if err != nil {
 		t.Fatalf("BeginHold() for expiry proof error = %v", err)
+	}
+	if _, err := service.BeginHold(ctx, fixture.binding.BindingRef); !errors.Is(err, ErrTransitionConflict) {
+		t.Fatalf("second active BeginHold() error = %v, want ErrTransitionConflict", err)
 	}
 	fixture.advance(fixture.config.MaxChallengeLifetime)
 	expired, err := service.Expire(ctx, pending.ApprovalID)

--- a/core/pkg/boundary/generatedspecapprovalceremony/source_contract.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/source_contract.go
@@ -1,0 +1,169 @@
+package generatedspecapprovalceremony
+
+// quantum_posture: approver authority snapshots carry classical Ed25519
+// public keys and SHA-256 commitments only; they make no post-quantum claim.
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/approvalverify"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+)
+
+const (
+	AuthoritySnapshotDomainV1 = "HELM/GeneratedSpecApprovalAuthoritySnapshot/v1"
+	AuthoritySnapshotSchemaV1 = "generated-spec-approval-authority-snapshot.v1"
+)
+
+// AuthoritySnapshot is the transport-safe projection returned by the
+// server-side authority registry. Public keys are canonical lowercase hex so
+// the snapshot has one deterministic commitment across services.
+type AuthoritySnapshot struct {
+	Domain                string                 `json:"domain"`
+	SchemaVersion         string                 `json:"schema_version"`
+	AuthoritySource       string                 `json:"authority_source"`
+	AuthorityVersion      string                 `json:"authority_version"`
+	AuthoritySnapshotHash string                 `json:"authority_snapshot_hash"`
+	Keys                  []AuthoritySnapshotKey `json:"keys"`
+}
+
+type AuthoritySnapshotKey struct {
+	KeyID        string    `json:"key_id"`
+	TenantID     string    `json:"tenant_id"`
+	PrincipalID  string    `json:"principal_id"`
+	CredentialID string    `json:"credential_id"`
+	DeviceID     string    `json:"device_id"`
+	PublicKey    string    `json:"public_key"`
+	WorkspaceIDs []string  `json:"workspace_ids"`
+	Roles        []string  `json:"roles"`
+	Actions      []string  `json:"actions"`
+	Audiences    []string  `json:"audiences"`
+	Enabled      bool      `json:"enabled"`
+	NotBefore    time.Time `json:"not_before"`
+	NotAfter     time.Time `json:"not_after"`
+}
+
+// SealAuthoritySnapshot normalizes set-valued fields, rejects ambiguous keys,
+// and commits the exact authority snapshot consumed by quorum verification.
+func SealAuthoritySnapshot(snapshot AuthoritySnapshot) (AuthoritySnapshot, error) {
+	if snapshot.Domain == "" {
+		snapshot.Domain = AuthoritySnapshotDomainV1
+	}
+	if snapshot.SchemaVersion == "" {
+		snapshot.SchemaVersion = AuthoritySnapshotSchemaV1
+	}
+	if snapshot.Domain != AuthoritySnapshotDomainV1 || snapshot.SchemaVersion != AuthoritySnapshotSchemaV1 ||
+		!validToken(snapshot.AuthoritySource) || !validToken(snapshot.AuthorityVersion) ||
+		len(snapshot.Keys) == 0 || len(snapshot.Keys) > 256 {
+		return AuthoritySnapshot{}, errors.New("generated spec approval authority snapshot metadata is invalid")
+	}
+
+	normalized := snapshot
+	normalized.AuthoritySnapshotHash = ""
+	normalized.Keys = append([]AuthoritySnapshotKey(nil), snapshot.Keys...)
+	seen := make(map[string]struct{}, len(normalized.Keys))
+	enabled := false
+	for index := range normalized.Keys {
+		key := &normalized.Keys[index]
+		if _, duplicate := seen[key.KeyID]; duplicate {
+			return AuthoritySnapshot{}, fmt.Errorf("generated spec approval authority snapshot has duplicate key %q", key.KeyID)
+		}
+		seen[key.KeyID] = struct{}{}
+		key.WorkspaceIDs = normalizeAuthoritySet(key.WorkspaceIDs)
+		key.Roles = normalizeAuthoritySet(key.Roles)
+		key.Actions = normalizeAuthoritySet(key.Actions)
+		key.Audiences = normalizeAuthoritySet(key.Audiences)
+		if err := validateAuthoritySnapshotKey(*key); err != nil {
+			return AuthoritySnapshot{}, err
+		}
+		enabled = enabled || key.Enabled
+	}
+	if !enabled {
+		return AuthoritySnapshot{}, errors.New("generated spec approval authority snapshot has no enabled key")
+	}
+	slices.SortFunc(normalized.Keys, func(left, right AuthoritySnapshotKey) int {
+		return strings.Compare(left.KeyID, right.KeyID)
+	})
+	hash, err := authoritySnapshotHash(normalized)
+	if err != nil {
+		return AuthoritySnapshot{}, err
+	}
+	normalized.AuthoritySnapshotHash = hash
+	return normalized, nil
+}
+
+// TrustStore verifies the snapshot commitment before projecting it into the
+// verifier's pinned authority store.
+func (snapshot AuthoritySnapshot) TrustStore() (approvalverify.TrustStore, error) {
+	sealed, err := SealAuthoritySnapshot(snapshot)
+	if err != nil {
+		return approvalverify.TrustStore{}, err
+	}
+	if snapshot.AuthoritySnapshotHash == "" || sealed.AuthoritySnapshotHash != snapshot.AuthoritySnapshotHash {
+		return approvalverify.TrustStore{}, errors.New("generated spec approval authority snapshot hash mismatch")
+	}
+	keys := make(map[string]approvalverify.TrustedApproverKey, len(sealed.Keys))
+	for _, key := range sealed.Keys {
+		publicKey, _ := hex.DecodeString(key.PublicKey)
+		keys[key.KeyID] = approvalverify.TrustedApproverKey{
+			KeyID: key.KeyID, TenantID: key.TenantID, PrincipalID: key.PrincipalID,
+			CredentialID: key.CredentialID, DeviceID: key.DeviceID,
+			PublicKey:    append(ed25519.PublicKey(nil), publicKey...),
+			WorkspaceIDs: append([]string(nil), key.WorkspaceIDs...), Roles: append([]string(nil), key.Roles...),
+			Actions: append([]string(nil), key.Actions...), Audiences: append([]string(nil), key.Audiences...),
+			Enabled: key.Enabled, NotBefore: key.NotBefore, NotAfter: key.NotAfter,
+		}
+	}
+	return approvalverify.TrustStore{
+		AuthoritySource: sealed.AuthoritySource, AuthorityVersion: sealed.AuthorityVersion,
+		AuthoritySnapshotHash: sealed.AuthoritySnapshotHash, Keys: keys,
+	}, nil
+}
+
+func authoritySnapshotHash(snapshot AuthoritySnapshot) (string, error) {
+	snapshot.AuthoritySnapshotHash = ""
+	hash, err := canonicalize.CanonicalHash(snapshot)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize generated spec approval authority snapshot: %w", err)
+	}
+	return "sha256:" + hash, nil
+}
+
+func validateAuthoritySnapshotKey(key AuthoritySnapshotKey) error {
+	for _, value := range []string{key.KeyID, key.TenantID, key.PrincipalID, key.CredentialID, key.DeviceID} {
+		if !validToken(value) {
+			return errors.New("generated spec approval authority key identity is invalid")
+		}
+	}
+	publicKey, err := hex.DecodeString(key.PublicKey)
+	if err != nil || len(publicKey) != ed25519.PublicKeySize || hex.EncodeToString(publicKey) != key.PublicKey {
+		return errors.New("generated spec approval authority public key must be canonical lowercase Ed25519 hex")
+	}
+	if len(key.WorkspaceIDs) == 0 || len(key.Roles) == 0 || len(key.Actions) == 0 || len(key.Audiences) == 0 {
+		return errors.New("generated spec approval authority key scope is incomplete")
+	}
+	for _, set := range [][]string{key.WorkspaceIDs, key.Roles, key.Actions, key.Audiences} {
+		for _, value := range set {
+			if !validToken(value) {
+				return errors.New("generated spec approval authority key scope is invalid")
+			}
+		}
+	}
+	if key.NotBefore.IsZero() || key.NotAfter.IsZero() || key.NotBefore.Location() != time.UTC ||
+		key.NotAfter.Location() != time.UTC || !key.NotAfter.After(key.NotBefore) {
+		return errors.New("generated spec approval authority key lifetime is invalid")
+	}
+	return nil
+}
+
+func normalizeAuthoritySet(values []string) []string {
+	values = append([]string(nil), values...)
+	slices.Sort(values)
+	return slices.Compact(values)
+}

--- a/core/pkg/boundary/generatedspecapprovalceremony/source_contract_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/source_contract_test.go
@@ -1,0 +1,46 @@
+package generatedspecapprovalceremony
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+)
+
+func TestAuthoritySnapshotSealAndTamperDetection(t *testing.T) {
+	now := time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC)
+	publicKey := make([]byte, 32)
+	for index := range publicKey {
+		publicKey[index] = byte(index + 1)
+	}
+	snapshot, err := SealAuthoritySnapshot(AuthoritySnapshot{
+		AuthoritySource:  "control-plane-approver-registry",
+		AuthorityVersion: "authority-v1",
+		Keys: []AuthoritySnapshotKey{{
+			KeyID: "key-1", TenantID: "tenant-1", PrincipalID: "approver-1",
+			CredentialID: "credential-1", DeviceID: "device-1", PublicKey: hex.EncodeToString(publicKey),
+			WorkspaceIDs: []string{"workspace-1", "workspace-1"}, Roles: []string{"reviewer"},
+			Actions:   []string{contracts.GeneratedSpecApprovalActionV1},
+			Audiences: []string{contracts.GeneratedSpecApprovalAudienceV1}, Enabled: true,
+			NotBefore: now.Add(-time.Hour), NotAfter: now.Add(time.Hour),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("seal authority snapshot: %v", err)
+	}
+	store, err := snapshot.TrustStore()
+	if err != nil {
+		t.Fatalf("project trust store: %v", err)
+	}
+	if len(store.Keys) != 1 || len(store.Keys["key-1"].WorkspaceIDs) != 1 || store.AuthoritySnapshotHash != snapshot.AuthoritySnapshotHash {
+		t.Fatalf("unexpected trust store projection: %#v", store)
+	}
+
+	tampered := snapshot
+	tampered.Keys = append([]AuthoritySnapshotKey(nil), snapshot.Keys...)
+	tampered.Keys[0].Roles = []string{"administrator"}
+	if _, err := tampered.TrustStore(); err == nil {
+		t.Fatal("tampered authority snapshot must not verify")
+	}
+}


### PR DESCRIPTION
## Summary
- activate the PostgreSQL-backed GeneratedSpec approval ceremony behind scoped workload JWTs
- derive immutable binding and authority snapshots from authenticated source endpoints
- issue and durably consume short-lived signed grants with recovery after uncertain delivery
- expose generated_spec_id on every ceremony response so pending states remain path-bound
- add migration, route, source, recovery, and contract coverage

## Validation
- GOWORK=off go test ./... -count=1
- GOWORK=off go test ./cmd/helm-ai-kernel -count=1

## Delivery boundary
This PR establishes source and test evidence. Deployment, configured runtime, and production approval evidence remain separate gates.