### PR TITLE
fix(approval): #773 upgrade safety

### DIFF
--- a/core/cmd/helm-ai-kernel/generated_spec_approval_routes_test.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_routes_test.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary/generatedspecapprovalceremony"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
 )
 
 func TestGeneratedSpecApprovalResponseCarriesPendingSpecBinding(t *testing.T) {
@@ -26,5 +29,92 @@ func TestGeneratedSpecApprovalResponseCarriesPendingSpecBinding(t *testing.T) {
 	}
 	if response.GeneratedSpecID != "generated-spec-a" {
 		t.Fatalf("generated_spec_id=%q", response.GeneratedSpecID)
+	}
+}
+
+func TestGeneratedSpecApprovalRoutesFailClosedOnWorkloadAuthentication(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		body      string
+		control   approvalConsumerTokenValidator
+		consumer  approvalConsumerTokenValidator
+		token     string
+		status    int
+		scopeFail bool
+	}{
+		{
+			name: "missing control bearer", path: generatedSpecApprovalBeginPath, body: `{"binding_ref":"binding-a"}`,
+			control:  fakeApprovalConsumerTokenValidator{claims: approvalConsumerRouteClaims(5 * time.Minute)},
+			consumer: fakeApprovalConsumerTokenValidator{claims: approvalConsumerRouteClaims(5 * time.Minute)}, status: http.StatusUnauthorized,
+		},
+		{
+			name: "consumer scope missing", path: generatedSpecApprovalConsumePath, body: validApprovalConsumptionRequest(), token: "token",
+			control:  fakeApprovalConsumerTokenValidator{claims: approvalConsumerRouteClaims(5 * time.Minute)},
+			consumer: fakeApprovalConsumerTokenValidator{err: &mcppkg.JWKSValidationError{Kind: mcppkg.JWKSErrMissingScope}},
+			status:   http.StatusForbidden, scopeFail: true,
+		},
+		{
+			name: "consumer audience rejected", path: generatedSpecApprovalConsumePath, body: validApprovalConsumptionRequest(), token: "token",
+			control:  fakeApprovalConsumerTokenValidator{claims: approvalConsumerRouteClaims(5 * time.Minute)},
+			consumer: fakeApprovalConsumerTokenValidator{err: &mcppkg.JWKSValidationError{Kind: mcppkg.JWKSErrInvalidAudience}},
+			status:   http.StatusUnauthorized,
+		},
+		{
+			name: "consumer resource rejected", path: generatedSpecApprovalConsumePath, body: validApprovalConsumptionRequest(), token: "token",
+			control:  fakeApprovalConsumerTokenValidator{claims: approvalConsumerRouteClaims(5 * time.Minute)},
+			consumer: fakeApprovalConsumerTokenValidator{err: &mcppkg.JWKSValidationError{Kind: mcppkg.JWKSErrInvalidResource}},
+			status:   http.StatusUnauthorized,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			registerGeneratedSpecApprovalRoutes(mux, generatedSpecApprovalRouteTestRuntime(test.control, test.consumer))
+			response := postApprovalConsumptionRoute(t, mux, test.path, test.body, test.token)
+			if response.Code != test.status || response.Header().Get("Cache-Control") != "no-store" {
+				t.Fatalf("status=%d cache=%q body=%s", response.Code, response.Header().Get("Cache-Control"), response.Body.String())
+			}
+			if test.scopeFail && !strings.Contains(response.Header().Get("WWW-Authenticate"), `error="insufficient_scope"`) {
+				t.Fatalf("scope rejection challenge=%q", response.Header().Get("WWW-Authenticate"))
+			}
+		})
+	}
+}
+
+func TestGeneratedSpecApprovalRoutesRejectMalformedAndCrossScopeRecoveryTuples(t *testing.T) {
+	crossScopeRecovery := validApprovalConsumptionRequest()
+	crossScopeRecovery = crossScopeRecovery[:len(crossScopeRecovery)-1] + `,"tenant_id":"tenant-other","workspace_id":"workspace-other"}`
+	tests := []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "malformed consume tuple", path: generatedSpecApprovalConsumePath, body: `{"approval_id":"approval-a","grant_id":"grant-a","grant_hash":"sha256:bad","nonce":"not-a-nonce"}`},
+		{name: "malformed recovery tuple", path: generatedSpecApprovalRecoverPath, body: `{"approval_id":"approval-a","grant_id":"grant-a","grant_hash":"sha256:bad","nonce":"not-a-nonce"}`},
+		{name: "recovery rejects caller supplied scope", path: generatedSpecApprovalRecoverPath, body: crossScopeRecovery},
+	}
+
+	validator := fakeApprovalConsumerTokenValidator{claims: approvalConsumerRouteClaims(5 * time.Minute)}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			registerGeneratedSpecApprovalRoutes(mux, generatedSpecApprovalRouteTestRuntime(validator, validator))
+			response := postApprovalConsumptionRoute(t, mux, test.path, test.body, "token")
+			if response.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+			}
+		})
+	}
+}
+
+func generatedSpecApprovalRouteTestRuntime(control, consumer approvalConsumerTokenValidator) *generatedSpecApprovalRuntime {
+	return &generatedSpecApprovalRuntime{
+		service:           &generatedspecapprovalceremony.Service{},
+		controlValidator:  control,
+		consumerValidator: consumer,
+		audience:          contracts.GeneratedSpecApprovalAudienceV1,
+		maxTokenTTL:       5 * time.Minute,
 	}
 }

--- a/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/ceremony_test.go
@@ -191,6 +191,16 @@ func TestConsumeRejectsWrongConsumerAndReplay(t *testing.T) {
 	if _, err := fixture.service.RecoverGrantConsumption(ctx, consumed.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrConsumerUnavailable) {
 		t.Fatalf("RecoverGrantConsumption(other identity) error = %v, want consumer rejection", err)
 	}
+	fixture.consumer.identity.Subject = consumed.ConsumedBy
+	fixture.consumer.identity.TenantID = "tenant-other"
+	if _, err := fixture.service.RecoverGrantConsumption(ctx, consumed.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("RecoverGrantConsumption(other tenant) error = %v, want not found", err)
+	}
+	fixture.consumer.identity.TenantID = consumed.TenantID
+	fixture.consumer.identity.WorkspaceID = "workspace-other"
+	if _, err := fixture.service.RecoverGrantConsumption(ctx, consumed.ApprovalID, grant.GrantID, grant.GrantHash, grant.Nonce); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("RecoverGrantConsumption(other workspace) error = %v, want not found", err)
+	}
 }
 
 func TestConsumeGrantSealerPinsCallerScope(t *testing.T) {

--- a/core/pkg/boundary/generatedspecapprovalceremony/migrations/001_generated_spec_approval_ceremonies.sql
+++ b/core/pkg/boundary/generatedspecapprovalceremony/migrations/001_generated_spec_approval_ceremonies.sql
@@ -196,6 +196,33 @@ CREATE TABLE IF NOT EXISTS generated_spec_approval_ceremonies (
     )
 );
 
+-- Fail closed before enforcing one active binding for legacy rows.
+DO $$
+DECLARE
+    has_duplicate_active_binding BOOLEAN;
+BEGIN
+    BEGIN
+        PERFORM set_config('row_security', 'off', true);
+        SELECT EXISTS (
+            SELECT 1
+            FROM generated_spec_approval_ceremonies
+            WHERE state IN ('HOLD_PENDING', 'CHALLENGE_ISSUED', 'QUORUM_VERIFIED', 'GRANT_ISSUED')
+            GROUP BY tenant_id, workspace_id, binding_ref
+            HAVING COUNT(*) > 1
+        ) INTO has_duplicate_active_binding;
+    EXCEPTION
+        WHEN insufficient_privilege THEN
+            RAISE EXCEPTION 'generated spec approval ceremony migration blocked: cannot inspect legacy active bindings with complete visibility'
+                USING ERRCODE = 'P0001';
+    END;
+
+    IF has_duplicate_active_binding THEN
+        RAISE EXCEPTION 'generated spec approval ceremony migration blocked: duplicate active bindings require operator reconciliation'
+            USING ERRCODE = 'P0001';
+    END IF;
+END
+$$;
+
 CREATE INDEX IF NOT EXISTS generated_spec_approval_ceremonies_active_scope_idx
     ON generated_spec_approval_ceremonies (tenant_id, workspace_id, state, updated_at DESC)
     WHERE state IN ('HOLD_PENDING', 'CHALLENGE_ISSUED', 'QUORUM_VERIFIED', 'GRANT_ISSUED');

--- a/core/pkg/boundary/generatedspecapprovalceremony/migrations/001_generated_spec_approval_ceremonies.sql
+++ b/core/pkg/boundary/generatedspecapprovalceremony/migrations/001_generated_spec_approval_ceremonies.sql
@@ -201,8 +201,17 @@ DO $$
 DECLARE
     has_duplicate_active_binding BOOLEAN;
 BEGIN
+    IF NOT pg_catalog.has_table_privilege(
+        current_user,
+        'generated_spec_approval_ceremonies'::regclass,
+        'SELECT'
+    ) THEN
+        RAISE EXCEPTION 'generated spec approval ceremony migration blocked: migration role lacks SELECT privilege for legacy active-binding preflight'
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    PERFORM pg_catalog.set_config('row_security', 'off', true);
     BEGIN
-        PERFORM set_config('row_security', 'off', true);
         SELECT EXISTS (
             SELECT 1
             FROM generated_spec_approval_ceremonies
@@ -212,7 +221,7 @@ BEGIN
         ) INTO has_duplicate_active_binding;
     EXCEPTION
         WHEN insufficient_privilege THEN
-            RAISE EXCEPTION 'generated spec approval ceremony migration blocked: cannot inspect legacy active bindings with complete visibility'
+            RAISE EXCEPTION 'generated spec approval ceremony migration blocked: row-level security prevents complete legacy active-binding visibility'
                 USING ERRCODE = 'P0001';
     END;
 

--- a/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
@@ -74,6 +74,106 @@ func TestPostgresSchemaKeepsOneActiveCeremonyPerBinding(t *testing.T) {
 	}
 }
 
+func TestPostgresSchemaPreflightsLegacyDuplicateActiveBindings(t *testing.T) {
+	const diagnostic = "generated spec approval ceremony migration blocked: duplicate active bindings require operator reconciliation"
+	preflight := strings.Index(generatedSpecApprovalPostgresSchema, diagnostic)
+	uniqueIndex := strings.Index(generatedSpecApprovalPostgresSchema, "CREATE UNIQUE INDEX IF NOT EXISTS generated_spec_approval_ceremonies_active_binding_ref_uq")
+	if preflight < 0 || uniqueIndex < 0 || preflight > uniqueIndex {
+		t.Fatalf("legacy duplicate preflight must precede active binding unique index")
+	}
+	if !strings.Contains(generatedSpecApprovalPostgresSchema, "PERFORM set_config('row_security', 'off', true)") {
+		t.Fatal("legacy duplicate preflight must require complete row visibility")
+	}
+}
+
+// TestPostgresStoreInitPreflightsLegacyActiveBindings exercises a schema that
+// predates the active-binding unique index. It never repairs or exposes the
+// duplicate scope; the migration must stop with its static operator diagnostic.
+func TestPostgresStoreInitPreflightsLegacyActiveBindings(t *testing.T) {
+	postgresURL := os.Getenv("HELM_TEST_POSTGRES_URL")
+	if postgresURL == "" {
+		t.Skip("set HELM_TEST_POSTGRES_URL to run generated spec approval PostgreSQL migration proof")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, test := range []struct {
+		name       string
+		duplicates bool
+		wantErr    bool
+	}{
+		{name: "valid legacy data migrates"},
+		{name: "duplicate active bindings fail closed", duplicates: true, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			schema := fmt.Sprintf("helm_generated_spec_approval_migration_%d", time.Now().UnixNano())
+			db := openGeneratedSpecApprovalTestPostgres(t, postgresURL, schema, "", "")
+			defer func() { _ = db.Close() }()
+			if _, err := db.ExecContext(ctx, `CREATE SCHEMA `+pq.QuoteIdentifier(schema)); err != nil {
+				t.Fatalf("create generated spec approval migration schema: %v", err)
+			}
+			defer func() {
+				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cleanupCancel()
+				_, _ = db.ExecContext(cleanupCtx, `DROP SCHEMA IF EXISTS `+pq.QuoteIdentifier(schema)+` CASCADE`)
+			}()
+			if _, err := db.ExecContext(ctx, generatedSpecApprovalLegacyTableSchema(t)); err != nil {
+				t.Fatalf("create legacy generated spec approval table: %v", err)
+			}
+
+			fixture := newCeremonyFixture(t)
+			legacyStore := NewPostgresStore(db, fixture.verifier)
+			hold, err := fixture.service.BeginHold(ctx, fixture.binding.BindingRef)
+			if err != nil {
+				t.Fatalf("create legacy hold: %v", err)
+			}
+			if _, err := legacyStore.CreateHold(ctx, hold); err != nil {
+				t.Fatalf("persist legacy hold: %v", err)
+			}
+			if test.duplicates {
+				duplicate := hold
+				duplicate.ApprovalID = "approval-legacy-duplicate"
+				if _, err := legacyStore.CreateHold(ctx, duplicate); err != nil {
+					t.Fatalf("persist duplicate legacy hold: %v", err)
+				}
+			}
+
+			err = legacyStore.Init(ctx)
+			if test.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "generated spec approval ceremony migration blocked: duplicate active bindings require operator reconciliation") {
+					t.Fatalf("legacy duplicate migration error = %v", err)
+				}
+				for _, identifier := range []string{"tenant-a", "workspace-a", "binding-a", "approval-legacy-duplicate"} {
+					if strings.Contains(err.Error(), identifier) {
+						t.Fatalf("legacy duplicate migration diagnostic leaked %q: %v", identifier, err)
+					}
+				}
+				var index sql.NullString
+				if indexErr := db.QueryRowContext(ctx, `SELECT to_regclass('generated_spec_approval_ceremonies_active_binding_ref_uq')`).Scan(&index); indexErr != nil || index.Valid {
+					t.Fatalf("duplicate migration created active binding unique index = %q, error = %v", index.String, indexErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("migrate valid legacy data: %v", err)
+			}
+			var index sql.NullString
+			if err := db.QueryRowContext(ctx, `SELECT to_regclass('generated_spec_approval_ceremonies_active_binding_ref_uq')`).Scan(&index); err != nil || !index.Valid {
+				t.Fatalf("active binding unique index = %q, error = %v", index.String, err)
+			}
+		})
+	}
+}
+
+func generatedSpecApprovalLegacyTableSchema(t *testing.T) string {
+	t.Helper()
+	legacySchema, _, found := strings.Cut(generatedSpecApprovalPostgresSchema, "\n-- Fail closed before enforcing one active binding for legacy rows.")
+	if !found {
+		t.Fatal("generated spec approval migration missing legacy duplicate preflight")
+	}
+	return legacySchema
+}
+
 // TestPostgresLifecycleSingleIssueConsumeAndFence is a source-owned real-
 // Postgres proof. It intentionally skips until the caller supplies a database
 // URL; it never falls back to SQLite or a missing emergency-stop table.

--- a/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
@@ -81,8 +81,22 @@ func TestPostgresSchemaPreflightsLegacyDuplicateActiveBindings(t *testing.T) {
 	if preflight < 0 || uniqueIndex < 0 || preflight > uniqueIndex {
 		t.Fatalf("legacy duplicate preflight must precede active binding unique index")
 	}
-	if !strings.Contains(generatedSpecApprovalPostgresSchema, "PERFORM set_config('row_security', 'off', true)") {
+	if !strings.Contains(generatedSpecApprovalPostgresSchema, "PERFORM pg_catalog.set_config('row_security', 'off', true)") {
 		t.Fatal("legacy duplicate preflight must require complete row visibility")
+	}
+}
+
+func TestPostgresSchemaPreflightDistinguishesLegacyPrivilegeAndRLS(t *testing.T) {
+	const missingSelect = "generated spec approval ceremony migration blocked: migration role lacks SELECT privilege for legacy active-binding preflight"
+	const rlsBlocked = "generated spec approval ceremony migration blocked: row-level security prevents complete legacy active-binding visibility"
+	privilegeCheck := strings.Index(generatedSpecApprovalPostgresSchema, "pg_catalog.has_table_privilege")
+	missingSelectDiagnostic := strings.Index(generatedSpecApprovalPostgresSchema, missingSelect)
+	rlsDiagnostic := strings.Index(generatedSpecApprovalPostgresSchema, rlsBlocked)
+	rowSecurityCheck := strings.Index(generatedSpecApprovalPostgresSchema, "pg_catalog.set_config('row_security', 'off', true)")
+	legacyScan := strings.Index(generatedSpecApprovalPostgresSchema, "SELECT EXISTS")
+	visibilityException := strings.Index(generatedSpecApprovalPostgresSchema, "WHEN insufficient_privilege")
+	if privilegeCheck < 0 || missingSelectDiagnostic < privilegeCheck || rowSecurityCheck < missingSelectDiagnostic || legacyScan < rowSecurityCheck || visibilityException < legacyScan || rlsDiagnostic < visibilityException {
+		t.Fatal("legacy visibility preflight must distinguish missing SELECT before RLS visibility")
 	}
 }
 
@@ -160,6 +174,87 @@ func TestPostgresStoreInitPreflightsLegacyActiveBindings(t *testing.T) {
 			var index sql.NullString
 			if err := db.QueryRowContext(ctx, `SELECT to_regclass('generated_spec_approval_ceremonies_active_binding_ref_uq')`).Scan(&index); err != nil || !index.Valid {
 				t.Fatalf("active binding unique index = %q, error = %v", index.String, err)
+			}
+		})
+	}
+}
+
+// TestPostgresStoreInitPreflightsLegacyVisibility verifies that a migration
+// role receives different static diagnostics for missing SELECT and forced RLS.
+func TestPostgresStoreInitPreflightsLegacyVisibility(t *testing.T) {
+	postgresURL := os.Getenv("HELM_TEST_POSTGRES_URL")
+	if postgresURL == "" {
+		t.Skip("set HELM_TEST_POSTGRES_URL to run generated spec approval PostgreSQL visibility proof")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for _, test := range []struct {
+		name       string
+		forceRLS   bool
+		diagnostic string
+	}{
+		{
+			name:       "migration role lacks select",
+			diagnostic: "generated spec approval ceremony migration blocked: migration role lacks SELECT privilege for legacy active-binding preflight",
+		},
+		{
+			name:       "forced row level security",
+			forceRLS:   true,
+			diagnostic: "generated spec approval ceremony migration blocked: row-level security prevents complete legacy active-binding visibility",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			schema := fmt.Sprintf("helm_generated_spec_approval_visibility_%d", time.Now().UnixNano())
+			ownerDB := openGeneratedSpecApprovalTestPostgres(t, postgresURL, schema, "", "")
+			defer func() { _ = ownerDB.Close() }()
+			if _, err := ownerDB.ExecContext(ctx, `CREATE SCHEMA `+pq.QuoteIdentifier(schema)); err != nil {
+				t.Fatalf("create generated spec approval visibility schema: %v", err)
+			}
+			role := fmt.Sprintf("helm_generated_spec_visibility_%d", time.Now().UnixNano())
+			quotedRole := pq.QuoteIdentifier(role)
+			if _, err := ownerDB.ExecContext(ctx, `CREATE ROLE `+quotedRole+` WITH
+				LOGIN PASSWORD 'helm-generated-spec-visibility-password' NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS`); err != nil {
+				t.Fatalf("create generated spec approval visibility role: %v", err)
+			}
+			defer func() {
+				cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cleanupCancel()
+				_, _ = ownerDB.ExecContext(cleanupCtx, `DROP SCHEMA IF EXISTS `+pq.QuoteIdentifier(schema)+` CASCADE`)
+				_, _ = ownerDB.ExecContext(cleanupCtx, `DROP OWNED BY `+quotedRole)
+				_, _ = ownerDB.ExecContext(cleanupCtx, `DROP ROLE IF EXISTS `+quotedRole)
+			}()
+			if _, err := ownerDB.ExecContext(ctx, `GRANT USAGE, CREATE ON SCHEMA `+pq.QuoteIdentifier(schema)+` TO `+quotedRole); err != nil {
+				t.Fatalf("grant migration role schema access: %v", err)
+			}
+			if _, err := ownerDB.ExecContext(ctx, generatedSpecApprovalLegacyTableSchema(t)); err != nil {
+				t.Fatalf("create legacy generated spec approval table: %v", err)
+			}
+			if test.forceRLS {
+				if _, err := ownerDB.ExecContext(ctx, `ALTER TABLE generated_spec_approval_ceremonies OWNER TO `+quotedRole); err != nil {
+					t.Fatalf("assign legacy table owner: %v", err)
+				}
+			}
+			var hasSelect bool
+			if err := ownerDB.QueryRowContext(ctx, `SELECT pg_catalog.has_table_privilege($1, 'generated_spec_approval_ceremonies'::regclass, 'SELECT')`, role).Scan(&hasSelect); err != nil {
+				t.Fatalf("read migration role legacy table privilege: %v", err)
+			}
+			if hasSelect != test.forceRLS {
+				t.Fatalf("migration role SELECT privilege = %t, want %t", hasSelect, test.forceRLS)
+			}
+
+			runtimeDB := openGeneratedSpecApprovalTestPostgres(t, postgresURL, schema, role, "helm-generated-spec-visibility-password")
+			defer func() { _ = runtimeDB.Close() }()
+			if test.forceRLS {
+				if _, err := runtimeDB.ExecContext(ctx, `ALTER TABLE generated_spec_approval_ceremonies ENABLE ROW LEVEL SECURITY; ALTER TABLE generated_spec_approval_ceremonies FORCE ROW LEVEL SECURITY; CREATE POLICY generated_spec_approval_ceremonies_visibility_test ON generated_spec_approval_ceremonies USING (false)`); err != nil {
+					t.Fatalf("force legacy table RLS: %v", err)
+				}
+			}
+
+			fixture := newCeremonyFixture(t)
+			err := NewPostgresStore(runtimeDB, fixture.verifier).Init(ctx)
+			if err == nil || !strings.Contains(err.Error(), test.diagnostic) {
+				t.Fatalf("legacy visibility migration error = %v, want %q", err, test.diagnostic)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- fail closed before creating the GeneratedSpec active-binding unique index when legacy active duplicates exist
- require complete row visibility for the preflight and keep diagnostics identifier-free
- add route-level workload-auth, tuple, caller-scope, and recovery-isolation coverage

## Validation
- `GOWORK=off go test ./pkg/boundary/generatedspecapprovalceremony -count=1`
- `GOWORK=off go test ./cmd/helm-ai-kernel -run '^TestGeneratedSpecApproval' -count=1`\n- `make verify-generated-spec-approval-ceremony-vectors`\n- `make verify-boundary`\n\n## Remaining gate\nThe real Postgres legacy-upgrade fixture is intentionally opt-in and was not run locally because `HELM_TEST_POSTGRES_URL` is unset. Do not merge or promote until it passes against a representative upgrade database.