### PR TITLE
fix(approval): fail closed without credential verification (HELM-142)

### DIFF
--- a/core/cmd/helm-ai-kernel/contract_routes.go
+++ b/core/cmd/helm-ai-kernel/contract_routes.go
@@ -848,36 +848,12 @@ func registerContractRoutes(mux *http.ServeMux, svc *Services) {
 			api.WriteMethodNotAllowed(w)
 			return
 		}
-		var req struct {
-			ServerID          string   `json:"server_id"`
-			ApproverID        string   `json:"approver_id"`
-			ApprovalReceiptID string   `json:"approval_receipt_id"`
-			Reason            string   `json:"reason"`
-			ToolNames         []string `json:"tool_names"`
-			Effects           []string `json:"effects"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			api.WriteBadRequest(w, "Invalid MCP approval request")
-			return
-		}
-		record, err := mcpQuarantine.Approve(r.Context(), mcppkg.ApprovalDecision{
-			ServerID:          req.ServerID,
-			ApproverID:        req.ApproverID,
-			ApprovalReceiptID: req.ApprovalReceiptID,
-			ApprovedAt:        time.Now().UTC(),
-			Reason:            req.Reason,
-			ToolNames:         req.ToolNames,
-			Effects:           req.Effects,
-		})
-		if err != nil {
-			api.WriteBadRequest(w, err.Error())
-			return
-		}
-		if _, err := surfaces.PutMCPServer(record); err != nil {
-			api.WriteInternal(w, err)
-			return
-		}
-		writeContractJSON(w, http.StatusOK, record)
+		// MCP approval authority must come from a credential-verified approval
+		// ceremony, never from caller-supplied body fields. Do not parse the
+		// opaque metadata first: it must never influence an approval result or
+		// change the public 503 contract. Local operators keep the
+		// receipt-backed `helm-ai-kernel mcp approve` CLI path.
+		api.WriteError(w, http.StatusServiceUnavailable, "MCP approval verification unavailable", boundarypkg.ErrApprovalVerificationUnavailable.Error())
 	}))
 
 	mux.HandleFunc("/api/v1/mcp/registry/", protectRuntimeHandler(RouteAuthAdmin, func(w http.ResponseWriter, r *http.Request) {
@@ -901,35 +877,10 @@ func registerContractRoutes(mux *http.ServeMux, svc *Services) {
 			}
 			writeContractJSON(w, http.StatusOK, record)
 		case action == "approve" && r.Method == http.MethodPost:
-			var req struct {
-				ApproverID        string   `json:"approver_id"`
-				ApprovalReceiptID string   `json:"approval_receipt_id"`
-				Reason            string   `json:"reason"`
-				ToolNames         []string `json:"tool_names"`
-				Effects           []string `json:"effects"`
-			}
-			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-				api.WriteBadRequest(w, "Invalid MCP approval request")
-				return
-			}
-			record, err := mcpQuarantine.Approve(r.Context(), mcppkg.ApprovalDecision{
-				ServerID:          serverID,
-				ApproverID:        req.ApproverID,
-				ApprovalReceiptID: req.ApprovalReceiptID,
-				ApprovedAt:        time.Now().UTC(),
-				Reason:            req.Reason,
-				ToolNames:         req.ToolNames,
-				Effects:           req.Effects,
-			})
-			if err != nil {
-				api.WriteBadRequest(w, err.Error())
-				return
-			}
-			if _, err := surfaces.PutMCPServer(record); err != nil {
-				api.WriteInternal(w, err)
-				return
-			}
-			writeContractJSON(w, http.StatusOK, record)
+			// See the collection endpoint: the path-scoped variant must also
+			// reject without parsing or trusting caller-provided approval
+			// fields.
+			api.WriteError(w, http.StatusServiceUnavailable, "MCP approval verification unavailable", boundarypkg.ErrApprovalVerificationUnavailable.Error())
 		case action == "revoke" && r.Method == http.MethodPost:
 			var req struct {
 				Reason string `json:"reason"`
@@ -1348,6 +1299,10 @@ func registerContractRoutes(mux *http.ServeMux, svc *Services) {
 			}
 			approval, err := surfaces.AssertApprovalChallenge(req)
 			if err != nil {
+				if errors.Is(err, boundarypkg.ErrApprovalVerificationUnavailable) {
+					api.WriteError(w, http.StatusServiceUnavailable, "Approval verification unavailable", err.Error())
+					return
+				}
 				api.WriteBadRequest(w, err.Error())
 				return
 			}

--- a/core/cmd/helm-ai-kernel/contract_routes_test.go
+++ b/core/cmd/helm-ai-kernel/contract_routes_test.go
@@ -785,15 +785,43 @@ func TestBoundaryContractRoutesExposeNewControlSurfaces(t *testing.T) {
 	authorizeTestRequest(approveReq)
 	approveRec := httptest.NewRecorder()
 	mux.ServeHTTP(approveRec, approveReq)
-	if approveRec.Code != http.StatusOK {
+	if approveRec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("approve status=%d body=%s", approveRec.Code, approveRec.Body.String())
 	}
-	var approval map[string]any
-	if err := json.Unmarshal(approveRec.Body.Bytes(), &approval); err != nil {
+	if contentType := approveRec.Header().Get("Content-Type"); !strings.Contains(contentType, "application/problem+json") {
+		t.Fatalf("approve content type = %q", contentType)
+	}
+	var approvalProblem struct {
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(approveRec.Body.Bytes(), &approvalProblem); err != nil {
 		t.Fatal(err)
 	}
-	if approval["state"] != "approved" {
-		t.Fatalf("approval state = %+v", approval)
+	if approvalProblem.Detail != boundarypkg.ErrApprovalVerificationUnavailable.Error() {
+		t.Fatalf("approve detail = %q", approvalProblem.Detail)
+	}
+
+	pathApproveReq := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/registry/srv-1/approve", strings.NewReader(`{"approver_id":"user:alice","approval_receipt_id":"approval-r1","reason":"reviewed"}`))
+	authorizeTestRequest(pathApproveReq)
+	pathApproveRec := httptest.NewRecorder()
+	mux.ServeHTTP(pathApproveRec, pathApproveReq)
+	if pathApproveRec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("path approve status=%d body=%s", pathApproveRec.Code, pathApproveRec.Body.String())
+	}
+
+	getAfterApproveReq := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/registry/srv-1", nil)
+	authorizeTestRequest(getAfterApproveReq)
+	getAfterApproveRec := httptest.NewRecorder()
+	mux.ServeHTTP(getAfterApproveRec, getAfterApproveReq)
+	if getAfterApproveRec.Code != http.StatusOK {
+		t.Fatalf("registry get status=%d body=%s", getAfterApproveRec.Code, getAfterApproveRec.Body.String())
+	}
+	var quarantined map[string]any
+	if err := json.Unmarshal(getAfterApproveRec.Body.Bytes(), &quarantined); err != nil {
+		t.Fatal(err)
+	}
+	if quarantined["state"] == "approved" {
+		t.Fatalf("caller-body approve minted authority: %+v", quarantined)
 	}
 
 	sandboxReq := httptest.NewRequest(http.MethodGet, "/api/v1/sandbox/grants/inspect?runtime=wazero", nil)
@@ -837,6 +865,26 @@ func TestBoundaryContractRoutesExposeNewControlSurfaces(t *testing.T) {
 func TestMCPAuthorizeCallAPIFailClosedAndPinnedAllow(t *testing.T) {
 	svc, cleanup := newContractRouteTestServices(t)
 	defer cleanup()
+	// The caller-body HTTP approve path fails closed now, so approval
+	// authority reaches the API only as persisted state written by the
+	// governed receipt-backed path. Seed the approved record and let route
+	// registration hydrate the quarantine registry from it.
+	surfaces := boundarypkg.NewSurfaceRegistry(time.Now)
+	if _, err := surfaces.PutMCPServer(mcppkg.ServerQuarantineRecord{
+		ServerID:          "api-fixture",
+		ToolNames:         []string{"local.echo"},
+		ApprovedToolNames: []string{"local.echo"},
+		Risk:              "high",
+		State:             mcppkg.QuarantineApproved,
+		DiscoveredAt:      time.Now().UTC(),
+		ApprovedAt:        time.Now().UTC(),
+		ApprovedBy:        "user:alice",
+		ApprovalReceiptID: "approval-r1",
+		Reason:            "reviewed",
+	}); err != nil {
+		t.Fatalf("seed approved mcp server: %v", err)
+	}
+	svc.BoundarySurfaces = surfaces
 	mux := http.NewServeMux()
 	registerContractRoutes(mux, svc)
 
@@ -861,22 +909,6 @@ func TestMCPAuthorizeCallAPIFailClosedAndPinnedAllow(t *testing.T) {
 	}, http.StatusForbidden)
 	if unknownServer["verdict"] != "DENY" && unknownServer["verdict"] != "ESCALATE" {
 		t.Fatalf("unknown server verdict = %+v", unknownServer)
-	}
-
-	discoverReq := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/registry", strings.NewReader(`{"server_id":"api-fixture","tool_names":["local.echo"],"risk":"high"}`))
-	authorizeTestRequest(discoverReq)
-	discoverRec := httptest.NewRecorder()
-	mux.ServeHTTP(discoverRec, discoverReq)
-	if discoverRec.Code != http.StatusAccepted {
-		t.Fatalf("discover status=%d body=%s", discoverRec.Code, discoverRec.Body.String())
-	}
-
-	approveReq := httptest.NewRequest(http.MethodPost, "/api/v1/mcp/registry/api-fixture/approve", strings.NewReader(`{"approver_id":"user:alice","approval_receipt_id":"approval-r1","reason":"reviewed","tool_names":["local.echo"]}`))
-	authorizeTestRequest(approveReq)
-	approveRec := httptest.NewRecorder()
-	mux.ServeHTTP(approveRec, approveReq)
-	if approveRec.Code != http.StatusOK {
-		t.Fatalf("approve status=%d body=%s", approveRec.Code, approveRec.Body.String())
 	}
 
 	unknownTool := postMCPAuthorizeForTest(t, mux, map[string]any{
@@ -1123,13 +1155,19 @@ func TestTrustedEvidenceBundleSealSignerRejectsUnsupportedRuntimeProfiles(t *tes
 	}
 }
 
-func TestApprovalRoutesSupportWebAuthnChallengeAssertion(t *testing.T) {
-	svc, cleanup := newContractRouteTestServices(t)
-	defer cleanup()
-	mux := http.NewServeMux()
-	registerContractRoutes(mux, svc)
+// routeApprovalAssertionVerifier is a test double for the credential verifier
+// consulted by the WebAuthn assert route.
+type routeApprovalAssertionVerifier struct {
+	err error
+}
 
-	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/approvals", strings.NewReader(`{"approval_id":"approval-webauthn","subject":"mcp:srv","action":"mcp.approve","requested_by":"agent:test","quorum":1}`))
+func (v *routeApprovalAssertionVerifier) VerifyApprovalAssertion(contracts.ApprovalWebAuthnChallenge, contracts.ApprovalWebAuthnAssertion) error {
+	return v.err
+}
+
+func webAuthnRouteChallengeID(t *testing.T, mux *http.ServeMux, approvalID string) string {
+	t.Helper()
+	createReq := httptest.NewRequest(http.MethodPost, "/api/v1/approvals", strings.NewReader(fmt.Sprintf(`{"approval_id":%q,"subject":"mcp:srv","action":"mcp.approve","requested_by":"agent:test","quorum":1}`, approvalID)))
 	authorizeTestRequest(createReq)
 	createRec := httptest.NewRecorder()
 	mux.ServeHTTP(createRec, createReq)
@@ -1137,7 +1175,7 @@ func TestApprovalRoutesSupportWebAuthnChallengeAssertion(t *testing.T) {
 		t.Fatalf("create approval status=%d body=%s", createRec.Code, createRec.Body.String())
 	}
 
-	challengeReq := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/approval-webauthn/webauthn/challenge", strings.NewReader(`{"method":"passkey","ttl_ms":60000}`))
+	challengeReq := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/"+approvalID+"/webauthn/challenge", strings.NewReader(`{"method":"passkey","ttl_ms":60000}`))
 	authorizeTestRequest(challengeReq)
 	challengeRec := httptest.NewRecorder()
 	mux.ServeHTTP(challengeRec, challengeReq)
@@ -1152,6 +1190,77 @@ func TestApprovalRoutesSupportWebAuthnChallengeAssertion(t *testing.T) {
 	if challengeID == "" {
 		t.Fatalf("challenge missing id: %+v", challenge)
 	}
+	return challengeID
+}
+
+func TestApprovalWebAuthnAssertFailsClosedWithoutVerifier(t *testing.T) {
+	svc, cleanup := newContractRouteTestServices(t)
+	defer cleanup()
+	mux := http.NewServeMux()
+	registerContractRoutes(mux, svc)
+
+	challengeID := webAuthnRouteChallengeID(t, mux, "approval-webauthn")
+
+	assertReq := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/approval-webauthn/webauthn/assert", strings.NewReader(fmt.Sprintf(`{"challenge_id":%q,"actor":"user:alice","assertion":"signed-client-data","receipt_id":"rcpt-approval"}`, challengeID)))
+	authorizeTestRequest(assertReq)
+	assertRec := httptest.NewRecorder()
+	mux.ServeHTTP(assertRec, assertReq)
+	if assertRec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("assert status=%d body=%s", assertRec.Code, assertRec.Body.String())
+	}
+	if contentType := assertRec.Header().Get("Content-Type"); !strings.Contains(contentType, "application/problem+json") {
+		t.Fatalf("assert content type = %q", contentType)
+	}
+	var problem struct {
+		Title  string `json:"title"`
+		Detail string `json:"detail"`
+	}
+	if err := json.Unmarshal(assertRec.Body.Bytes(), &problem); err != nil {
+		t.Fatal(err)
+	}
+	if problem.Title != "Approval verification unavailable" || !strings.Contains(problem.Detail, boundarypkg.ErrApprovalVerificationUnavailable.Error()) {
+		t.Fatalf("assert problem = %+v", problem)
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/approvals", nil)
+	authorizeTestRequest(listReq)
+	listRec := httptest.NewRecorder()
+	mux.ServeHTTP(listRec, listReq)
+	if listRec.Code != http.StatusOK || strings.Contains(listRec.Body.String(), `"approval_id":"approval-webauthn","state":"approved"`) {
+		t.Fatalf("unverified assertion minted approval authority: status=%d body=%s", listRec.Code, listRec.Body.String())
+	}
+}
+
+func TestApprovalWebAuthnAssertRejectsFailedVerification(t *testing.T) {
+	svc, cleanup := newContractRouteTestServices(t)
+	defer cleanup()
+	registry := boundarypkg.NewSurfaceRegistry(time.Now)
+	registry.SetApprovalAssertionVerifier(&routeApprovalAssertionVerifier{err: fmt.Errorf("signature does not match registered credential")})
+	svc.BoundarySurfaces = registry
+	mux := http.NewServeMux()
+	registerContractRoutes(mux, svc)
+
+	challengeID := webAuthnRouteChallengeID(t, mux, "approval-webauthn-reject")
+
+	assertReq := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/approval-webauthn-reject/webauthn/assert", strings.NewReader(fmt.Sprintf(`{"challenge_id":%q,"actor":"user:alice","assertion":"garbage","receipt_id":"rcpt-approval"}`, challengeID)))
+	authorizeTestRequest(assertReq)
+	assertRec := httptest.NewRecorder()
+	mux.ServeHTTP(assertRec, assertReq)
+	if assertRec.Code != http.StatusBadRequest || !strings.Contains(assertRec.Body.String(), "approval assertion rejected") {
+		t.Fatalf("rejected assert status=%d body=%s", assertRec.Code, assertRec.Body.String())
+	}
+}
+
+func TestApprovalRoutesSupportWebAuthnChallengeAssertionWithVerifier(t *testing.T) {
+	svc, cleanup := newContractRouteTestServices(t)
+	defer cleanup()
+	registry := boundarypkg.NewSurfaceRegistry(time.Now)
+	registry.SetApprovalAssertionVerifier(&routeApprovalAssertionVerifier{})
+	svc.BoundarySurfaces = registry
+	mux := http.NewServeMux()
+	registerContractRoutes(mux, svc)
+
+	challengeID := webAuthnRouteChallengeID(t, mux, "approval-webauthn")
 
 	assertReq := httptest.NewRequest(http.MethodPost, "/api/v1/approvals/approval-webauthn/webauthn/assert", strings.NewReader(fmt.Sprintf(`{"challenge_id":%q,"actor":"user:alice","assertion":"signed-client-data","receipt_id":"rcpt-approval"}`, challengeID)))
 	authorizeTestRequest(assertReq)

--- a/core/pkg/boundary/surface_registry.go
+++ b/core/pkg/boundary/surface_registry.go
@@ -34,6 +34,11 @@ type SurfaceRegistry struct {
 	db   *sql.DB
 	ctx  context.Context
 
+	// assertionVerifier is nil until runtime wiring registers a credential
+	// verifier; while nil, AssertApprovalChallenge fails closed with
+	// ErrApprovalVerificationUnavailable.
+	assertionVerifier ApprovalAssertionVerifier
+
 	records            map[string]contracts.ExecutionBoundaryRecord
 	checkpoints        map[string]contracts.BoundaryCheckpoint
 	approvals          map[string]contracts.ApprovalCeremony
@@ -59,6 +64,21 @@ type SurfaceRegistry struct {
 // reviewed its sealed ceremony hash. Callers must load the current ceremony
 // and require a new review before trying again.
 var ErrApprovalTransitionConflict = errors.New("approval ceremony changed")
+
+// ErrApprovalVerificationUnavailable keeps approval assertions fail-closed:
+// without a registered credential verifier an opaque assertion string must
+// never transition a ceremony to allowed. Routes map this error to an RFC 7807
+// problem-details 503 response.
+var ErrApprovalVerificationUnavailable = errors.New("approval verification unavailable")
+
+// ApprovalAssertionVerifier verifies a WebAuthn/passkey approval assertion
+// against a registered credential before any ceremony transition. A verifier
+// that cannot handle the ceremony's credential or method must return an error
+// wrapping ErrApprovalVerificationUnavailable so the surface stays fail-closed
+// instead of degrading into acceptance.
+type ApprovalAssertionVerifier interface {
+	VerifyApprovalAssertion(challenge contracts.ApprovalWebAuthnChallenge, assertion contracts.ApprovalWebAuthnAssertion) error
+}
 
 func NewSurfaceRegistry(now func() time.Time) *SurfaceRegistry {
 	r := newSurfaceRegistry(now)
@@ -643,6 +663,21 @@ func (r *SurfaceRegistry) CreateApprovalChallenge(approvalID, method string, ttl
 	return record, nil
 }
 
+// SetApprovalAssertionVerifier registers the credential verifier consulted by
+// AssertApprovalChallenge before any ceremony transition. Passing nil returns
+// the surface to its fail-closed default, where assertions cannot transition
+// ceremonies at all.
+func (r *SurfaceRegistry) SetApprovalAssertionVerifier(v ApprovalAssertionVerifier) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.assertionVerifier = v
+}
+
+// AssertApprovalChallenge binds a WebAuthn/passkey assertion to an approval
+// ceremony. The assertion is verified against the registered credential
+// verifier before any transition: with no verifier registered the surface
+// fails closed with ErrApprovalVerificationUnavailable, and a rejected
+// assertion never mutates the ceremony or the challenge record.
 func (r *SurfaceRegistry) AssertApprovalChallenge(assertion contracts.ApprovalWebAuthnAssertion) (contracts.ApprovalCeremony, error) {
 	if strings.TrimSpace(assertion.ChallengeID) == "" || strings.TrimSpace(assertion.Actor) == "" || strings.TrimSpace(assertion.Assertion) == "" {
 		return contracts.ApprovalCeremony{}, fmt.Errorf("challenge_id, actor, and assertion are required")
@@ -663,6 +698,17 @@ func (r *SurfaceRegistry) AssertApprovalChallenge(assertion contracts.ApprovalWe
 	}
 	if r.now().UTC().After(challenge.ExpiresAt) {
 		return contracts.ApprovalCeremony{}, fmt.Errorf("approval challenge expired")
+	}
+	if r.assertionVerifier == nil {
+		// Fail closed: an opaque assertion string must never mint approval
+		// authority. Hashing the assertion is bookkeeping, not verification.
+		return contracts.ApprovalCeremony{}, fmt.Errorf("cannot verify assertion for challenge %q: %w", assertion.ChallengeID, ErrApprovalVerificationUnavailable)
+	}
+	if err := r.assertionVerifier.VerifyApprovalAssertion(challenge, assertion); err != nil {
+		if errors.Is(err, ErrApprovalVerificationUnavailable) {
+			return contracts.ApprovalCeremony{}, err
+		}
+		return contracts.ApprovalCeremony{}, fmt.Errorf("approval assertion rejected: %w", err)
 	}
 	approval, err := r.transitionApprovalLocked(challenge.ApprovalID, contracts.ApprovalCeremonyAllowed, assertion.Actor, assertion.ReceiptID, assertion.Reason, "")
 	if err != nil {

--- a/core/pkg/boundary/surface_registry_test.go
+++ b/core/pkg/boundary/surface_registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -185,9 +186,107 @@ func TestApprovalTransitionEnforcesQuorumAndTimelock(t *testing.T) {
 	}
 }
 
-func TestApprovalChallengeAssertionBindsPasskeyEvidence(t *testing.T) {
+// approvalAssertionVerifierFunc adapts a function to ApprovalAssertionVerifier
+// for tests.
+type approvalAssertionVerifierFunc func(challenge contracts.ApprovalWebAuthnChallenge, assertion contracts.ApprovalWebAuthnAssertion) error
+
+func (f approvalAssertionVerifierFunc) VerifyApprovalAssertion(challenge contracts.ApprovalWebAuthnChallenge, assertion contracts.ApprovalWebAuthnAssertion) error {
+	return f(challenge, assertion)
+}
+
+func TestApprovalChallengeAssertionFailsClosedWithoutVerifier(t *testing.T) {
 	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
 	registry := NewSurfaceRegistry(func() time.Time { return now })
+	challenge, err := registry.CreateApprovalChallenge("approval-bootstrap", "passkey", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertion := contracts.ApprovalWebAuthnAssertion{
+		ChallengeID: challenge.ChallengeID,
+		Actor:       "user:alice",
+		Assertion:   "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0.valid-looking-opaque-signature",
+		ReceiptID:   "rcpt-passkey",
+		Reason:      "passkey assertion",
+	}
+	for _, name := range []string{"first attempt", "repeated request"} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := registry.AssertApprovalChallenge(assertion); !errors.Is(err, ErrApprovalVerificationUnavailable) {
+				t.Fatalf("assertion error = %v, want %v", err, ErrApprovalVerificationUnavailable)
+			}
+			approval := registry.approvals["approval-bootstrap"]
+			if approval.State != contracts.ApprovalCeremonyPending {
+				t.Fatalf("approval state = %q, want pending", approval.State)
+			}
+			if approval.AuthMethod != "" || approval.ChallengeID != "" || approval.ChallengeHash != "" || approval.AssertionHash != "" {
+				t.Fatalf("approval claimed unverified passkey evidence: %+v", approval)
+			}
+			persisted := registry.challenges[challenge.ChallengeID]
+			if persisted.Verified || persisted.AssertionHash != "" {
+				t.Fatalf("challenge claimed verification: %+v", persisted)
+			}
+		})
+	}
+}
+
+func TestApprovalChallengeAssertionRejectedByVerifierDoesNotTransition(t *testing.T) {
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	registry := NewSurfaceRegistry(func() time.Time { return now })
+	registry.SetApprovalAssertionVerifier(approvalAssertionVerifierFunc(func(contracts.ApprovalWebAuthnChallenge, contracts.ApprovalWebAuthnAssertion) error {
+		return errors.New("signature does not match registered credential")
+	}))
+	challenge, err := registry.CreateApprovalChallenge("approval-bootstrap", "passkey", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = registry.AssertApprovalChallenge(contracts.ApprovalWebAuthnAssertion{
+		ChallengeID: challenge.ChallengeID,
+		Actor:       "user:alice",
+		Assertion:   "garbage-signature",
+	})
+	if err == nil || errors.Is(err, ErrApprovalVerificationUnavailable) || !strings.Contains(err.Error(), "approval assertion rejected") {
+		t.Fatalf("rejected assertion error = %v, want rejection distinct from unavailability", err)
+	}
+	if approval := registry.approvals["approval-bootstrap"]; approval.State != contracts.ApprovalCeremonyPending {
+		t.Fatalf("rejected assertion transitioned approval: %+v", approval)
+	}
+	if persisted := registry.challenges[challenge.ChallengeID]; persisted.Verified || persisted.AssertionHash != "" {
+		t.Fatalf("rejected assertion marked challenge verified: %+v", persisted)
+	}
+}
+
+func TestApprovalChallengeAssertionVerifierUnavailableForCredentialFailsClosed(t *testing.T) {
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	registry := NewSurfaceRegistry(func() time.Time { return now })
+	registry.SetApprovalAssertionVerifier(approvalAssertionVerifierFunc(func(challenge contracts.ApprovalWebAuthnChallenge, _ contracts.ApprovalWebAuthnAssertion) error {
+		return fmt.Errorf("no verifier registered for method %q: %w", challenge.Method, ErrApprovalVerificationUnavailable)
+	}))
+	challenge, err := registry.CreateApprovalChallenge("approval-bootstrap", "hardware-token", time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := registry.AssertApprovalChallenge(contracts.ApprovalWebAuthnAssertion{
+		ChallengeID: challenge.ChallengeID,
+		Actor:       "user:alice",
+		Assertion:   "assertion-for-unsupported-method",
+	}); !errors.Is(err, ErrApprovalVerificationUnavailable) {
+		t.Fatalf("assertion error = %v, want %v", err, ErrApprovalVerificationUnavailable)
+	}
+	if approval := registry.approvals["approval-bootstrap"]; approval.State != contracts.ApprovalCeremonyPending {
+		t.Fatalf("unavailable verifier transitioned approval: %+v", approval)
+	}
+}
+
+func TestApprovalChallengeAssertionBindsPasskeyEvidenceWithVerifier(t *testing.T) {
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	registry := NewSurfaceRegistry(func() time.Time { return now })
+	var verified int
+	registry.SetApprovalAssertionVerifier(approvalAssertionVerifierFunc(func(challenge contracts.ApprovalWebAuthnChallenge, assertion contracts.ApprovalWebAuthnAssertion) error {
+		verified++
+		if challenge.ApprovalID != "approval-bootstrap" || assertion.Assertion != "signed-client-data" {
+			return errors.New("unexpected verification input")
+		}
+		return nil
+	}))
 	challenge, err := registry.CreateApprovalChallenge("approval-bootstrap", "passkey", time.Minute)
 	if err != nil {
 		t.Fatal(err)
@@ -202,11 +301,17 @@ func TestApprovalChallengeAssertionBindsPasskeyEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if verified != 1 {
+		t.Fatalf("verifier consulted %d times, want 1", verified)
+	}
 	if approval.State != contracts.ApprovalCeremonyAllowed || approval.AuthMethod != "passkey" {
 		t.Fatalf("passkey approval not bound: %+v", approval)
 	}
 	if approval.ChallengeHash == "" || approval.AssertionHash == "" {
 		t.Fatalf("challenge/assertion hashes missing: %+v", approval)
+	}
+	if persisted := registry.challenges[challenge.ChallengeID]; !persisted.Verified || persisted.AssertionHash != approval.AssertionHash {
+		t.Fatalf("verified challenge not recorded: %+v", persisted)
 	}
 }
 


### PR DESCRIPTION
Narrow re-derivation of #549 on current main.

## The hole
`AssertApprovalChallenge` accepted ANY non-empty assertion string, hashed it, and transitioned the ceremony to Allowed — no cryptographic verification against a registered credential. The caller-body MCP quarantine approve endpoints likewise minted approval authority from request fields. Main's #736 hardening (authenticated principal + expected_ceremony_hash + TransitionApprovalIfCurrent) constrains who/when, not whether the credential is real.

## The fix
- `ApprovalAssertionVerifier` interface + `SetApprovalAssertionVerifier` wiring on `SurfaceRegistry`; with no verifier registered, assertion paths fail closed with `ErrApprovalVerificationUnavailable` (RFC 7807 problem-details 503 at the routes). A rejected assertion never mutates ceremony or challenge state.
- Caller-body MCP approve endpoints (collection and path-scoped) return 503 without parsing the body; approval reaches the API only as persisted state from the governed receipt-backed path (`hydrateMCPQuarantine`).
- Tests: garbage assertions no longer flip ceremonies; 503 problem-details contract asserted; authorize-call pinned-allow test now seeds approval through persisted governed state.

## Compat
Local `approvals assert` CLI and any API caller relying on assertion-string approvals now receive an explicit verification-unavailable error until a credential verifier is wired. This is the intended fail-closed posture.

Supersedes the containment core of #549 (67-file head, 13 conflicts, unmergeable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)