### PR TITLE
fix(riskscan): require EvidencePack attestation hash

### DIFF
--- a/core/pkg/riskscan/evidence_pack.go
+++ b/core/pkg/riskscan/evidence_pack.go
@@ -221,6 +221,9 @@ func VerifyEvidencePack(packDir string) EvidencePackVerification {
 		return verificationError(result, fmt.Errorf("decode evidence pack: %w", err))
 	}
 	result.PackID = pack.PackID
+	if strings.TrimSpace(pack.Attestation.PackHash) == "" {
+		return verificationError(result, fmt.Errorf("evidence pack attestation.pack_hash is required"))
+	}
 	if issues := executor.ValidateEvidencePack(&pack); len(issues) > 0 {
 		return verificationError(result, fmt.Errorf("validate evidence pack: %s", strings.Join(issues, "; ")))
 	}

--- a/core/pkg/riskscan/scan_test.go
+++ b/core/pkg/riskscan/scan_test.go
@@ -117,6 +117,34 @@ func TestEvidencePackTarUsesCurrentContract(t *testing.T) {
 	if result := VerifyEvidencePack(extracted); !result.Verified {
 		t.Fatalf("verify evidence pack: %+v", result)
 	}
+	packPath := filepath.Join(extracted, riskScanEvidencePackFile)
+	packJSON, err := os.ReadFile(packPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]json.RawMessage
+	if err := json.Unmarshal(packJSON, &document); err != nil {
+		t.Fatal(err)
+	}
+	var attestation map[string]json.RawMessage
+	if err := json.Unmarshal(document["attestation"], &attestation); err != nil {
+		t.Fatal(err)
+	}
+	delete(attestation, "pack_hash")
+	document["attestation"], err = json.Marshal(attestation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packJSON, err = json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(packPath, append(packJSON, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if result := VerifyEvidencePack(extracted); result.Verified || !strings.Contains(strings.Join(result.Errors, "\n"), "attestation.pack_hash is required") {
+		t.Fatalf("missing pack hash verified: %+v", result)
+	}
 	if err := os.WriteFile(filepath.Join(extracted, "unexpected.json"), []byte("{}\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Require a risk-scan EvidencePack attestation pack hash before generic validation. This closes the omitted-hash fail-open path found after the v0.8 EvidencePack recut. Includes a focused regression test that removes the field from an otherwise valid exported pack and proves verification fails closed.