### PR TITLE
ci(release): expose evidence signing PEM to the binaries job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,6 +316,9 @@ jobs:
       HELM_EVIDENCE_KMS_KEY_ID: ${{ secrets.HELM_EVIDENCE_KMS_KEY_ID }}
       HELM_EVIDENCE_KMS_PUBLIC_KEY_HEX: ${{ secrets.HELM_EVIDENCE_KMS_PUBLIC_KEY_HEX }}
       HELM_EVIDENCE_KMS_SIGN_COMMAND: ${{ secrets.HELM_EVIDENCE_KMS_SIGN_COMMAND }}
+      # Interim soft-key posture (2026-08): the sign command reads this PEM.
+      # Replace with cloud-KMS material and drop the PEM once HELM-<kms> lands.
+      HELM_EVIDENCE_KMS_PRIVATE_PEM: ${{ secrets.HELM_EVIDENCE_KMS_PRIVATE_PEM }}
     permissions:
       actions: read
       attestations: write


### PR DESCRIPTION
One-line env wire: the binaries job exports `HELM_EVIDENCE_KMS_PRIVATE_PEM` from secrets so the interim soft-key `HELM_EVIDENCE_KMS_SIGN_COMMAND` can read it (the external-signer contract runs the command via `sh -c` with the payload JSON on stdin; key material stays outside the kernel process).

Part of the v0.8.0 release evidence-trust interim posture (soft Ed25519 key + rekor anchor + Actions-artifact/Release-asset off-host copies), to be replaced by cloud KMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)