### PR TITLE
fix(release): remove raw evidence PEM exposure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,9 +316,6 @@ jobs:
       HELM_EVIDENCE_KMS_KEY_ID: ${{ secrets.HELM_EVIDENCE_KMS_KEY_ID }}
       HELM_EVIDENCE_KMS_PUBLIC_KEY_HEX: ${{ secrets.HELM_EVIDENCE_KMS_PUBLIC_KEY_HEX }}
       HELM_EVIDENCE_KMS_SIGN_COMMAND: ${{ secrets.HELM_EVIDENCE_KMS_SIGN_COMMAND }}
-      # Interim soft-key posture (2026-08): the sign command reads this PEM.
-      # Replace with cloud-KMS material and drop the PEM once HELM-<kms> lands.
-      HELM_EVIDENCE_KMS_PRIVATE_PEM: ${{ secrets.HELM_EVIDENCE_KMS_PRIVATE_PEM }}
     permissions:
       actions: read
       attestations: write

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -103,6 +103,9 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         ):
             self.assertIn(asset, github_release)
 
+    def test_release_workflow_never_exposes_raw_evidence_private_pem(self) -> None:
+        self.assertNotIn("HELM_EVIDENCE_KMS_PRIVATE_PEM", self.workflow)
+
     def test_console_assets_are_verified_before_publication(self) -> None:
         console_assets = self.job("console-release-assets")
         self.assertIn("needs: console-local-sidecar", console_assets)


### PR DESCRIPTION
Revert the raw HELM_EVIDENCE_KMS_PRIVATE_PEM release-runner environment wire. Keep evidence signing fail closed until a real KMS or OIDC-backed external signer and protected v-star tag policy are available. Adds a workflow contract regression for this exact raw-key exposure.