### PR TITLE
fix(sdk-ts): fail closed named adapter aliases

### DIFF
--- a/docs/INTEGRATIONS/framework-adapters.md
+++ b/docs/INTEGRATIONS/framework-adapters.md
@@ -56,6 +56,15 @@ produces the same `AgentFrameworkAction` and uses the same receipt-bearing HELM
 client. Use `fromRawMCPToolCall` for another framework that exposes an MCP tool
 call instead of adding a provider-specific authority path.
 
+Named helpers expect the provider's canonical envelope:
+
+- `fromCodexToolCall`: `recipient_name` + `parameters`
+- `fromClaudeToolCall`: `tool_name` + `tool_input`
+- `fromHermesToolCall`: `tool_name` + `arguments`
+
+If those canonical fields are missing, or alias fields disagree with them, the
+helper throws `TypeError` before any HELM request is built.
+
 Source presence is not package-release proof. Before a production integration,
 verify the installed SDK version contains the helper, route one allow case and
 blocked deny/escalate cases, and verify the resulting receipt offline.

--- a/sdk/ts/README.md
+++ b/sdk/ts/README.md
@@ -61,7 +61,10 @@ tool-call events. These helpers normalize each framework event into a HELM
 governance request and submit it through `chatCompletionsWithReceipt`,
 preserving the kernel receipt returned in `X-Helm-*` headers. Frameworks
 without a named adapter can use the raw MCP adapter; no model-specific policy
-path is required.
+path is required. The named Codex, Claude Code, and Hermes helpers expect their
+canonical provider fields (`recipient_name` + `parameters`, `tool_name` +
+`tool_input`, `tool_name` + `arguments`) and throw before dispatch if alias
+fields conflict with that envelope.
 
 ```ts
 import { HelmClient, createAgentFrameworkAdapter, fromOpenAIAgentsToolCall } from "@mindburn/helm-ai-kernel";

--- a/sdk/ts/src/adapters/agent-frameworks.test.ts
+++ b/sdk/ts/src/adapters/agent-frameworks.test.ts
@@ -194,6 +194,20 @@ describe("agent framework adapters", () => {
     ).toThrow("hermes adapter rejects conflicting name");
   });
 
+  it("canonicalizes populated named helper identities before alias comparison", () => {
+    expect(
+      fromCodexToolCall({
+        recipient_name: "  functions.exec_command  ",
+        name: "functions.exec_command",
+        parameters: { cmd: "pwd" },
+      }),
+    ).toMatchObject({
+      framework: "codex",
+      toolName: "functions.exec_command",
+      arguments: { cmd: "pwd" },
+    });
+  });
+
   it("rejects alias-shaped or mismatched arguments for named helpers", () => {
     expect(() =>
       fromCodexToolCall({

--- a/sdk/ts/src/adapters/agent-frameworks.test.ts
+++ b/sdk/ts/src/adapters/agent-frameworks.test.ts
@@ -145,6 +145,102 @@ describe("agent framework adapters", () => {
     });
   });
 
+  it("rejects named helper payloads that omit canonical identity fields", () => {
+    expect(() =>
+      fromCodexToolCall({
+        name: "functions.exec_command",
+        parameters: { cmd: "pwd" },
+      }),
+    ).toThrow("codex adapter requires canonical recipient_name");
+
+    expect(() =>
+      fromClaudeToolCall({
+        name: "Bash",
+        tool_input: { command: "pwd" },
+      }),
+    ).toThrow("claude-code adapter requires canonical tool_name");
+
+    expect(() =>
+      fromHermesToolCall({
+        name: "web.search",
+        arguments: { query: "boundary" },
+      }),
+    ).toThrow("hermes adapter requires canonical tool_name");
+  });
+
+  it("rejects conflicting alias identities for named helpers", () => {
+    expect(() =>
+      fromCodexToolCall({
+        recipient_name: "functions.exec_command",
+        name: "functions.write_stdin",
+        parameters: { cmd: "pwd" },
+      }),
+    ).toThrow("codex adapter rejects conflicting name");
+
+    expect(() =>
+      fromClaudeToolCall({
+        tool_name: "Bash",
+        name: "Edit",
+        tool_input: { command: "pwd" },
+      }),
+    ).toThrow("claude-code adapter rejects conflicting name");
+
+    expect(() =>
+      fromHermesToolCall({
+        tool_name: "web.search",
+        name: "terminal",
+        arguments: { query: "boundary" },
+      }),
+    ).toThrow("hermes adapter rejects conflicting name");
+  });
+
+  it("rejects alias-shaped or mismatched arguments for named helpers", () => {
+    expect(() =>
+      fromCodexToolCall({
+        recipient_name: "functions.exec_command",
+        arguments: { cmd: "pwd" },
+      }),
+    ).toThrow("codex adapter requires canonical parameters");
+
+    expect(() =>
+      fromClaudeToolCall({
+        tool_name: "Bash",
+        arguments: { command: "pwd" },
+      }),
+    ).toThrow("claude-code adapter requires canonical tool_input");
+
+    expect(() =>
+      fromHermesToolCall({
+        tool_name: "web.search",
+        args: { query: "boundary" },
+      }),
+    ).toThrow("hermes adapter requires canonical arguments");
+
+    expect(() =>
+      fromCodexToolCall({
+        recipient_name: "functions.exec_command",
+        parameters: { cmd: "pwd" },
+        input: { cmd: "git status" },
+      }),
+    ).toThrow("codex adapter rejects conflicting input");
+
+    expect(() =>
+      fromClaudeToolCall({
+        tool_name: "Bash",
+        tool_input: { command: "pwd" },
+        input: { command: "git status" },
+      }),
+    ).toThrow("claude-code adapter rejects conflicting input");
+
+    expect(() =>
+      fromHermesToolCall({
+        tool_name: "web.search",
+        arguments: { query: "boundary" },
+        args: { query: "other" },
+      }),
+    ).toThrow("hermes adapter rejects conflicting args");
+  });
+
   it("normalizes PydanticAI and LlamaIndex variants", () => {
     expect(
       fromPydanticAIToolCall({

--- a/sdk/ts/src/adapters/agent-frameworks.ts
+++ b/sdk/ts/src/adapters/agent-frameworks.ts
@@ -367,10 +367,24 @@ export function fromOpenAIAgentsToolCall(
 }
 
 export function fromCodexToolCall(call: CodexToolCall): AgentFrameworkAction {
+  const toolName = requireCanonicalToolName(
+    "codex",
+    "recipient_name",
+    call.recipient_name,
+  );
+  rejectConflictingAliasToolName("codex", "recipient_name", toolName, {
+    tool_name: call.tool_name,
+    name: call.name,
+  });
+  const args = requireCanonicalArguments("codex", "parameters", call.parameters, {
+    arguments: call.arguments,
+    input: call.input,
+    payload: call.payload,
+  });
   return frameworkAction(
     "codex",
-    call.tool_name ?? call.name ?? call.recipient_name,
-    call.arguments ?? call.parameters ?? call.input ?? call.payload,
+    toolName,
+    args,
     {
       toolCallId: call.id,
       runId: call.thread_id ?? call.session_id,
@@ -384,10 +398,27 @@ export function fromCodexToolCall(call: CodexToolCall): AgentFrameworkAction {
 }
 
 export function fromClaudeToolCall(call: ClaudeToolCall): AgentFrameworkAction {
+  const toolName = requireCanonicalToolName(
+    "claude-code",
+    "tool_name",
+    call.tool_name,
+  );
+  rejectConflictingAliasToolName("claude-code", "tool_name", toolName, {
+    name: call.name,
+  });
+  const args = requireCanonicalArguments(
+    "claude-code",
+    "tool_input",
+    call.tool_input,
+    {
+      input: call.input,
+      arguments: call.arguments,
+    },
+  );
   return frameworkAction(
     "claude-code",
-    call.tool_name ?? call.name,
-    call.tool_input ?? call.input ?? call.arguments,
+    toolName,
+    args,
     {
       toolCallId: call.tool_use_id ?? call.id,
       runId: call.session_id,
@@ -400,10 +431,26 @@ export function fromClaudeToolCall(call: ClaudeToolCall): AgentFrameworkAction {
 }
 
 export function fromHermesToolCall(call: HermesToolCall): AgentFrameworkAction {
+  const toolName = requireCanonicalToolName(
+    "hermes",
+    "tool_name",
+    call.tool_name,
+  );
+  rejectConflictingAliasToolName("hermes", "tool_name", toolName, {
+    name: call.name,
+  });
+  const args = requireCanonicalArguments(
+    "hermes",
+    "arguments",
+    call.arguments,
+    {
+      args: call.args,
+    },
+  );
   return frameworkAction(
     "hermes",
-    call.tool_name ?? call.name,
-    call.arguments ?? call.args,
+    toolName,
+    args,
     {
       toolCallId: call.id,
       agentId: call.profile,
@@ -693,4 +740,74 @@ function displayName(framework: AgentFramework): string {
     agentFrameworkAdapters.find((adapter) => adapter.framework === framework)
       ?.displayName ?? framework
   );
+}
+
+function requireCanonicalToolName(
+  framework: "codex" | "claude-code" | "hermes",
+  field: string,
+  value: unknown,
+): string {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError(`${framework} adapter requires canonical ${field}`);
+  }
+  return value;
+}
+
+function rejectConflictingAliasToolName(
+  framework: "codex" | "claude-code" | "hermes",
+  canonicalField: string,
+  canonicalValue: string,
+  aliases: Record<string, unknown>,
+): void {
+  for (const [field, value] of Object.entries(aliases)) {
+    if (value == null) continue;
+    if (typeof value !== "string" || !value.trim()) {
+      throw new TypeError(
+        `${framework} adapter rejects blank alias ${field}; use canonical ${canonicalField}`,
+      );
+    }
+    if (value.trim() !== canonicalValue.trim()) {
+      throw new TypeError(
+        `${framework} adapter rejects conflicting ${field}; use canonical ${canonicalField}`,
+      );
+    }
+  }
+}
+
+function requireCanonicalArguments(
+  framework: "codex" | "claude-code" | "hermes",
+  canonicalField: string,
+  canonicalValue: unknown,
+  aliases: Record<string, unknown>,
+): unknown {
+  if (canonicalValue === undefined) {
+    throw new TypeError(`${framework} adapter requires canonical ${canonicalField}`);
+  }
+  for (const [field, value] of Object.entries(aliases)) {
+    if (value === undefined) continue;
+    if (!sameNormalizedArguments(canonicalValue, value)) {
+      throw new TypeError(
+        `${framework} adapter rejects conflicting ${field}; use canonical ${canonicalField}`,
+      );
+    }
+  }
+  return canonicalValue;
+}
+
+function sameNormalizedArguments(left: unknown, right: unknown): boolean {
+  return stableSerialize(normalizeArguments(left)) === stableSerialize(normalizeArguments(right));
+}
+
+function stableSerialize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerialize(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableSerialize(object[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }

--- a/sdk/ts/src/adapters/agent-frameworks.ts
+++ b/sdk/ts/src/adapters/agent-frameworks.ts
@@ -750,7 +750,7 @@ function requireCanonicalToolName(
   if (typeof value !== "string" || !value.trim()) {
     throw new TypeError(`${framework} adapter requires canonical ${field}`);
   }
-  return value;
+  return value.trim();
 }
 
 function rejectConflictingAliasToolName(
@@ -766,7 +766,7 @@ function rejectConflictingAliasToolName(
         `${framework} adapter rejects blank alias ${field}; use canonical ${canonicalField}`,
       );
     }
-    if (value.trim() !== canonicalValue.trim()) {
+    if (value.trim() !== canonicalValue) {
       throw new TypeError(
         `${framework} adapter rejects conflicting ${field}; use canonical ${canonicalField}`,
       );


### PR DESCRIPTION
## Why

Named Codex, Claude Code, and Hermes adapter payloads previously accepted alias-only or conflicting identity/argument fields. A whitespace-differing name alias could also leave the policy payload and provider call with different identities.

## Change

- Require each framework's canonical named identity and argument field before constructing the governed action.
- Reject alias-only, missing, or conflicting populated fields before HELM dispatch.
- Canonicalize the accepted tool name once by trimming whitespace, then use it for both policy and provider surfaces.

## Validation

- sdk/ts focused Vitest: 2 files, 18 tests passed
- npm run build
- independent exact-head review: approved

No new adapter abstraction or public configuration was added.