### PR TITLE
chore(release): pin the fixed Console sidecar source for v0.8.0

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -2,6 +2,17 @@
   "schema": "helm.console.local-sidecar.source-pins.v2",
   "pins": [
     {
+      "kernel_release_version": "v0.8.0",
+      "source_repository": "Mindburn-Labs/app-helm-console",
+      "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
+      "source": {
+        "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
+        "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
+        "version": "0.2.1",
+        "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9"
+      }
+    },
+    {
       "kernel_release_version": "v0.8.1",
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.1",


### PR DESCRIPTION
Release-blocking for v0.8.0.

Adds the v0.8.0 Console source pin at app-helm-console `c0fd6b4` ([app-helm-console#130](https://github.com/Mindburn-Labs/app-helm-console/pull/130)), which fixes `provenance.runtime.platform.arch` writing Node's `x64` where the target says `amd64`. This repository's verifier caught it correctly (`sidecar provenance runtime platform does not match its target`, run 31054216955).

- `helm-console-sidecar-v0.8.0` now points at `c0fd6b4`.
- The pre-existing v0.8.1 pin entry is untouched.
- `console_local_sidecar.py pin --kernel-release v0.8.0` resolves; its 28-test suite passes.

v0.8.0 will be retagged on this commit — no GitHub Release object exists yet, and published SDK/registry artifacts are skip-if-published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)