### PR TITLE
chore(release): pin the fixed Console sidecar source for v0.8.1

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -2,23 +2,12 @@
   "schema": "helm.console.local-sidecar.source-pins.v2",
   "pins": [
     {
-      "kernel_release_version": "v0.8.0",
-      "source_repository": "Mindburn-Labs/app-helm-console",
-      "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.0",
-      "source": {
-        "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
-        "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
-        "version": "0.2.1",
-        "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9"
-      }
-    },
-    {
       "kernel_release_version": "v0.8.1",
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.1",
       "source": {
-        "commit": "97c0fa8fe2f243e3d487db6b14c90740a21f006e",
-        "tree": "4f6f6705f97f7ec7958fce0162fd1757f47506d6",
+        "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
+        "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
         "version": "0.2.1",
         "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9"
       }

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,8 +28,8 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "97c0fa8fe2f243e3d487db6b14c90740a21f006e",
-    "tree": "4f6f6705f97f7ec7958fce0162fd1757f47506d6",
+    "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
+    "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
     "version": "0.2.1",
     "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9",
 }


### PR DESCRIPTION
Release-blocking for v0.8.1.

The v0.8.1 Console pin referenced `97c0fa8`, whose sidecar writes `provenance.runtime.platform.arch=x64` (Node spelling) while its target says `amd64` — this repository's verifier rejected it in run 31054216955 (`sidecar provenance runtime platform does not match its target`). [app-helm-console#130](https://github.com/Mindburn-Labs/app-helm-console/pull/130) fixed it; this pins `c0fd6b4`.

- `helm-console-sidecar-v0.8.1` will be tagged at `c0fd6b4` before the release tag.
- The stale v0.8.0 pin entry is removed — 0.8.0 remains partially published and unreleased per #793.
- `console_local_sidecar_test.py` (28 tests) passes with the updated expectation; `make verify-boundary` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)