### PR TITLE
fix(release): require the tag on main by ancestry, not equality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,23 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
-      - name: Require tagged commit to be current origin/main
+      - name: Require tagged commit to be on origin/main
         run: |
           set -euo pipefail
+          # The rule is "never release a commit that is not on main". Requiring
+          # the tag to EQUAL current origin/main enforced something stricter and
+          # unachievable: any merge landing while the release runs — or between
+          # a failed job and its rerun — moved main and made the tagged release
+          # permanently uncompletable, even though its commit is still on main.
+          # v0.8.1 hit exactly that: artifacts published from 44bcb7e0, then a
+          # later merge stranded the run. Ancestry keeps the guarantee (the
+          # tagged commit is reachable from main, so nothing off-main ships)
+          # without forbidding the repository to move.
           tag_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
-          main_commit="$(git ls-remote --exit-code origin refs/heads/main | awk 'NR == 1 { print $1 }')"
-          if [ "$tag_commit" != "$main_commit" ]; then
-            echo "::error::Refusing to release ${GITHUB_REF_NAME}: tag commit ${tag_commit} is not current origin/main ${main_commit}."
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "${tag_commit}" origin/main; then
+            main_commit="$(git rev-parse origin/main)"
+            echo "::error::Refusing to release ${GITHUB_REF_NAME}: tag commit ${tag_commit} is not reachable from origin/main ${main_commit}."
             exit 1
           fi
       - name: Require contracts catalog OpenAPI to already match

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -35,7 +35,12 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         preflight = self.job("release-preflight")
         self.assertIn("needs: version-contract", preflight)
         self.assertIn('tag_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"', preflight)
-        self.assertIn("git ls-remote --exit-code origin refs/heads/main", preflight)
+        # Ancestry, not equality: the tagged commit must be reachable from
+        # main so nothing off-main ships, while a merge landing mid-release no
+        # longer strands the tag (v0.8.1 was stranded exactly that way).
+        self.assertIn("git merge-base --is-ancestor", preflight)
+        self.assertIn("origin/main", preflight)
+        self.assertNotIn('if [ "$tag_commit" != "$main_commit" ]', preflight)
         self.assertIn("kernel_blob=\"$(git hash-object --no-filters api/openapi/helm.openapi.yaml)\"", preflight)
         self.assertIn(
             "repos/Mindburn-Labs/contracts-catalog/contents/api/specs/helm.openapi.yaml?ref=main",


### PR DESCRIPTION
**v0.8.1 is stranded and cannot be finished without this.**

`release-preflight` required the tagged commit to *equal* current `origin/main`. The rule it means to enforce is "never release a commit that is not on main" — equality is stricter than that, and it makes any tagged release uncompletable as soon as anything merges: a merge landing mid-run, or between a failed job and its rerun, moves main and strands the tag permanently.

That is not hypothetical. Run 31108074585 (tag v0.8.1 = `44bcb7e0`) published **binaries, container, chart, npm, crates, Maven, the Go SDK tag, the Console sidecar closure, artifacthub-repo and both cosign jobs** before it was cancelled. `44bcb7e0` is still an ancestor of main. But main has since moved to `cd371d8e`, so every rerun now fails at preflight and `github-release` can never run.

Moving the tag forward is not an option: the artifacts already public were built from the tagged tree, and repointing the tag would make it disagree with them.

Ancestry preserves the guarantee — a commit unreachable from main still cannot ship — without forbidding the repository to move during a release.

`scripts/ci/release_workflow_contract_test.py` is updated to pin the new rule and to assert the old equality comparison is gone (7/7 pass). `make verify-boundary` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)