### PR TITLE
fix(mcp): verify the permit at dispatch so signing is actually enforced

### DIFF
--- a/core/pkg/runtimeadapters/mcp/bridge.go
+++ b/core/pkg/runtimeadapters/mcp/bridge.go
@@ -431,6 +431,29 @@ func (b *GovernedBridge) Govern(ctx context.Context, req *runtimeadapters.Adapte
 		base.DispatchState = DispatchStateNoDispatch
 		return base
 	}
+	// Connector-side signature verification is the contract, but it is only as
+	// live as its configuration: linear.Config.PermitPublicKey is a no-op when
+	// unset and nothing in this repository sets it, and the independent review
+	// of #798 found linear.NewConnector itself has zero non-test callers. So on
+	// every path that ships today the permit is signed and nothing checks the
+	// signature. This gate closes that at the last point the kernel controls. It
+	// needs no key distribution — the bridge already holds the signing key — and
+	// it covers every connector rather than one. Connector-side verification
+	// remains as defence in depth wherever a key is configured.
+	if err := b.verifyPermitBeforeDispatch(permit); err != nil {
+		resolved, resolutionErr := b.resolvePreDispatchFailure(ctx, lifecycle, "PERMIT_UNVERIFIED")
+		applyEffectReservation(&base, resolved)
+		base.Verdict = contracts.VerdictDeny
+		base.ReasonCode = "PERMIT_UNVERIFIED"
+		base.Reason = err.Error()
+		if resolutionErr != nil {
+			base.ReasonCode = "EFFECT_LIFECYCLE_UNCERTAIN"
+			base.Reason = resolutionErr.Error()
+		}
+		base.DispatchState = DispatchStateNoDispatch
+		return base
+	}
+
 	var output any
 	var execErr error
 	if lifecycle != nil {
@@ -823,6 +846,39 @@ func (b *GovernedBridge) PermitSigningPublicKey() string {
 		return ""
 	}
 	return b.permitSigner.PublicKey()
+}
+
+// verifyPermitBeforeDispatch refuses to hand a connector a permit that does not
+// verify under the bridge's own signing key.
+//
+// It is the enforcement half of permit signing. Without it, signing is an
+// unobserved side effect: the only connector that can check a signature does so
+// exclusively when an operator supplies a public key by hand, and no code path
+// in this repository supplies one.
+func (b *GovernedBridge) verifyPermitBeforeDispatch(permit *effects.EffectPermit) error {
+	if permit == nil {
+		return fmt.Errorf("permit is nil")
+	}
+	if b.permitSignerErr != nil {
+		return b.permitSignerErr
+	}
+	if b.permitSigner == nil {
+		// No signing configured: permits are minted unsigned by design in that
+		// mode, so there is nothing to verify here. The unsigned-permit risk is
+		// owned by the mint path, not silently re-litigated at dispatch.
+		return nil
+	}
+	if permit.Signature == "" {
+		return fmt.Errorf("permit carries no signature though this bridge signs permits")
+	}
+	ok, err := helmcrypto.VerifyPermit(b.permitSigner.PublicKey(), permit)
+	if err != nil {
+		return fmt.Errorf("permit signature verification failed: %w", err)
+	}
+	if !ok {
+		return fmt.Errorf("permit signature does not verify under the issuing key")
+	}
+	return nil
 }
 
 func connectorIDFor(c effects.Connector) string {

--- a/core/pkg/runtimeadapters/mcp/bridge_permit_dispatch_gate_test.go
+++ b/core/pkg/runtimeadapters/mcp/bridge_permit_dispatch_gate_test.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/effects"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtimeadapters"
+)
+
+type permitRecordingConnector struct {
+	id     string
+	permit *effects.EffectPermit
+	calls  int
+}
+
+func (c *permitRecordingConnector) ID() string { return c.id }
+
+func (c *permitRecordingConnector) Execute(_ context.Context, permit *effects.EffectPermit, _ string, _ map[string]any) (any, error) {
+	c.calls++
+	c.permit = permit
+	return map[string]any{"ok": true}, nil
+}
+
+// Signing is only worth anything if something downstream requires it. This
+// asserts the permit that reaches a connector is signed, so the signing path
+// cannot silently regress to a no-op.
+func TestDispatchedPermitReachesTheConnectorSigned(t *testing.T) {
+	connector := &permitRecordingConnector{id: "linear"}
+	adapter, _ := newAdapter(t, BridgeConfig{Profile: operateProfile(), Connector: connector, Now: fixedClock()})
+	resp, err := adapter.Intercept(context.Background(), &runtimeadapters.AdaptedRequest{
+		RuntimeType: "mcp", ToolName: "linear.get_issue",
+		Arguments:   map[string]any{"issue_id": "ISS-1"},
+		PrincipalID: "ve-assistant",
+	})
+	if err != nil {
+		t.Fatalf("intercept: %v", err)
+	}
+	if !resp.Allowed {
+		t.Fatalf("expected ALLOW, got %+v", resp.DenyReason)
+	}
+	if connector.calls != 1 || connector.permit == nil {
+		t.Fatalf("connector was not dispatched with a permit: calls=%d", connector.calls)
+	}
+	if connector.permit.Signature == "" {
+		t.Fatal("the connector received an unsigned permit from a signing bridge")
+	}
+}
+
+// The dispatch gate must be reachable. A permit mutated after issuance, or one
+// carrying no signature at all, has to be refused before any connector runs —
+// this is what keeps signing from being an unobserved side effect while the
+// connector-side key is unconfigured.
+func TestBridgeDispatchGateRefusesUnsignedAndTamperedPermits(t *testing.T) {
+	bridge := NewGovernedBridge(withTestSigningSeed(BridgeConfig{
+		Profile: operateProfile(), Connector: &permitRecordingConnector{id: "linear"}, Now: fixedClock(),
+	}))
+	if bridge.permitSigner == nil {
+		t.Fatal("test bridge has no permit signer; the gate would be vacuous")
+	}
+
+	if err := bridge.verifyPermitBeforeDispatch(&effects.EffectPermit{ConnectorID: "linear"}); err == nil {
+		t.Fatal("an unsigned permit passed the dispatch gate")
+	}
+
+	signed := &effects.EffectPermit{
+		PermitID:    "permit-gate",
+		ConnectorID: "linear",
+		Scope:       effects.EffectScope{AllowedAction: "linear.get_issue"},
+		Nonce:       "nonce-gate",
+	}
+	if err := helmcrypto.SignPermit(bridge.permitSigner, signed); err != nil {
+		t.Fatalf("sign permit: %v", err)
+	}
+	if err := bridge.verifyPermitBeforeDispatch(signed); err != nil {
+		t.Fatalf("an intact permit was refused: %v", err)
+	}
+	signed.Scope.AllowedAction = "linear.create_issue"
+	if err := bridge.verifyPermitBeforeDispatch(signed); err == nil {
+		t.Fatal("a permit whose scope was widened after signing passed the gate")
+	}
+}


### PR DESCRIPTION
Follow-up to #798, and to the independent review's **D7**.

#798 signs every minted permit and gives the Linear connector a fail-closed signature check that mutation testing proved is real. Both are true, and neither runs on any shipping path:

- `linear.Config.PermitPublicKey` is a **no-op when unset** (`verifyPermitSignature` returns `nil`), and `git grep PermitPublicKey` outside the linear package returns nothing — no wiring in this repository ever sets it.
- The review verified `linear.NewConnector` has **zero non-test callers** anywhere in the estate (kernel, enterprise, control-plane, data-plane, agent-integrations).

So today a permit is signed and no signature is ever checked. Scope and expiry are checked by the connector; the cryptographic binding is not.

## What this adds
A gate at the last point the kernel controls before a connector executes. It denies with `PERMIT_UNVERIFIED`, needs **no key distribution** (the bridge already holds the signing key), and covers **every** connector rather than one. Connector-side verification stays as defence in depth wherever a key is configured.

Behaviour when no signing seed is configured is unchanged: permits are minted unsigned by design in that mode, so the gate does not deny — that risk is owned by the mint path, not silently re-litigated at dispatch. A signer that was configured but failed to build already denies (`permitSignerErr`, from #798's own follow-up).

## Keeping it from becoming decorative
Two tests, because a verification path nothing calls is not enforcement — the exact defect this PR exists to fix:
- `TestDispatchedPermitReachesTheConnectorSigned` — the permit a connector actually receives is signed.
- `TestBridgeDispatchGateRefusesUnsignedAndTamperedPermits` — an unsigned permit and a permit whose scope was widened after signing are both refused; an intact one passes.

## Gates
`go test ./pkg/runtimeadapters/mcp/ ./pkg/connectors/linear/` green, `make verify-boundary` green, quantum-crypto-inventory clean. No manifest change: `core/pkg/runtimeadapters/mcp/` is not a protected directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)