### PR TITLE
feat(chart): add opt-in telemetry values block (HELM-453)

### DIFF
--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -103,6 +103,8 @@ flowchart TD
 | `ingress.enabled` | `false` | Enables Kubernetes ingress. |
 | `helm.metrics.enabled` | `false` | Enables `/metrics` on `service.metricsPort`. |
 | `helm.metrics.serviceMonitor.enabled` | `false` | Emits a Prometheus Operator `ServiceMonitor`. |
+| `telemetry.enabled` | `false` | Renders `OTEL_EXPORTER_OTLP_ENDPOINT` into the kernel container. Enable per stand, never in a chart default. |
+| `telemetry.endpoint` | empty | OTLP gRPC target, e.g. `http://telemetry-gateway.telemetry-system.svc.cluster.local:4317`. Required when `telemetry.enabled=true`; keep the `http://` prefix. |
 
 ## Production Notes
 
@@ -138,6 +140,11 @@ flowchart TD
   evidence.
 - Keep `serviceAccount.automountServiceAccountToken=false` unless CRD mode is
   enabled or another integration explicitly requires Kubernetes API access.
+- Leave `telemetry.enabled=false` in every values file and turn it on per
+  stand. The endpoint is the only thing the application declares: the gateway
+  strips the data-class, environment, cluster, and namespace resource keys from
+  whatever a client sends and re-derives them from namespace labels, so
+  attributes set here would be dropped without a trace.
 - Use `make kind-smoke` to prove install, health, receipt persistence,
   evidence export, replay verification, and signing-key stability across pod
   restart.

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -194,6 +194,10 @@ spec:
               value: {{ ternary "1" "0" .Values.helm.metrics.enabled | quote }}
             - name: HELM_METRICS_PORT
               value: {{ .Values.service.metricsPort | quote }}
+            {{- if .Values.telemetry.enabled }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ required "telemetry.endpoint is required when telemetry.enabled is true" .Values.telemetry.endpoint | quote }}
+            {{- end }}
             - name: HELM_LIMIT_GLOBAL_RPS
               value: {{ .Values.helm.limits.global.rps | quote }}
             - name: HELM_LIMIT_GLOBAL_BURST

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -818,6 +818,22 @@
         }
       }
     },
+    "telemetry": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Opt-in OTLP trace export to a central telemetry gateway. Off by default; enabled per stand, never in a chart default. Renders exactly one variable, OTEL_EXPORTER_OTLP_ENDPOINT, into the kernel container.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Export traces to telemetry.endpoint. A stand handed an endpoint starts exporting the moment it boots, so keep this false until the stand is meant to report."
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "OTLP gRPC target of the in-cluster gateway, e.g. http://telemetry-gateway.telemetry-system.svc.cluster.local:4317. Required when enabled is true. Keep the http:// prefix: the kernel strips the scheme before dialing and uses its presence to select an insecure connection, and the gateway does not terminate TLS in-cluster."
+        }
+      }
+    },
     "persistence": {
       "type": "object",
       "additionalProperties": false,

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -281,6 +281,29 @@ helm:
     referencePackID: "helm-chart-reference-pack"
     referencePackLabel: "HELM chart default fail-closed reference pack"
 
+# Telemetry (HELM-453). Off by default and it must stay that way: the
+# Application Readiness Gate is closed, and a stand handed an endpoint starts
+# exporting the moment it boots. Enabled per stand, never in a chart default.
+telemetry:
+  enabled: false
+  # In-cluster gateway. Plaintext on purpose: TLS terminates at the central
+  # frontdoor, not inside the cluster. Example:
+  #   http://telemetry-gateway.telemetry-system.svc.cluster.local:4317
+  #
+  # Keep the http:// prefix. The kernel's otlpEndpointFromEnv strips the scheme
+  # before handing host:port to the otlptracegrpc exporter and treats its
+  # presence as the insecure-dial switch; without it the exporter negotiates
+  # TLS against a listener that does not terminate it.
+  #
+  # Only the endpoint belongs here — do not add OTEL_RESOURCE_ATTRIBUTES with a
+  # data class, environment, namespace, or cluster: the gateway's client lane
+  # deletes those keys before enrichment and re-derives them from namespace
+  # labels, so anything the chart declared about where it runs is dropped
+  # silently. service.name survives, but the kernel pins it to
+  # helm-sovereign-os in code and ignores OTEL_SERVICE_NAME (HELM-477), so
+  # overriding it from the chart has no effect either.
+  endpoint: ""
+
 # Persistent storage for HELM dataDir and SQLite state.
 persistence:
   enabled: true


### PR DESCRIPTION
## What this adds

An opt-in `telemetry` block in the chart, defaulting to **off**, that renders exactly one environment variable:

```yaml
telemetry:
  enabled: false
  endpoint: ""   # http://telemetry-gateway.telemetry-system.svc.cluster.local:4317
```

Nothing changes for any existing deployment: with the defaults, `helm template` emits no OTEL variable at all.

## Why the kernel needs it

The observability programme ([HELM-453](https://linear.app/mindburn/issue/HELM-453)) has the collector, the gateway, the storage and the Grafana surface live on QA since 2026-08-06. Application **logs** flow end to end. Application **traces** do not exist — `otel_traces` holds ten spans from a synthetic canary and nothing else — for one reason: nothing hands the application an endpoint. The kernel's exporter is already inert without one (HELM-345), and this is the missing half.

## Why exactly one variable

The gateway's client lane **deletes** `helm.data_class`, `deployment.environment.name`, `k8s.cluster.name`, `k8s.namespace.name`, `k8s.pod.name` and eight more keys from whatever a client sends — *before* enrichment — then re-derives them from namespace labels and states cluster identity itself. That is deliberate: `k8s_attributes` in collector 0.157 skips a key the client already set, so an unstripped key is client-assertable rather than connection-derived.

So the chart must not send scope attributes. Anything it wrote into those keys would travel the wire and be dropped at the far end. The application does not declare where it lives; it only needs to know where to send. The values comment says this in one sentence, because the natural instinct is to add the attributes back.

`service.name` is **not** in the strip list and stays with the application.

## The `http://` prefix is load-bearing

`otlpEndpointFromEnv` (`core/cmd/helm-ai-kernel/services.go`) strips the scheme and uses its presence to decide whether to dial insecure. The in-cluster gateway is plaintext — TLS terminates at the central frontdoor, not inside the cluster — so an endpoint written without `http://` makes the kernel attempt TLS against a listener that does not terminate it. The values comment carries that warning next to the example.

## Verification

`helm template` in both directions, plus the guards:

```
# defaults — no OTEL variable anywhere in the render
$ helm template … | grep -ci otel                      → 0
initContainer/prepare-authority-state OTEL=0
container/helm-ai-kernel              OTEL=0

# enabled
$ helm template … --set telemetry.enabled=true --set telemetry.endpoint=http://x:4317
            - name: HELM_METRICS_PORT
              value: "9090"
            - name: OTEL_EXPORTER_OTLP_ENDPOINT
              value: "http://x:4317"
$ … | grep -c OTEL_                                    → 1
initContainer/prepare-authority-state OTEL=0           ← init container untouched
container/helm-ai-kernel              OTEL=1

# guards
Error: telemetry.endpoint is required when telemetry.enabled is true
- at '/telemetry/enabled': got string, want boolean
- at '/telemetry': additional properties 'dataClass' not allowed
```

`helm lint` clean apart from the pre-existing "icon is recommended".

## Chart version deliberately not bumped

Every template-only change in this chart's history (`3b3eaea1`, `0d8c1dfa`, `b5574d7c`, `563831b5`) leaves `Chart.yaml` alone; every version move is a release commit (`20208b7f` v0.8.1, `71b7e73a` v0.7.5). Following that, the chart stays at `0.8.1`. Said here so it does not read as an oversight — the two sibling charts have the opposite convention and were bumped.

## Known gap this does not fix

The kernel's spans will arrive as `service.name = helm-sovereign-os`, not `helm-ai-kernel`. `observability.New` merges `resource.Default()` (which reads `OTEL_SERVICE_NAME`) as the **first** argument and the hardcoded `ServiceName` second, so the hardcoded value wins — setting the env var from the chart would do nothing. The fix is to plumb the name into `Config.ServiceName`, tracked in [HELM-477](https://linear.app/mindburn/issue/HELM-477).

## Rollout

Merging this changes nothing by itself. The first use is a single trace canary — the kernel in `dev-3`, which already carries the log side, so `trace_id` correlation between a log line and its span can be checked in the same run. Design and acceptance in the programme spec §19.