### PR TITLE
docs: replace the fabricated operations runbook with verified commands

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,22 +1,66 @@
-# Operations Runbook: helm-ai-kernel Core Daemon
+# Operations Runbook: helm-ai-kernel
 
-This runbook outlines operational procedures, troubleshooting steps, and fail-closed configurations for the HELM core daemon.
+Local diagnostics for a running kernel. Every command below is registered in
+`core/cmd/helm-ai-kernel/`; run `helm-ai-kernel help` for the full surface.
 
-## Diagnostic Steps
-* Check local daemon status:
-  ```bash
-  helm-ai-kernel status
-  ```
-* Stream runtime audit traces:
-  ```bash
-  helm-ai-kernel tail -f audit.log
-  ```
+## Is it up, and is the setup sane?
 
-## Emergency Troubleshooting
-* **Symptom**: Daemon enters fail-closed deadlock and rejects all agent inputs.
-* **Resolution**: Verify Kyverno/OPA policies have not been corrupted in the policy cache. Reload policies by executing:
-  ```bash
-  helm-ai-kernel reload-policies
-  ```
-* **Symptom**: Out of Memory (OOM) on high-throughput analytical loops.
-* **Resolution**: Enforce resource limits inside the sandbox supervisor config, restart daemon, and confirm telemetry metrics are flowing.
+```bash
+helm-ai-kernel health            # local HELM server health
+helm-ai-kernel doctor            # crypto, policies, connectors, config (alias: diag)
+```
+
+`doctor` is the first thing to run on a machine that "used to work" — it checks the
+setup surfaces independently rather than only asking the server whether it is alive.
+
+## What did it decide, and why?
+
+```bash
+helm-ai-kernel receipts tail --agent <id>   # durable receipts as they land
+helm-ai-kernel traces                       # hash-linked harness traces
+helm-ai-kernel boundary status              # execution-boundary status
+helm-ai-kernel boundary records --verdict <ALLOW|DENY|ESCALATE>
+```
+
+Receipts and boundary records are the audit surface. There is no `audit.log` file to
+tail; durability lives in the receipt store and the transparency log.
+
+```bash
+helm-ai-kernel log sth                      # signed tree head
+helm-ai-kernel log verify-inclusion         # prove a receipt is in the log
+helm-ai-kernel verify --bundle <path> --json  # verify an exported EvidencePack
+```
+
+## Stopping everything
+
+```bash
+helm-ai-kernel freeze --principal <id>
+helm-ai-kernel unfreeze --principal <id>
+```
+
+Global freeze is the deliberate stop lever. Use it when you need dispatch to stop
+before you have diagnosed why — freezing is cheap, and a fail-closed kernel that
+denies is behaving correctly, not malfunctioning.
+
+## Policy
+
+```bash
+helm-ai-kernel policy            # compilation and testing
+helm-ai-kernel bundle build <file> --language <cel|rego|cedar>
+```
+
+Policy is compiled into signed bundles from CEL, Rego, or Cedar sources. There is no
+runtime policy cache to flush and no admission controller in this repo, so "reload the
+policies" is not an operation that exists — rebuild the bundle and restart.
+
+## A note on this file
+
+Until 2026-08-09 this runbook told operators to run `helm-ai-kernel status`,
+`helm-ai-kernel tail -f audit.log`, and `helm-ai-kernel reload-policies`. None of the
+three is a registered subcommand — each returns "Unknown command". It also instructed
+them to check a Kyverno/OPA policy cache for corruption; the only file in this
+repository that has ever mentioned Kyverno was this runbook.
+
+It was generator boilerplate cloned across peripheral repos in June 2026 and was named
+by the 2026-06-29 markdown estate audit. Replaced under HELM-486 with commands verified
+against `core/cmd/helm-ai-kernel/`.


### PR DESCRIPTION
Sweep S0 of the documentation estate program ([HELM-486](https://linear.app/mindburn/issue/HELM-486)). Closes the oldest surviving instance of a defect the 2026-06-29 estate audit already named.

## What the runbook said

- `helm-ai-kernel status`
- `helm-ai-kernel tail -f audit.log`
- `helm-ai-kernel reload-policies`

**None of the three is a registered subcommand.** Each returns "Unknown command". The file also instructed operators to check a Kyverno/OPA policy cache for corruption after a fail-closed deadlock — and the only file in this entire repository that has ever mentioned Kyverno is that runbook.

It is generator boilerplate, cloned into peripheral repos in June 2026. The remaining seven copies are being replaced in their own repos.

## What it says now

The real diagnostic surface, every command checked against `core/cmd/helm-ai-kernel/`:

| Need | Command |
|---|---|
| Is it up? | `health` |
| Is the setup sane? | `doctor` (crypto, policies, connectors, config) |
| What did it decide? | `receipts tail --agent`, `traces`, `boundary status`, `boundary records --verdict` |
| Prove it | `log sth`, `log verify-inclusion`, `verify --bundle` |
| Stop everything | `freeze --principal` / `unfreeze --principal` |
| Policy | `policy`, `bundle build <file> --language cel\|rego\|cedar` |

It states plainly that there is no `audit.log` to tail and no runtime policy cache to flush, so nobody re-derives the old instructions from a gap. It also records what the file used to claim, so the correction is visible rather than silent.

One editorial addition worth flagging: the freeze section says a fail-closed kernel that denies is behaving correctly, not malfunctioning. The old text framed fail-closed as a "deadlock" to be cleared — the wrong instinct to hand an operator for this product.

## Verification

All 12 commands referenced in the new file confirmed registered in `core/cmd/helm-ai-kernel/*.go`. `docs/runbook.md` is not in `tools/boundary/protected.manifest`, so no manifest regeneration is involved. Nothing else in the repo references this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)