### PR TITLE
chore(core): mark go-isatty direct so go mod tidy stops emitting stray diffs

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/cel-go v0.29.0
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
+	github.com/mattn/go-isatty v0.0.20
 	github.com/minio/minio-go/v7 v7.0.100
 	github.com/open-policy-agent/opa v1.15.2
 	github.com/prometheus/client_golang v1.23.2
@@ -105,7 +106,6 @@ require (
 	github.com/lestrrat-go/httprc/v3 v3.0.2 // indirect
 	github.com/lestrrat-go/jwx/v3 v3.0.13 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/minio/crc64nvme v1.1.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect


### PR DESCRIPTION
## Summary

`core/internal/cli/ui/terminal.go:8` imports `github.com/mattn/go-isatty`
directly, but `core/go.mod` still listed it under the indirect require block.
The `// indirect` marker is bookkeeping only — nothing about the build cares —
so the drift was invisible until someone ran `go mod tidy` and found an
unrelated one-line diff in their branch. This spends that diff once, on a PR
where it is the whole point, so it stops landing in unrelated ones.

Noticed while working on an unrelated crypto change and deliberately left out
of that PR to keep the diff scoped.

The entire change:

```diff
+	github.com/mattn/go-isatty v0.0.20
-	github.com/mattn/go-isatty v0.0.20 // indirect
```

Produced by `cd core && GOWORK=off go mod tidy` — nothing hand-edited.

## Verification that this is only a marker move

Confirmed mechanically, not by eyeballing the diff:

| Check | Result |
|---|---|
| `module@version` pairs before vs. after (markers stripped, sorted) | **identical**, 145 modules — no upgrade, downgrade, addition or removal |
| `core/go.sum` | **byte-identical** — zero churn |
| `module` / `go` / `toolchain` / `replace` / `exclude` directives | **unchanged** |
| Tidy with vs. without `GOWORK=off` | **identical** — `go mod tidy` is per-module and ignores `go.work` |

No behavior change. `core/go.mod` is not pinned by any boundary/TCB manifest,
so there is no manifest repin to do.

## Validation

```bash
cd core && GOWORK=off go mod tidy
```

```bash
GOWORK=off make test
```

```bash
GOWORK=off make lint
```

Both green — exit code 0, captured directly rather than through a pipe. All
`core/pkg/...` and `core/cmd/release-permit-verify/...` packages `ok`; `go vet`
and `gofmt -l` clean; `docs-coverage` and `docs-truth` passed. The remaining CI
profile (`make quality-pr` and friends) runs on this PR.

## Question, not a proposal: is a tidiness gate worth it?

There is no CI gate enforcing tidiness today, which is why this drifted. I have
deliberately **not** bundled one into this PR — it is a policy call, and this
PR should stay a one-line fix. Raising it here so it is decided rather than
forgotten. Some legwork so the question is answerable:

**This file churns often enough for the question to be live.** While this PR was
open, #808 landed its own indirect→direct move on `core/go.mod`, promoting
`google.golang.org/protobuf`. That one was *correct* — #808 added a direct
import, so tidy was right to promote it, and it belonged in that PR. But it
shows marker movement on this file is routine, not a one-off. This branch was
rebased onto that change; `go mod tidy` is now a verified no-op on the result,
so `core/go.mod` is fully tidy as of current `main`.

**There is already an obvious home for it.** `scripts/ci/check_dependency_hygiene.py`
is wired into `scripts/ci/quality-gates.json` and already knows about
`core/go.mod`. It currently checks only that manifests *exist* and that
Dependabot covers them — not that they are tidy. A tidy check would be a few
lines in a gate that already runs, not a new CI job. `scripts/ci/go_module_tests.sh`
is also a ready-made pattern: it enumerates every module with
`git ls-files '**/go.mod'` and runs `GOWORK=off` in each. And `sdk-drift`
("regenerate-and-diff") is established precedent in this repo, so the concept
is not novel here.

**But scope is the real decision, and repo-wide would fail today.** I surveyed
all 12 modules by tidying each and diffing:

| Module | Tidy? |
|---|---|
| `core` (after this PR), `sdk/go`, `core/pkg/compliance/zkprovider/gdpr17`, `examples/go_client`, `examples/otel-genai`, `tools/doccheck`, `tools/invcheck`, `tools/tcbcheck`, `tools/launchpad/egressproxy` | tidy |
| `tests/conformance` | **untidy** — 15 deletions |
| `tests/launchpad` | **untidy** — 8 insertions, 17 deletions |
| `tests/skills` | **untidy** — 196 `go.sum` insertions |

So:

- A **`core`-only** gate is adoptable the moment this merges, and `core` is
  where the contributor pain actually is.
- A **repo-wide** gate fails on day one and needs a cleanup PR for those three
  `tests/*` modules first.

**The honest case against any gate:** `go mod tidy` output is toolchain-sensitive,
so a gate quietly becomes a second place the Go version is pinned — CI pins
`1.25.12` today, and a contributor on a different minor could get a red check
for something they did not do. That is a real, if small, tax.

My read, weakly held: **`core`-only, folded into the existing dependency-hygiene
gate** — nearly free, covers the module that actually caused this, and does not
require cleaning up `tests/*` first. Happy to do it as a follow-up, or to drop
the idea entirely if the toolchain-pinning tax is judged not worth it. Which
way do you want it?

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes. — n/a, no behavior change.
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. — n/a.
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path. — the fix itself is the first-PR improvement; no doc change needed.
- [x] Release version surfaces are lockstep (`make version-drift`). — n/a, no release surface touched.
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`. — n/a, no interface change.
- [x] Advisory quality warnings are acknowledged or tracked when relevant. — the tidiness-gate question above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
