### PR TITLE
fix(cli): stop three commands from acting when they were only asked

### DIFF
--- a/core/cmd/helm-ai-kernel/boundary_surface_cmd.go
+++ b/core/cmd/helm-ai-kernel/boundary_surface_cmd.go
@@ -21,6 +21,21 @@ import (
 	runtimesandbox "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtime/sandbox"
 )
 
+// answeredSurfaceHelp answers a help request for a boundary-surface router and
+// reports whether it did. Every one of these routers builds the file-backed
+// registry before it inspects its arguments, and on a fresh data directory that
+// seeds and writes authority state. Asking a governance command what it does
+// must not be the same as running it, so help is answered here, upstream of the
+// registry. Leaf-specific flag help is a separate improvement (plan 004); this
+// only guarantees the question is side-effect free.
+func answeredSurfaceHelp(usage string, args []string, stdout io.Writer) bool {
+	if len(args) == 0 || !isHelpRequest(args) {
+		return false
+	}
+	fmt.Fprintln(stdout, usage)
+	return true
+}
+
 func newLocalSurfaceRegistry() *boundarypkg.SurfaceRegistry {
 	registry, err := boundarypkg.NewFileBackedSurfaceRegistry(defaultBoundaryRegistryPath(), time.Now)
 	if err == nil {
@@ -74,6 +89,9 @@ func runBoundarySurfaceCmd(args []string, stdout, stderr io.Writer) int {
 	}
 	if args[0] == "profile" {
 		return runBoundaryProfileCmd(args[1:], stdout, stderr)
+	}
+	if answeredSurfaceHelp("Usage: helm-ai-kernel boundary <status|capabilities|records|get|verify|checkpoint|profile> [flags]", args, stdout) {
+		return 0
 	}
 	registry := newLocalSurfaceRegistry()
 	switch args[0] {
@@ -263,6 +281,9 @@ func runAuthzSurfaceCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Usage: helm-ai-kernel authz <health|check|snapshots|get> [flags]")
 		return 2
 	}
+	if answeredSurfaceHelp("Usage: helm-ai-kernel authz <list|show|grant|revoke> [flags]", args, stdout) {
+		return 0
+	}
 	registry := newLocalSurfaceRegistry()
 	switch args[0] {
 	case "health":
@@ -391,6 +412,9 @@ func runApprovalsSurfaceCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Usage: helm-ai-kernel approvals <list|create|approve|deny|revoke|challenge|assert> [flags]")
 		return 2
 	}
+	if answeredSurfaceHelp("Usage: helm-ai-kernel approvals <list|show|approve|deny|challenge|assert> [flags]", args, stdout) {
+		return 0
+	}
 	registry := newLocalSurfaceRegistry()
 	switch args[0] {
 	case "list":
@@ -509,9 +533,9 @@ func runApprovalsAssert(args []string, registry *boundarypkg.SurfaceRegistry, st
 	cmd := flag.NewFlagSet("approvals assert", flag.ContinueOnError)
 	cmd.SetOutput(stderr)
 	challengeID := cmd.String("challenge-id", "", "Challenge id")
-	actor := cmd.String("actor", "user:local-admin", "Actor")
+	actor := cmd.String("actor", "", "Principal presenting the assertion (required)")
 	assertion := cmd.String("assertion", "", "Passkey/WebAuthn assertion or local signed assertion")
-	receiptID := cmd.String("receipt-id", "receipt-local-approval", "Receipt id")
+	receiptID := cmd.String("receipt-id", "", "Receipt this assertion is recorded against (required)")
 	reason := cmd.String("reason", "passkey assertion accepted", "Reason")
 	jsonOutput := cmd.Bool("json", false, "Output as JSON")
 	if err := cmd.Parse(args); err != nil {
@@ -519,6 +543,13 @@ func runApprovalsAssert(args []string, registry *boundarypkg.SurfaceRegistry, st
 	}
 	if *challengeID == "" || *assertion == "" {
 		fmt.Fprintln(stderr, "Error: --challenge-id and --assertion are required")
+		return 2
+	}
+	// An assertion names the principal it authenticates. Defaulting the actor or
+	// the receipt would attribute a passkey ceremony to a principal who never
+	// presented one.
+	if missing := missingApprovalIdentity(*actor, *receiptID); len(missing) > 0 {
+		fmt.Fprintf(stderr, "Error: %s required; an assertion must name the principal and the receipt\n", strings.Join(missing, ", "))
 		return 2
 	}
 	approval, err := registry.AssertApprovalChallenge(contracts.ApprovalWebAuthnAssertion{
@@ -542,12 +573,31 @@ func runApprovalsAssert(args []string, registry *boundarypkg.SurfaceRegistry, st
 	return 0
 }
 
+// missingApprovalIdentity names the identity fields an approval command left
+// empty. It exists so the transition and assertion paths cannot drift: both
+// write a principal and a receipt into the permanent ceremony record, and
+// neither may invent one.
+func missingApprovalIdentity(actor, receiptID string) []string {
+	var missing []string
+	if strings.TrimSpace(actor) == "" {
+		missing = append(missing, "--actor")
+	}
+	if strings.TrimSpace(receiptID) == "" {
+		missing = append(missing, "--receipt-id")
+	}
+	return missing
+}
+
 func runApprovalsTransition(args []string, registry *boundarypkg.SurfaceRegistry, state contracts.ApprovalCeremonyState, stdout, stderr io.Writer) int {
 	cmd := flag.NewFlagSet("approvals transition", flag.ContinueOnError)
 	cmd.SetOutput(stderr)
-	approvalID := cmd.String("approval-id", "approval-bootstrap", "Approval id")
-	actor := cmd.String("actor", "user:local-admin", "Actor")
-	receiptID := cmd.String("receipt-id", "receipt-local-approval", "Receipt id")
+	// None of these carry a default. A transition records who exercised authority
+	// and against which receipt; a default would write an unattended command into
+	// the ceremony as though a named principal had reviewed it.
+	approvalID := cmd.String("approval-id", "", "Approval id (required; may also be given positionally)")
+	actor := cmd.String("actor", "", "Principal exercising the authority (required)")
+	receiptID := cmd.String("receipt-id", "", "Receipt this decision is recorded against (required)")
+	expectedCeremonyHash := cmd.String("expected-ceremony-hash", "", "Refuse the transition unless the approval still matches this reviewed hash")
 	reason := cmd.String("reason", string(state), "Reason")
 	jsonOutput := cmd.Bool("json", false, "Output as JSON")
 	if err := cmd.Parse(args); err != nil {
@@ -556,7 +606,15 @@ func runApprovalsTransition(args []string, registry *boundarypkg.SurfaceRegistry
 	if *approvalID == "" && cmd.NArg() > 0 {
 		*approvalID = cmd.Arg(0)
 	}
-	approval, err := registry.TransitionApproval(*approvalID, state, *actor, *receiptID, *reason)
+	missing := missingApprovalIdentity(*actor, *receiptID)
+	if strings.TrimSpace(*approvalID) == "" {
+		missing = append([]string{"--approval-id"}, missing...)
+	}
+	if len(missing) > 0 {
+		fmt.Fprintf(stderr, "Error: %s required; a transition must name the approval, the principal, and the receipt\n", strings.Join(missing, ", "))
+		return 2
+	}
+	approval, err := registry.TransitionApprovalIfCurrent(*approvalID, state, *actor, *receiptID, *reason, *expectedCeremonyHash)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 1
@@ -572,6 +630,9 @@ func runBudgetSurfaceCmd(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "Usage: helm-ai-kernel budget <list|set|verify> [flags]")
 		return 2
+	}
+	if answeredSurfaceHelp("Usage: helm-ai-kernel budget <list|set|verify> [flags]", args, stdout) {
+		return 0
 	}
 	registry := newLocalSurfaceRegistry()
 	switch args[0] {
@@ -895,6 +956,9 @@ func runMCPAuthProfile(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "Usage: helm-ai-kernel mcp auth-profile <list|put|verify> [flags]")
 		return 2
+	}
+	if answeredSurfaceHelp("Usage: helm-ai-kernel mcp auth-profile [flags]", args, stdout) {
+		return 0
 	}
 	registry := newLocalSurfaceRegistry()
 	switch args[0] {
@@ -1341,6 +1405,9 @@ func runEvidenceEnvelope(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "Usage: helm-ai-kernel evidence envelope <list|create|get|verify> [flags]")
 		return 2
+	}
+	if answeredSurfaceHelp("Usage: helm-ai-kernel evidence envelope [flags]", args, stdout) {
+		return 0
 	}
 	registry := newLocalSurfaceRegistry()
 	switch args[0] {

--- a/core/cmd/helm-ai-kernel/boundary_surface_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/boundary_surface_cmd_test.go
@@ -51,3 +51,90 @@ func TestLocalApprovalTransitionRetainsExplicitActor(t *testing.T) {
 		t.Fatalf("local actor was not retained: %+v", updated)
 	}
 }
+
+// TestApprovalTransitionRefusesUnattributedAuthority pins the reason the actor
+// and receipt flags carry no defaults. They used to default to
+// "user:local-admin" and "receipt-local-approval", so `approvals approve` with
+// no arguments at all approved whatever bootstrap ceremony a fresh data
+// directory contained, and wrote a principal who had never seen it into the
+// permanent record.
+func TestApprovalTransitionRefusesUnattributedAuthority(t *testing.T) {
+	pending := func(t *testing.T) *boundarypkg.SurfaceRegistry {
+		t.Helper()
+		now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+		registry := boundarypkg.NewSurfaceRegistry(func() time.Time { return now })
+		if _, err := registry.PutApproval(contracts.ApprovalCeremony{
+			ApprovalID:  "approval-bootstrap",
+			Subject:     "mcp:local",
+			Action:      "mcp.approve",
+			State:       contracts.ApprovalCeremonyPending,
+			RequestedBy: "agent:requester",
+			Quorum:      1,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return registry
+	}
+
+	for name, args := range map[string][]string{
+		"no arguments at all": {},
+		"no actor":            {"--approval-id", "approval-bootstrap", "--receipt-id", "receipt-x"},
+		"no receipt":          {"--approval-id", "approval-bootstrap", "--actor", "user:someone"},
+		"no approval id":      {"--actor", "user:someone", "--receipt-id", "receipt-x"},
+		"blank actor":         {"--approval-id", "approval-bootstrap", "--actor", "   ", "--receipt-id", "receipt-x"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			registry := pending(t)
+			var stdout, stderr bytes.Buffer
+			code := runApprovalsTransition(args, registry, contracts.ApprovalCeremonyAllowed, &stdout, &stderr)
+			if code != 2 {
+				t.Fatalf("code=%d, want 2; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			for _, item := range registry.ListApprovals() {
+				if item.ApprovalID == "approval-bootstrap" && item.State != contracts.ApprovalCeremonyPending {
+					t.Fatalf("refused transition still changed state to %s", item.State)
+				}
+			}
+		})
+	}
+}
+
+// TestApprovalTransitionHonoursReviewedCeremonyHash proves the CLI can now pin
+// the snapshot it reviewed, the way the HTTP route already required.
+func TestApprovalTransitionHonoursReviewedCeremonyHash(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	registry := boundarypkg.NewSurfaceRegistry(func() time.Time { return now })
+	approval, err := registry.PutApproval(contracts.ApprovalCeremony{
+		ApprovalID:  "approval-hash",
+		Subject:     "mcp:local",
+		Action:      "mcp.approve",
+		State:       contracts.ApprovalCeremonyPending,
+		RequestedBy: "agent:requester",
+		Quorum:      1,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	base := []string{"--approval-id", approval.ApprovalID, "--actor", "user:reviewer", "--receipt-id", "receipt-hash"}
+
+	var stdout, stderr bytes.Buffer
+	if code := runApprovalsTransition(append(append([]string{}, base...), "--expected-ceremony-hash", "sha256:not-the-one"), registry, contracts.ApprovalCeremonyAllowed, &stdout, &stderr); code == 0 {
+		t.Fatalf("a stale reviewed hash was accepted: stdout=%q", stdout.String())
+	}
+	for _, item := range registry.ListApprovals() {
+		if item.ApprovalID == approval.ApprovalID && item.State != contracts.ApprovalCeremonyPending {
+			t.Fatalf("stale-hash transition still changed state to %s", item.State)
+		}
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := runApprovalsTransition(append(append([]string{}, base...), "--expected-ceremony-hash", approval.CeremonyHash), registry, contracts.ApprovalCeremonyAllowed, &stdout, &stderr); code != 0 {
+		t.Fatalf("the reviewed hash was rejected: code=%d stderr=%q", code, stderr.String())
+	}
+}

--- a/core/cmd/helm-ai-kernel/cli_safety_test.go
+++ b/core/cmd/helm-ai-kernel/cli_safety_test.go
@@ -45,6 +45,69 @@ func TestDispatchHelpSkipsHandler(t *testing.T) {
 	}
 }
 
+// TestNestedHelpWritesNoAuthorityState pins the property the depth-1 help test
+// cannot see. Nested help legitimately reaches the leaf (see
+// TestNestedHelpReachesLeafFlagSets), but the boundary-surface routers built
+// the file-backed registry before inspecting their arguments, so on a fresh
+// data directory `boundary status --help` seeded and wrote authority state
+// before printing anything. Asking a governance command what it does must never
+// be the same as running it.
+func TestNestedHelpWritesNoAuthorityState(t *testing.T) {
+	for _, args := range [][]string{
+		{"boundary", "status", "--help"},
+		{"boundary", "--help"},
+		{"approvals", "list", "--help"},
+		{"budget", "list", "--help"},
+		{"traces", "--help"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HELM_DATA_DIR", dir)
+
+			var stdout, stderr bytes.Buffer
+			if code := Run(append([]string{"helm-ai-kernel"}, args...), &stdout, &stderr); code != 0 {
+				t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+
+			var written []string
+			if err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if !info.IsDir() {
+					written = append(written, path)
+				}
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if len(written) != 0 {
+				t.Fatalf("help wrote %v", written)
+			}
+		})
+	}
+}
+
+// TestUnknownFlagDoesNotStartTheServer pins the dispatcher's default branch. An
+// unrecognized flag used to fall through to startServer as a backward-compat
+// convenience, so a typo launched a listener and generated a persistent trust
+// root in the working directory.
+func TestUnknownFlagDoesNotStartTheServer(t *testing.T) {
+	for _, arg := range []string{"--frobnicate", "-x", "--port"} {
+		var stdout, stderr bytes.Buffer
+		code := Run([]string{"helm-ai-kernel", arg}, &stdout, &stderr)
+		if code != 2 {
+			t.Fatalf("arg=%s code=%d, want 2", arg, code)
+		}
+		if !strings.Contains(stderr.String(), "Unknown flag") {
+			t.Fatalf("arg=%s stderr does not name the unknown flag: %q", arg, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "serve") {
+			t.Fatalf("arg=%s stderr does not point at the explicit way to start the server: %q", arg, stderr.String())
+		}
+	}
+}
+
 func TestRegisterRejectsDuplicateNamesAndAliases(t *testing.T) {
 	original := subcommands
 	subcommands = make(map[string]Subcommand)

--- a/core/cmd/helm-ai-kernel/harness_surface_cmd.go
+++ b/core/cmd/helm-ai-kernel/harness_surface_cmd.go
@@ -11,6 +11,9 @@ import (
 )
 
 func runEvidenceScopes(args []string, stdout, stderr io.Writer) int {
+	if answeredSurfaceHelp("Usage: helm-ai-kernel evidence scopes [flags]", args, stdout) {
+		return 0
+	}
 	registry := newLocalSurfaceRegistry()
 	return runHarnessObjectCommand(args, stdout, stderr, "evidence scopes", func(action string, id string, input string) (any, int, error) {
 		switch action {
@@ -38,6 +41,9 @@ func runEvidenceScopes(args []string, stdout, stderr io.Writer) int {
 }
 
 func runPlanTransactions(args []string, stdout, stderr io.Writer) int {
+	if answeredSurfaceHelp("Usage: helm-ai-kernel plan transactions [flags]", args, stdout) {
+		return 0
+	}
 	registry := newLocalSurfaceRegistry()
 	return runHarnessObjectCommand(args, stdout, stderr, "plan transactions", func(action string, id string, input string) (any, int, error) {
 		switch action {
@@ -65,6 +71,9 @@ func runPlanTransactions(args []string, stdout, stderr io.Writer) int {
 }
 
 func runTracesCmd(args []string, stdout, stderr io.Writer) int {
+	if answeredSurfaceHelp("Usage: helm-ai-kernel traces [flags]", args, stdout) {
+		return 0
+	}
 	registry := newLocalSurfaceRegistry()
 	return runHarnessObjectCommand(args, stdout, stderr, "traces", func(action string, id string, input string) (any, int, error) {
 		switch action {
@@ -95,6 +104,9 @@ func runHarnessCmd(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 || args[0] != "changes" {
 		fmt.Fprintln(stderr, "Usage: helm-ai-kernel harness changes <list|get|put|verify|approve> [flags]")
 		return 2
+	}
+	if answeredSurfaceHelp("Usage: helm-ai-kernel harness [flags]", args, stdout) {
+		return 0
 	}
 	registry := newLocalSurfaceRegistry()
 	return runHarnessObjectCommand(args[1:], stdout, stderr, "harness changes", func(action string, id string, input string) (any, int, error) {

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -128,11 +128,17 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return 0
 	default:
 		if args[1][0] == '-' {
-			if err := startServer(); err != nil { // Default backward compat behavior for flags passed without 'server'.
-				_, _ = fmt.Fprintf(stderr, "Error: start server: %v\n", err)
-				return 1
-			}
-			return 0
+			// An unrecognized flag used to start the server, as a convenience for
+			// `helm-ai-kernel --port …` without the subcommand. Nothing in the
+			// estate invokes it that way — every image, chart and unit names
+			// `serve`, `server` or a subcommand explicitly — and the convenience
+			// meant a mistyped flag silently launched a listener and minted a
+			// trust root in the working directory. A boundary that starts by
+			// accident is not a boundary.
+			_, _ = fmt.Fprintf(stderr, "Unknown flag: %s\n", args[1])
+			_, _ = fmt.Fprintf(stderr, "To start the server, name it: helm-ai-kernel serve %s\n", args[1])
+			printUsage(stderr)
+			return 2
 		}
 		_, _ = fmt.Fprintf(stderr, "Unknown command: %s\n", args[1])
 		printUsage(stderr)

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -197,16 +197,30 @@ func TestServerNarrationWriterSeparatesJSONAndText(t *testing.T) {
 	}
 }
 
-func TestRunLegacyServerFlagsReportStartupFailure(t *testing.T) {
+// TestRunUnknownFlagDoesNotStartTheServer replaces the former
+// TestRunLegacyServerFlagsReportStartupFailure, which pinned the opposite
+// behaviour: any unrecognized flag fell through to startServer as a
+// backward-compatible way to spell `serve`. The test's own fixture flag
+// (--legacy-server-flag) shows the breadth of it — every typo started a
+// listener and generated a persistent trust root in the working directory,
+// with the guardian roster empty. This is a deliberate breaking change; the
+// error names the flag and the explicit command that does start the server.
+func TestRunUnknownFlagDoesNotStartTheServer(t *testing.T) {
 	originalRunServer := startServer
 	defer func() { startServer = originalRunServer }()
-	startServer = func() error { return errors.New("legacy bind failed") }
+	started := false
+	startServer = func() error {
+		started = true
+		return nil
+	}
 
 	var stdout, stderr bytes.Buffer
 	exitCode := Run([]string{"helm", "--legacy-server-flag"}, &stdout, &stderr)
 
-	assert.Equal(t, 1, exitCode)
-	assert.Contains(t, stderr.String(), "legacy bind failed")
+	assert.Equal(t, 2, exitCode)
+	assert.False(t, started, "an unknown flag must not start the server")
+	assert.Contains(t, stderr.String(), "Unknown flag: --legacy-server-flag")
+	assert.Contains(t, stderr.String(), "helm-ai-kernel serve")
 }
 
 // TestRun_Health_Fail verifies availability of the health subcommand logic.

--- a/core/cmd/helm-ai-kernel/registry.go
+++ b/core/cmd/helm-ai-kernel/registry.go
@@ -62,6 +62,9 @@ func Dispatch(name string, args []string, stdout, stderr io.Writer) (int, bool) 
 	if !ok {
 		return 0, false
 	}
+	// Only depth-1 help is answered here. Deeper help belongs to the leaf, which
+	// owns the flag set being described — see TestNestedHelpReachesLeafFlagSets.
+	// A leaf is responsible for answering it before it touches any state.
 	if len(args) == 1 && isHelpRequest(args) {
 		printSubcommandHelp(cmd, stdout)
 		return 0, true

--- a/core/pkg/boundary/surface_registry.go
+++ b/core/pkg/boundary/surface_registry.go
@@ -93,23 +93,33 @@ func NewFileBackedSurfaceRegistry(path string, now func() time.Time) (*SurfaceRe
 		return NewSurfaceRegistry(now), nil
 	}
 	r := newSurfaceRegistry(now)
+	seeded := false
 	if data, err := os.ReadFile(path); err == nil {
 		if len(strings.TrimSpace(string(data))) == 0 {
 			r.seed()
+			seeded = true
 		} else if err := r.loadSnapshot(data); err != nil {
 			return nil, fmt.Errorf("load boundary registry %s: %w", path, err)
 		}
 	} else if os.IsNotExist(err) {
 		r.seed()
+		seeded = true
 	} else {
 		return nil, fmt.Errorf("read boundary registry %s: %w", path, err)
 	}
 	r.path = path
-	r.mu.Lock()
-	err := r.persistLocked()
-	r.mu.Unlock()
-	if err != nil {
-		return nil, err
+	// Only a fresh seed is written back. Persisting an unchanged snapshot meant
+	// that merely opening the registry — which every read-only surface command
+	// does, including help paths — rewrote authority state on disk. The seed
+	// still persists on first use, so its generated ids stay stable across
+	// invocations; that stability was the reason for the unconditional write.
+	if seeded {
+		r.mu.Lock()
+		err := r.persistLocked()
+		r.mu.Unlock()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return r, nil
 }


### PR DESCRIPTION
Three CLI surfaces let an invocation take effect that never named what it was authorizing. Each was reproduced against a throwaway data directory before and after the change.

## 1. `approvals approve` with no arguments approved a ceremony

    $ helm-ai-kernel approvals approve
    Approval approval-bootstrap transitioned to approved receipt=receipt-local-approval
    EXIT=0

`--actor` defaulted to `user:local-admin` — a principal that does not exist — and `--receipt-id` to the literal string `receipt-local-approval`. `--approval-id` defaulted to the bootstrap ceremony a fresh data directory already contains, so the bare command word approved it and wrote an attribution nobody had made into the permanent record.

The flags now carry no defaults and the command refuses without them. `--expected-ceremony-hash` was added and routed through `TransitionApprovalIfCurrent`, so a scripted caller can pin the snapshot it reviewed the way the HTTP route already required. The documented local-owner semantics — an empty expected hash is accepted for a process that owns the registry directly — are unchanged.

`approvals assert` had the same two fabricated defaults and is fixed identically.

## 2. An unknown flag started the server

    $ helm-ai-kernel --frobnicate
    HELM AI Kernel starting...
    [helm] trust: generating new persistent root key at data/root.key

It kept running, bound its ports, and wrote `data/root.key`, `data/root.pub` and `data/keys/credentials.keystore.json` into the **current working directory**, ignoring `HELM_DATA_DIR`, with the guardian roster empty.

This is a **deliberate breaking change**. The previous behaviour was pinned by `TestRunLegacyServerFlagsReportStartupFailure`, whose fixture flag `--legacy-server-flag` shows its breadth: any unrecognized flag was a way to spell `serve`. Every image, chart and unit in the estate already names `serve`, `server` or a subcommand explicitly — `Dockerfile` CMD, `deploy/helm-chart/templates/deployment.yaml`, `deploy/systemd/helm-gateway.service`, `deploy/appliance/helm-gateway.service`. The error now names the flag and the exact command that does start the server.

## 3. `--help` wrote authority state

    $ helm-ai-kernel boundary status --help     # in an empty directory
    EXIT=2
    data/boundary/surfaces.json                 # created, containing DENY records

Root cause was not the help path. `NewFileBackedSurfaceRegistry` persisted its snapshot on construction even when nothing had changed, and **nine** surface routers construct it before inspecting their arguments. Construction now writes only a fresh seed — whose generated ids must stay stable across invocations, which was the reason for the unconditional write — and the routers answer help upstream of the registry.

A read-only command no longer rewrites an existing registry either; verified by hashing `surfaces.json` across repeated `approvals list` and `boundary status` runs.

## Scope held deliberately

Nested help still reaches the leaf flag set, per `TestNestedHelpReachesLeafFlagSets`. Leaf-specific flag help for the boundary surfaces stays with plan 004; this change only guarantees that asking is side-effect free.

## Tests

- `TestApprovalTransitionRefusesUnattributedAuthority` — five argument shapes, each must exit 2 **and** leave the ceremony pending
- `TestApprovalTransitionHonoursReviewedCeremonyHash` — a stale hash is refused and changes nothing; the reviewed hash is accepted
- `TestRunUnknownFlagDoesNotStartTheServer` — replaces the former legacy-flag test; asserts `startServer` is never reached
- `TestNestedHelpWritesNoAuthorityState` — five nested help invocations must leave the data directory empty

`go test ./cmd/helm-ai-kernel/ ./pkg/boundary/... ./pkg/api/...` green; `go build ./...` and `go vet` clean.