### PR TITLE
chore(sdk): repin generated-file manifests after the 0.8.3 version bump

### DIFF
--- a/sdk/go/generated.manifest.json
+++ b/sdk/go/generated.manifest.json
@@ -2,13 +2,13 @@
   "files": [
     {
       "path": "client/types_gen.go",
-      "sha256": "51642295f35c24a9006f5b0ae01b3975e214b6a12b32c353da77065c441a6375"
+      "sha256": "6f2bdfd63dcbd9d9ff215743b1dc44a312729c9e37659fbf4ba8f7bd067d50c2"
     }
   ],
   "generator": "openapitools/openapi-generator-cli:v7.4.0@sha256:579832bed49ea6c275ce2fb5f2d515f5b03d2b6243f3c80fa8430e4f5a770e9a",
   "sdk": "go",
   "source": {
-    "sha256": "09f958ecc86d7af7efd9db92644cc722c7369bb8b1e85fe1d6f4cfb2851a4616",
+    "sha256": "fa2863e113035a09341425508c705e4ae73c245df2f58e61ea60e039f51404e7",
     "spec": "api/openapi/helm.openapi.yaml"
   }
 }

--- a/sdk/java/generated.manifest.json
+++ b/sdk/java/generated.manifest.json
@@ -2,13 +2,13 @@
   "files": [
     {
       "path": "src/main/java/labs/mindburn/helm/TypesGen.java",
-      "sha256": "d71201fe4c355edcb987406e206b92012879ff3b544b9060463ae25248a91e2b"
+      "sha256": "c10eb93f4258958230a77427c4d9521231cd59111b1ee944076153c37481fd38"
     }
   ],
   "generator": "openapitools/openapi-generator-cli:v7.4.0@sha256:579832bed49ea6c275ce2fb5f2d515f5b03d2b6243f3c80fa8430e4f5a770e9a",
   "sdk": "java",
   "source": {
-    "sha256": "09f958ecc86d7af7efd9db92644cc722c7369bb8b1e85fe1d6f4cfb2851a4616",
+    "sha256": "fa2863e113035a09341425508c705e4ae73c245df2f58e61ea60e039f51404e7",
     "spec": "api/openapi/helm.openapi.yaml"
   }
 }

--- a/sdk/python/generated.manifest.json
+++ b/sdk/python/generated.manifest.json
@@ -2,13 +2,13 @@
   "files": [
     {
       "path": "helm_sdk/types_gen.py",
-      "sha256": "d62199b8004f4c0c97d104ec2068b62e3717031255ad652fe366dae23453bb37"
+      "sha256": "0bc672bdb23dcd236fcea62a2deaf057f1f966e43efc3de48b2723526232f6db"
     }
   ],
   "generator": "openapitools/openapi-generator-cli:v7.4.0@sha256:579832bed49ea6c275ce2fb5f2d515f5b03d2b6243f3c80fa8430e4f5a770e9a",
   "sdk": "python",
   "source": {
-    "sha256": "09f958ecc86d7af7efd9db92644cc722c7369bb8b1e85fe1d6f4cfb2851a4616",
+    "sha256": "fa2863e113035a09341425508c705e4ae73c245df2f58e61ea60e039f51404e7",
     "spec": "api/openapi/helm.openapi.yaml"
   }
 }

--- a/sdk/rust/generated.manifest.json
+++ b/sdk/rust/generated.manifest.json
@@ -2,13 +2,13 @@
   "files": [
     {
       "path": "src/types_gen.rs",
-      "sha256": "6a73c501d57cadd5972a1323f2dbeb87ce0cc49872aadd3395a9e86784c06480"
+      "sha256": "cd494082a0c500838e3495140f96413ac0c4d212922637b4aaa3b089d85e2bf0"
     }
   ],
   "generator": "openapitools/openapi-generator-cli:v7.4.0@sha256:579832bed49ea6c275ce2fb5f2d515f5b03d2b6243f3c80fa8430e4f5a770e9a",
   "sdk": "rust",
   "source": {
-    "sha256": "09f958ecc86d7af7efd9db92644cc722c7369bb8b1e85fe1d6f4cfb2851a4616",
+    "sha256": "fa2863e113035a09341425508c705e4ae73c245df2f58e61ea60e039f51404e7",
     "spec": "api/openapi/helm.openapi.yaml"
   }
 }

--- a/sdk/ts/generated.manifest.json
+++ b/sdk/ts/generated.manifest.json
@@ -2,13 +2,13 @@
   "files": [
     {
       "path": "src/types.gen.ts",
-      "sha256": "fcab60df5bda2779ae4afb894800909795447fa586429c8de6c2c676bcfd1003"
+      "sha256": "2d491cef8aeb6c8f1af21545ab3f0c0adb7198d907b5ba9db47f7a1cd624931d"
     }
   ],
   "generator": "openapitools/openapi-generator-cli:v7.4.0@sha256:579832bed49ea6c275ce2fb5f2d515f5b03d2b6243f3c80fa8430e4f5a770e9a",
   "sdk": "ts",
   "source": {
-    "sha256": "09f958ecc86d7af7efd9db92644cc722c7369bb8b1e85fe1d6f4cfb2851a4616",
+    "sha256": "fa2863e113035a09341425508c705e4ae73c245df2f58e61ea60e039f51404e7",
     "spec": "api/openapi/helm.openapi.yaml"
   }
 }


### PR DESCRIPTION
Completes #815. `prepare-version` rewrites the version literal inside every generated types file but not the five `generated.manifest.json` files that pin their hashes. The regenerate-and-diff gate on #815's head proved the regenerated sources byte-identical to the committed ones — the drift was confined to the five manifests — but that gate is not in the PR required set, so auto-merge fired before this fix landed. The release profile runs `codegen-drift`; tagging v0.8.3 without this repin fails `validate` and burns the tag. Rewritten with `scripts/sdk/manifest.py` against the same pinned generator image and spec; `manifest.py verify` green for all five SDKs. Follow-up: add the manifest rewrite to `prepare-version` so this class ends.