### PR TITLE
docs: correct six stale status claims against their own evidence files

### DIFF
--- a/docs/launch/LAUNCH_READINESS.md
+++ b/docs/launch/LAUNCH_READINESS.md
@@ -1,19 +1,49 @@
-# HELM AI Kernel Launch Readiness Checklist
+# HELM AI Kernel Launch Readiness Checklist — 2026-05-19 snapshot
 
-This document tracks the final launch-readiness state of the `helm-ai-kernel` repository. It is updated mechanically by the `scripts/launch/launch-ready.sh` verification tool.
+This is a frozen snapshot of one `scripts/launch/launch-ready.sh --write` run.
+It is **not** a live status page and nothing keeps it current.
+
+- Snapshot taken: 2026-05-19T17:15:07Z, against launch target `0.5.0`.
+- `VERSION` is now `0.8.3`, and the tool derives its launch target from
+  `cat VERSION`, so a fresh run would check a different target.
+- The tool writes to `${HELM_LAUNCH_READY_REPORT}` and otherwise to
+  `$LOG_DIR/launch-readiness.txt` in a `mktemp` directory. `make launch-ready`
+  passes neither, so it never rewrites this file. This copy was produced by
+  pointing `HELM_LAUNCH_READY_REPORT` here once and committing the result.
+- The tool no longer emits the "Config Boundary: wrangler.toml…" row below;
+  there is no `wrangler.toml` tracked in this repository.
+- The "Homebrew" row below is false as of 2026-08-09. The tool's check is
+  `rg -q 'brew install mindburnlabs/tap/helm-ai-kernel' README.md`, and
+  `README.md` instead documents `brew tap mindburn-labs/tap` followed by
+  `brew install helm-ai-kernel`. Either the check or the README is wrong;
+  neither has been changed here, because deciding which tap name is canonical
+  is a public-claims call.
+
+To get current state, run the tool rather than reading this file:
+
+```bash
+make launch-ready                                  # temp-file report, prints final status
+HELM_LAUNCH_READY_REPORT=/tmp/launch-readiness.md \
+  bash scripts/launch/launch-ready.sh --write      # same run, report at a path you choose
+```
+
+The tool exits non-zero unless every check passes, so its exit status — not a
+committed checkbox — is the readiness signal.
+
+## Snapshot contents (2026-05-19, launch target 0.5.0)
 
 Last verification: 2026-05-19T17:15:07Z
 Verification logs are emitted by the tool for each run and are intentionally
 not committed to the repository.
 
-## Phase 0: Boundary Hardening
+### Phase 0: Boundary Hardening
 - [x] **PR Boundary: No open PRs contain commercial infrastructure terminology.**
-- [x] **Config Boundary: wrangler.toml does not enforce hosted domains.**
+- [x] **Config Boundary: wrangler.toml does not enforce hosted domains.** (row no longer emitted)
 - [x] **Terminology Boundary: VERDICT_CANONICALIZATION.md exists and resolves the ALLOW/DENY/ESCALATE vs. DEFER drift.**
-- [x] **Version: VERSION is set to launch target 0.5.0.**
-- [x] **Homebrew: README points to canonical mindburnlabs/tap/helm-ai-kernel.**
+- [x] **Version: VERSION is set to launch target 0.5.0.** (target is now 0.8.3)
+- [x] **Homebrew: README points to canonical mindburnlabs/tap/helm-ai-kernel.** (false as of 2026-08-09)
 
-## Phase 1: Implementation & Proof
+### Phase 1: Implementation & Proof
 - [x] **Build: make build completes cleanly.**
 - [x] **Test: make test completes cleanly.**
 - [x] **Demos: examples/launch headless suite is present.**
@@ -21,10 +51,10 @@ not committed to the repository.
 - [x] **Proxy: OpenAI base-url proxy demo path is verified.**
 - [x] **Proof: Evidence verification and tamper-failure paths are documented and verifiable.**
 
-## Phase 2: Community & Release
+### Phase 2: Community & Release
 - [x] **Issue Templates: bug_report, feature_request, docs_gap, integration_request, policy_example_request are present.**
 - [x] **Docs Sync: docs-coverage and docs-truth checks pass.**
 - [x] **Release: Dry-run release script confirms artifacts can be generated.**
 
-## Final Status
-**CURRENT STATE: READY**
+### Snapshot final status
+**STATE AT 2026-05-19: READY** — for launch target 0.5.0 only.

--- a/docs/launchpad/CLEAN_INSTALL_GA.md
+++ b/docs/launchpad/CLEAN_INSTALL_GA.md
@@ -1,16 +1,17 @@
 ---
 title: Launchpad Clean Install GA
-last_reviewed: 2026-05-20
+last_reviewed: 2026-08-09
 ---
 
 # Launchpad Clean Install GA
 
-Status: v0.5.9 gate implemented; v1 promotes OpenClaw, Hermes, OpenCode, and
-Kilo Code into the supported-app clean-install set after workflow
-`26198407296` passed signed artifact, live conformance, teardown, receipts, and
-offline EvidencePack verification.
+Status: the gate is implemented and its release target tracks the current
+release tag, `v0.8.3`. The supported-app clean-install set is OpenClaw and
+Hermes, which passed signed artifact, live conformance, teardown, receipts, and
+offline EvidencePack verification in workflow `26198407296`. OpenCode and Kilo
+Code are in the verify-only set, not the supported set.
 
-Launchpad GA is a product-adoption gate for the `v0.5.9` release. It proves the
+Launchpad GA is a product-adoption gate for the current release. It proves the
 Homebrew package, signed Launchpad artifacts, local-container app launcher,
 MCP interceptor posture, signed receipts, teardown, and offline EvidencePack
 verification survive a machine that did not build the release.
@@ -29,9 +30,16 @@ offline verification.
 
 ## Source Truth
 
-- Release target: `v0.5.9`
-- Current four-app Launchpad artifact workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26198407296>
-- Current macOS Homebrew clean-install workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26199878246>
+- Release target: `v0.8.3`. Do not hand-edit that number here. It is the
+  `RELEASE_TAG` default in `scripts/launch/clean_install_gate.sh` and the
+  `release_tag` input default in `.github/workflows/launchpad-clean-install.yml`,
+  and `tests/launchpad/claims_truth_test.go` fails the build unless both equal
+  `v` + the `version:` field of `deploy/helm-chart/Chart.yaml`.
+- Four-app Launchpad artifact workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26198407296>
+- Last executed macOS Homebrew clean-install workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26199878246>.
+  That run was against release tag `v0.5.5`, not against the current target;
+  `docs/launchpad/clean_install_report.json` is its recorded output. No
+  clean-install run has been executed against `v0.8.3`.
 - Current Launchpad v1 report: `docs/launchpad/v1_report.json`
 - Historical `v0.5.4` release report: `docs/launchpad/final_report.json`
 - Clean-install report: `docs/launchpad/clean_install_report.json`
@@ -102,7 +110,7 @@ Use the repo-native gate to collect redacted evidence:
 ```bash
 export OPENAI_API_KEY='<fresh CI-only key>'
 bash scripts/launch/clean_install_gate.sh \
-  --release-tag v0.5.9 \
+  --release-tag v0.8.3 \
   --artifact-run-id 26198407296 \
   --host-kind developer_macos \
   --output docs/launchpad/clean_install_report.json
@@ -118,14 +126,21 @@ OpenClaw and Hermes. OpenCode and Kilo Code are `verify_only`; `--version`
 smoke checks do not count as live-agent F2 coverage. `--include-candidates`
 remains accepted for backward compatibility but does not launch verify-only apps.
 
-## Supported App Digests
+## App Digests
 
-| App | Support level | Image |
+| App | Support level | Pinned digest |
 | --- | --- | --- |
-| OpenClaw | `agent_live` | `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995` |
-| Hermes | `agent_live` | `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652` |
-| OpenCode | `verify_only` | `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550`; `--version` smoke checks do not count as live-agent F2 coverage |
-| Kilo Code | `verify_only` | `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6`; `--version` smoke checks do not count as live-agent F2 coverage |
+| OpenClaw | `agent_live` | `registry/launchpad/apps/openclaw.yaml` → `install.digest` |
+| Hermes | `agent_live` | `registry/launchpad/apps/hermes.yaml` → `install.digest` |
+| OpenCode | `verify_only` | `registry/launchpad/apps/opencode.yaml` → `install.digest`; `--version` smoke checks do not count as live-agent F2 coverage |
+| Kilo Code | `verify_only` | `registry/launchpad/apps/kilocode.yaml` → `install.digest`; `--version` smoke checks do not count as live-agent F2 coverage |
+
+The registry files are the pin a launch actually resolves, and the
+`ci(launchpad): promote signed launchpad image refs` automation rewrites them,
+so this page names the file instead of restating a digest that goes stale on
+the next promotion. `docs/launchpad/v1_report.json` (`apps.*.ghcr_digest`)
+records the digests that evidence run `26198407296` exercised; for OpenClaw and
+Hermes those are older than the current registry pins.
 
 Codex, Claude Code, Cursor, and Junie remain external/BYO adapters.
 
@@ -136,9 +151,12 @@ Manual CI entrypoint:
 ```bash
 gh workflow run launchpad-clean-install.yml \
   --repo Mindburn-Labs/helm-ai-kernel \
-  -f release_tag=v0.5.9 \
+  -f release_tag=v0.8.3 \
   -f artifact_run_id=26198407296
 ```
+
+Both inputs already default to these values in the workflow, so a plain
+`gh workflow run launchpad-clean-install.yml` dispatches the same run.
 
 The CI report is the current repeatable macOS Homebrew gate. A separately
 operated clean Mac transcript can be attached as an additional adoption artifact

--- a/docs/launchpad/CONFORMANCE.md
+++ b/docs/launchpad/CONFORMANCE.md
@@ -1,14 +1,23 @@
 ---
 title: Launchpad Conformance
-last_reviewed: 2026-05-20
+last_reviewed: 2026-08-09
 ---
 
 # Launchpad Conformance
 
-Status: OpenClaw, Hermes, OpenCode, and Kilo Code passed the v1.0 signed
-artifact, live local-container, teardown, receipt, and offline EvidencePack
-bar in workflow `26198407296`. DigitalOcean opt-in beta passed for all four
-apps; Hetzner remains fail-closed until a scoped provider token is available.
+Status: OpenClaw and Hermes are `oss_supported` / `agent_live`. They passed the
+v1.0 signed artifact, live local-container, teardown, receipt, and offline
+EvidencePack bar in workflow `26198407296`. OpenCode and Kilo Code are
+`oss_candidate` / `verify_only` from the same workflow — signed artifact plus a
+`--version` smoke only, which is not live-agent F2 coverage. DigitalOcean
+opt-in beta passed for OpenClaw and Hermes only; verify-only apps are not
+eligible for it, and Hetzner remains fail-closed until a scoped provider token
+is available.
+
+This header is derived from `docs/launchpad/v1_report.json`
+(`status`, `apps.*.availability`, `apps.*.support_level`,
+`substrates.digitalocean.controlled_live_apps`) and from
+`registry/launchpad/apps/*.yaml`. If it ever disagrees with them, they win.
 
 ## Audience
 
@@ -60,14 +69,15 @@ Implemented checks currently prove:
   EvidencePack verification, not from assertion.
 - OpenCode and Kilo Code are `verify_only`; `--version` smoke checks do not
   count as live-agent F2 coverage.
-- OpenClaw image:
-  `ghcr.io/mindburn-labs/helm-launchpad/openclaw@sha256:4da80a1e48b5603fd203b7d2b98539a01f796142b0ed9315e5ed86b25bf5d995`.
-- Hermes image:
-  `ghcr.io/mindburn-labs/helm-launchpad/hermes@sha256:4ec024dd8d0191fc887f04dc92c959fc865808d1526f782b5093f395fdd41652`.
-- OpenCode image (`verify_only`):
-  `ghcr.io/mindburn-labs/helm-launchpad/opencode@sha256:cdbeb88cfbd698809e673339d525083cdf1cdb3e91529e01c6834cd90b778550`.
-- Kilo Code image (`verify_only`):
-  `ghcr.io/mindburn-labs/helm-launchpad/kilocode@sha256:7b03834725235714ea8e698d38d89ce9b8bd81230b7e784016cb20a2c3c93ca6`.
+- The image pin that a launch actually resolves lives in
+  `registry/launchpad/apps/<app>.yaml` under `install.image` / `install.digest`.
+  The `ci(launchpad): promote signed launchpad image refs` automation re-pins
+  those files, so this page names the file rather than restating a digest that
+  goes stale on the next promotion.
+- `docs/launchpad/v1_report.json` (`apps.*.ghcr_digest`) records the digests
+  that evidence run `26198407296` exercised. Those are the digests the v1.0
+  claims above are about; they are older than the current registry pins for
+  OpenClaw and Hermes, which have been re-promoted since.
 - F2 reports are blocked unless they attach contract preflight JSON, launch
   plan, kernel verdict, sandbox grant, egress receipt, MCP quarantine receipt,
   healthcheck receipt, runtime environment, EvidencePack, offline verify output,

--- a/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
+++ b/docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md
@@ -5,10 +5,16 @@ HELM Launchpad OpenClaw/Hermes local-container support, and HELM AI Enterprise
 Launchpad/Skills governance surfaces.
 
 This file is not the current Launchpad GA support truth. Current Launchpad v1
-truth is recorded in `docs/launchpad/v1_report.json`: OpenClaw, Hermes,
-OpenCode, and Kilo Code are `oss_supported` after workflow `26186959337`
-passed signed artifact build, SBOM, vulnerability scan, live OpenRouter
-launch, teardown, and offline EvidencePack verification for all four.
+truth is recorded in `docs/launchpad/v1_report.json`, from artifact workflow
+`26198407296`: OpenClaw and Hermes are `oss_supported` / `agent_live` after
+signed artifact build, SBOM, vulnerability scan, live launch, teardown, and
+offline EvidencePack verification; OpenCode and Kilo Code are `oss_candidate` /
+`verify_only`, proven by signed artifact plus a `--version` smoke, which is not
+live-agent F2 coverage. Workflow `26186959337` is this historical report's own
+`artifact_workflow_run_id` in `docs/launchpad/final_report.json` — it is not a
+v1 promotion run, and no run has promoted all four apps to `oss_supported`.
+`registry/launchpad/apps/{opencode,kilocode}.yaml` still carry
+`availability: oss_candidate` and `support_level: verify_only`.
 
 `mission_100_percent_complete` is true for this production deployment milestone. Kernel PR #161 and Enterprise PR #30 are merged. Kernel release `v0.5.4` is published from `main`, release workflow `26131090671` passed, and the release EvidencePack verifies offline. Homebrew PR https://github.com/mindburnlabs/homebrew-tap/pull/2 merged the public tap update to v0.5.4. Public website claims remain blocked until docs-truth and owner review approve a public claims update.
 

--- a/docs/reference/workstation-adapter-feasibility.md
+++ b/docs/reference/workstation-adapter-feasibility.md
@@ -1,4 +1,9 @@
-# Workstation Adapter Feasibility Matrix
+# Workstation Adapter Feasibility Matrix (M0, historical)
+
+This is the M0 planning artifact that chose the first two workstation adapters.
+Its sequencing advice has been overtaken — see "Status of the M0 gate" at the
+bottom before treating anything here as guidance. The scoring table is kept as
+the record of what was known at M0.
 
 M0 scores what a manifest-first adapter can reliably observe today without private APIs. Scores are `0` unavailable, `1` partial/manual, `2` supported through stable local artifacts or documented exports.
 
@@ -19,3 +24,20 @@ M0 scores what a manifest-first adapter can reliably observe today without priva
 Codex is the first adapter because the local CLI/App Server direction and OTel event categories line up with a manifest-first receipt importer. Claude Code is second because hooks and local settings are strong, but parity depends on which local hook payloads are available in the customer environment.
 
 M0-M2 should ship as `observe-only`. M3 can be started only after the fixture set proves deterministic import for allowed observe, allowed draft, denied network, denied memory, recurring loop, and tainted-context cases.
+
+## Status of the M0 gate
+
+That gate is satisfied and M3 has shipped. Do not read the paragraph above as
+open sequencing work.
+
+- All six named fixture classes exist:
+  `fixtures/workstation/{allowed-observe,allowed-draft,denied-network,denied-memory,denied-recurring-loop,prompt-injection-tainted}`.
+- The workstation surface is no longer observe-only. `helm-ai-kernel
+  workstation` dispatches `decide` and `enforce`
+  (`core/cmd/helm-ai-kernel/workstation_cmd.go`), implemented in
+  `core/cmd/helm-ai-kernel/workstation_m3_cmd.go`. `workstation enforce` exits
+  `126` on a `DENY` verdict instead of running the wrapped command, so it acts
+  on the verdict rather than only recording it.
+
+The rest of this page is a historical scoring record. Current adapter behavior
+lives in `core/pkg/workstation/` and `core/cmd/helm-ai-kernel/workstation_*.go`.

--- a/docs/security/owasp-agentic-top10-coverage.md
+++ b/docs/security/owasp-agentic-top10-coverage.md
@@ -1,6 +1,6 @@
 ---
 title: OWASP Agentic Top 10 Mapping
-last_reviewed: 2026-05-05
+last_reviewed: 2026-08-09
 ---
 
 # OWASP Agentic Top 10 Mapping
@@ -11,73 +11,48 @@ Security reviewers checking which OWASP Agentic AI Top 10 risks are covered by c
 
 ## Outcome
 
-After this page you should know what this surface is for, which source files own the behavior, which public route or adjacent page to use next, and which validation command to run before changing the claim.
+After this page you should know which ASI category maps to which kernel control, which package test and conformance scenario exercise it, what residual risk each category leaves outside the OSS boundary, and which command re-checks the mapping.
 
 ## Source Truth
 
-- Public route: `security/owasp-agentic-top10-mapping`
-- Source document: `helm-ai-kernel/docs/security/owasp-agentic-top10-coverage.md`
-- Public manifest: `helm-ai-kernel/docs/public-docs.manifest.json`
-- Source inventory: `helm-ai-kernel/docs/source-inventory.manifest.json`
-- Validation: `make docs-coverage`, `make docs-truth`, and `npm run coverage:inventory` from `docs-platform`
+- Machine-readable mapping: `core/pkg/conformance/agentsafety/registry.go` — 60 case entries, each naming a baseline policy rule, config guard, package test, conformance scenario, residual risk, and expected policy action.
+- Case matrix: `docs/security/agent-safety-conformance-cases.md` — the per-case narrative. `core/pkg/conformance/agentsafety/registry_test.go` parses its case IDs and fails if the registry and the matrix disagree, or if the count is not 60.
+- Baseline policy rules: `core/pkg/policybundles` — `TestRegistryRulesExistInBaselineBundle` fails if a registry entry names a rule that is not in `AgentSafetyBaselineBundle()`, or if the rule's action or canonical reason code differs from the entry's.
+- Shared conformance scenario: `core/pkg/conformance/scenarios/agent_safety_baseline_test.go` (`TestAgentSafetyBaselineRegistryScenarios`).
+- Validation: `cd core && go test ./pkg/conformance/agentsafety/... ./pkg/conformance/scenarios/... ./pkg/policybundles/...`, then `make docs-coverage` and `make docs-truth`.
 
-Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the inventory manifest points to code, schemas, tests, examples, or an owner doc that proves the claim.
+This page is not published. It is absent from `docs/public-docs.manifest.json`, which lists 30 documents and carries only `docs/security/quantum-posture.md` under `docs/security/`. There is no `security/owasp-agentic-top10-mapping` public route; do not cite one. The adjacent MCP-specific mapping is `docs/OWASP_MCP_THREAT_MAPPING.md`.
 
-## Troubleshooting
+Do not expand this page with unsupported product, SDK, deployment, compliance, or integration claims unless the registry points to code, schemas, tests, examples, or an owner doc that proves the claim.
 
-| Symptom | First check |
-| --- | --- |
-| Published output is stale or incomplete | Run `npm run helm-public:accuracy` in `docs-platform`, then check the source path and public manifest row for this page. |
-| A claim needs implementation backing | Check the Source Truth files above and update the implementation, manifest, source inventory, or page in the same change. |
+## Category Map
 
-## Diagram
+Category labels below are the ones the code enforces — the `Group` strings in `core/pkg/conformance/agentsafety/registry.go`. They are the OWASP Top 10 for Agentic Applications (December 2025) categories, not the LLM Top 10, and not the older "prompt injection / tool poisoning / excessive permission…" list this page used to carry.
 
-This scheme maps the main sections of OWASP Agentic Top 10 Mapping in reading order.
+| Category | Cases | Baseline rules | Control packages | Verdicts | Residual risk |
+| --- | --- | --- | --- | --- | --- |
+| ASI01 Agent Goal Hijack | `AGH-01`–`AGH-05` | `TaintedHighRisk`, `MemoryInfluenceOnly`, `EgressBoundary`, `ProtectedConfig` | `pkg/policybundles`, `pkg/memory`, `pkg/firewall`, `pkg/manifest` | `deny` | Source tainting adapters are deployment-specific; longitudinal drift detection depends on runtime observation windows. |
+| ASI02 Tool Misuse and Exploitation | `TME-01`–`TME-06` | `TaintedHighRisk`, `EgressBoundary`, `HighImpactApproval`, `ToolContract`, `ApprovedArgs` | `pkg/policycel`, `pkg/firewall`, `pkg/contracts`, `pkg/manifest` | `deny`, `require_approval` | Tool adapters must preserve output taint and supply approved-argument hash bindings; covert-channel and DNS-signature detection is out of OSS scope. |
+| ASI03 Identity and Privilege Abuse | `IPA-01`–`IPA-06` | `DelegationIdentity`, `A2AVerification`, `ToolContract` | `pkg/a2a`, `pkg/identity`, `pkg/contracts` | `deny` | Privilege attenuation depends on tenant RBAC data; registry authenticity depends on configured trust roots; clock trust is inherited from runtime attestation. |
+| ASI04 Agentic Supply Chain Vulnerabilities | `ASC-01`–`ASC-06` | `SupplyChain`, `SafeDepOverride`, `ToolContract`, `TaintedHighRisk`, `EgressBoundary` | `pkg/safedep`, `pkg/manifest`, `pkg/evidencepack`, `pkg/policycel`, `pkg/conformance/sandbox` | `deny` | External transparency logs are optional deployment hardening. |
+| ASI05 Unexpected Code Execution | `RCE-01`–`RCE-06` | `TaintedHighRisk`, `ApprovedArgs`, `ProtectedConfig`, `SafeDepOverride`, `EgressBoundary` | `pkg/conformance/sandbox`, `pkg/conformance/scenarios`, `pkg/manifest`, `pkg/memory` | `deny` | Shell-free executors stay responsible for avoiding string expansion. |
+| ASI06 Memory and Context Poisoning | `MEM-01`–`MEM-06` | `MemoryInfluenceOnly` | `pkg/memory`, `pkg/a2a` | `deny` | Memory scoring quality depends on upstream provenance capture. |
+| ASI07 Insecure Inter-Agent Communication | `A2A-01`–`A2A-05` | `A2AVerification`, `ToolContract` | `pkg/a2a`, `pkg/manifest` | `deny` | Nonce persistence depends on a transport-specific replay cache. |
+| ASI08 Cascading Failures | `CAS-01`–`CAS-06` | `BudgetCircuitBreaker`, `HighImpactApproval`, `SupplyChain`, `SafeDepOverride` | `pkg/effectgraph`, `pkg/contracts`, `pkg/conformance`, `pkg/conformance/scenarios`, `pkg/safedep` | `deny`, `require_approval` | Planner quality is advisory until effect policies approve. |
+| ASI09 Human-Agent Trust Exploitation | `HITL-01`–`HITL-04` | `HighImpactApproval`, `PreviewSideEffect`, `SafeDepOverride` | `pkg/contracts`, `pkg/manifest`, `pkg/safedep` | `deny`, `require_approval` | UI presentation requirements live outside core package tests. |
+| ASI10 Rogue Agents | `ROG-01`–`ROG-06` | `A2AVerification`, `EgressBoundary`, `HighImpactApproval`, `ProtectedConfig`, `SafeDepOverride` | `pkg/a2a`, `pkg/firewall`, `pkg/effectgraph`, `pkg/contracts`, `pkg/safedep` | `deny`, `require_approval` | Observer store hardening depends on the production evidence backend. |
 
-```mermaid
-flowchart TD
-    subgraph Ingestion["1. Ingestion & Context Plane"]
-        Page["OWASP Agentic Top 10 Mapping"]
-        A["Source truth"]
-        C["Validation"]
-    end
+An eleventh group, `Benchmark Imports` (`BENCH-01`–`BENCH-04`), is registered alongside the ten categories. Its expected action is `log`, not `deny` — it records imported benchmark evidence and blocks nothing. Do not count it as coverage.
 
-    subgraph Execution["3. Execution & Verdict Plane"]
-        B["Reader action"]
-    end
-
-    %% Operational Flow Edges
-    Page --> A
-    A --> B
-    B --> C
-
-    %% Premium Styling Rules
-    style B fill:#3182ce,stroke:#2b6cb0,stroke-width:2px,color:#fff
-```
-
-
-This file is a code-oriented inventory of retained control points in the OSS kernel.
-
-| OWASP Category | Repository Control Points |
-| --- | --- |
-| ASI-01 Prompt Injection | `core/pkg/threatscan/`, guarded execution boundary |
-| ASI-02 Tool Poisoning | contract validation, firewall, connector validation |
-| ASI-03 Excessive Permission | policy and effect-boundary packages |
-| ASI-04 Insufficient Validation | guardian, manifest, schema, and policy packages |
-| ASI-05 Improper Output Handling | evidence, receipts, and verification flow |
-| ASI-06 Resource Overuse | budget and execution-control packages |
-| ASI-07 Cascading Effects | proof graph and effect tracking |
-| ASI-08 Sensitive Data Exposure | firewall, policy, and receipt material |
-| ASI-09 Insecure Tool Integration | MCP, connector, and schema surfaces |
-| ASI-10 Insufficient Monitoring | evidence export, proof graph, and verification commands |
-
-Use this page as an implementation map. Validation still depends on the code, tests, and verification commands in the repository.
-
-<!-- docs-depth-final-pass -->
+`registry.go` is the authority for the per-case detail this table summarises: each entry also carries the specific `ConfigGuard`, `PackageTest`, `ExpectedReasonCode`, and whether a receipt is required. Read the entry, not this table, before making a claim about one case.
 
 ## Coverage Discipline
 
-OWASP Agentic Top 10 coverage must stay evidence-backed. For each risk, name the HELM AI Kernel control, the code or schema that implements it, the public example or fixture that exercises it, and the residual risk that remains outside the OSS boundary. Do not imply that policy evaluation replaces app authorization, secrets management, sandboxing, or network egress controls. The strongest public page shows both prevention and observability: how a risky action is blocked, how the receipt records it, how the verifier checks it, and what an operator should inspect when the action is allowed under policy.
+OWASP Agentic Top 10 coverage must stay evidence-backed. The registry is the enforcement point for that discipline: `registry_test.go` rejects any entry missing a case ID, group, policy rule, config guard, package test, conformance scenario, residual risk, or expected action, so a category cannot be claimed without all seven.
 
-<!-- docs-depth-final-pass-extra -->
- Link every mitigation to a concrete evidence artifact so evaluators can check the claim without reading unrelated implementation internals.
+Two boundaries this mapping does not cross:
+
+- Policy evaluation does not replace app authorization, secrets management, sandboxing, or network egress controls. The residual-risk column names what each category still leaves to the deployment.
+- A `deny` in the table is a policy verdict, not proof that a given deployment's adapters feed the kernel the facts the rule needs. Several residual risks say exactly that — tainting, provenance, and approved-argument bindings come from adapters.
+
+When changing a claim here, change the registry entry and the case matrix in the same commit; the tests fail otherwise.

--- a/tests/launchpad/claims_truth_test.go
+++ b/tests/launchpad/claims_truth_test.go
@@ -222,8 +222,12 @@ func TestHistoricalLaunchpadReportsDeclareSupersededTruth(t *testing.T) {
 	requireContains(t, report, "historical `v0.5.4` production report")
 	requireContains(t, report, "This file is not the current Launchpad GA support truth")
 	requireContains(t, report, "docs/launchpad/v1_report.json")
-	requireContains(t, report, "OpenClaw, Hermes,")
-	requireContains(t, report, "OpenCode, and Kilo Code are `oss_supported`")
+	// The forward pointer must restate the contract-first v1 support levels, not
+	// the retracted "all four are oss_supported" line. registry/launchpad/apps/
+	// {opencode,kilocode}.yaml and v1_report.json both say oss_candidate/verify_only.
+	requireContains(t, report, "OpenClaw and Hermes are `oss_supported`")
+	requireContains(t, report, "OpenCode and Kilo Code are `oss_candidate`")
+	requireNotContains(t, report, "OpenCode, and Kilo Code are `oss_supported`", "docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md")
 
 	jsonReport := readDoc(t, root, "docs/launchpad/final_report.json")
 	requireContains(t, jsonReport, `"historical_report": true`)


### PR DESCRIPTION
## Defect

Six internal docs in this repo assert states that the repo's own committed
evidence contradicts. This is a documentation-truth sweep: every claim was
re-checked against code, registry YAML, and report JSON before editing, and the
claims that turned out to be true were left alone.

No public-facing surface is touched. None of these pages is in
`docs/public-docs.manifest.json` (30 documents, only `docs/security/quantum-posture.md`
under `docs/security/`), and none is mirrored in `app-helm-docs`.

## Claim-by-claim evidence

### `docs/launchpad/CONFORMANCE.md`
- **Was:** "OpenClaw, Hermes, OpenCode, and Kilo Code passed the v1.0 … bar"; "DigitalOcean opt-in beta passed for all four apps".
- **Is:** `docs/launchpad/v1_report.json` `status` = `…openclaw_hermes_live_opencode_kilocode_verify_only`; `apps.opencode`/`apps.kilocode` = `oss_candidate` / `verify_only`, matching `registry/launchpad/apps/{opencode,kilocode}.yaml:9-10` **and this file's own table at lines 47-48**. `substrates.digitalocean.controlled_live_apps` = `["openclaw","hermes"]`; both verify-only apps carry `cloud_beta: not_supported_for_verify_only`.
- Four hard-coded image digests were also stale: registry pins OpenClaw at `sha256:3c8c7069…` and Hermes at `sha256:2dc8aea1…`, not the `sha256:4da80a1e…` / `sha256:4ec024dd…` printed here. Since `ci(launchpad): promote signed launchpad image refs` rewrites the registry, the page now names the registry file instead of restating a digest that goes stale on the next promotion.

### `docs/launchpad/CLEAN_INSTALL_GA.md`
- **Was:** release target `v0.5.9`, in five places.
- **Is:** `scripts/launch/clean_install_gate.sh:6` and `.github/workflows/launchpad-clean-install.yml:9` both say `v0.8.3`, and `tests/launchpad/claims_truth_test.go` fails the build unless both equal `v` + `deploy/helm-chart/Chart.yaml` `version:` (`0.8.3`). The one clean-install run that was actually executed, `26199878246`, was against `v0.5.5` — `docs/launchpad/clean_install_report.json` `release_tag` = `v0.5.5`. **No artifact in the repo says `v0.5.9`.** The doc now states the current target, and states plainly that no clean-install run has been executed against it.

### `docs/launchpad/FINAL_IMPLEMENTATION_REPORT.md`
- **Was:** "Current Launchpad v1 truth …: OpenClaw, Hermes, OpenCode, and Kilo Code are `oss_supported` after workflow `26186959337`".
- **Is:** v1's artifact run is `26198407296`. `26186959337` is *this historical report's own* `artifact_workflow_run_id` in `docs/launchpad/final_report.json` — and that same file records `opencode`/`kilocode` as `oss_candidate`. No run has promoted all four.
- **Test change:** `tests/launchpad/claims_truth_test.go` was pinning the false sentence via `requireContains(report, "OpenCode, and Kilo Code are \`oss_supported\`")`. The assertion now pins the contract-first levels and forbids the retracted string. This is the one non-doc change in the PR.

### `docs/launch/LAUNCH_READINESS.md`
- **Was:** "It is updated mechanically by the `scripts/launch/launch-ready.sh` verification tool", plus a bare `CURRENT STATE: READY`.
- **Is:** the tool *does* emit this exact document — but only under `--write`, and only to `${HELM_LAUNCH_READY_REPORT}` or a `mktemp` path (`scripts/launch/launch-ready.sh:12,138`). `make launch-ready` passes neither, so nothing keeps this file current. (The audit verdict I was executing claimed the script never writes this document at all; that half was wrong and is not what this change says.)
- The snapshot is from 2026-05-19 for launch target `0.5.0` while `VERSION` is `0.8.3`; its "Config Boundary: wrangler.toml…" row is no longer emitted and no `wrangler.toml` is tracked; and its Homebrew row is **false today** — the check is `rg -q 'brew install mindburnlabs/tap/helm-ai-kernel' README.md` and `README.md:18` says `brew install helm-ai-kernel` under `brew tap mindburn-labs/tap`.
- Reframed as a dated snapshot with the regeneration command. **The tap-name discrepancy is recorded, not resolved** — deciding whether `mindburnlabs/tap` or `mindburn-labs/tap` is canonical is a public-claims call and touches the README. Worth a follow-up: `make launch-ready` fails on that check as things stand.

### `docs/security/owasp-agentic-top10-coverage.md`
- **Was:** ten category labels (`ASI-01 Prompt Injection`, `ASI-02 Tool Poisoning`, `ASI-03 Excessive Permission`, …) and `Public route: security/owasp-agentic-top10-mapping`.
- **Is:** the code-enforced taxonomy in `core/pkg/conformance/agentsafety/registry.go` is `ASI01 Agent Goal Hijack`, `ASI02 Tool Misuse and Exploitation`, `ASI03 Identity and Privilege Abuse`, `ASI04 Agentic Supply Chain Vulnerabilities`, `ASI05 Unexpected Code Execution`, `ASI06 Memory and Context Poisoning`, `ASI07 Insecure Inter-Agent Communication`, `ASI08 Cascading Failures`, `ASI09 Human-Agent Trust Exploitation`, `ASI10 Rogue Agents` — enforced against `docs/security/agent-safety-conformance-cases.md` by `registry_test.go` (60 cases, count-checked). The public route does not exist.
- Rewritten to give case-ID range, baseline rules, control packages, verdicts, and residual risk per category — which is what the page's own "Coverage Discipline" section demands and never delivered. The `Benchmark Imports` group is called out as `log`-only so it is not counted as coverage.

### `docs/reference/workstation-adapter-feasibility.md`
- **Was:** "M3 can be started only after the fixture set proves …" read as open sequencing work.
- **Is:** all six named fixture classes exist under `fixtures/workstation/`, and M3 shipped — `core/cmd/helm-ai-kernel/workstation_cmd.go` dispatches `decide` and `enforce`, implemented in `workstation_m3_cmd.go`, and `enforce` exits `126` on a `DENY` verdict rather than only observing. Labelled as a historical M0 artifact with the gate's status recorded. Content kept — it is an accurate record of what was known at M0.

## Not changed

`docs/runbook.md` was in the same audit batch but was already fixed in #809; I
re-read it and left it alone.

## Gates run locally

- `make lint` — `docs-coverage`, `docs-truth`, `go vet ./...`, `gofmt -l` (all clean)
- `make verify-boundary` — 1108 entries, manifest matches the tree
- `go test ./... -count=1` in `tests/launchpad` — ok
- `go test ./pkg/conformance/... ./pkg/policybundles/... -count=1` in `core` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)