### PR TITLE
ci(lint): fail the lint gate when core/go.mod is not tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,9 +162,17 @@ bench:
 bench-report:
 	cd core && go test -v -run TestOverheadReport -count=1 ./benchmarks/
 
+# The go.mod tidiness check is core-only on purpose. core/go.mod is where the
+# drift actually reached contributors: go-isatty sat in the indirect block while
+# core/internal/cli/ui/terminal.go imported it directly, so anyone who ran
+# `go mod tidy` picked up an unrelated diff (#813). Widening this to every module
+# needs a cleanup pass first — tests/conformance, tests/launchpad and
+# tests/skills are not tidy as of 2026-08-09. scripts/ci/go_module_tests.sh has
+# the enumeration pattern to reuse when that cleanup lands.
 lint: docs-coverage docs-truth
 	cd core && go vet ./...
 	cd core && test -z "$$(gofmt -l .)" || (echo "Run gofmt -w ." && exit 1)
+	cd core && GOWORK=off go mod tidy -diff || (echo "Run cd core && GOWORK=off go mod tidy" && exit 1)
 
 # lint-security runs golangci-lint with gosec over the trusted computing base.
 #


### PR DESCRIPTION
## Summary

Follow-up to #813, which asked whether a tidiness gate was worth adding. This
is the `core`-only answer, offered for review rather than assumed — close it if
the call is "not worth the tax", and the reasoning is all below either way.

#813 moved `github.com/mattn/go-isatty` from the indirect require block to the
direct one, where its import in `core/internal/cli/ui/terminal.go` had put it
all along. Nothing caught that drift, so it sat there until a contributor ran
`go mod tidy` on unrelated work and inherited a diff they did not create. One
line closes that for `core/go.mod`:

```make
	cd core && GOWORK=off go mod tidy -diff || (echo "Run cd core && GOWORK=off go mod tidy" && exit 1)
```

## Why `lint`, not a new CI job

#813 guessed `scripts/ci/check_dependency_hygiene.py`. On implementing it,
`lint` is the better home, so I changed course:

- `lint` already does exactly this class of check — `go vet`, `gofmt -l`. A
  tidiness check is the same kind of "source-controlled file is not in its
  canonical form" assertion, with the same shape of fix.
- CI already runs it in two places (`ci.yml:140` in the `kernel` job, and
  `scripts/ci/quality-gates.json:295`), so this needs no new job and no new
  workflow wiring.
- Contributors get the failure **locally** from `make lint`, instead of on a red
  PR. The hygiene script only ever runs in CI.

`go mod tidy -diff` (Go 1.23+) prints what tidy would change and exits non-zero
**without modifying the tree**, so there is no temp-copy-and-restore dance to
get wrong.

Nothing else depends on `lint` as a prerequisite, so the blast radius is exactly
those two call sites.

## Why core-only

The recipe carries a comment saying so, because the scope is the non-obvious
part. I tidied all 12 modules and diffed:

| Module | Tidy? |
|---|---|
| `core`, `sdk/go`, `core/pkg/compliance/zkprovider/gdpr17`, `examples/go_client`, `examples/otel-genai`, `tools/doccheck`, `tools/invcheck`, `tools/tcbcheck`, `tools/launchpad/egressproxy` | tidy |
| `tests/conformance` | **untidy** — 15 deletions |
| `tests/launchpad` | **untidy** — 8 insertions, 17 deletions |
| `tests/skills` | **untidy** — 196 `go.sum` insertions |

A repo-wide gate fails on day one. `core` is both tidy today and the module
where the drift actually reached people. When those three get cleaned up,
widening this is a small change — `scripts/ci/go_module_tests.sh` already has
the `git ls-files '**/go.mod'` enumeration pattern to copy. I have not bundled
that cleanup here; happy to send it separately if wanted.

## Validation

Both directions, because a gate that cannot fail is worthless:

```bash
GOWORK=off make lint
```

Exits **0** on the current tree.

Then, re-introducing the exact drift #813 fixed — putting `go-isatty` back in
the indirect block — and re-running:

```
	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

Run cd core && GOWORK=off go mod tidy
make: *** [lint] Error 1
```

Exits **non-zero** with the remediation hint. `core/go.mod` was restored
afterwards; the only file changed in this PR is the `Makefile`.

```bash
GOWORK=off make test
```

Green — this change touches only the `lint` recipe, but ran it anyway.

## The honest tax

`go mod tidy` output is toolchain-sensitive, so this becomes a second place the
Go version effectively matters: a contributor on a different minor could get a
red check for something they did not do. CI pins `1.25.12` and `core/go.mod`'s
`toolchain` directive pulls contributors to the same version, which should keep
it quiet — but it is a real cost, and it is the reason to say no if you want to
say no.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes. — n/a, build-time check only.
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. — n/a.
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path. — the failure message names the exact fix command; the recipe comment explains the scope.
- [x] Release version surfaces are lockstep (`make version-drift`). — n/a, no release surface touched.
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`. — n/a.
- [x] Advisory quality warnings are acknowledged or tracked when relevant. — the toolchain-sensitivity tax is stated above rather than hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
