### PR TITLE
chore(tools): raise doccheck, invcheck and tcbcheck to go 1.25.12

### DIFF
--- a/tools/doccheck/go.mod
+++ b/tools/doccheck/go.mod
@@ -1,3 +1,3 @@
 module github.com/Mindburn-Labs/helm-ai-kernel/tools/doccheck
 
-go 1.22
+go 1.25.12

--- a/tools/invcheck/go.mod
+++ b/tools/invcheck/go.mod
@@ -1,3 +1,3 @@
 module github.com/Mindburn-Labs/helm-ai-kernel/tools/invcheck
 
-go 1.22
+go 1.25.12

--- a/tools/tcbcheck/go.mod
+++ b/tools/tcbcheck/go.mod
@@ -1,3 +1,3 @@
 module github.com/Mindburn-Labs/helm-ai-kernel/tools/tcbcheck
 
-go 1.22
+go 1.25.12


### PR DESCRIPTION
## Summary

Closes the exception #831 had to carve out.

`go mod tidy -diff` landed in Go 1.23, and `GOTOOLCHAIN=auto` honours each
module's own `go` directive — so `tools/doccheck`, `tools/invcheck` and
`tools/tcbcheck`, all declaring `go 1.22`, actually ran **go1.22.12**, a
toolchain without the flag. `scripts/ci/go_mod_tidy_check.sh` skipped them and
said so on every run. This raises the directive instead of permanently working
around it:

```
- go 1.22
+ go 1.25.12
```

Three lines, one per module. Before and after:

```
go mod tidy check passed: 9 module(s) tidy, 3 skipped.
go mod tidy check passed: 12 module(s) tidy, 0 skipped.
```

## Why this is a safe language-version bump

It is about as low-risk as this class of change gets:

- All three are **single-file, stdlib-only** tools — 93, 684 and 110 lines —
  with an **empty require block and no `go.sum`**. There is no dependency graph
  to disturb, which is why `go mod tidy` produced nothing beyond the directive.
- Go **1.22** already carried the new loop-variable semantics, so `1.22 → 1.25`
  crosses no behavioural cliff.
- All three `go build ./...` and `go vet ./...` clean.

Every module in the repo is now on 1.25.x except `tools/launchpad/egressproxy`
(`go 1.23`), which was already above the threshold and always covered.

## Validation

```bash
bash scripts/ci/go_mod_tidy_check.sh
```

`12 module(s) tidy, 0 skipped`, exit 0.

```bash
GOWORK=off make lint
```

```bash
GOWORK=off make test
```

`make lint` green. `make test` green on re-run — 277 packages ok — but worth
stating plainly rather than rounding up: the **first** local run failed
`TestDockerRunnerValidateAndRun` in `core/pkg/sandbox/docker`
(`TimedOut:true`, `ExitCode:-1`). That test starts a real container against a
1s timeout, and it lost the race while the full suite and 11 other containers
were loading the machine. It passes in isolation and passed on a clean re-run,
and this PR cannot reach it: `core` does not depend on `tools/*` through either
`core/go.mod` or `go.work`, and the diff is three `go` directives in modules
with no reverse dependencies. Flagging it as a flaky test worth its own look,
not as a result of this change.

CI is green on this head.

`.github/workflows/launchpad-reference-packs.yml` is unaffected — it pins
`go-version: '1.22'` but only runs `make build`, which builds `core` (`go
1.25.12` long before this PR), so it already relied on toolchain resolution and
never touched these three modules. That stale pin is pre-existing drift and is
being handled separately rather than bundled here.

## One judgement call for you

The version-skip branch in `scripts/ci/go_mod_tidy_check.sh` is now **dormant** —
nothing in the repo trips it. I left it in place deliberately: it means a future
module added with an older directive degrades to a clearly named skip instead of
being misreported as untidy with a fix command that would not help. That was a
real false positive I hit while building #831, not a hypothetical.

If you would rather not carry a dormant branch, say so and I will delete it —
it is a clean subtraction either way.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes. — n/a, no behavior change.
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. — n/a; the launchpad reference-packs workflow is unaffected, see above.
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path. — n/a, the gate's own output already reflects the change.
- [x] Release version surfaces are lockstep (`make version-drift`). — n/a, no release surface touched.
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`. — n/a, internal build tools.
- [x] Advisory quality warnings are acknowledged or tracked when relevant. — the dormant skip branch is raised above rather than left for a reviewer to find.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
