### PR TITLE
ci(launchpad): pin the reference-pack gate to go 1.25.12 like every other workflow

### DIFF
--- a/.github/workflows/launchpad-reference-packs.yml
+++ b/.github/workflows/launchpad-reference-packs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
-          go-version: '1.22'
+          go-version: "1.25.12"
 
       - name: Build helm-ai-kernel CLI
         run: make build


### PR DESCRIPTION
## What

One line in `.github/workflows/launchpad-reference-packs.yml`:

```diff
-          go-version: '1.22'
+          go-version: "1.25.12"
```

## Why

That step pinned `1.22` while `core/go.mod` declares `go 1.25.12` and carries no
`toolchain` line. The job only ever built because `GOTOOLCHAIN=auto` silently
downloads a newer toolchain on every run — wasted CI time now, and a hard
failure the day toolchain downloads are restricted or the runner has no network.

This machine reproduces the CI condition exactly: its base toolchain is
`go1.22.12`, and `go version` reports `1.25.12` only because `auto` already
swapped it out.

Every other workflow in `.github/workflows/` pins `"1.25.12"` — `ci.yml` uses it
in all eight of its `setup-go` steps. This one was simply missed.

Noticed while raising the `go` directive in `tools/doccheck`, `tools/invcheck`
and `tools/tcbcheck` (#833); kept out of that PR to keep it scoped to module
directives.

## Verification

Locally, with the toolchain pinned to the exact version `setup-go` will now
install (`GOTOOLCHAIN=go1.25.12 GOWORK=off`):

- `make build` — ok
- all four `verify --bundle` steps — `VERIFIED`, seal valid, sig 1/1
- `make lint` — pass (docs-coverage, docs-truth, `go vet`, `gofmt`, tidy check)
- `make test` — pass, except `pkg/sandbox/docker` timing out under the parallel
  load of a full run; it passes in 0.77s when run alone, and `main`'s CI is green

## Blocked behind #817 — please merge that first

This PR touches the workflow file, so it triggers the gate — and the gate is
**already red on `main`**, for a reason unrelated to this change.

Since #691 (2026-07-25) tightened evidence policy, the kernel refuses
self-attested seals by default, and all four reference packs carry one:

```
FAILED · envelope ep_b2a394a3c8ab
  - evidence_pack_seal: seal for signer file-dev:a4c0a69527e6e648 is self-attested
```

Nobody noticed because the path filter only fires on
`reference_packs/launchpad/**`, `registry/launchpad/**`, `policies/launchpad/**`
or the workflow file — none of which changed between 2026-07-06 and 2026-08-09.
The last `main` run is 2026-07-06.

#817 fixes exactly this (adds `HELM_ALLOW_SELF_ATTESTED_EVIDENCE` to the four
steps, plus a weekly schedule so the gate cannot silently rot again). The four
`VERIFIED` results above were produced with that flag, to isolate the Go bump
from the pre-existing breakage.

**Sequence: merge #817, then rebase and merge this.** The two touch different
lines and should merge cleanly.

## Not done

Left `go-version-file: core/go.mod` alone — `claude-managed-agents-live-evidence.yml`
already uses it and it would end the drift for good, but converting 25 pins is a
separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)