### PR TITLE
feat(mcp): wire the GitHub connector through the governed bridge on a shipped path (W1 keystone)

### DIFF
--- a/core/cmd/helm-ai-kernel/mcp_effects.go
+++ b/core/cmd/helm-ai-kernel/mcp_effects.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/canonicalize"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/connectors/github"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtimeadapters"
+	rtmcp "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtimeadapters/mcp"
+)
+
+// Environment contract for governed GitHub dispatch on the local MCP runtime.
+//
+// HELM_GITHUB_TOKEN arms the github.* tools: the runtime constructs the real
+// GitHub connector and hands it to a GovernedBridge whose permit signer is
+// keyed from the same root seed that signs receipts (data-dir root.key). Unset,
+// the tools are not registered and the handler refuses with a structured
+// reason — there is no mode where a github tool call is "allowed but not
+// dispatched" or dispatched under an unverifiable permit.
+const (
+	githubEffectsTokenEnv   = "HELM_GITHUB_TOKEN"
+	githubEffectsBaseURLEnv = "HELM_GITHUB_API_URL"
+	githubEffectsServerID   = "helm-github-effects"
+)
+
+// githubEffectsRuntime is the shipped wiring of the governed effects stack:
+// a real connector bound to a GovernedBridge that signs every minted
+// EffectPermit and verifies the signature at dispatch (PERMIT_UNVERIFIED
+// denial on failure). Reads dispatch under single-use permits; writes stay
+// fail-closed behind the approval ceremony (no ApprovalStore is configured
+// here, so bounded writes always escalate and never dispatch).
+type githubEffectsRuntime struct {
+	bridge *rtmcp.GovernedBridge
+}
+
+// newGitHubEffectsRuntimeFromEnv builds the governed GitHub dispatch runtime,
+// or returns (nil, nil) when HELM_GITHUB_TOKEN is unset. A set token with an
+// unusable permit signing seed is a hard error, never a silent downgrade to
+// unsigned permits: the bridge's dispatch gate is deliberately a no-op without
+// a signer, so arming dispatch without one would make the tamper check
+// vacuously pass.
+func newGitHubEffectsRuntimeFromEnv(dataDir string) (*githubEffectsRuntime, error) {
+	token := strings.TrimSpace(os.Getenv(githubEffectsTokenEnv))
+	if token == "" {
+		return nil, nil
+	}
+	seed, err := localPermitSigningSeed(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("github effects: %w", err)
+	}
+	return newGitHubEffectsRuntime(token, strings.TrimSpace(os.Getenv(githubEffectsBaseURLEnv)), seed)
+}
+
+// newGitHubEffectsRuntime constructs the governed dispatch runtime from
+// explicit inputs. It refuses a seed that yields no permit signer: the bridge's
+// dispatch gate is a no-op without a signer, so arming dispatch without one
+// would make the permit-tamper check pass vacuously — the one failure mode this
+// wiring exists to prevent.
+func newGitHubEffectsRuntime(token, baseURL string, seed []byte) (*githubEffectsRuntime, error) {
+	if strings.TrimSpace(token) == "" {
+		return nil, fmt.Errorf("github effects: token is required")
+	}
+	connector := github.NewConnector(github.Config{Token: token, BaseURL: baseURL})
+	bridge := rtmcp.NewGovernedBridge(rtmcp.BridgeConfig{
+		ServerID:    githubEffectsServerID,
+		Profile:     githubEffectsProfile(),
+		SigningSeed: seed,
+		Connector:   connector,
+	})
+	if bridge.PermitSigningPublicKey() == "" {
+		return nil, fmt.Errorf("github effects: permit signer unavailable; a valid Ed25519 signing seed is required")
+	}
+	return &githubEffectsRuntime{bridge: bridge}, nil
+}
+
+// localPermitSigningSeed reads the Ed25519 seed the local runtime already uses
+// for receipt signing (data-dir root.key, hex-encoded). The bridge reuses it
+// so a permit and the decision receipt that authorized it trace to one key.
+func localPermitSigningSeed(dataDir string) ([]byte, error) {
+	if dataDir == "" {
+		dataDir = "data"
+	}
+	keyPath := filepath.Join(dataDir, "root.key")
+	keyHex, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read permit signing seed: %w", err)
+	}
+	seed, err := hex.DecodeString(strings.TrimSpace(string(keyHex)))
+	if err != nil {
+		return nil, fmt.Errorf("permit signing seed at %s is not hex: %w", keyPath, err)
+	}
+	if len(seed) != ed25519.SeedSize {
+		return nil, fmt.Errorf("permit signing seed at %s has %d bytes, need %d", keyPath, len(seed), ed25519.SeedSize)
+	}
+	return seed, nil
+}
+
+// githubEffectsProfile authorizes operate-class MCP tool calls for this
+// bridge. Scope below this profile is enforced by the connector's declared
+// permit contract (exact tool, exact params) and the permit signature gate;
+// above it, the serve-policy Guardian gate stays deny-all unless --policy
+// explicitly allows each github tool. This profile never ships as a default
+// for anything else.
+func githubEffectsProfile() contracts.WorkstationPolicyProfile {
+	return contracts.WorkstationPolicyProfile{
+		ID:      "workstation.github.effects.v1",
+		Mode:    "operate",
+		Operate: contracts.WorkstationOperatePolicy{Permissions: []string{contracts.WorkstationPermissionMCPMutate}},
+	}
+}
+
+// toolRefs returns the catalog entries for the governed GitHub tools. Schemas
+// mirror the connector's declared permit scope exactly; the connector refuses
+// unknown params by name, so the schemas refuse them too.
+func (r *githubEffectsRuntime) toolRefs() []mcppkg.ToolRef {
+	repoProp := map[string]any{"type": "string", "description": "owner/name"}
+	return []mcppkg.ToolRef{
+		{
+			Name:        "github.list_prs",
+			Title:       "List GitHub pull requests",
+			Description: "Lists pull requests in a repository. Dispatches under a signed EffectPermit verified at dispatch.",
+			ServerID:    githubEffectsServerID,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"repo":  repoProp,
+					"state": map[string]any{"type": "string", "enum": []string{"open", "closed", "all"}},
+				},
+				"required":             []string{"repo"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "github.read_pr",
+			Title:       "Read a GitHub pull request",
+			Description: "Reads one pull request. Dispatches under a signed EffectPermit verified at dispatch.",
+			ServerID:    githubEffectsServerID,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"repo":   repoProp,
+					"number": map[string]any{"type": "integer"},
+				},
+				"required":             []string{"repo", "number"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "github.create_issue",
+			Title:       "Create a GitHub issue",
+			Description: "Bounded write: requires human approval evidence before dispatch; without it the call escalates and nothing is sent.",
+			ServerID:    githubEffectsServerID,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"repo":      repoProp,
+					"title":     map[string]any{"type": "string"},
+					"body":      map[string]any{"type": "string"},
+					"labels":    map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					"assignees": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				},
+				"required":             []string{"repo", "title"},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "github.add_comment",
+			Title:       "Comment on a GitHub issue",
+			Description: "Bounded write: requires human approval evidence before dispatch; without it the call escalates and nothing is sent.",
+			ServerID:    githubEffectsServerID,
+			Schema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"repo":         repoProp,
+					"issue_number": map[string]any{"type": "integer"},
+					"body":         map[string]any{"type": "string"},
+				},
+				"required":             []string{"repo", "issue_number", "body"},
+				"additionalProperties": false,
+			},
+		},
+	}
+}
+
+// execute routes a github.* tool call through the governed bridge and returns
+// the outcome as a machine document: verdict, dispatch state, the signed
+// permit itself, and the key that verifies it offline
+// (receipt_verify --key <permit_public_key>).
+func (r *githubEffectsRuntime) execute(ctx context.Context, req mcppkg.ToolExecutionRequest) (mcppkg.ToolExecutionResponse, error) {
+	adapted := &runtimeadapters.AdaptedRequest{
+		RuntimeType:         "mcp",
+		ToolName:            req.ToolName,
+		Arguments:           req.Arguments,
+		PrincipalID:         firstNonEmpty(req.SessionID, "workstation-local"),
+		SessionID:           req.SessionID,
+		DelegationSessionID: req.DelegationSessionID,
+	}
+	inputHash, err := canonicalize.CanonicalHash(adapted)
+	if err != nil {
+		return mcppkg.ToolExecutionResponse{}, fmt.Errorf("github effects: input hash: %w", err)
+	}
+	outcome := r.bridge.Govern(ctx, adapted, inputHash)
+
+	doc := map[string]any{
+		"verdict":           string(outcome.Verdict),
+		"dispatch_state":    outcome.DispatchState,
+		"decision_id":       outcome.DecisionID,
+		"receipt_hash":      outcome.ReceiptHash,
+		"input_hash":        inputHash,
+		"permit":            outcome.Permit,
+		"permit_public_key": r.bridge.PermitSigningPublicKey(),
+	}
+	if outcome.Verdict == contracts.VerdictAllow {
+		doc["result"] = outcome.Output
+		doc["output_hash"] = outcome.OutputHash
+		doc["next_steps"] = []string{
+			"verify the permit offline: wrap it as {\"receipts\":[],\"permits\":[<permit>]} and run receipt_verify --receipt bundle.json --key " + r.bridge.PermitSigningPublicKey(),
+		}
+		return structuredLocalMCPResponse(doc)
+	}
+
+	doc["reason_code"] = outcome.ReasonCode
+	doc["reason"] = outcome.Reason
+	doc["denied_by"] = "governed-bridge"
+	if outcome.Verdict == contracts.VerdictEscalate {
+		doc["next_steps"] = []string{"obtain human approval evidence for this exact request, then retry"}
+	} else {
+		doc["next_steps"] = []string{"do not retry the same call; modify scope or fix the configuration named in reason"}
+	}
+	resp, err := structuredLocalMCPResponse(doc)
+	if err != nil {
+		return resp, err
+	}
+	resp.IsError = true
+	return resp, nil
+}

--- a/core/cmd/helm-ai-kernel/mcp_effects.go
+++ b/core/cmd/helm-ai-kernel/mcp_effects.go
@@ -1,3 +1,8 @@
+// quantum_posture: this wiring consumes a classical Ed25519 seed only to key
+// the bridge's permit signer; it implements no cryptography itself and claims
+// no hybrid or post-quantum protection. Signing and verification are delegated
+// to the bridge and core/pkg/crypto, whose posture governs.
+
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/mcp_effects_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_effects_test.go
@@ -1,3 +1,6 @@
+// quantum_posture: this test verifies classical Ed25519 permit signatures via
+// core/pkg/crypto; it exercises no post-quantum or hybrid path and asserts none.
+
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/mcp_effects_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_effects_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	helmcrypto "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/effects"
+	mcppkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/mcp"
+	rtmcp "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/runtimeadapters/mcp"
+)
+
+// testSigningSeed is a valid 32-byte Ed25519 seed for the wiring tests. It is
+// not a real key and signs nothing that ships.
+func testSigningSeed() []byte { return []byte("0123456789abcdef0123456789abcdef") }
+
+// decodeEffectsDoc pulls the machine document out of a governed tool response.
+func decodeEffectsDoc(t *testing.T, resp mcppkg.ToolExecutionResponse) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(resp.Content), &doc); err != nil {
+		t.Fatalf("decode effects doc: %v (content=%q)", err, resp.Content)
+	}
+	return doc
+}
+
+// TestGitHubEffectsRuntimeDispatchesReadUnderVerifiedPermit is the W1 keystone
+// acceptance proof on the shipped path: a governed github.list_prs call
+// dispatches against a real HTTP endpoint under a permit the bridge signed and
+// verified, the receipt's output hash reflects the real response, and the
+// emitted permit verifies offline with the reported key. The mutation at the
+// end shows the signature actually covers the permit: flip one byte and offline
+// verification fails.
+func TestGitHubEffectsRuntimeDispatchesReadUnderVerifiedPermit(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"number":7,"title":"Fix","body":"Body","state":"open","created_at":"2026-08-01T00:00:00Z","user":{"login":"ada"},"head":{"ref":"feature"},"base":{"ref":"main"}}]`))
+	}))
+	defer server.Close()
+
+	rt, err := newGitHubEffectsRuntime("ghp-test", server.URL, testSigningSeed())
+	if err != nil {
+		t.Fatalf("construct runtime: %v", err)
+	}
+
+	resp, err := rt.execute(context.Background(), mcppkg.ToolExecutionRequest{
+		ToolName:  "github.list_prs",
+		Arguments: map[string]any{"repo": "owner/repo", "state": "open"},
+		SessionID: "sess-read",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("read call reported error: %s", resp.Content)
+	}
+	doc := decodeEffectsDoc(t, resp)
+
+	// Acceptance 1 + 4: the call actually dispatched and the receipt binds the
+	// real response.
+	if doc["verdict"] != "ALLOW" {
+		t.Fatalf("verdict = %v, want ALLOW (reason=%v)", doc["verdict"], doc["reason"])
+	}
+	if doc["dispatch_state"] != rtmcp.DispatchStateDispatched {
+		t.Fatalf("dispatch_state = %v, want %q", doc["dispatch_state"], rtmcp.DispatchStateDispatched)
+	}
+	if doc["dispatch_state"] == rtmcp.DispatchStateNoDispatch {
+		t.Fatal("shipped path emitted a no-dispatch proof; the connector was not wired")
+	}
+	if oh, _ := doc["output_hash"].(string); oh == "" {
+		t.Fatal("output_hash is empty; the receipt does not bind the real response")
+	}
+	if !strings.Contains(gotPath, "/repos/owner/repo/pulls") {
+		t.Fatalf("connector did not reach the GitHub pulls endpoint; hit %q", gotPath)
+	}
+	if doc["result"] == nil {
+		t.Fatal("no result returned from a dispatched read")
+	}
+
+	// Acceptance 2 + 5: the emitted permit is signed and verifies offline with
+	// the key the response reports — no HELM service in the trust path.
+	pubKey, _ := doc["permit_public_key"].(string)
+	if pubKey == "" {
+		t.Fatal("response did not report the permit public key")
+	}
+	permit := decodePermit(t, doc["permit"])
+	if permit.Signature == "" {
+		t.Fatal("dispatched permit is unsigned")
+	}
+	ok, err := helmcrypto.VerifyPermit(pubKey, permit)
+	if err != nil || !ok {
+		t.Fatalf("emitted permit failed offline verification: ok=%v err=%v", ok, err)
+	}
+
+	// Mutation: the signature must actually cover the permit. Widen the scope
+	// after issuance and offline verification must reject it.
+	tampered := *permit
+	tampered.Scope.AllowedAction = "github.create_issue"
+	if ok, _ := helmcrypto.VerifyPermit(pubKey, &tampered); ok {
+		t.Fatal("a permit whose scope was changed after signing still verified; the signature does not cover scope")
+	}
+}
+
+// TestGitHubEffectsRuntimeRefusesWithoutSigningSeed is the vacuous-pass guard.
+// The dispatch gate is a no-op when the bridge has no permit signer, so the
+// wiring must refuse to construct without a valid seed rather than arm dispatch
+// behind a gate that can never fire. The second half shows exactly what it is
+// preventing: a bridge built the same way but seedless has no signing key and
+// waves an unsigned permit straight through.
+func TestGitHubEffectsRuntimeRefusesWithoutSigningSeed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed []byte
+	}{
+		{"nil seed", nil},
+		{"short seed", []byte("too-short")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := newGitHubEffectsRuntime("ghp-test", "https://api.github.test", tc.seed); err == nil {
+				t.Fatal("runtime armed dispatch without a usable permit signer")
+			}
+		})
+	}
+
+	// Demonstrate the failure mode the guard prevents: a seedless bridge built
+	// the same way has no signing key, so the dispatch gate it exposes is a
+	// no-op. (The gate's enforcement with a signer present is proven inside the
+	// mcp package by TestBridgeDispatchGateRefusesUnsignedAndTamperedPermits;
+	// here we only show why the seed is mandatory for this wiring.)
+	seedless := rtmcp.NewGovernedBridge(rtmcp.BridgeConfig{
+		ServerID: githubEffectsServerID,
+		Profile:  githubEffectsProfile(),
+	})
+	if seedless.PermitSigningPublicKey() != "" {
+		t.Fatal("a seedless bridge reported a signing key")
+	}
+	seeded := rtmcp.NewGovernedBridge(rtmcp.BridgeConfig{
+		ServerID:    githubEffectsServerID,
+		Profile:     githubEffectsProfile(),
+		SigningSeed: testSigningSeed(),
+	})
+	if seeded.PermitSigningPublicKey() == "" {
+		t.Fatal("a seeded bridge reported no signing key; permits would be unsigned")
+	}
+}
+
+// TestGitHubEffectsWriteEscalatesWithoutApproval proves bounded writes stay
+// fail-closed on this path: with no approval store configured, create_issue
+// escalates and never dispatches, so no external write can occur.
+func TestGitHubEffectsWriteEscalatesWithoutApproval(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("write reached GitHub without approval")
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	rt, err := newGitHubEffectsRuntime("ghp-test", server.URL, testSigningSeed())
+	if err != nil {
+		t.Fatalf("construct runtime: %v", err)
+	}
+	resp, err := rt.execute(context.Background(), mcppkg.ToolExecutionRequest{
+		ToolName:  "github.create_issue",
+		Arguments: map[string]any{"repo": "owner/repo", "title": "should not send"},
+		SessionID: "sess-write",
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatalf("bounded write was not refused: %s", resp.Content)
+	}
+	doc := decodeEffectsDoc(t, resp)
+	if doc["verdict"] != "ESCALATE" {
+		t.Fatalf("verdict = %v, want ESCALATE", doc["verdict"])
+	}
+	if doc["dispatch_state"] == rtmcp.DispatchStateDispatched {
+		t.Fatal("bounded write dispatched without approval")
+	}
+}
+
+// decodePermit round-trips the response's permit field back into an
+// effects.EffectPermit for offline verification.
+func decodePermit(t *testing.T, v any) *effects.EffectPermit {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal permit: %v", err)
+	}
+	var permit effects.EffectPermit
+	if err := json.Unmarshal(raw, &permit); err != nil {
+		t.Fatalf("unmarshal permit: %v", err)
+	}
+	return &permit
+}

--- a/core/cmd/helm-ai-kernel/mcp_runtime.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime.go
@@ -56,7 +56,14 @@ func newLocalMCPRuntimeWithDataDirAndPolicy(dataDir string, policyGraph *prg.Gra
 	if err != nil {
 		return nil, mcppkg.GovernedExecutor{}, err
 	}
-	return newLocalMCPRuntimeWithSignerAndPolicy(signer, policyGraph)
+	// Governed GitHub dispatch arms only from the environment (see
+	// mcp_effects.go); a misconfigured signer seed fails loudly here instead of
+	// degrading to unsigned permits.
+	githubEffects, err := newGitHubEffectsRuntimeFromEnv(dataDir)
+	if err != nil {
+		return nil, mcppkg.GovernedExecutor{}, err
+	}
+	return newLocalMCPRuntimeWithSignerPolicyAndEffects(signer, policyGraph, githubEffects)
 }
 
 func newLocalMCPRuntimeWithSigner(signer helmcrypto.Signer) (*mcppkg.ToolCatalog, mcppkg.GovernedExecutor, error) {
@@ -69,13 +76,17 @@ func newLocalMCPRuntimeWithSigner(signer helmcrypto.Signer) (*mcppkg.ToolCatalog
 // denied, because an empty graph carries no allow rule. Pass a compiled graph
 // (see `mcp serve --policy`) to authorize the actions it declares.
 func newLocalMCPRuntimeWithSignerAndPolicy(signer helmcrypto.Signer, policyGraph *prg.Graph) (*mcppkg.ToolCatalog, mcppkg.GovernedExecutor, error) {
+	return newLocalMCPRuntimeWithSignerPolicyAndEffects(signer, policyGraph, nil)
+}
+
+func newLocalMCPRuntimeWithSignerPolicyAndEffects(signer helmcrypto.Signer, policyGraph *prg.Graph, githubEffects *githubEffectsRuntime) (*mcppkg.ToolCatalog, mcppkg.GovernedExecutor, error) {
 	if signer == nil {
 		return nil, mcppkg.GovernedExecutor{}, fmt.Errorf("mcp signer is required")
 	}
 	if policyGraph == nil {
 		policyGraph = prg.NewGraph()
 	}
-	return newLocalMCPRuntimeWithEvaluator(guardian.NewGuardian(signer, policyGraph, nil))
+	return newLocalMCPRuntimeWithEvaluatorAndEffects(guardian.NewGuardian(signer, policyGraph, nil), githubEffects)
 }
 
 // newLocalMCPRuntimeWithEvaluator builds the local MCP runtime whose governance
@@ -84,15 +95,26 @@ func newLocalMCPRuntimeWithSignerAndPolicy(signer helmcrypto.Signer, policyGraph
 // (including reference-pack runtime_actions) instead of a static boot-time
 // graph that never sees reconciler updates.
 func newLocalMCPRuntimeWithEvaluator(evaluator mcppkg.PolicyEvaluator) (*mcppkg.ToolCatalog, mcppkg.GovernedExecutor, error) {
+	return newLocalMCPRuntimeWithEvaluatorAndEffects(evaluator, nil)
+}
+
+func newLocalMCPRuntimeWithEvaluatorAndEffects(evaluator mcppkg.PolicyEvaluator, githubEffects *githubEffectsRuntime) (*mcppkg.ToolCatalog, mcppkg.GovernedExecutor, error) {
 	if evaluator == nil {
 		return nil, mcppkg.GovernedExecutor{}, fmt.Errorf("mcp policy evaluator is required")
 	}
 	catalog := mcppkg.NewInMemoryCatalog()
 	catalog.RegisterCommonTools()
 	catalog.RegisterGovernanceTools()
+	if githubEffects != nil {
+		for _, ref := range githubEffects.toolRefs() {
+			if err := catalog.Register(context.Background(), ref); err != nil {
+				return nil, mcppkg.GovernedExecutor{}, fmt.Errorf("register github effect tool %s: %w", ref.Name, err)
+			}
+		}
+	}
 	firewall := mcppkg.NewGovernanceFirewall(evaluator, catalog)
 
-	return catalog, firewall.GovernedExecutor(localMCPToolHandler(evaluator)), nil
+	return catalog, firewall.GovernedExecutor(localMCPToolHandler(evaluator, githubEffects)), nil
 }
 
 func newLocalMCPGateway() (*mcppkg.Gateway, error) {
@@ -160,8 +182,23 @@ func (e *receiptPersistingEvaluator) EvaluateDecision(ctx context.Context, req g
 	return decision, nil
 }
 
-func localMCPToolHandler(evaluator mcppkg.PolicyEvaluator) mcppkg.ToolHandler {
+func localMCPToolHandler(evaluator mcppkg.PolicyEvaluator, githubEffects *githubEffectsRuntime) mcppkg.ToolHandler {
 	return func(ctx context.Context, req mcppkg.ToolExecutionRequest) (mcppkg.ToolExecutionResponse, error) {
+		if strings.HasPrefix(req.ToolName, "github.") {
+			if githubEffects == nil {
+				resp, err := structuredLocalMCPResponse(map[string]any{
+					"error":      "github effects dispatch is not configured",
+					"denied_by":  "local-mcp-runtime",
+					"next_steps": []string{"set " + githubEffectsTokenEnv + " and restart 'mcp serve'"},
+				})
+				if err != nil {
+					return resp, err
+				}
+				resp.IsError = true
+				return resp, nil
+			}
+			return githubEffects.execute(ctx, req)
+		}
 		return runLocalMCPTool(ctx, evaluator, req)
 	}
 }


### PR DESCRIPTION
## W1 keystone — HELM-518 (programme HELM-517)

HELM had a proof system with no execution attached. The permit-signature half landed in #798/#801/#803/#808, but **no shipped binary constructed a connector** — every governed path emitted a "signed permit, nothing dispatched" no-dispatch proof. This wires `helm-ai-kernel mcp serve`'s local runtime to a real GitHub connector behind a `GovernedBridge`, so **a minted+signed EffectPermit governs a real external call for the first time.**

### What changed
- `HELM_GITHUB_TOKEN` arms `github.{list_prs,read_pr,create_issue,add_comment}`. Unset, the tools are absent and the handler refuses — there is no "allowed but not dispatched" mode for these tools.
- The bridge's permit signer is keyed from the same data-dir `root.key` that signs receipts, so a permit and its authorizing receipt trace to one key.
- `newGitHubEffectsRuntime` **refuses to construct without a valid Ed25519 signing seed.** The dispatch gate is a no-op without a signer, so arming dispatch seedless would make the permit-tamper check pass vacuously — this closes that (the one failure mode the wiring exists to prevent).
- Reads dispatch under single-use permits; bounded writes stay **fail-closed to ESCALATE** because no `ApprovalStore` is wired on this path.
- Responses are machine documents: `verdict`, `dispatch_state`, the signed `permit`, and `permit_public_key` so the permit verifies offline via `receipt_verify`.

### Acceptance (per the programme's binary criteria)
| # | Criterion | Proof |
|---|---|---|
| 1 | shipped path where a governed GitHub call dispatches | `TestGitHubEffectsRuntimeDispatchesReadUnderVerifiedPermit`: verdict ALLOW, `dispatch_state=dispatched`, connector hits `/repos/owner/repo/pulls` |
| 2 | tampered permit refused | offline `crypto.VerifyPermit` rejects a permit whose scope was changed after signing |
| 3 | `SigningSeed` provably set (no vacuous pass) | `TestGitHubEffectsRuntimeRefusesWithoutSigningSeed`: nil/short seeds refused at construction |
| 4 | `DispatchState != no_dispatch_proof`; `output_hash` reflects real response | asserted in test 1 |
| 5 | offline verify, no HELM service in trust path | emitted permit verifies via the reported `permit_public_key` using the `receipt_verify` crypto envelope |

Bounded-write fail-closed: `TestGitHubEffectsWriteEscalatesWithoutApproval` (create_issue → ESCALATE, never dispatched).

### Mutation results (required by programme §1.3)
Break the thing each gate guards → the guarding test must fail; restore → green.

| Mutation | Result |
|---|---|
| drop `SigningSeed` from the shipped bridge config | **FAIL** ✓ |
| point the write-escalation test at a read tool (would dispatch) | **FAIL** ✓ |
| make the post-signing scope mutation a no-op | **FAIL** ✓ |
| restore all | **ok** ✓ |

### Local gates
`verify-boundary` (1107 entries match), `docs-truth`, `docs-coverage`, `GOWORK=off` full-module build + `go vet`, and `cmd/helm-ai-kernel` + `runtimeadapters/mcp` + `connectors/github` package tests — all green.

### Scope notes
- The enforcement point is the **bridge dispatch gate** (`PERMIT_UNVERIFIED`), not the connector: the github connector has no connector-side signature check, and `linear.Config.PermitPublicKey` is opt-in defence-in-depth. The programme's original criterion-2 wording ("the connector rejects") was corrected to "the shipped path rejects at dispatch" during recon.
- A live end-to-end receipt against a scratch GitHub repo (the programme's "one real receipt" evidence) needs a real `HELM_GITHUB_TOKEN` and is out of CI scope — the wiring is proven against an httptest GitHub endpoint here; the token path is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)