### PR TITLE
fix(logging): keep daemon output structured by default

### DIFF
--- a/core/cmd/helm-ai-kernel/cli_safety_test.go
+++ b/core/cmd/helm-ai-kernel/cli_safety_test.go
@@ -188,6 +188,8 @@ func TestHelpMatrix(t *testing.T) {
 	assertSafeHelp(t, []string{"help", "--all"})
 	assertSafeHelp(t, []string{"--help"})
 	assertSafeHelp(t, []string{"-h"})
+	assertSafeHelp(t, []string{"serve", "--policy", "unused.toml", "--help"})
+	assertSafeHelp(t, []string{"server", "--port", "8080", "-h"})
 
 	if startCalls != 0 {
 		t.Fatalf("help started the server %d times", startCalls)

--- a/core/cmd/helm-ai-kernel/lite_mode.go
+++ b/core/cmd/helm-ai-kernel/lite_mode.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -119,9 +120,7 @@ func loadOrGenerateEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
 	}
 
 	log.Printf("[helm] trust: generating new persistent root key at %s", keyPath)
-	fmt.Fprintf(os.Stderr, "\n%s⚠️  SECURITY WARNING: Using auto-generated root key.%s\n", ColorBold+ColorYellow, ColorReset)
-	fmt.Fprintf(os.Stderr, "   Key saved to: %s\n", keyPath)
-	fmt.Fprintf(os.Stderr, "   In production, use a hardware security module (HSM) or cloud KMS.\n\n")
+	slog.Warn("using auto-generated root key", "path", keyPath, "production_guidance", "use an HSM or cloud KMS")
 
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/core/cmd/helm-ai-kernel/lite_mode.go
+++ b/core/cmd/helm-ai-kernel/lite_mode.go
@@ -1,3 +1,5 @@
+// quantum_posture: structured logging changes only signer lifecycle warnings;
+// existing classical Ed25519 and optional ML-DSA-65 profile behavior is unchanged.
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/lite_mode.go
+++ b/core/cmd/helm-ai-kernel/lite_mode.go
@@ -136,7 +136,7 @@ func loadOrGenerateEd25519Root(dataDir string) (*crypto.Ed25519Signer, error) {
 
 	pubPath := filepath.Join(dataDir, "root.pub")
 	if err := os.WriteFile(pubPath, []byte(hex.EncodeToString(pub)), 0644); err != nil {
-		log.Printf("⚠️  failed to save root.pub: %v", err)
+		slog.Error("failed to save root public key", "error", err)
 	}
 
 	return crypto.NewEd25519SignerFromKey(priv, "root"), nil

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -364,43 +364,43 @@ func runServerWithOptions(opts serverOptions) error {
 			db, _, receiptStore, err = setupLiteModeWithDataDir(ctx, dataDir)
 		}
 		if err != nil {
-			log.Fatalf("Failed to setup Lite Mode: %v", err)
+			return fmt.Errorf("setup Lite Mode: %w", err)
 		}
 		principalBindingStore, err = store.NewSQLitePrincipalBindingStore(db)
 		if err != nil {
-			log.Fatalf("Failed to init sqlite principal binding store: %v", err)
+			return fmt.Errorf("init sqlite principal binding store: %w", err)
 		}
 	} else {
 		databaseMode = "postgres"
 		if envBool("HELM_PRODUCTION") {
 			if err := validateProductionDatabaseURL(dbURL); err != nil {
-				log.Fatalf("Invalid production DATABASE_URL: %v", err)
+				return fmt.Errorf("invalid production DATABASE_URL: %w", err)
 			}
 		}
 		db, err = sql.Open("postgres", dbURL)
 		if err != nil {
-			log.Fatalf("Failed to connect to DB: %v", err)
+			return fmt.Errorf("connect to DB: %w", err)
 		}
 		configurePostgresPool(db)
 		if err := db.PingContext(ctx); err != nil {
-			log.Fatalf("DB Ping failed: %v", err)
+			return fmt.Errorf("ping DB: %w", err)
 		}
 		log.Println("[helm] postgres: connected")
 
 		// Initialize Postgres stores (used by Services layer)
 		pl := ledger.NewPostgresLedger(db)
 		if err := pl.Init(ctx); err != nil {
-			log.Fatalf("Failed to init ledger: %v", err)
+			return fmt.Errorf("init ledger: %w", err)
 		}
 		_ = pl // Ledger is managed via Services layer
 		ps := store.NewPostgresReceiptStore(db)
 		if err := ps.Init(ctx); err != nil {
-			log.Fatalf("Failed to init receipt store: %v", err)
+			return fmt.Errorf("init receipt store: %w", err)
 		}
 		receiptStore = ps
 		pbs, pbErr := store.NewPostgresPrincipalBindingStore(db)
 		if pbErr != nil {
-			log.Fatalf("Failed to init postgres principal binding store: %v", pbErr)
+			return fmt.Errorf("init postgres principal binding store: %w", pbErr)
 		}
 		principalBindingStore = pbs
 	}
@@ -410,7 +410,7 @@ func runServerWithOptions(opts serverOptions) error {
 	// Signing Authority
 	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
 	if err != nil {
-		log.Fatalf("Failed to init signer: %v", err)
+		return fmt.Errorf("init signer: %w", err)
 	}
 	verifier, _ := crypto.NewEd25519Verifier(signer.PublicKeyBytes())
 	writeServerNarration(logger, logFormat, narration,
@@ -420,7 +420,7 @@ func runServerWithOptions(opts serverOptions) error {
 	// 2. Registry
 	reg := registry.NewPostgresRegistry(db)
 	if err := reg.Init(ctx); err != nil {
-		log.Fatalf("Failed to init registry: %v", err)
+		return fmt.Errorf("init registry: %w", err)
 	}
 	log.Println("[helm] registry: ready")
 
@@ -441,9 +441,9 @@ func runServerWithOptions(opts serverOptions) error {
 		// service graph would make readiness ambiguous and hide a bad authority
 		// or durable-store configuration.
 		if servicesInitFailureIsFatal() {
-			log.Fatalf("Services init failed while a fail-closed runtime boundary is enabled: %v", svcErr)
+			return fmt.Errorf("services init failed while a fail-closed runtime boundary is enabled: %w", svcErr)
 		}
-		log.Printf("Services init (non-fatal, degraded mode): %v", svcErr)
+		logger.Warn("services init failed; continuing in degraded mode", "error", svcErr)
 	}
 	if services != nil {
 		services.DatabaseMode = databaseMode
@@ -468,15 +468,15 @@ func runServerWithOptions(opts serverOptions) error {
 	if opts.PolicyPath != "" {
 		policySource, policySourceKind, sourceErr := policySourceFromEnv(opts.PolicyPath, policyScope)
 		if sourceErr != nil {
-			log.Fatalf("Failed to configure policy source: %v", sourceErr)
+			return fmt.Errorf("configure policy source: %w", sourceErr)
 		}
 		policyVerifier, requirePolicySignature, verifierErr := policySignatureVerifierFromEnv(policySourceKind)
 		if verifierErr != nil {
-			log.Fatalf("Failed to configure policy signature verifier: %v", verifierErr)
+			return fmt.Errorf("configure policy signature verifier: %w", verifierErr)
 		}
 		keepLastKnownGood, lkgMaxAge, lkgConfigErr := policyLastKnownGoodConfigFromEnv()
 		if lkgConfigErr != nil {
-			log.Fatalf("Failed to configure last-known-good policy retention: %v", lkgConfigErr)
+			return fmt.Errorf("configure last-known-good policy retention: %w", lkgConfigErr)
 		}
 		policyStore = policyreconcile.NewAtomicSnapshotStore()
 		policyReconciler, err = policyreconcile.NewReconciler(policyreconcile.ReconcilerConfig{
@@ -490,7 +490,7 @@ func runServerWithOptions(opts serverOptions) error {
 			Clock:               runtimeClock.Now,
 		})
 		if err != nil {
-			log.Fatalf("Failed to initialize policy reconciler: %v", err)
+			return fmt.Errorf("initialize policy reconciler: %w", err)
 		}
 		reconcileCtx := ctx
 		if timeout := policyInitialReconcileTimeoutFromEnv(); timeout > 0 {
@@ -500,11 +500,11 @@ func runServerWithOptions(opts serverOptions) error {
 		}
 		status, recErr := policyReconciler.Reconcile(reconcileCtx, policyScope)
 		if recErr != nil {
-			log.Fatalf("Failed to reconcile initial policy snapshot: %v", recErr)
+			return fmt.Errorf("reconcile initial policy snapshot: %w", recErr)
 		}
 		snapshot, ok := policyStore.Get(policyScope)
 		if !ok || snapshot == nil {
-			log.Fatalf("Failed to install initial policy snapshot: %s", status.ReconcileStatus)
+			return fmt.Errorf("install initial policy snapshot: %s", status.ReconcileStatus)
 		}
 		if snapshot.Graph != nil {
 			ruleGraph = snapshot.Graph
@@ -539,7 +539,7 @@ func runServerWithOptions(opts serverOptions) error {
 		if !fallbackMock {
 			cmd := exec.Command("docker", "info")
 			if err := cmd.Run(); err != nil {
-				log.Println("[helm] Docker daemon not reachable, falling back to mock warm sandboxes")
+				logger.Warn("Docker daemon not reachable; falling back to mock warm sandboxes")
 				fallbackMock = true
 			}
 		}
@@ -569,11 +569,11 @@ func runServerWithOptions(opts serverOptions) error {
 		services.PolicyScope = policyScope
 		services.ApprovalConsumption, err = newApprovalConsumptionRuntime(ctx, db, databaseMode, signer, services.EmergencyStops)
 		if err != nil {
-			log.Fatalf("Failed to initialize approval grant consumption runtime: %v", err)
+			return fmt.Errorf("initialize approval grant consumption runtime: %w", err)
 		}
 		services.GeneratedSpecApproval, err = newGeneratedSpecApprovalRuntime(ctx, db, databaseMode, signer, services.EmergencyStops)
 		if err != nil {
-			log.Fatalf("Failed to initialize GeneratedSpec approval runtime: %v", err)
+			return fmt.Errorf("initialize GeneratedSpec approval runtime: %w", err)
 		}
 
 		// Receipt transparency log: anchor decision-record receipt hashes at
@@ -585,9 +585,9 @@ func runServerWithOptions(opts serverOptions) error {
 		transpLog, transpErr := translog.Open(filepath.Join(dataDir, "translog"))
 		if transpErr != nil {
 			if envBool("HELM_PRODUCTION") {
-				log.Fatalf("Failed to open receipt transparency log: %v", transpErr)
+				return fmt.Errorf("open receipt transparency log: %w", transpErr)
 			}
-			log.Printf("[helm] receipt transparency log disabled (dev): %v", transpErr)
+			logger.Warn("receipt transparency log disabled in development", "error", transpErr)
 		} else {
 			services.TranspLog = transpLog
 			services.TranspLogID = translog.LogIDFromPublicKey(signer.PublicKeyBytes())
@@ -619,7 +619,7 @@ func runServerWithOptions(opts serverOptions) error {
 		IdleTimeout:       120 * time.Second,
 	}
 	if bindAddr == "0.0.0.0" {
-		log.Printf("[helm] WARNING: API server binding to all interfaces (0.0.0.0:%d) — ensure firewall rules are in place", port)
+		logger.Warn("API server binding to all interfaces; ensure firewall rules are in place", "port", port)
 	}
 	go func() {
 		log.Printf("[helm] API server: %s:%d", bindAddr, port)
@@ -656,7 +656,7 @@ func runServerWithOptions(opts serverOptions) error {
 		go func() {
 			log.Printf("[helm] health server: %s:%d", bindAddr, healthPort)
 			if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Printf("[helm] health server error: %v", err)
+				logger.Error("health server failed", "error", err)
 			}
 		}()
 	}
@@ -675,7 +675,7 @@ func runServerWithOptions(opts serverOptions) error {
 		go func() {
 			log.Printf("[helm] metrics server: %s:%d", bindAddr, metricsPort)
 			if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				log.Printf("[helm] metrics server error: %v", err)
+				logger.Error("metrics server failed", "error", err)
 			}
 		}()
 	}
@@ -689,16 +689,16 @@ func runServerWithOptions(opts serverOptions) error {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if err := server.Shutdown(shutdownCtx); err != nil {
-			log.Printf("[helm] API server shutdown error: %v", err)
+			logger.Error("API server shutdown failed", "error", err)
 		}
 		if healthServer != nil {
 			if err := healthServer.Shutdown(shutdownCtx); err != nil {
-				log.Printf("[helm] health server shutdown error: %v", err)
+				logger.Error("health server shutdown failed", "error", err)
 			}
 		}
 		if metricsServer != nil {
 			if err := metricsServer.Shutdown(shutdownCtx); err != nil {
-				log.Printf("[helm] metrics server shutdown error: %v", err)
+				logger.Error("metrics server shutdown failed", "error", err)
 			}
 		}
 		// Flush the OTLP batchers last, after the servers stopped accepting.
@@ -711,7 +711,7 @@ func runServerWithOptions(opts serverOptions) error {
 		// the case it exists for.
 		if services != nil && services.Observability != nil {
 			if err := flushObservability(services.Observability); err != nil {
-				log.Printf("[helm] observability shutdown error: %v", err)
+				logger.Error("observability shutdown failed", "error", err)
 			}
 		}
 	}

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -178,8 +178,10 @@ func printGlobalCommandHelp(name string, stdout io.Writer) {
 		fmt.Fprintln(stdout, "Usage: helm-ai-kernel help [--all|--json|<command>]")
 	case "server":
 		fmt.Fprintln(stdout, "Usage: helm-ai-kernel server [--policy PATH] [--addr ADDR] [--port PORT] [--data-dir DIR] [--json]")
+		fmt.Fprintln(stdout, "Logs default to JSON; set HELM_LOG_FORMAT=text for local human-readable output.")
 	case "serve":
 		fmt.Fprintln(stdout, "Usage: helm-ai-kernel serve --policy PATH [--addr ADDR] [--port PORT] [--data-dir DIR] [--json]")
+		fmt.Fprintln(stdout, "Logs default to JSON; set HELM_LOG_FORMAT=text for local human-readable output.")
 	case "threat":
 		fmt.Fprintln(stdout, "Usage: helm-ai-kernel threat <scan|test> [flags]")
 	case "version":
@@ -208,20 +210,37 @@ func runServer() error {
 	return runServerWithOptions(serverOptions{Mode: "server", Stdout: os.Stdout, Stderr: os.Stderr})
 }
 
+func newServerLogHandler(w io.Writer) (slog.Handler, error) {
+	var handler slog.Handler
+	switch format := strings.ToLower(strings.TrimSpace(os.Getenv("HELM_LOG_FORMAT"))); format {
+	case "", "json":
+		handler = slog.NewJSONHandler(w, nil)
+	case "text":
+		handler = slog.NewTextHandler(w, nil)
+	default:
+		return nil, fmt.Errorf("invalid HELM_LOG_FORMAT %q: expected json or text", format)
+	}
+	return tracing.NewSlogHandler(handler), nil
+}
+
 //nolint:gocognit,gocyclo
 func runServerWithOptions(opts serverOptions) error {
+	if opts.Stdout == nil {
+		opts.Stdout = os.Stdout
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = os.Stderr
+	}
+	logHandler, logConfigErr := newServerLogHandler(opts.Stderr)
+	if logConfigErr != nil {
+		return logConfigErr
+	}
 	// Consume the Desktop launch secret before any optional runtime setup can
 	// spawn a subprocess. The route retains only the in-memory copy below.
 	desktopReadyToken := takeDesktopReadyToken()
 	desktopTransport, transportErr := desktopTransportV1ForOptions(opts)
 	if transportErr != nil {
 		return fmt.Errorf("desktop transport v1 configuration: %w", transportErr)
-	}
-	if opts.Stdout == nil {
-		opts.Stdout = os.Stdout
-	}
-	if opts.Stderr == nil {
-		opts.Stderr = os.Stderr
 	}
 	narration := serverNarrationWriter(opts)
 	// SEC: Default to localhost to prevent accidental network exposure.
@@ -284,7 +303,7 @@ func runServerWithOptions(opts serverOptions) error {
 	// handler must be an explicit sink handler: wrapping the stdlib bridge
 	// (slog.Default().Handler()) and re-SetDefault-ing creates a log→slog→log
 	// cycle that deadlocks the first log.Printf at boot.
-	logger := slog.New(tracing.NewSlogHandler(slog.NewTextHandler(opts.Stderr, nil)))
+	logger := slog.New(logHandler)
 	slog.SetDefault(logger)
 	dataDir := opts.DataDir
 	if dataDir == "" {

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -214,7 +214,12 @@ func newServerLogHandler(w io.Writer) (slog.Handler, error) {
 	var handler slog.Handler
 	switch format := strings.ToLower(strings.TrimSpace(os.Getenv("HELM_LOG_FORMAT"))); format {
 	case "", "json":
-		handler = slog.NewJSONHandler(w, nil)
+		handler = slog.NewJSONHandler(w, &slog.HandlerOptions{ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+			if len(groups) == 0 && attr.Key == slog.TimeKey && attr.Value.Kind() == slog.KindTime {
+				return slog.String("timestamp", attr.Value.Time().UTC().Format("2006-01-02T15:04:05.000Z07:00"))
+			}
+			return attr
+		}})
 	case "text":
 		handler = slog.NewTextHandler(w, nil)
 	default:

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -210,10 +210,24 @@ func runServer() error {
 	return runServerWithOptions(serverOptions{Mode: "server", Stdout: os.Stdout, Stderr: os.Stderr})
 }
 
-func newServerLogHandler(w io.Writer) (slog.Handler, error) {
+func resolveServerLogFormat(mode string) (string, error) {
+	format := strings.ToLower(strings.TrimSpace(os.Getenv("HELM_LOG_FORMAT")))
+	if format == "" {
+		if mode == "quickstart" {
+			return "text", nil
+		}
+		return "json", nil
+	}
+	if format != "json" && format != "text" {
+		return "", fmt.Errorf("invalid HELM_LOG_FORMAT %q: expected json or text", format)
+	}
+	return format, nil
+}
+
+func newServerLogHandler(w io.Writer, format string) slog.Handler {
 	var handler slog.Handler
-	switch format := strings.ToLower(strings.TrimSpace(os.Getenv("HELM_LOG_FORMAT"))); format {
-	case "", "json":
+	switch format {
+	case "json":
 		handler = slog.NewJSONHandler(w, &slog.HandlerOptions{ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
 			if len(groups) == 0 && attr.Key == slog.TimeKey && attr.Value.Kind() == slog.KindTime {
 				return slog.String("timestamp", attr.Value.Time().UTC().Format("2006-01-02T15:04:05.000Z07:00"))
@@ -222,10 +236,26 @@ func newServerLogHandler(w io.Writer) (slog.Handler, error) {
 		}})
 	case "text":
 		handler = slog.NewTextHandler(w, nil)
-	default:
-		return nil, fmt.Errorf("invalid HELM_LOG_FORMAT %q: expected json or text", format)
 	}
-	return tracing.NewSlogHandler(handler), nil
+	return tracing.NewSlogHandler(handler)
+}
+
+func configureServerLogger(w io.Writer, mode string) (*slog.Logger, string, error) {
+	format, err := resolveServerLogFormat(mode)
+	if err != nil {
+		return nil, "", err
+	}
+	logger := slog.New(newServerLogHandler(w, format))
+	slog.SetDefault(logger)
+	return logger, format, nil
+}
+
+func writeServerNarration(logger *slog.Logger, format string, human io.Writer, humanText, message string, attrs ...any) {
+	if format == "json" {
+		logger.Info(message, attrs...)
+		return
+	}
+	_, _ = fmt.Fprintln(human, humanText)
 }
 
 //nolint:gocognit,gocyclo
@@ -236,7 +266,7 @@ func runServerWithOptions(opts serverOptions) error {
 	if opts.Stderr == nil {
 		opts.Stderr = os.Stderr
 	}
-	logHandler, logConfigErr := newServerLogHandler(opts.Stderr)
+	logger, logFormat, logConfigErr := configureServerLogger(opts.Stderr, opts.Mode)
 	if logConfigErr != nil {
 		return logConfigErr
 	}
@@ -247,7 +277,10 @@ func runServerWithOptions(opts serverOptions) error {
 	if transportErr != nil {
 		return fmt.Errorf("desktop transport v1 configuration: %w", transportErr)
 	}
-	narration := serverNarrationWriter(opts)
+	narration := opts.Stdout
+	if opts.JSON {
+		narration = opts.Stderr
+	}
 	// SEC: Default to localhost to prevent accidental network exposure.
 	// HELM_BIND_ADDR=0.0.0.0 remains an explicit opt-in for server mode.
 	bindAddr := opts.BindAddr
@@ -300,16 +333,11 @@ func runServerWithOptions(opts serverOptions) error {
 	}
 	defer func() { _ = apiListener.Close() }()
 
-	fmt.Fprintf(narration, "%sHELM AI Kernel starting...%s\n", ColorBold+ColorBlue, ColorReset)
+	writeServerNarration(logger, logFormat, narration,
+		ColorBold+ColorBlue+"HELM AI Kernel starting..."+ColorReset,
+		"HELM AI Kernel starting")
 	ctx, runtimeCancel := context.WithCancel(context.Background())
 	defer runtimeCancel()
-	// Stamp trace_id/span_id/correlation_id from ctx onto every record
-	// (HELM-333); requires *Context slog variants at call sites. The wrapped
-	// handler must be an explicit sink handler: wrapping the stdlib bridge
-	// (slog.Default().Handler()) and re-SetDefault-ing creates a log→slog→log
-	// cycle that deadlocks the first log.Printf at boot.
-	logger := slog.New(logHandler)
-	slog.SetDefault(logger)
 	dataDir := opts.DataDir
 	if dataDir == "" {
 		dataDir = "data"
@@ -326,7 +354,9 @@ func runServerWithOptions(opts serverOptions) error {
 	// 0.2 Connect to Database (Infrastructure)
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		fmt.Fprintf(narration, "ℹ️  DATABASE_URL not set. Falling back to %sLite Mode%s (SQLite).\n", ColorBold+ColorCyan, ColorReset)
+		writeServerNarration(logger, logFormat, narration,
+			"ℹ️  DATABASE_URL not set. Falling back to "+ColorBold+ColorCyan+"Lite Mode"+ColorReset+" (SQLite).",
+			"DATABASE_URL not set; using Lite Mode", "database", "sqlite")
 		if opts.SQLitePath != "" {
 			db, _, receiptStore, err = setupLiteModeWithDBPath(ctx, opts.SQLitePath)
 			dataDir = filepath.Dir(opts.SQLitePath)
@@ -383,7 +413,9 @@ func runServerWithOptions(opts serverOptions) error {
 		log.Fatalf("Failed to init signer: %v", err)
 	}
 	verifier, _ := crypto.NewEd25519Verifier(signer.PublicKeyBytes())
-	fmt.Fprintf(narration, "🔑 Trust Root: %s%s%s\n", ColorBold+ColorGreen, signer.PublicKey(), ColorReset)
+	writeServerNarration(logger, logFormat, narration,
+		"🔑 Trust Root: "+ColorBold+ColorGreen+signer.PublicKey()+ColorReset,
+		"trust root ready", "public_key", signer.PublicKey())
 
 	// 2. Registry
 	reg := registry.NewPostgresRegistry(db)
@@ -683,7 +715,7 @@ func runServerWithOptions(opts serverOptions) error {
 			}
 		}
 	}
-	if err := writeServerReady(opts, bindAddr, port); err != nil {
+	if err := writeServerReady(opts, logger, logFormat, bindAddr, port); err != nil {
 		shutdown()
 		return err
 	}
@@ -706,17 +738,7 @@ func runServerWithOptions(opts serverOptions) error {
 	return runtimeErr
 }
 
-// serverNarrationWriter keeps human-only startup prose out of a command's JSON
-// data stream. JSON callers retain stdout for machine data and receive
-// diagnostics and narration on stderr.
-func serverNarrationWriter(opts serverOptions) io.Writer {
-	if opts.JSON {
-		return opts.Stderr
-	}
-	return opts.Stdout
-}
-
-func writeServerReady(opts serverOptions, bindAddr string, port int) error {
+func writeServerReady(opts serverOptions, logger *slog.Logger, logFormat, bindAddr string, port int) error {
 	if opts.OnReady != nil {
 		if err := opts.OnReady(bindAddr, port); err != nil {
 			return err
@@ -730,6 +752,8 @@ func writeServerReady(opts serverOptions, bindAddr string, port int) error {
 			"ready":  true,
 			"policy": opts.PolicyPath,
 		})
+	} else if logFormat == "json" {
+		logger.Info("server ready", "name", "helm-edge-local", "addr", bindAddr, "port", port, "policy", opts.PolicyPath)
 	} else if opts.Mode == "serve" {
 		fmt.Fprintf(opts.Stdout, "helm-edge-local · listening :%d · ready\n", port)
 	} else {

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -168,6 +168,7 @@ func TestRun_Unknown(t *testing.T) {
 }
 
 func TestRunServerCommandReportsStartupFailure(t *testing.T) {
+	t.Setenv("HELM_LOG_FORMAT", "")
 	originalRunServer := startServer
 	defer func() { startServer = originalRunServer }()
 	startServer = func() error { return errors.New("bind failed") }
@@ -176,7 +177,11 @@ func TestRunServerCommandReportsStartupFailure(t *testing.T) {
 	exitCode := runServerCommand("server", nil, &stdout, &stderr)
 
 	assert.Equal(t, 1, exitCode)
-	assert.Contains(t, stderr.String(), "bind failed")
+	var record map[string]any
+	assert.NoError(t, json.Unmarshal(stderr.Bytes(), &record))
+	assert.Equal(t, "ERROR", record["level"])
+	assert.Equal(t, "server command failed", record["msg"])
+	assert.Contains(t, record["error"], "bind failed")
 }
 
 func TestServerLogFormatDefaultsAndOverrides(t *testing.T) {

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -11,6 +14,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
+	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 func chdirTempDir(t *testing.T) string {
@@ -195,6 +199,53 @@ func TestServerNarrationWriterSeparatesJSONAndText(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestServerLogHandler(t *testing.T) {
+	traceID := oteltrace.TraceID{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	spanID := oteltrace.SpanID{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
+	ctx := oteltrace.ContextWithSpanContext(context.Background(), oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+
+	t.Run("json by default", func(t *testing.T) {
+		t.Setenv("HELM_LOG_FORMAT", "")
+		var output bytes.Buffer
+		handler, err := newServerLogHandler(&output)
+		if err != nil {
+			t.Fatal(err)
+		}
+		slog.New(handler).InfoContext(ctx, "request served", "status", http.StatusOK)
+
+		var record map[string]any
+		if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+			t.Fatalf("decode JSON log %q: %v", output.String(), err)
+		}
+		assert.Equal(t, "INFO", record["level"])
+		assert.Equal(t, "request served", record["msg"])
+		assert.Equal(t, float64(http.StatusOK), record["status"])
+		assert.Equal(t, traceID.String(), record["trace_id"])
+		assert.Equal(t, spanID.String(), record["span_id"])
+	})
+
+	t.Run("text is an explicit local opt-in", func(t *testing.T) {
+		t.Setenv("HELM_LOG_FORMAT", "text")
+		var output bytes.Buffer
+		handler, err := newServerLogHandler(&output)
+		if err != nil {
+			t.Fatal(err)
+		}
+		slog.New(handler).InfoContext(ctx, "request served")
+		assert.Contains(t, output.String(), "level=INFO")
+		assert.Contains(t, output.String(), "trace_id="+traceID.String())
+	})
+
+	t.Run("unknown format fails closed", func(t *testing.T) {
+		t.Setenv("HELM_LOG_FORMAT", "yaml")
+		_, err := newServerLogHandler(&bytes.Buffer{})
+		assert.EqualError(t, err, `invalid HELM_LOG_FORMAT "yaml": expected json or text`)
+	})
 }
 
 // TestRunUnknownFlagDoesNotStartTheServer replaces the former

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -180,25 +179,49 @@ func TestRunServerCommandReportsStartupFailure(t *testing.T) {
 	assert.Contains(t, stderr.String(), "bind failed")
 }
 
-func TestServerNarrationWriterSeparatesJSONAndText(t *testing.T) {
+func TestServerLogFormatDefaultsAndOverrides(t *testing.T) {
 	for _, test := range []struct {
-		name       string
-		json       bool
-		wantStdout string
-		wantStderr string
+		name, mode, env, want string
 	}{
-		{name: "json", json: true, wantStderr: "human startup narration"},
-		{name: "text", wantStdout: "human startup narration"},
+		{name: "daemon defaults to json", mode: "serve", want: "json"},
+		{name: "server defaults to json", mode: "server", want: "json"},
+		{name: "quickstart defaults to text", mode: "quickstart", want: "text"},
+		{name: "quickstart json override", mode: "quickstart", env: "json", want: "json"},
+		{name: "daemon text override", mode: "serve", env: "text", want: "text"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			var stdout, stderr bytes.Buffer
-			if _, err := fmt.Fprint(serverNarrationWriter(serverOptions{JSON: test.json, Stdout: &stdout, Stderr: &stderr}), "human startup narration"); err != nil {
-				t.Fatal(err)
-			}
-			if stdout.String() != test.wantStdout || stderr.String() != test.wantStderr {
-				t.Fatalf("narration routing stdout=%q stderr=%q", stdout.String(), stderr.String())
+			t.Setenv("HELM_LOG_FORMAT", test.env)
+			got, err := resolveServerLogFormat(test.mode)
+			if err != nil || got != test.want {
+				t.Fatalf("resolveServerLogFormat(%q) = %q, %v; want %q", test.mode, got, err, test.want)
 			}
 		})
+	}
+}
+
+func TestDaemonNarrationAndReadinessAreStructured(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	logger := slog.New(newServerLogHandler(&stderr, "json"))
+	writeServerNarration(logger, "json", &stdout, "human startup narration", "kernel starting")
+	if err := writeServerReady(serverOptions{Mode: "serve", Stdout: &stdout}, logger, "json", "127.0.0.1", 7714); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("structured daemon wrote plain stdout: %q", stdout.String())
+	}
+	for _, line := range strings.Split(strings.TrimSpace(stderr.String()), "\n") {
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("daemon emitted non-JSON line %q: %v", line, err)
+		}
+		for _, key := range []string{"timestamp", "level", "msg"} {
+			if record[key] == nil {
+				t.Fatalf("daemon record lacks %s: %v", key, record)
+			}
+		}
+		if strings.Contains(line, "\x1b") {
+			t.Fatalf("daemon record contains ANSI: %q", line)
+		}
 	}
 }
 
@@ -213,10 +236,11 @@ func TestServerLogHandler(t *testing.T) {
 	t.Run("json by default", func(t *testing.T) {
 		t.Setenv("HELM_LOG_FORMAT", "")
 		var output bytes.Buffer
-		handler, err := newServerLogHandler(&output)
+		format, err := resolveServerLogFormat("serve")
 		if err != nil {
 			t.Fatal(err)
 		}
+		handler := newServerLogHandler(&output, format)
 		slog.New(handler).InfoContext(ctx, "request served", "status", http.StatusOK)
 
 		var record map[string]any
@@ -241,10 +265,11 @@ func TestServerLogHandler(t *testing.T) {
 	t.Run("text is an explicit local opt-in", func(t *testing.T) {
 		t.Setenv("HELM_LOG_FORMAT", "text")
 		var output bytes.Buffer
-		handler, err := newServerLogHandler(&output)
+		format, err := resolveServerLogFormat("serve")
 		if err != nil {
 			t.Fatal(err)
 		}
+		handler := newServerLogHandler(&output, format)
 		slog.New(handler).InfoContext(ctx, "request served")
 		assert.Contains(t, output.String(), "level=INFO")
 		assert.Contains(t, output.String(), "trace_id="+traceID.String())
@@ -252,7 +277,7 @@ func TestServerLogHandler(t *testing.T) {
 
 	t.Run("unknown format fails closed", func(t *testing.T) {
 		t.Setenv("HELM_LOG_FORMAT", "yaml")
-		_, err := newServerLogHandler(&bytes.Buffer{})
+		_, err := resolveServerLogFormat("serve")
 		assert.EqualError(t, err, `invalid HELM_LOG_FORMAT "yaml": expected json or text`)
 	})
 }

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -184,6 +184,21 @@ func TestRunServerCommandReportsStartupFailure(t *testing.T) {
 	assert.Contains(t, record["error"], "bind failed")
 }
 
+func TestRunServerCommandInvalidLogFormatIsStructured(t *testing.T) {
+	t.Setenv("HELM_LOG_FORMAT", "yaml")
+	var stdout, stderr bytes.Buffer
+
+	exitCode := runServerCommand("serve", nil, &stdout, &stderr)
+
+	assert.Equal(t, 2, exitCode)
+	assert.Empty(t, stdout.String())
+	var record map[string]any
+	assert.NoError(t, json.Unmarshal(stderr.Bytes(), &record))
+	assert.Equal(t, "ERROR", record["level"])
+	assert.Equal(t, "server command failed", record["msg"])
+	assert.Contains(t, record["error"], `invalid HELM_LOG_FORMAT "yaml"`)
+}
+
 func TestServerLogFormatDefaultsAndOverrides(t *testing.T) {
 	for _, test := range []struct {
 		name, mode, env, want string

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
@@ -222,6 +223,14 @@ func TestServerLogHandler(t *testing.T) {
 		if err := json.Unmarshal(output.Bytes(), &record); err != nil {
 			t.Fatalf("decode JSON log %q: %v", output.String(), err)
 		}
+		timestamp, ok := record["timestamp"].(string)
+		if !ok {
+			t.Fatalf("JSON log has no string timestamp: %v", record)
+		}
+		if _, err := time.Parse("2006-01-02T15:04:05.999Z07:00", timestamp); err != nil {
+			t.Fatalf("timestamp %q does not match the collector contract: %v", timestamp, err)
+		}
+		assert.NotContains(t, record, "time")
 		assert.Equal(t, "INFO", record["level"])
 		assert.Equal(t, "request served", record["msg"])
 		assert.Equal(t, float64(http.StatusOK), record["status"])

--- a/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -463,4 +464,27 @@ func TestGovernedDeployedMCPGatewayRequiresReceiptComponents(t *testing.T) {
 	if err != nil || gateway == nil {
 		t.Fatalf("fully receipted governed gateway unavailable: gateway=%v err=%v", gateway, err)
 	}
+}
+
+func TestUnavailableMCPGatewayLogsWarning(t *testing.T) {
+	previousLogger := slog.Default()
+	var output bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&output, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	svc, cleanup := newContractRouteTestServices(t)
+	defer cleanup()
+	svc.Guardian = &guardian.Guardian{}
+	RegisterSubsystemRoutes(http.NewServeMux(), svc)
+
+	for _, line := range strings.Split(strings.TrimSpace(output.String()), "\n") {
+		var record map[string]any
+		if json.Unmarshal([]byte(line), &record) == nil && record["msg"] == "MCP gateway unavailable" {
+			if record["level"] != "WARN" {
+				t.Fatalf("MCP gateway log level = %v, want WARN", record["level"])
+			}
+			return
+		}
+	}
+	t.Fatalf("MCP gateway warning missing from logs: %s", output.String())
 }

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -64,6 +64,10 @@ func runQuickstartCmdWithReady(args []string, stdout, stderr io.Writer, onReady 
 		fmt.Fprintf(stderr, "quickstart: %v\n", err)
 		return 2
 	}
+	if _, _, err := configureServerLogger(stderr, "quickstart"); err != nil {
+		fmt.Fprintf(stderr, "quickstart: %v\n", err)
+		return 2
+	}
 	planned, err := planQuickstart(opts)
 	if err != nil {
 		fmt.Fprintf(stderr, "quickstart: %v\n", err)
@@ -409,6 +413,7 @@ func printQuickstartUsage(stdout io.Writer) {
 	fmt.Fprintln(stdout)
 	printLocalConsoleJourney(stdout)
 	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Quickstart logs default to text; set HELM_LOG_FORMAT=json for structured logs.")
 	fmt.Fprintln(stdout, "Pass --reset --yes only to replace HELM-owned quickstart state.")
 }
 

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -56,21 +57,28 @@ func runQuickstartCmdWithReady(args []string, stdout, stderr io.Writer, onReady 
 		printQuickstartUsage(stdout)
 		return 0
 	}
-	opts, code := parseQuickstartArgs(args, stderr)
-	if code != 0 {
-		return code
-	}
-	if err := validateQuickstartOptions(opts); err != nil {
+	logger, logFormat, err := configureServerLogger(stderr, "quickstart")
+	if err != nil {
 		fmt.Fprintf(stderr, "quickstart: %v\n", err)
 		return 2
 	}
-	if _, _, err := configureServerLogger(stderr, "quickstart"); err != nil {
-		fmt.Fprintf(stderr, "quickstart: %v\n", err)
+	var parseOutput strings.Builder
+	opts, err := parseQuickstartArgs(args, &parseOutput)
+	if err != nil {
+		if logFormat == "json" || parseOutput.Len() == 0 {
+			writeQuickstartError(logger, logFormat, stderr, err, "")
+		} else {
+			_, _ = io.WriteString(stderr, parseOutput.String())
+		}
+		return 2
+	}
+	if err := validateQuickstartOptions(opts); err != nil {
+		writeQuickstartError(logger, logFormat, stderr, err, "")
 		return 2
 	}
 	planned, err := planQuickstart(opts)
 	if err != nil {
-		fmt.Fprintf(stderr, "quickstart: %v\n", err)
+		writeQuickstartError(logger, logFormat, stderr, err, "")
 		return 1
 	}
 	if opts.DryRun {
@@ -79,7 +87,7 @@ func runQuickstartCmdWithReady(args []string, stdout, stderr io.Writer, onReady 
 		// it passes would falsely imply that deletion is authorized.
 		_, planned, err = preflightQuickstartReset(opts, planned)
 		if err != nil {
-			fmt.Fprintf(stderr, "quickstart: %v\n", err)
+			writeQuickstartError(logger, logFormat, stderr, err, "")
 			return 1
 		}
 		_ = json.NewEncoder(stdout).Encode(planned.summary("preview"))
@@ -87,14 +95,14 @@ func runQuickstartCmdWithReady(args []string, stdout, stderr io.Writer, onReady 
 	}
 	prepared, err := prepareQuickstart(opts)
 	if err != nil {
-		fmt.Fprintf(stderr, "quickstart: %v\n", err)
+		writeQuickstartError(logger, logFormat, stderr, err, "")
 		return 1
 	}
 	var console *localConsoleSupervisor
 	if opts.Console {
 		console, err = newLocalConsoleSupervisor(prepared.ConsoleBundle, opts.ConsolePort, prepared.Runtime)
 		if err != nil {
-			fmt.Fprintf(stderr, "quickstart: %v\n", err)
+			writeQuickstartError(logger, logFormat, stderr, err, "")
 			return 1
 		}
 	}
@@ -134,13 +142,25 @@ func runQuickstartCmdWithReady(args []string, stdout, stderr io.Writer, onReady 
 		Stdout: stdout,
 		Stderr: stderr,
 	}); err != nil {
-		fmt.Fprintf(stderr, "quickstart: start Kernel: %v\n", err)
-		if route := quickstartErrorRoute(err, opts); route != "" {
-			fmt.Fprintf(stderr, "  %s\n", route)
-		}
+		writeQuickstartError(logger, logFormat, stderr, fmt.Errorf("start Kernel: %w", err), quickstartErrorRoute(err, opts))
 		return 1
 	}
 	return 0
+}
+
+func writeQuickstartError(logger *slog.Logger, logFormat string, stderr io.Writer, err error, route string) {
+	if logFormat == "json" {
+		attrs := []any{"error", err}
+		if route != "" {
+			attrs = append(attrs, "next_step", route)
+		}
+		logger.Error("quickstart failed", attrs...)
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "quickstart: %v\n", err)
+	if route != "" {
+		_, _ = fmt.Fprintf(stderr, "  %s\n", route)
+	}
 }
 
 // quickstartErrorRoute turns the most common start failures into a concrete
@@ -169,7 +189,7 @@ func installQuickstartRuntimeEnv(runtime *quickstartRuntime) {
 	_ = os.Setenv(quickstartExpiresAtEnv, runtime.ExpiresAt.Format(time.RFC3339Nano))
 }
 
-func parseQuickstartArgs(args []string, stderr io.Writer) (quickstartOptions, int) {
+func parseQuickstartArgs(args []string, stderr io.Writer) (quickstartOptions, error) {
 	opts := quickstartOptions{
 		Addr:    "127.0.0.1",
 		Port:    7714,
@@ -191,13 +211,12 @@ func parseQuickstartArgs(args []string, stderr io.Writer) (quickstartOptions, in
 	fs.IntVar(&opts.ConsolePort, "console-port", 3400, "Local Console port (0 chooses a loopback ephemeral port)")
 	fs.BoolVar(&opts.NoOpen, "no-open", false, "Do not open the local Console in a browser")
 	if err := fs.Parse(args); err != nil {
-		return opts, 2
+		return opts, err
 	}
 	if fs.NArg() > 0 {
-		fmt.Fprintf(stderr, "quickstart: unexpected argument %q\n", fs.Arg(0))
-		return opts, 2
+		return opts, fmt.Errorf("unexpected argument %q", fs.Arg(0))
 	}
-	return opts, 0
+	return opts, nil
 }
 
 func validateQuickstartOptions(opts quickstartOptions) error {

--- a/core/cmd/helm-ai-kernel/quickstart_cmd_test.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd_test.go
@@ -180,13 +180,18 @@ path = "./data/receipts.db"
 }
 
 func TestRunServerCommandServeRequiresPolicy(t *testing.T) {
+	t.Setenv("HELM_LOG_FORMAT", "")
 	var stdout, stderr bytes.Buffer
 	code := runServerCommand("serve", nil, &stdout, &stderr)
 	if code != 2 {
 		t.Fatalf("exit code = %d, want 2", code)
 	}
-	if !strings.Contains(stderr.String(), "requires --policy") {
-		t.Fatalf("stderr missing policy error: %s", stderr.String())
+	var record map[string]any
+	if err := json.Unmarshal(stderr.Bytes(), &record); err != nil {
+		t.Fatalf("stderr is not JSON: %v\n%s", err, stderr.String())
+	}
+	if record["level"] != "ERROR" || record["msg"] != "server command failed" || !strings.Contains(record["error"].(string), "requires --policy") {
+		t.Fatalf("unexpected policy error record: %#v", record)
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
+++ b/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
@@ -269,8 +269,12 @@ func TestQuickstartJSONStdoutIsSingleReadyDocument(t *testing.T) {
 		}
 		// Exercise the same production output boundary that runtime startup uses:
 		// human narration must be redirected while the ready callback owns stdout.
-		_, _ = fmt.Fprintf(serverNarrationWriter(opts), "%sstartup narration%s\n", ColorBold, ColorReset)
-		writeServerReady(opts, opts.BindAddr, opts.Port)
+		_, _ = fmt.Fprintf(opts.Stderr, "%sstartup narration%s\n", ColorBold, ColorReset)
+		logger, format, err := configureServerLogger(opts.Stderr, opts.Mode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeServerReady(opts, logger, format, opts.BindAddr, opts.Port)
 		return nil
 	}
 

--- a/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
+++ b/core/cmd/helm-ai-kernel/quickstart_local_first_run_test.go
@@ -308,6 +308,78 @@ func TestQuickstartJSONStdoutIsSingleReadyDocument(t *testing.T) {
 	}
 }
 
+func TestQuickstartJSONLogFailuresAreStructured(t *testing.T) {
+	t.Setenv("HELM_LOG_FORMAT", "json")
+	t.Setenv("HELM_ADMIN_API_KEY", "")
+	t.Setenv(runtimeTenantIDEnv, "")
+	t.Setenv(runtimePrincipalIDEnv, "")
+	t.Setenv(quickstartExpiresAtEnv, "")
+	originalRunQuickstartServer := runQuickstartServer
+	t.Cleanup(func() { runQuickstartServer = originalRunQuickstartServer })
+	runQuickstartServer = func(serverOptions) error {
+		return errors.New("listen tcp: bind: address already in use")
+	}
+
+	unmarkedDir := filepath.Join(t.TempDir(), "unmarked")
+	if err := os.MkdirAll(unmarkedDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	sentinel := filepath.Join(unmarkedDir, "keep")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, test := range []struct {
+		name string
+		args []string
+		code int
+		want string
+	}{
+		{name: "parse", args: []string{"--unknown"}, code: 2, want: "flag provided but not defined"},
+		{name: "validation", args: []string{"--data-dir", ""}, code: 2, want: "--data-dir must not be empty"},
+		{name: "preparation", args: []string{"--reset", "--yes", "--data-dir", unmarkedDir}, code: 1, want: "unmarked target"},
+		{name: "start", args: []string{"--data-dir", filepath.Join(t.TempDir(), "start")}, code: 1, want: "address already in use"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := runQuickstartCmd(test.args, &stdout, &stderr); code != test.code {
+				t.Fatalf("exit code = %d, want %d; stdout=%s stderr=%s", code, test.code, stdout.String(), stderr.String())
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("failure wrote stdout: %q", stdout.String())
+			}
+
+			decoder := json.NewDecoder(strings.NewReader(stderr.String()))
+			errorRecords := 0
+			foundError := false
+			for {
+				var record map[string]any
+				if err := decoder.Decode(&record); err == io.EOF {
+					break
+				} else if err != nil {
+					t.Fatalf("stderr contains non-JSON output: %v\n%s", err, stderr.String())
+				}
+				if record["level"] == "ERROR" {
+					errorRecords++
+					if record["msg"] == "quickstart failed" && strings.Contains(fmt.Sprint(record["error"]), test.want) {
+						foundError = true
+					}
+				}
+			}
+			if errorRecords != 1 || !foundError {
+				t.Fatalf("structured failure mismatch: errors=%d want=%q stderr=%s", errorRecords, test.want, stderr.String())
+			}
+			if test.name == "start" && !strings.Contains(stderr.String(), `"next_step"`) {
+				t.Fatalf("start failure omitted recovery route: %s", stderr.String())
+			}
+		})
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("preparation failure touched sentinel: %v", err)
+	}
+}
+
 func TestQuickstartResetGuardRejectsUnsafeTargets(t *testing.T) {
 	home := t.TempDir()
 	workspaceRoot := t.TempDir()

--- a/core/cmd/helm-ai-kernel/server_cmd.go
+++ b/core/cmd/helm-ai-kernel/server_cmd.go
@@ -10,9 +10,14 @@ import (
 )
 
 func runServerCommand(name string, args []string, stdout, stderr io.Writer) int {
+	if isHelpRequest(args) {
+		printGlobalCommandHelp(name, stdout)
+		return 0
+	}
 	logger, logFormat, logConfigErr := configureServerLogger(stderr, name)
 	if logConfigErr != nil {
-		_, _ = fmt.Fprintf(stderr, "Error: %v\n", logConfigErr)
+		logger = slog.New(newServerLogHandler(stderr, "json"))
+		writeServerCommandError(logger, "json", stderr, logConfigErr)
 		return 2
 	}
 	if name == "server" && len(args) == 0 {

--- a/core/cmd/helm-ai-kernel/server_cmd.go
+++ b/core/cmd/helm-ai-kernel/server_cmd.go
@@ -4,21 +4,31 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 )
 
 func runServerCommand(name string, args []string, stdout, stderr io.Writer) int {
+	logger, logFormat, logConfigErr := configureServerLogger(stderr, name)
+	if logConfigErr != nil {
+		_, _ = fmt.Fprintf(stderr, "Error: %v\n", logConfigErr)
+		return 2
+	}
 	if name == "server" && len(args) == 0 {
 		if err := startServer(); err != nil {
-			_, _ = fmt.Fprintf(stderr, "Error: start server: %v\n", err)
+			writeServerCommandError(logger, logFormat, stderr, fmt.Errorf("start server: %w", err))
 			return 1
 		}
 		return 0
 	}
 
 	cmd := flag.NewFlagSet(name, flag.ContinueOnError)
-	cmd.SetOutput(stderr)
+	if logFormat == "json" {
+		cmd.SetOutput(io.Discard)
+	} else {
+		cmd.SetOutput(stderr)
+	}
 
 	var opts serverOptions
 	opts.Mode = name
@@ -33,21 +43,24 @@ func runServerCommand(name string, args []string, stdout, stderr io.Writer) int 
 	cmd.BoolVar(&opts.JSON, "json", false, "Print startup status as JSON")
 
 	if err := cmd.Parse(args); err != nil {
+		if logFormat == "json" {
+			writeServerCommandError(logger, logFormat, stderr, err)
+		}
 		return 2
 	}
 	if cmd.NArg() > 0 {
-		_, _ = fmt.Fprintf(stderr, "Error: unexpected argument: %s\n", cmd.Arg(0))
+		writeServerCommandError(logger, logFormat, stderr, fmt.Errorf("unexpected argument: %s", cmd.Arg(0)))
 		return 2
 	}
 	if name == "serve" && opts.PolicyPath == "" {
-		_, _ = fmt.Fprintln(stderr, "Error: helm-ai-kernel serve requires --policy <path>")
+		writeServerCommandError(logger, logFormat, stderr, fmt.Errorf("helm-ai-kernel serve requires --policy <path>"))
 		return 2
 	}
 
 	if opts.PolicyPath != "" {
 		policy, err := loadServePolicy(opts.PolicyPath)
 		if err != nil {
-			_, _ = fmt.Fprintf(stderr, "Error: invalid policy: %v\n", err)
+			writeServerCommandError(logger, logFormat, stderr, fmt.Errorf("invalid policy: %w", err))
 			return 2
 		}
 		if opts.BindAddr == "" {
@@ -63,11 +76,11 @@ func runServerCommand(name string, args []string, stdout, stderr io.Writer) int 
 			}
 		case "postgres", "postgresql":
 			if os.Getenv("DATABASE_URL") == "" {
-				_, _ = fmt.Fprintln(stderr, "Error: policy receipts.store=postgres requires DATABASE_URL")
+				writeServerCommandError(logger, logFormat, stderr, fmt.Errorf("policy receipts.store=postgres requires DATABASE_URL"))
 				return 2
 			}
 		default:
-			_, _ = fmt.Fprintf(stderr, "Error: unsupported receipts.store %q\n", policy.Receipts.Store)
+			writeServerCommandError(logger, logFormat, stderr, fmt.Errorf("unsupported receipts.store %q", policy.Receipts.Store))
 			return 2
 		}
 	}
@@ -84,8 +97,16 @@ func runServerCommand(name string, args []string, stdout, stderr io.Writer) int 
 	}
 
 	if err := runServerWithOptions(opts); err != nil {
-		_, _ = fmt.Fprintf(stderr, "Error: start server: %v\n", err)
+		writeServerCommandError(logger, logFormat, stderr, fmt.Errorf("start server: %w", err))
 		return 1
 	}
 	return 0
+}
+
+func writeServerCommandError(logger *slog.Logger, logFormat string, stderr io.Writer, err error) {
+	if logFormat == "json" {
+		logger.Error("server command failed", "error", err)
+		return
+	}
+	_, _ = fmt.Fprintf(stderr, "Error: %v\n", err)
 }

--- a/core/cmd/helm-ai-kernel/subsystems.go
+++ b/core/cmd/helm-ai-kernel/subsystems.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"runtime"
@@ -238,7 +239,7 @@ func RegisterSubsystemRoutes(mux *http.ServeMux, svc *Services) {
 	// --- MCP Gateway ---
 	mcpGateway, err := newDeployedMCPGateway(svc)
 	if err != nil {
-		log.Printf("[helm] routes: MCP gateway unavailable: %v", err)
+		slog.Warn("MCP gateway unavailable", "error", err)
 	} else {
 		registerDeployedMCPRoutes(mux, mcpGateway)
 		log.Println("[helm] routes: MCP gateway routes registered")

--- a/core/pkg/credentials/credentials_core_coverage_test.go
+++ b/core/pkg/credentials/credentials_core_coverage_test.go
@@ -159,8 +159,13 @@ func TestCoverageGoogleOAuthBranches(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			g := NewGoogleOAuth("client", "secret")
+			bodyReader := strings.NewReader(tc.body)
 			g.httpClient = &http.Client{Transport: credentialsRoundTripFunc(func(*http.Request) (*http.Response, error) {
-				return credentialsHTTPResponse(tc.status, tc.body), nil
+				return &http.Response{
+					StatusCode: tc.status,
+					Body:       io.NopCloser(bodyReader),
+					Header:     make(http.Header),
+				}, nil
 			})}
 			err := tc.call(g)
 			if name == "revoke already revoked" {
@@ -174,6 +179,9 @@ func TestCoverageGoogleOAuthBranches(t *testing.T) {
 			}
 			if strings.Contains(err.Error(), "SECRET-CANARY") {
 				t.Fatalf("oauth error leaked provider response body: %v", err)
+			}
+			if (name == "exchange status" || name == "refresh status") && bodyReader.Len() != 0 {
+				t.Fatalf("oauth error response body was not drained: %d bytes remain", bodyReader.Len())
 			}
 		})
 	}

--- a/core/pkg/credentials/credentials_core_coverage_test.go
+++ b/core/pkg/credentials/credentials_core_coverage_test.go
@@ -126,7 +126,7 @@ func TestCoverageGoogleOAuthBranches(t *testing.T) {
 		body   string
 		call   func(*GoogleOAuth) error
 	}{
-		"exchange status": {http.StatusBadRequest, `bad exchange`, func(g *GoogleOAuth) error {
+		"exchange status": {http.StatusBadRequest, `{"access_token":"SECRET-CANARY"}`, func(g *GoogleOAuth) error {
 			_, err := g.ExchangeCode(ctx, "code", "verifier", "redirect")
 			return err
 		}},
@@ -134,7 +134,7 @@ func TestCoverageGoogleOAuthBranches(t *testing.T) {
 			_, err := g.ExchangeCode(ctx, "code", "verifier", "redirect")
 			return err
 		}},
-		"refresh status": {http.StatusUnauthorized, `bad refresh`, func(g *GoogleOAuth) error {
+		"refresh status": {http.StatusUnauthorized, `{"refresh_token":"SECRET-CANARY"}`, func(g *GoogleOAuth) error {
 			_, err := g.RefreshToken(ctx, "refresh")
 			return err
 		}},
@@ -171,6 +171,9 @@ func TestCoverageGoogleOAuthBranches(t *testing.T) {
 			}
 			if err == nil {
 				t.Fatal("expected oauth error")
+			}
+			if strings.Contains(err.Error(), "SECRET-CANARY") {
+				t.Fatalf("oauth error leaked provider response body: %v", err)
 			}
 		})
 	}

--- a/core/pkg/credentials/credentials_core_coverage_test.go
+++ b/core/pkg/credentials/credentials_core_coverage_test.go
@@ -180,7 +180,7 @@ func TestCoverageGoogleOAuthBranches(t *testing.T) {
 			if strings.Contains(err.Error(), "SECRET-CANARY") {
 				t.Fatalf("oauth error leaked provider response body: %v", err)
 			}
-			if (name == "exchange status" || name == "refresh status") && bodyReader.Len() != 0 {
+			if (strings.Contains(name, " status") || name == "revoke already revoked") && bodyReader.Len() != 0 {
 				t.Fatalf("oauth error response body was not drained: %d bytes remain", bodyReader.Len())
 			}
 		})

--- a/core/pkg/credentials/google_oauth.go
+++ b/core/pkg/credentials/google_oauth.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -84,6 +85,7 @@ func (g *GoogleOAuth) ExchangeCode(ctx context.Context, code, codeVerifier, redi
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
+		drainOAuthErrorBody(resp.Body)
 		return nil, fmt.Errorf("token exchange failed with status: %d", resp.StatusCode)
 	}
 
@@ -117,6 +119,7 @@ func (g *GoogleOAuth) RefreshToken(ctx context.Context, refreshToken string) (*T
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
+		drainOAuthErrorBody(resp.Body)
 		return nil, fmt.Errorf("token refresh failed with status: %d", resp.StatusCode)
 	}
 
@@ -126,6 +129,10 @@ func (g *GoogleOAuth) RefreshToken(ctx context.Context, refreshToken string) (*T
 	}
 
 	return &tokenResp, nil
+}
+
+func drainOAuthErrorBody(body io.Reader) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, 1<<20))
 }
 
 // GetUserInfo fetches user info using an access token.

--- a/core/pkg/credentials/google_oauth.go
+++ b/core/pkg/credentials/google_oauth.go
@@ -150,6 +150,7 @@ func (g *GoogleOAuth) GetUserInfo(ctx context.Context, accessToken string) (*Use
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
+		drainOAuthErrorBody(resp.Body)
 		return nil, fmt.Errorf("user info request failed: %d", resp.StatusCode)
 	}
 
@@ -176,6 +177,7 @@ func (g *GoogleOAuth) RevokeToken(ctx context.Context, token string) error {
 		return fmt.Errorf("revoke failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	drainOAuthErrorBody(resp.Body)
 
 	// 200 = success, 400 = already revoked (both are okay)
 	if resp.StatusCode != 200 && resp.StatusCode != 400 {

--- a/core/pkg/credentials/google_oauth.go
+++ b/core/pkg/credentials/google_oauth.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -85,8 +84,7 @@ func (g *GoogleOAuth) ExchangeCode(ctx context.Context, code, codeVerifier, redi
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token exchange failed: %s", string(body))
+		return nil, fmt.Errorf("token exchange failed with status: %d", resp.StatusCode)
 	}
 
 	var tokenResp TokenResponse
@@ -119,8 +117,7 @@ func (g *GoogleOAuth) RefreshToken(ctx context.Context, refreshToken string) (*T
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("token refresh failed: %s", string(body))
+		return nil, fmt.Errorf("token refresh failed with status: %d", resp.StatusCode)
 	}
 
 	var tokenResp TokenResponse


### PR DESCRIPTION
## Summary

- emit daemon `serve`/`server` output as collector-compatible JSON by default, including startup narration, command-validation/startup failures, invalid-format fallback diagnostics, generated-key warning, readiness, legacy `log` calls, and shutdown
- preserve warning/error severity at daemon call sites while retaining the legacy bridge for informational lifecycle messages; degraded MCP gateway setup is explicitly `WARN`
- preserve the interactive quickstart journey and daemon help as text by default, including combined flag/help forms; an explicit `HELM_LOG_FORMAT=json|text` overrides every quickstart runtime failure from parse through server start
- align JSON records with the live telemetry-agent contract: UTC millisecond `timestamp`, `level`, `msg`, plus existing `trace_id`, `span_id`, and `correlation_id` enrichment
- reject unknown formats before server side effects while emitting one machine-readable fallback error
- prevent Google OAuth error bodies from reaching the generic logged `error` field, and bounded-drain every response body not otherwise decoded before close

Tracks [HELM-475](https://linear.app/mindburn/issue/HELM-475).

## Validation

- `go test ./cmd/helm-ai-kernel -run '^(TestRunServerCommandReportsStartupFailure|TestRunServerCommandServeRequiresPolicy|TestRunServerCommandInvalidLogFormatIsStructured|TestHelpMatrix|TestUnavailableMCPGatewayLogsWarning|TestQuickstartJSONLogFailuresAreStructured)$' -count=1`
- `go test ./pkg/credentials -run '^TestCoverageGoogleOAuthBranches$' -count=1` (secret canaries excluded; exchange, refresh, userinfo and revoke bodies drained)
- `go test ./cmd/helm-ai-kernel ./pkg/credentials -count=1`
- `go test -race ./cmd/helm-ai-kernel -count=1`
- `make quantum-crypto-inventory`
- `make quality-pr`
- real built-binary daemon smoke: 39/39 non-empty stderr lines parsed as JSON, stdout empty, no ANSI; startup, key warning, readiness and graceful shutdown observed
- real quickstart parse/validation smokes under `HELM_LOG_FORMAT=json`: exit 2, stdout empty, exactly one JSON `ERROR`, no ANSI/plain fragments
- real occupied-port quickstart smoke: exit 1, all stderr records JSON, exactly one `ERROR` with a structured `next_step`; default text-mode validation remains human-readable
- real invalid-format daemon smoke: exactly one fallback JSON `ERROR`, exit 2
- real combined `serve --policy unused.toml --help`: human stdout, empty stderr, exit 0, including with invalid runtime log-format env
- cross-repo contract check against `mindburn-infra/Ansible/roles/k3s/templates/manifests/k3s-telemetry-agent.yaml.j2` (`timestamp`, `level`, `msg`, `trace_id`, `span_id`)

## Runtime gate still open

This PR does **not** claim HELM-475 runtime acceptance. After merge, deploy the exact image only to an approved QA/dev slot and prove a stored kernel request row has non-empty `SeverityText`, request `TraceId`, message-only `Body`, and no secret canary. Stage was not touched.
