### PR TITLE
fix(release): correct v0.8.4 console sidecar pin

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,10 +6,10 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.1",
       "source": {
-        "commit": "38ab285d38fa3382a9e4c5180bb05659deaf61d5",
-        "tree": "1832cbd65ddeebb22f66e3d14da8ee998249029b",
+        "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
+        "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
         "version": "0.2.1",
-        "package_lock_sha256": "0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1"
+        "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9"
       }
     },
     {

--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -6,10 +6,10 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.1",
       "source": {
-        "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
-        "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
+        "commit": "38ab285d38fa3382a9e4c5180bb05659deaf61d5",
+        "tree": "1832cbd65ddeebb22f66e3d14da8ee998249029b",
         "version": "0.2.1",
-        "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9"
+        "package_lock_sha256": "0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1"
       }
     },
     {
@@ -28,10 +28,10 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.4",
       "source": {
-        "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
-        "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
+        "commit": "38ab285d38fa3382a9e4c5180bb05659deaf61d5",
+        "tree": "1832cbd65ddeebb22f66e3d14da8ee998249029b",
         "version": "0.2.1",
-        "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9"
+        "package_lock_sha256": "0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1"
       }
     }
   ]

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,10 +28,10 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
-    "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
-    "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
+    "commit": "38ab285d38fa3382a9e4c5180bb05659deaf61d5",
+    "tree": "1832cbd65ddeebb22f66e3d14da8ee998249029b",
     "version": "0.2.1",
-    "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9",
+    "package_lock_sha256": "0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1",
 }
 RELEASE_WORKFLOW_REF = "refs/tags/helm-console-sidecar-v0.8.1"
 TEST_WORKFLOW_REF = "refs/tags/test-console-source"

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -28,6 +28,12 @@ SOURCE = {
 }
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 RELEASE_SOURCE_PIN = {
+    "commit": "c0fd6b4467bed8f03fdbcbca16544ea440cbb34d",
+    "tree": "c4175cccfaf1a3317f845c423e3a6e9d5a9b354a",
+    "version": "0.2.1",
+    "package_lock_sha256": "5a548841282cac8e37a7380088cbfdf9aec08dba4ed33200a483644a362860c9",
+}
+V084_RELEASE_SOURCE_PIN = {
     "commit": "38ab285d38fa3382a9e4c5180bb05659deaf61d5",
     "tree": "1832cbd65ddeebb22f66e3d14da8ee998249029b",
     "version": "0.2.1",
@@ -571,6 +577,18 @@ class ConsoleLocalSidecarTests(unittest.TestCase):
         self.assertEqual(pin["source_repository"], sidecar.CONSOLE_REPOSITORY)
         self.assertEqual(pin["source"], RELEASE_SOURCE_PIN)
         self.assertEqual(pin["workflow_ref"], RELEASE_WORKFLOW_REF)
+
+    def test_v084_source_pin_matches_the_exact_console_release_contract(self) -> None:
+        pin = sidecar.resolve_pin(
+            REPOSITORY_ROOT / "release/console-local-sidecar-pins.json",
+            "v0.8.4",
+        )
+        self.assertEqual(pin["source_repository"], sidecar.CONSOLE_REPOSITORY)
+        self.assertEqual(pin["source"], V084_RELEASE_SOURCE_PIN)
+        self.assertEqual(
+            pin["workflow_ref"],
+            "refs/tags/helm-console-sidecar-v0.8.4",
+        )
 
     def test_manifest_digest_flows_into_normal_and_reproducible_linker_flags(self) -> None:
         expected_digest = "d" * 64


### PR DESCRIPTION
## Summary
- update only the v0.8.4 Console local-sidecar source tuple to the qualified 38ab285 closure
- add a release-specific regression while preserving the immutable v0.8.1 and v0.8.3 pins exactly

## Live source authority
- workflow ref: `refs/tags/helm-console-sidecar-v0.8.4`
- tag target: `38ab285d38fa3382a9e4c5180bb05659deaf61d5`
- source tree: `1832cbd65ddeebb22f66e3d14da8ee998249029b`
- Console package version: `0.2.1`
- package-lock SHA-256: `0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1`

Ivan performed the guarded human release-authority retag and the tuple was independently re-read from GitHub before this PR.

## Review correction
The initial commit accidentally rewrote the historical v0.8.1 row. Forward commit `46e83ccdd697a753725e6ff85058f557340b211e` restores that row and its regression fixture. The current unique release-pin diff changes only v0.8.4; v0.8.1 and v0.8.3 remain on `c0fd6b4467bed8f03fdbcbca16544ea440cbb34d`.

Current base: `7a7b2d780144ab4abc36c21e7003366b0e680c74`
Current exact head after guarded base update: `a8028b64a454dbae5ab80d205e966b5bc3e0dfdf`

## Validation
- exact pin resolver returned the full v0.8.4 tuple above
- `scripts/release/console_local_sidecar_test.py`: 29/29 pass in a clean PATH
- full impact-aware `make quality-pr`: all applicable blocking gates pass
- independent review caught the historical-row defect before merge and verified the forward correction shape

## Release hold
No Kernel `v0.8.4` tag or GitHub Release exists yet. Merge this correction before any Kernel release tag is created; the remaining release train and final exact-head qualification still apply.