### PR TITLE
fix(release): make published drift retry executable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1396,8 +1396,8 @@ jobs:
           for attempt in $(seq 1 40); do
             if python3 scripts/release/check_version_drift.py \
               --expected-version "$VERSION" \
-              --surface-timeout 10 \
-              published; then
+              published \
+              --surface-timeout 10; then
               exit 0
             fi
             if [ "$attempt" -lt 40 ]; then

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -177,7 +177,10 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertIn("always()", post_release)
         self.assertIn("needs.console-release-assets.result == 'success'", post_release)
         self.assertIn("for attempt in $(seq 1 40); do", post_release)
-        self.assertIn("--surface-timeout 10", post_release)
+        self.assertRegex(
+            post_release,
+            r'--expected-version "\$VERSION" \\\n\s+published \\\n\s+--surface-timeout 10',
+        )
         self.assertIn("Published version surfaces did not converge within the bounded retry budget.", post_release)
         self.assertLess(
             post_release.index("- name: Wait for published version convergence"),


### PR DESCRIPTION
## Root cause

The v0.8.3 release published its artifacts, but post-release-version-drift failed because the workflow passed the published-only --surface-timeout option before the published argparse subcommand. Every retry exited during argument parsing instead of checking public surfaces.

## Fix

- place published before --surface-timeout
- strengthen the release workflow contract test to lock the executable argument order

## Evidence

- reproduced from release run 31330205611 / job 93295444919
- focused release workflow contract: 7/7 pass
- corrected CLI form reaches the published checks rather than argparse failure
- diff check clean

## Release gate

This must merge before creating the Kernel v0.8.4 tag. It does not publish or deploy anything by itself.