### PR TITLE
fix(cli): finish v0.8.4 discoverability and preview UX

### DIFF
--- a/core/cmd/helm-ai-kernel/cli_discoverability_test.go
+++ b/core/cmd/helm-ai-kernel/cli_discoverability_test.go
@@ -171,6 +171,38 @@ func TestCompletionScriptsAreDeterministicAndSideEffectFree(t *testing.T) {
 	}
 }
 
+func TestCompletionAliasesReuseCanonicalContexts(t *testing.T) {
+	isolateDiscoverabilityTest(t)
+
+	for _, tc := range []struct {
+		path []string
+		want []string
+	}{
+		{path: []string{"launchpad"}, want: completionCandidates([]string{"launch"})},
+		{path: []string{"--help"}, want: completionCandidates([]string{"help"})},
+		{path: []string{"-h"}, want: completionCandidates([]string{"help"})},
+		{path: []string{"help", "launchpad"}, want: completionCandidates([]string{"help", "launch"})},
+	} {
+		if got := completionCandidates(tc.path); !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("completionCandidates(%v) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+
+	bash := runDiscoverabilityCommand(t, "completion", "bash")
+	for _, token := range []string{`"launchpad") words="matrix apps substrates plan status logs repair delete evidence promote secrets imports"`, `"--help") words=`, `"-h") words=`} {
+		if !strings.Contains(bash, token) {
+			t.Fatalf("bash completion omitted alias context %q", token)
+		}
+	}
+
+	zsh := runDiscoverabilityCommand(t, "completion", "zsh")
+	for _, token := range []string{`"launchpad")`, `"--help")`, `"-h")`} {
+		if !strings.Contains(zsh, token) {
+			t.Fatalf("zsh completion omitted alias context %q", token)
+		}
+	}
+}
+
 func TestCompletionRejectsMissingInvalidAndExtraArguments(t *testing.T) {
 	isolateDiscoverabilityTest(t)
 

--- a/core/cmd/helm-ai-kernel/cli_discoverability_test.go
+++ b/core/cmd/helm-ai-kernel/cli_discoverability_test.go
@@ -26,7 +26,7 @@ func TestHelpJSONCatalogIsStableAndSideEffectFree(t *testing.T) {
 	if err := json.Unmarshal([]byte(first), &raw); err != nil {
 		t.Fatalf("help --json is not valid JSON: %v\n%s", err, first)
 	}
-	if len(raw) != 2 || raw["schema_version"] == nil || raw["commands"] == nil {
+	if raw["schema_version"] == nil || raw["commands"] == nil {
 		t.Fatalf("unexpected catalog schema: %s", first)
 	}
 
@@ -75,6 +75,51 @@ func TestHelpJSONCatalogIsStableAndSideEffectFree(t *testing.T) {
 	if !catalogContainsName(catalog, "watch") {
 		t.Fatal("catalog omitted the integrated watch command")
 	}
+
+	wantSections := []struct {
+		id    string
+		title string
+	}{
+		{id: "get-started", title: "Get started"},
+		{id: "use-helm", title: "Use HELM"},
+		{id: "evidence", title: "Evidence"},
+		{id: "operate", title: "Operate"},
+	}
+	if len(catalog.Sections) != len(wantSections) {
+		t.Fatalf("catalog section count=%d, want %d", len(catalog.Sections), len(wantSections))
+	}
+	seenSections := make(map[string]struct{}, len(catalog.Sections))
+	for index, section := range catalog.Sections {
+		if section.ID != wantSections[index].id || section.Title != wantSections[index].title {
+			t.Fatalf("catalog section[%d]=%+v, want id=%q title=%q", index, section, wantSections[index].id, wantSections[index].title)
+		}
+		if len(section.Commands) == 0 {
+			t.Fatalf("catalog section %q is empty", section.ID)
+		}
+		seenSections[section.Title] = struct{}{}
+		for _, command := range section.Commands {
+			if command.Group != section.Title {
+				t.Fatalf("command %q group=%q, want %q", command.Name, command.Group, section.Title)
+			}
+		}
+	}
+	if !sectionContainsCommand(catalog, "get-started", "quickstart") {
+		t.Fatal("get-started section omitted quickstart")
+	}
+	if !sectionContainsCommand(catalog, "use-helm", "watch") {
+		t.Fatal("use-helm section omitted watch")
+	}
+	if !sectionContainsCommand(catalog, "evidence", "verify") {
+		t.Fatal("evidence section omitted verify")
+	}
+	if !sectionContainsCommand(catalog, "operate", "workstation") {
+		t.Fatal("operate section omitted workstation")
+	}
+	for _, title := range []string{"Get started", "Use HELM", "Evidence", "Operate"} {
+		if _, ok := seenSections[title]; !ok {
+			t.Fatalf("missing catalog section %q", title)
+		}
+	}
 }
 
 func TestCompletionScriptsAreDeterministicAndSideEffectFree(t *testing.T) {
@@ -99,6 +144,27 @@ func TestCompletionScriptsAreDeterministicAndSideEffectFree(t *testing.T) {
 			for _, command := range commandCatalog().Commands {
 				if !strings.Contains(first, command.Name) {
 					t.Fatalf("%s completion omitted %q", shell, command.Name)
+				}
+			}
+			for _, token := range []string{
+				"launch",
+				"delete",
+				"evidence",
+				"setup",
+				"codex",
+				"status",
+				"quickstart",
+				"--console",
+				"receipts",
+				"tail",
+				"--agent",
+				"scan",
+				"--risk-envelope",
+				"watch",
+				"--api-key-file",
+			} {
+				if !strings.Contains(first, token) {
+					t.Fatalf("%s completion omitted nested token %q", shell, token)
 				}
 			}
 		})
@@ -223,6 +289,55 @@ func TestNestedHelpReachesLeafFlagSets(t *testing.T) {
 	}
 }
 
+func TestFrontDoorCommandsExposeSpecificHelp(t *testing.T) {
+	isolateDiscoverabilityTest(t)
+
+	for _, tc := range []struct {
+		name   string
+		args   []string
+		want   string
+		unwant string
+	}{
+		{"scan", []string{"scan", "--help"}, "--risk-envelope FILE", "Run `helm-ai-kernel help --all` to list commands."},
+		{"receipts", []string{"receipts", "--help"}, "--agent <id>", "Run `helm-ai-kernel help --all` to list commands."},
+		{"watch", []string{"watch", "--help"}, "--api-key-file FILE", "Run `helm-ai-kernel help --all` to list commands."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := Run(append([]string{"helm-ai-kernel"}, tc.args...), &stdout, &stderr)
+			if code != 0 || stderr.Len() != 0 {
+				t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tc.want) || strings.Contains(stdout.String(), tc.unwant) {
+				t.Fatalf("help output = %q", stdout.String())
+			}
+		})
+	}
+}
+
+func TestHelpAllGroupsCommandsByUserJourney(t *testing.T) {
+	isolateDiscoverabilityTest(t)
+
+	output := runDiscoverabilityCommand(t, "help", "--all")
+	sections := []string{"Get started:", "Use HELM:", "Evidence:", "Operate:"}
+	last := -1
+	for _, section := range sections {
+		index := strings.Index(output, section)
+		if index < 0 {
+			t.Fatalf("help --all omitted section %q\n%s", section, output)
+		}
+		if index <= last {
+			t.Fatalf("help --all section order is unstable\n%s", output)
+		}
+		last = index
+	}
+	for _, expected := range []string{"quickstart", "watch", "verify", "workstation"} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("help --all omitted %q\n%s", expected, output)
+		}
+	}
+}
+
 func isolateDiscoverabilityTest(t *testing.T) {
 	t.Helper()
 	root := t.TempDir()
@@ -285,6 +400,20 @@ func catalogContainsName(catalog commandCatalogDocument, name string) bool {
 	for _, command := range catalog.Commands {
 		if command.Name == name {
 			return true
+		}
+	}
+	return false
+}
+
+func sectionContainsCommand(catalog commandCatalogDocument, sectionID, commandName string) bool {
+	for _, section := range catalog.Sections {
+		if section.ID != sectionID {
+			continue
+		}
+		for _, command := range section.Commands {
+			if command.Name == commandName {
+				return true
+			}
 		}
 	}
 	return false

--- a/core/cmd/helm-ai-kernel/cli_support.go
+++ b/core/cmd/helm-ai-kernel/cli_support.go
@@ -181,67 +181,218 @@ func printCompletionUsage(out io.Writer) {
 }
 
 func completionScript(shell string) (string, bool) {
-	words := completionWords()
+	rootWords := completionWords()
+	contexts := completionContexts()
 	switch shell {
 	case "bash":
-		return bashCompletionScript(strings.Join(words, " ")), true
+		return bashCompletionScript(rootWords, contexts), true
 	case "zsh":
-		return zshCompletionScript(words), true
+		return zshCompletionScript(rootWords, contexts), true
 	case "fish":
-		return fishCompletionScript(words), true
+		return fishCompletionScript(rootWords, contexts), true
 	case "powershell":
-		return powerShellCompletionScript(words), true
+		return powerShellCompletionScript(rootWords, contexts), true
 	default:
 		return "", false
 	}
 }
 
-func bashCompletionScript(words string) string {
-	return fmt.Sprintf(`# bash completion for helm-ai-kernel
-_helm_ai_kernel_completion() {
-  local cur
-  cur="${COMP_WORDS[COMP_CWORD]}"
-  COMPREPLY=( $(compgen -W %q -- "$cur") )
-}
-complete -F _helm_ai_kernel_completion helm-ai-kernel
-`, words)
+func bashCompletionScript(rootWords []string, contexts []completionContext) string {
+	var script strings.Builder
+	fmt.Fprintf(&script, "# bash completion for helm-ai-kernel\n")
+	script.WriteString("_helm_ai_kernel_completion() {\n")
+	script.WriteString("  local cur context words\n")
+	script.WriteString("  cur=\"${COMP_WORDS[COMP_CWORD]}\"\n")
+	fmt.Fprintf(&script, "  words=%q\n", strings.Join(rootWords, " "))
+	script.WriteString("  if (( COMP_CWORD > 1 )); then\n")
+	script.WriteString("    context=\"${COMP_WORDS[1]}\"\n")
+	script.WriteString("    if (( COMP_CWORD >= 3 )) && [[ -n \"${COMP_WORDS[2]}\" ]]; then\n")
+	script.WriteString("      context=\"$context ${COMP_WORDS[2]}\"\n")
+	script.WriteString("    fi\n")
+	script.WriteString("    case \"$context\" in\n")
+	for _, context := range contexts {
+		if len(context.Path) < 2 {
+			continue
+		}
+		fmt.Fprintf(&script, "      %q) words=%q ;;\n", strings.Join(context.Path, " "), strings.Join(uniqueStrings(context.Candidates), " "))
+	}
+	script.WriteString("    esac\n")
+	script.WriteString("    if [[ \"$words\" == ")
+	fmt.Fprintf(&script, "%q", strings.Join(rootWords, " "))
+	script.WriteString(" ]]; then\n")
+	script.WriteString("      context=\"${COMP_WORDS[1]}\"\n")
+	script.WriteString("      case \"$context\" in\n")
+	for _, context := range contexts {
+		if len(context.Path) != 1 {
+			continue
+		}
+		fmt.Fprintf(&script, "        %q) words=%q ;;\n", strings.Join(context.Path, " "), strings.Join(uniqueStrings(context.Candidates), " "))
+	}
+	script.WriteString("      esac\n")
+	script.WriteString("    fi\n")
+	script.WriteString("  fi\n")
+	script.WriteString("  COMPREPLY=( $(compgen -W \"$words\" -- \"$cur\") )\n")
+	script.WriteString("}\n")
+	script.WriteString("complete -F _helm_ai_kernel_completion helm-ai-kernel\n")
+	return script.String()
 }
 
-func zshCompletionScript(words []string) string {
+func zshCompletionScript(rootWords []string, contexts []completionContext) string {
 	var script strings.Builder
 	script.WriteString("#compdef helm-ai-kernel\n\n")
 	script.WriteString("_helm_ai_kernel_completion() {\n")
-	script.WriteString("  local -a commands\n")
-	script.WriteString("  commands=(\n")
-	for _, word := range words {
-		fmt.Fprintf(&script, "    %q\n", word)
+	script.WriteString("  local -a choices\n")
+	script.WriteString("  local context\n")
+	script.WriteString("  if (( CURRENT > 2 )); then\n")
+	script.WriteString("    context=\"$words[2]\"\n")
+	script.WriteString("    if (( CURRENT > 3 )) && [[ -n \"$words[3]\" ]]; then\n")
+	script.WriteString("      context=\"$context $words[3]\"\n")
+	script.WriteString("    fi\n")
+	script.WriteString("    case \"$context\" in\n")
+	for _, context := range contexts {
+		if len(context.Path) < 2 {
+			continue
+		}
+		fmt.Fprintf(&script, "      %q)\n", strings.Join(context.Path, " "))
+		script.WriteString("        choices=(\n")
+		for _, word := range uniqueStrings(context.Candidates) {
+			fmt.Fprintf(&script, "          %q\n", word)
+		}
+		script.WriteString("        ) ;;\n")
 	}
-	script.WriteString("  )\n")
-	script.WriteString("  _describe -t commands 'helm-ai-kernel command' commands\n")
+	script.WriteString("    esac\n")
+	script.WriteString("    if (( $#choices == 0 )); then\n")
+	script.WriteString("      context=\"$words[2]\"\n")
+	script.WriteString("      case \"$context\" in\n")
+	for _, context := range contexts {
+		if len(context.Path) != 1 {
+			continue
+		}
+		fmt.Fprintf(&script, "        %q)\n", strings.Join(context.Path, " "))
+		script.WriteString("          choices=(\n")
+		for _, word := range uniqueStrings(context.Candidates) {
+			fmt.Fprintf(&script, "            %q\n", word)
+		}
+		script.WriteString("          ) ;;\n")
+	}
+	script.WriteString("      esac\n")
+	script.WriteString("    fi\n")
+	script.WriteString("  fi\n")
+	script.WriteString("  if (( $#choices == 0 )); then\n")
+	script.WriteString("    choices=(\n")
+	for _, word := range rootWords {
+		fmt.Fprintf(&script, "      %q\n", word)
+	}
+	script.WriteString("    )\n")
+	script.WriteString("  fi\n")
+	script.WriteString("  _describe -t commands 'helm-ai-kernel command' choices\n")
 	script.WriteString("}\n\n")
 	script.WriteString("compdef _helm_ai_kernel_completion helm-ai-kernel\n")
 	return script.String()
 }
 
-func fishCompletionScript(words []string) string {
+func fishCompletionScript(rootWords []string, contexts []completionContext) string {
 	var script strings.Builder
 	script.WriteString("# fish completion for helm-ai-kernel\n")
-	script.WriteString("complete -c helm-ai-kernel -f\n")
-	for _, word := range words {
-		fmt.Fprintf(&script, "complete -c helm-ai-kernel -n '__fish_use_subcommand' -a %q\n", word)
+	script.WriteString("function __fish_helm_ai_kernel_completion\n")
+	script.WriteString("  set -l tokens (commandline -opc)\n")
+	script.WriteString("  set -e tokens[1]\n")
+	script.WriteString("  set -l choices")
+	script.WriteByte('\n')
+	script.WriteString("  set -l context\n")
+	script.WriteString("  if test (count $tokens) -ge 1\n")
+	script.WriteString("    set context $tokens[1]\n")
+	script.WriteString("  end\n")
+	script.WriteString("  if test (count $tokens) -ge 2\n")
+	script.WriteString("    set context \"$tokens[1] $tokens[2]\"\n")
+	script.WriteString("  end\n")
+	script.WriteString("  switch $context\n")
+	for _, context := range contexts {
+		if len(context.Path) < 2 {
+			continue
+		}
+		fmt.Fprintf(&script, "    case %q\n", strings.Join(context.Path, " "))
+		for _, word := range uniqueStrings(context.Candidates) {
+			fmt.Fprintf(&script, "      set -a choices %q\n", word)
+		}
 	}
+	script.WriteString("  end\n")
+	script.WriteString("  if test (count $choices) -eq 0 -a (count $tokens) -ge 1\n")
+	script.WriteString("    switch $tokens[1]\n")
+	for _, context := range contexts {
+		if len(context.Path) != 1 {
+			continue
+		}
+		fmt.Fprintf(&script, "      case %q\n", strings.Join(context.Path, " "))
+		for _, word := range uniqueStrings(context.Candidates) {
+			fmt.Fprintf(&script, "        set -a choices %q\n", word)
+		}
+	}
+	script.WriteString("    end\n")
+	script.WriteString("  end\n")
+	script.WriteString("  if test (count $choices) -eq 0\n")
+	for _, word := range rootWords {
+		fmt.Fprintf(&script, "    set -a choices %q\n", word)
+	}
+	script.WriteString("  end\n")
+	script.WriteString("  for word in $choices\n")
+	script.WriteString("    echo $word\n")
+	script.WriteString("  end\n")
+	script.WriteString("end\n")
+	script.WriteString("complete -c helm-ai-kernel -f -a '(__fish_helm_ai_kernel_completion)'\n")
 	return script.String()
 }
 
-func powerShellCompletionScript(words []string) string {
+func powerShellCompletionScript(rootWords []string, contexts []completionContext) string {
 	var script strings.Builder
 	script.WriteString("Register-ArgumentCompleter -Native -CommandName helm-ai-kernel -ScriptBlock {\n")
 	script.WriteString("  param($wordToComplete, $commandAst, $cursorPosition)\n")
-	script.WriteString("  @(\n")
-	for _, word := range words {
-		fmt.Fprintf(&script, "    %s\n", powerShellQuote(word))
+	script.WriteString("  $elements = @($commandAst.CommandElements | ForEach-Object { $_.Extent.Text })\n")
+	script.WriteString("  if ($elements.Length -gt 0) { $elements = $elements[1..($elements.Length - 1)] }\n")
+	script.WriteString("  $choices = @()\n")
+	script.WriteString("  $context = ''\n")
+	script.WriteString("  if ($elements.Length -ge 2) { $context = \"$($elements[0]) $($elements[1])\" }\n")
+	script.WriteString("  switch ($context) {\n")
+	for _, context := range contexts {
+		if len(context.Path) < 2 {
+			continue
+		}
+		fmt.Fprintf(&script, "    %s { $choices = @(", powerShellQuote(strings.Join(context.Path, " ")))
+		for index, word := range uniqueStrings(context.Candidates) {
+			if index > 0 {
+				script.WriteString(", ")
+			}
+			script.WriteString(powerShellQuote(word))
+		}
+		script.WriteString(") }\n")
 	}
-	script.WriteString("  ) | Where-Object { $_ -like \"$wordToComplete*\" } | ForEach-Object {\n")
+	script.WriteString("  }\n")
+	script.WriteString("  if ($choices.Length -eq 0 -and $elements.Length -ge 1) {\n")
+	script.WriteString("    switch ($elements[0]) {\n")
+	for _, context := range contexts {
+		if len(context.Path) != 1 {
+			continue
+		}
+		fmt.Fprintf(&script, "      %s { $choices = @(", powerShellQuote(strings.Join(context.Path, " ")))
+		for index, word := range uniqueStrings(context.Candidates) {
+			if index > 0 {
+				script.WriteString(", ")
+			}
+			script.WriteString(powerShellQuote(word))
+		}
+		script.WriteString(") }\n")
+	}
+	script.WriteString("    }\n")
+	script.WriteString("  }\n")
+	script.WriteString("  if ($choices.Length -eq 0) { $choices = @(")
+	for index, word := range rootWords {
+		if index > 0 {
+			script.WriteString(", ")
+		}
+		script.WriteString(powerShellQuote(word))
+	}
+	script.WriteString(") }\n")
+	script.WriteString("  $choices | Where-Object { $_ -like \"$wordToComplete*\" } | ForEach-Object {\n")
 	script.WriteString("    [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)\n")
 	script.WriteString("  }\n")
 	script.WriteString("}\n")

--- a/core/cmd/helm-ai-kernel/local_console_test.go
+++ b/core/cmd/helm-ai-kernel/local_console_test.go
@@ -584,6 +584,47 @@ func TestQuickstartConsoleFailsBeforeMutationForExternalOverrideOrMissingBundle(
 	}
 }
 
+func TestQuickstartConsoleResetRejectsMissingBundleBeforeMutation(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "bin", "helm-ai-kernel")
+	if err := os.MkdirAll(filepath.Dir(executable), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executable, []byte("kernel"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	original := localConsoleExecutable
+	localConsoleExecutable = func() (string, error) { return executable, nil }
+	t.Cleanup(func() { localConsoleExecutable = original })
+
+	dataDir := filepath.Join(dir, "quickstart-data")
+	if err := os.MkdirAll(filepath.Join(dataDir, "quickstart"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, quickstartOwnershipMarker), []byte(quickstartOwnershipMarkerContents), 0600); err != nil {
+		t.Fatal(err)
+	}
+	sentinelPath := filepath.Join(dataDir, "quickstart", "sentinel.txt")
+	if err := os.WriteFile(sentinelPath, []byte("preserve"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runQuickstartCmdWithReady([]string{"--console", "--reset", "--yes", "--data-dir", dataDir}, &stdout, &stderr, nil)
+	if code != 1 {
+		t.Fatalf("reset exit code = %d, stdout = %s stderr = %s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Console-including packaged layout") {
+		t.Fatalf("missing bundle error = %s", stderr.String())
+	}
+	if got, err := os.ReadFile(sentinelPath); err != nil || string(got) != "preserve" {
+		t.Fatalf("reset mutated sentinel = %q, err=%v", got, err)
+	}
+	if marker, err := os.ReadFile(filepath.Join(dataDir, quickstartOwnershipMarker)); err != nil || string(marker) != quickstartOwnershipMarkerContents {
+		t.Fatalf("reset mutated ownership marker = %q, err=%v", marker, err)
+	}
+}
+
 func TestTrustedLocalConsoleReleaseRejectsMissingDigestAndTampering(t *testing.T) {
 	target, err := localConsoleTarget()
 	if err != nil {

--- a/core/cmd/helm-ai-kernel/local_console_test.go
+++ b/core/cmd/helm-ai-kernel/local_console_test.go
@@ -567,14 +567,17 @@ func TestQuickstartConsoleFailsBeforeMutationForExternalOverrideOrMissingBundle(
 	t.Cleanup(func() { localConsoleExecutable = original })
 	dataDir := filepath.Join(dir, "quickstart-data")
 	var stdout, stderr bytes.Buffer
-	if code := runQuickstartCmdWithReady([]string{"--console", "--dry-run", "--data-dir", dataDir}, &stdout, &stderr, nil); code != 1 {
-		t.Fatalf("dry-run exit code = %d, stderr = %s", code, stderr.String())
+	if code := runQuickstartCmdWithReady([]string{"--console", "--dry-run", "--data-dir", dataDir}, &stdout, &stderr, nil); code != 0 {
+		t.Fatalf("dry-run exit code = %d, stdout = %s stderr = %s", code, stdout.String(), stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "valid compiled release manifest digest") {
-		t.Fatalf("missing compiled digest error = %s", stderr.String())
+	if stderr.Len() != 0 {
+		t.Fatalf("dry-run wrote stderr = %s", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "Console-including packaged layout") {
-		t.Fatalf("missing Console layout guidance = %s", stderr.String())
+	if !strings.Contains(stdout.String(), "\"operation\":\"preview\"") {
+		t.Fatalf("missing preview summary = %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Console-including packaged layout") {
+		t.Fatalf("missing Console layout warning = %s", stdout.String())
 	}
 	if _, statErr := os.Stat(dataDir); !os.IsNotExist(statErr) {
 		t.Fatalf("missing bundle dry-run mutated %q: %v", dataDir, statErr)

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -332,17 +332,17 @@ func prepareQuickstart(opts quickstartOptions) (quickstartPrepared, error) {
 	if err != nil {
 		return quickstartPrepared{}, err
 	}
-	if opts.Reset {
-		if err := os.RemoveAll(opts.DataDir); err != nil {
-			return quickstartPrepared{}, fmt.Errorf("reset data dir %q: %w", opts.DataDir, err)
-		}
-	}
 	if opts.Console {
 		bundle, err := discoverLocalConsoleBundle()
 		if err != nil {
 			return quickstartPrepared{}, err
 		}
 		prepared.ConsoleBundle = bundle
+	}
+	if opts.Reset {
+		if err := os.RemoveAll(opts.DataDir); err != nil {
+			return quickstartPrepared{}, fmt.Errorf("reset data dir %q: %w", opts.DataDir, err)
+		}
 	}
 	if err := ensureQuickstartDataDirOwnership(opts.DataDir); err != nil {
 		return quickstartPrepared{}, err

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -318,12 +318,7 @@ func planQuickstart(opts quickstartOptions) (quickstartPrepared, error) {
 		Console:        opts.Console,
 	}
 	if opts.Console {
-		bundle, err := discoverLocalConsoleBundle()
-		if err != nil {
-			return quickstartPrepared{}, err
-		}
-		prepared.ConsoleBundle = bundle
-		prepared.PlannedActions = append(prepared.PlannedActions, "start the packaged local Console sidecar")
+		prepared.PlannedActions = append(prepared.PlannedActions, "start the packaged local Console sidecar (requires a Console-including packaged layout)")
 	}
 	return prepared, nil
 }
@@ -341,6 +336,13 @@ func prepareQuickstart(opts quickstartOptions) (quickstartPrepared, error) {
 		if err := os.RemoveAll(opts.DataDir); err != nil {
 			return quickstartPrepared{}, fmt.Errorf("reset data dir %q: %w", opts.DataDir, err)
 		}
+	}
+	if opts.Console {
+		bundle, err := discoverLocalConsoleBundle()
+		if err != nil {
+			return quickstartPrepared{}, err
+		}
+		prepared.ConsoleBundle = bundle
 	}
 	if err := ensureQuickstartDataDirOwnership(opts.DataDir); err != nil {
 		return quickstartPrepared{}, err

--- a/core/cmd/helm-ai-kernel/receipts_cmd.go
+++ b/core/cmd/helm-ai-kernel/receipts_cmd.go
@@ -161,5 +161,16 @@ func printReceiptEvent(stdout io.Writer, raw string, jsonOut bool) {
 }
 
 func init() {
-	Register(Subcommand{Name: "receipts", Aliases: []string{}, Usage: "Tail durable receipts (tail --agent)", RunFn: runReceiptsCmd})
+	Register(Subcommand{
+		Name:    "receipts",
+		Aliases: []string{},
+		Usage:   "Tail durable receipts (tail --agent)",
+		RunFn:   runReceiptsCmd,
+		HelpFn:  printReceiptsUsage,
+	})
+}
+
+func printReceiptsUsage(stdout io.Writer) {
+	fmt.Fprintln(stdout, "Usage: helm-ai-kernel receipts tail --agent <id> [--server URL] [--since CURSOR] [--limit N] [--json|--format text|json]")
+	fmt.Fprintln(stdout, "Tail the durable receipt stream for one agent from a HELM server.")
 }

--- a/core/cmd/helm-ai-kernel/registry.go
+++ b/core/cmd/helm-ai-kernel/registry.go
@@ -272,6 +272,72 @@ func explicitGlobalCommands() []commandCatalogEntry {
 	}
 }
 
+func completionCommandNames(name string) []string {
+	canonical := name
+	for _, command := range commandCatalog().Commands {
+		if command.Name == name {
+			return append([]string{command.Name}, command.Aliases...)
+		}
+		for _, alias := range command.Aliases {
+			if alias != name {
+				continue
+			}
+			return append([]string{command.Name}, command.Aliases...)
+		}
+	}
+	return []string{canonical}
+}
+
+func completionCanonicalPath(path []string) []string {
+	if len(path) == 0 {
+		return nil
+	}
+	normalized := append([]string(nil), path...)
+	normalized[0] = completionCommandNames(normalized[0])[0]
+	if len(normalized) > 1 && normalized[0] == "help" {
+		normalized[1] = completionCommandNames(normalized[1])[0]
+	}
+	return normalized
+}
+
+func expandCompletionContexts(contexts []completionContext) []completionContext {
+	expanded := make([]completionContext, 0, len(contexts))
+	seen := make(map[string]struct{}, len(contexts))
+	for _, context := range contexts {
+		var paths [][]string
+		paths = append(paths, []string{})
+		for index, segment := range context.Path {
+			names := []string{segment}
+			if index == 0 {
+				names = completionCommandNames(segment)
+			}
+			if index == 1 && len(context.Path) > 1 && completionCanonicalPath(context.Path)[0] == "help" {
+				names = completionCommandNames(segment)
+			}
+			next := make([][]string, 0, len(paths)*len(names))
+			for _, path := range paths {
+				for _, name := range names {
+					candidate := append(append([]string(nil), path...), name)
+					next = append(next, candidate)
+				}
+			}
+			paths = next
+		}
+		for _, path := range paths {
+			key := strings.Join(path, "\x00")
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			expanded = append(expanded, completionContext{
+				Path:       path,
+				Candidates: uniqueStrings(context.Candidates),
+			})
+		}
+	}
+	return expanded
+}
+
 func completionWords() []string {
 	seen := make(map[string]struct{})
 	for _, cmd := range commandCatalog().Commands {
@@ -370,7 +436,7 @@ func commandSectionSpecs() []commandSectionSpec {
 }
 
 func completionContexts() []completionContext {
-	return []completionContext{
+	return expandCompletionContexts([]completionContext{
 		{Path: []string{"completion"}, Candidates: []string{"bash", "zsh", "fish", "powershell"}},
 		{Path: []string{"help"}, Candidates: append([]string{"--all", "--json"}, completionWords()...)},
 		{Path: []string{"launch"}, Candidates: []string{"matrix", "apps", "substrates", "plan", "status", "logs", "repair", "delete", "evidence", "promote", "secrets", "imports"}},
@@ -389,7 +455,7 @@ func completionContexts() []completionContext {
 		{Path: []string{"setup", "status"}, Candidates: []string{"claude-code", "codex", "--scope", "user", "project", "--workspace", "--json", "--data-dir"}},
 		{Path: []string{"version"}, Candidates: []string{"--json"}},
 		{Path: []string{"watch"}, Candidates: []string{"--url", "--api-key-file", "--once", "--json"}},
-	}
+	})
 }
 
 func completionCandidates(path []string) []string {
@@ -397,6 +463,7 @@ func completionCandidates(path []string) []string {
 	if len(path) == 0 {
 		return root
 	}
+	path = completionCanonicalPath(path)
 	key := strings.Join(path, " ")
 	byKey := make(map[string][]string, len(completionContexts()))
 	for _, context := range completionContexts() {

--- a/core/cmd/helm-ai-kernel/registry.go
+++ b/core/cmd/helm-ai-kernel/registry.go
@@ -23,14 +23,33 @@ const commandCatalogSchemaVersion = "helm-ai-kernel.command-catalog.v1"
 
 // commandCatalogDocument is the stable, side-effect-free command discovery contract.
 type commandCatalogDocument struct {
-	SchemaVersion string                `json:"schema_version"`
-	Commands      []commandCatalogEntry `json:"commands"`
+	SchemaVersion string                  `json:"schema_version"`
+	Commands      []commandCatalogEntry   `json:"commands"`
+	Sections      []commandCatalogSection `json:"sections,omitempty"`
 }
 
 type commandCatalogEntry struct {
 	Name    string   `json:"name"`
 	Aliases []string `json:"aliases"`
 	Usage   string   `json:"usage"`
+	Group   string   `json:"group,omitempty"`
+}
+
+type commandCatalogSection struct {
+	ID       string                `json:"id"`
+	Title    string                `json:"title"`
+	Commands []commandCatalogEntry `json:"commands"`
+}
+
+type commandSectionSpec struct {
+	ID       string
+	Title    string
+	Commands []string
+}
+
+type completionContext struct {
+	Path       []string
+	Candidates []string
 }
 
 // Register adds a subcommand to the CLI registry.
@@ -196,25 +215,20 @@ func printUnknownCommand(out io.Writer, typed string) {
 }
 
 func printUsageAll(out io.Writer) {
+	catalog := commandCatalog()
 	fmt.Fprintf(out, "%s: Canonical Execution Verifier (Version %s, Commit %s)\n\n", terminalTitle(out, "HELM AI Kernel"), displayVersion(), displayCommit())
 	fmt.Fprintln(out, "Usage: helm-ai-kernel <command> [options]")
 	fmt.Fprintln(out, "\nCommands:")
-
-	for _, cmd := range canonicalRegisteredCommands() {
-		aliasStr := ""
-		if len(cmd.Aliases) > 0 {
-			aliasStr = fmt.Sprintf(" (aliases: %s)", strings.Join(cmd.Aliases, ", "))
+	fmt.Fprintln(out, "Common outcomes first; `help --json` keeps the stable machine catalog.")
+	for _, section := range catalog.Sections {
+		fmt.Fprintf(out, "\n%s:\n", section.Title)
+		for _, cmd := range section.Commands {
+			aliasStr := ""
+			if len(cmd.Aliases) > 0 {
+				aliasStr = fmt.Sprintf(" (aliases: %s)", strings.Join(cmd.Aliases, ", "))
+			}
+			fmt.Fprintf(out, "  %-20s %s%s\n", cmd.Name, cmd.Usage, aliasStr)
 		}
-		fmt.Fprintf(out, "  %-20s %s%s\n", cmd.Name, cmd.Usage, aliasStr)
-	}
-
-	fmt.Fprintln(out, "\nGlobal Commands:")
-	for _, cmd := range explicitGlobalCommands() {
-		aliasStr := ""
-		if len(cmd.Aliases) > 0 {
-			aliasStr = fmt.Sprintf(" (aliases: %s)", strings.Join(cmd.Aliases, ", "))
-		}
-		fmt.Fprintf(out, "  %-20s %s%s\n", cmd.Name, cmd.Usage, aliasStr)
 	}
 }
 
@@ -224,6 +238,7 @@ func commandCatalog() commandCatalogDocument {
 	return commandCatalogDocument{
 		SchemaVersion: commandCatalogSchemaVersion,
 		Commands:      commands,
+		Sections:      groupedCommandCatalogSections(commands),
 	}
 }
 
@@ -239,6 +254,7 @@ func canonicalRegisteredCommands() []commandCatalogEntry {
 			Name:    cmd.Name,
 			Aliases: aliases,
 			Usage:   cmd.Usage,
+			Group:   commandGroupTitle(cmd.Name),
 		})
 	}
 	sort.Slice(commands, func(i, j int) bool { return commands[i].Name < commands[j].Name })
@@ -247,12 +263,12 @@ func canonicalRegisteredCommands() []commandCatalogEntry {
 
 func explicitGlobalCommands() []commandCatalogEntry {
 	return []commandCatalogEntry{
-		{Name: "completion", Aliases: []string{}, Usage: "Generate static shell completion"},
-		{Name: "help", Aliases: []string{"--help", "-h"}, Usage: "Show command help"},
-		{Name: "server", Aliases: []string{}, Usage: "Start the HELM Guardian API and proxy services"},
-		{Name: "serve", Aliases: []string{}, Usage: "Start a local HELM boundary from --policy"},
-		{Name: "threat", Aliases: []string{}, Usage: "Run a threat scan or test"},
-		{Name: "version", Aliases: []string{"--version", "-v"}, Usage: "Print version and schema information"},
+		{Name: "completion", Aliases: []string{}, Usage: "Generate static shell completion", Group: commandGroupTitle("completion")},
+		{Name: "help", Aliases: []string{"--help", "-h"}, Usage: "Show command help", Group: commandGroupTitle("help")},
+		{Name: "server", Aliases: []string{}, Usage: "Start the HELM Guardian API and proxy services", Group: commandGroupTitle("server")},
+		{Name: "serve", Aliases: []string{}, Usage: "Start a local HELM boundary from --policy", Group: commandGroupTitle("serve")},
+		{Name: "threat", Aliases: []string{}, Usage: "Run a threat scan or test", Group: commandGroupTitle("threat")},
+		{Name: "version", Aliases: []string{"--version", "-v"}, Usage: "Print version and schema information", Group: commandGroupTitle("version")},
 	}
 }
 
@@ -270,6 +286,147 @@ func completionWords() []string {
 	}
 	sort.Strings(words)
 	return words
+}
+
+func groupedCommandCatalogSections(commands []commandCatalogEntry) []commandCatalogSection {
+	index := make(map[string]commandCatalogEntry, len(commands))
+	for _, command := range commands {
+		index[command.Name] = command
+	}
+	seen := make(map[string]struct{}, len(commands))
+	sections := make([]commandCatalogSection, 0, len(commandSectionSpecs()))
+	for _, spec := range commandSectionSpecs() {
+		grouped := make([]commandCatalogEntry, 0, len(spec.Commands))
+		for _, name := range spec.Commands {
+			command, ok := index[name]
+			if !ok {
+				continue
+			}
+			grouped = append(grouped, command)
+			seen[name] = struct{}{}
+		}
+		if spec.ID == "operate" {
+			var leftovers []commandCatalogEntry
+			for _, command := range commands {
+				if _, ok := seen[command.Name]; ok {
+					continue
+				}
+				leftovers = append(leftovers, command)
+			}
+			sort.Slice(leftovers, func(i, j int) bool { return leftovers[i].Name < leftovers[j].Name })
+			grouped = append(grouped, leftovers...)
+		}
+		sections = append(sections, commandCatalogSection{
+			ID:       spec.ID,
+			Title:    spec.Title,
+			Commands: grouped,
+		})
+	}
+	return sections
+}
+
+func commandGroupTitle(name string) string {
+	for _, spec := range commandSectionSpecs() {
+		for _, command := range spec.Commands {
+			if command == name {
+				return spec.Title
+			}
+		}
+	}
+	return "Operate"
+}
+
+func commandSectionSpecs() []commandSectionSpec {
+	return []commandSectionSpec{
+		{
+			ID:    "get-started",
+			Title: "Get started",
+			Commands: []string{
+				"setup", "quickstart", "scan", "doctor", "help", "completion", "version", "onboard", "init", "connect", "login",
+			},
+		},
+		{
+			ID:    "use-helm",
+			Title: "Use HELM",
+			Commands: []string{
+				"watch", "receipts", "mcp", "launch", "app", "up", "run", "proxy", "local", "sandbox", "hook", "serve", "server", "dev", "scaffold", "shadow", "skills", "control-plane", "integrate", "health", "threat",
+			},
+		},
+		{
+			ID:    "evidence",
+			Title: "Evidence",
+			Commands: []string{
+				"verify", "verify-scan", "evidence", "export", "audit", "report", "replay", "rollup", "log", "traces", "gui", "plan", "risk-summary", "conform", "certify", "coverage", "brief",
+			},
+		},
+		{
+			ID:    "operate",
+			Title: "Operate",
+			Commands: []string{
+				"approvals", "authz", "boundary", "budget", "bundle", "coexistence", "counterfactual", "did", "freeze", "identity", "import", "incident", "policy", "secret", "tee", "telemetry", "trust", "unfreeze", "workstation",
+			},
+		},
+	}
+}
+
+func completionContexts() []completionContext {
+	return []completionContext{
+		{Path: []string{"completion"}, Candidates: []string{"bash", "zsh", "fish", "powershell"}},
+		{Path: []string{"help"}, Candidates: append([]string{"--all", "--json"}, completionWords()...)},
+		{Path: []string{"launch"}, Candidates: []string{"matrix", "apps", "substrates", "plan", "status", "logs", "repair", "delete", "evidence", "promote", "secrets", "imports"}},
+		{Path: []string{"launch", "delete"}, Candidates: []string{"--cascade"}},
+		{Path: []string{"launch", "evidence"}, Candidates: []string{"--export", "--json", "--output"}},
+		{Path: []string{"launch", "plan"}, Candidates: []string{"--json"}},
+		{Path: []string{"quickstart"}, Candidates: []string{"--addr", "--port", "--data-dir", "--reset", "--offline", "--profile", "claude", "codex", "mcp", "openai-compatible", "--json", "--dry-run", "--yes", "--console", "--console-port", "--no-open"}},
+		{Path: []string{"receipts"}, Candidates: []string{"tail"}},
+		{Path: []string{"receipts", "tail"}, Candidates: []string{"--agent", "--server", "--since", "--json", "--format", "text", "json", "--limit"}},
+		{Path: []string{"scan"}, Candidates: []string{"--path", "--from-receipts", "--cohort", "unknown", "1-10repos", "11-50repos", "51-200repos", "201plusrepos", "--salt-file", "--risk-envelope", "--preview", "--evidence-pack", "--no-user-config", "--upload", "--upload-url", "--yes"}},
+		{Path: []string{"setup"}, Candidates: []string{"claude-code", "codex", "status", "repair", "remove", "--client", "--print-config", "--json", "--quickstart", "--profile", "claude", "codex", "mcp", "openai-compatible", "--yes", "--dry-run", "--data-dir", "--console", "--console-port", "--no-open", "--offline", "--reset"}},
+		{Path: []string{"setup", "claude-code"}, Candidates: []string{"--scope", "user", "project", "--workspace", "--data-dir", "--dry-run", "--json", "--yes", "--no-quickstart", "--quickstart", "--console", "--console-port", "--no-open", "--signing-seed-file", "--policy-profile", "--policy-profile-sha256"}},
+		{Path: []string{"setup", "codex"}, Candidates: []string{"--scope", "user", "project", "--workspace", "--data-dir", "--dry-run", "--json", "--yes", "--no-quickstart", "--quickstart", "--console", "--console-port", "--no-open", "--signing-seed-file", "--policy-profile", "--policy-profile-sha256"}},
+		{Path: []string{"setup", "remove"}, Candidates: []string{"claude-code", "codex", "--scope", "user", "project", "--workspace", "--yes", "--dry-run", "--json", "--data-dir"}},
+		{Path: []string{"setup", "repair"}, Candidates: []string{"claude-code", "codex", "--scope", "user", "project", "--workspace", "--yes", "--dry-run", "--json", "--data-dir"}},
+		{Path: []string{"setup", "status"}, Candidates: []string{"claude-code", "codex", "--scope", "user", "project", "--workspace", "--json", "--data-dir"}},
+		{Path: []string{"version"}, Candidates: []string{"--json"}},
+		{Path: []string{"watch"}, Candidates: []string{"--url", "--api-key-file", "--once", "--json"}},
+	}
+}
+
+func completionCandidates(path []string) []string {
+	root := completionWords()
+	if len(path) == 0 {
+		return root
+	}
+	key := strings.Join(path, " ")
+	byKey := make(map[string][]string, len(completionContexts()))
+	for _, context := range completionContexts() {
+		byKey[strings.Join(context.Path, " ")] = uniqueStrings(context.Candidates)
+	}
+	if candidates, ok := byKey[key]; ok {
+		return candidates
+	}
+	if len(path) > 1 {
+		if candidates, ok := byKey[path[0]]; ok {
+			return candidates
+		}
+	}
+	return root
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func writeCommandCatalogJSON(out io.Writer) int {

--- a/core/cmd/helm-ai-kernel/scan_cmd.go
+++ b/core/cmd/helm-ai-kernel/scan_cmd.go
@@ -178,8 +178,21 @@ func defaultScanSaltFile() (string, error) {
 
 func init() {
 	Register(Subcommand{
-		Name:  "scan",
-		Usage: "Local anonymized AI agent risk scan",
-		RunFn: runScanCmd,
+		Name:   "scan",
+		Usage:  "Local anonymized AI agent risk scan",
+		RunFn:  runScanCmd,
+		HelpFn: printScanUsage,
 	})
+}
+
+func printScanUsage(stdout io.Writer) {
+	fmt.Fprintln(stdout, "Usage: helm-ai-kernel scan [--path DIR | --from-receipts DIR] [options]")
+	fmt.Fprintln(stdout, "Build an anonymized local risk envelope for a repo or a receipts directory.")
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Common options:")
+	fmt.Fprintln(stdout, "  --risk-envelope FILE          Write anonymized RiskEnvelope JSON")
+	fmt.Fprintln(stdout, "  --preview FILE                Write a local .md or .html preview (repeatable)")
+	fmt.Fprintln(stdout, "  --evidence-pack FILE          Write an anonymized scan EvidencePack tar")
+	fmt.Fprintln(stdout, "  --no-user-config              Skip user-level Claude/Codex/Desktop MCP config")
+	fmt.Fprintln(stdout, "  --upload --upload-url URL     Upload only after local review; requires --yes")
 }

--- a/core/cmd/helm-ai-kernel/watch_cmd.go
+++ b/core/cmd/helm-ai-kernel/watch_cmd.go
@@ -31,10 +31,20 @@ const (
 
 func init() {
 	Register(Subcommand{
-		Name:  "watch",
-		Usage: "Review live approval state with typed APPROVE/DENY confirmation",
-		RunFn: runWatchCmd,
+		Name:   "watch",
+		Usage:  "Review live approval state with typed APPROVE/DENY confirmation",
+		RunFn:  runWatchCmd,
+		HelpFn: printWatchUsage,
 	})
+}
+
+func printWatchUsage(stdout io.Writer) {
+	fmt.Fprintln(stdout, "Usage: helm-ai-kernel watch [--url URL] [--api-key-file FILE] [--once|--json]")
+	fmt.Fprintln(stdout, "Review live approval state from the Kernel and confirm APPROVE or DENY with a second exact word.")
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Notes:")
+	fmt.Fprintln(stdout, "  --once and --json are snapshot-only and never prompt or change state.")
+	fmt.Fprintln(stdout, "  Set HELM_ADMIN_API_KEY or use --api-key-file; there is deliberately no --api-key flag.")
 }
 
 type watchClientFactory func(rawURL, apiKey string) (approvalClient, error)


### PR DESCRIPTION
## Summary
- keep `quickstart --console --dry-run` read-only by moving Console bundle discovery to the real startup path while still previewing the Console requirement in the dry-run plan
- add specific front-door help for `scan`, `receipts`, and `watch`, and group `help --all` into deterministic user-journey sections while preserving the legacy `Commands:` header
- extend the additive `help --json` catalog with section metadata and group tags, and generate nested shell completion choices from the existing command registry plus scoped subcommand/flag contexts

## Source Truth
- base branch: `main`
- base head when merged locally: `6adae47188a2eb3ef0ec21c97b445c344eaeefaf` (`origin/main` on 2026-08-10)
- feature checkpoint commit: `6434e01f0`
- feature head after guarded merge: `ed3ad645c`
- guarded merge brought in `origin/main` cleanly; the only merged file outside the owned CLI scope was `docs/use-cases/llm-audit-receipts.md`

## Validation
- `go test ./core/cmd/helm-ai-kernel`
- `go test ./core/cmd/...`
- exact-head binary smoke: `bin/helm-ai-kernel help --all`, `help --json`, `completion bash`, `quickstart --console --dry-run`
- `make verify-presentation`
- `make quality-pr`
