### PR TITLE
fix(release): refresh the manifests a version bump invalidates

### DIFF
--- a/scripts/release/prepare_version.py
+++ b/scripts/release/prepare_version.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -115,6 +116,69 @@ def rewrite_sdk_manifests() -> list[str]:
     return rewritten
 
 
+def refresh_public_docs_api_contract() -> bool:
+    """Repin the public docs manifest against the OpenAPI file this script just bumped.
+
+    docs/public-docs.manifest.json records the api_contract hashes of
+    api/openapi/helm.openapi.yaml, and the version bump above rewrites that
+    file. Leaving the manifest stale fails docs-truth — a blocking gate — with a
+    hash mismatch that reads like an unrelated documentation defect rather than
+    the version bump that caused it.
+
+    git_blob_sha1 is what the committed blob will be: check_documentation_truth
+    resolves it with `git rev-parse HEAD:<path>`, so it is only correct once the
+    commit carrying the bump exists. `git hash-object` on the working tree is
+    that same value, which is why it can be written here. docs-truth still
+    verifies it against HEAD after the commit, so a content filter that made the
+    two diverge would surface there rather than pass silently.
+    """
+    manifest_path = ROOT / "docs" / "public-docs.manifest.json"
+    if not manifest_path.exists():
+        return False
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    contract = payload.get("api_contract")
+    if not isinstance(contract, dict) or not contract.get("source_path"):
+        return False
+    source_path = ROOT / contract["source_path"]
+    if not source_path.exists():
+        return False
+
+    digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
+    blob = subprocess.run(
+        ["git", "hash-object", contract["source_path"]],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    before = json.dumps(contract, sort_keys=True, ensure_ascii=False)
+    contract["content_sha256"] = f"sha256:{digest}"
+    contract["git_blob_sha1"] = blob
+    if json.dumps(contract, sort_keys=True, ensure_ascii=False) == before:
+        return False
+    manifest_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return True
+
+
+def refresh_boundary_manifest() -> bool:
+    """Regenerate the protected-surface manifest after the version bump.
+
+    protocols/specs/effects/openapi.yaml carries a version string and is a
+    protected-surface file, so bumping it drifts tools/boundary/protected.manifest
+    and fails the blocking boundary-manifest gate. The generator is the only
+    sanctioned way to rewrite that manifest, so this shells out to it rather than
+    editing hashes in place.
+    """
+    generator = ROOT / "tools" / "boundary" / "generate-manifest.sh"
+    manifest = ROOT / "tools" / "boundary" / "protected.manifest"
+    if not generator.exists() or not manifest.exists():
+        return False
+    before = manifest.read_bytes()
+    run([str(generator)])
+    return manifest.read_bytes() != before
+
+
 def warn_missing_console_pin(version: str) -> None:
     """Point at the one per-release declaration this script cannot write.
 
@@ -184,6 +248,13 @@ def main() -> int:
         print("repinned generated-file manifests:")
         for manifest_id in rewritten:
             print(f"- {manifest_id}")
+    # Both of these derive from files the bump above rewrote. Refreshing them
+    # here keeps a version bump from failing docs-truth and boundary-manifest,
+    # which is how v0.8.4 discovered each of them from a red gate.
+    if refresh_public_docs_api_contract():
+        print("repinned docs/public-docs.manifest.json api_contract hashes")
+    if refresh_boundary_manifest():
+        print("regenerated tools/boundary/protected.manifest")
     warn_missing_console_pin(version)
     run(["python3", "scripts/release/check_version_drift.py", "--expected-version", version, "local"])
     return 0

--- a/scripts/release/prepare_version.py
+++ b/scripts/release/prepare_version.py
@@ -133,19 +133,34 @@ def refresh_public_docs_api_contract() -> bool:
     two diverge would surface there rather than pass silently.
     """
     manifest_path = ROOT / "docs" / "public-docs.manifest.json"
-    if not manifest_path.exists():
-        return False
-    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not manifest_path.is_file():
+        raise SystemExit(f"required public docs manifest is missing or not a file: {drift.rel(manifest_path)}")
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            f"required public docs manifest is unreadable or invalid: {drift.rel(manifest_path)}: {exc}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"required public docs manifest must contain a JSON object: {drift.rel(manifest_path)}")
     contract = payload.get("api_contract")
-    if not isinstance(contract, dict) or not contract.get("source_path"):
-        return False
-    source_path = ROOT / contract["source_path"]
-    if not source_path.exists():
-        return False
+    if not isinstance(contract, dict):
+        raise SystemExit(
+            f"required public docs manifest api_contract must be a JSON object: {drift.rel(manifest_path)}"
+        )
+    expected_source = "api/openapi/helm.openapi.yaml"
+    if contract.get("source_path") != expected_source:
+        raise SystemExit(
+            f"required public docs manifest api_contract.source_path must be {expected_source!r}: "
+            f"{drift.rel(manifest_path)}"
+        )
+    source_path = ROOT / expected_source
+    if not source_path.is_file():
+        raise SystemExit(f"required public docs API contract is missing or not a file: {drift.rel(source_path)}")
 
     digest = hashlib.sha256(source_path.read_bytes()).hexdigest()
     blob = subprocess.run(
-        ["git", "hash-object", contract["source_path"]],
+        ["git", "hash-object", expected_source],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -172,10 +187,14 @@ def refresh_boundary_manifest() -> bool:
     """
     generator = ROOT / "tools" / "boundary" / "generate-manifest.sh"
     manifest = ROOT / "tools" / "boundary" / "protected.manifest"
-    if not generator.exists() or not manifest.exists():
-        return False
+    if not generator.is_file():
+        raise SystemExit(f"required boundary manifest generator is missing or not a file: {drift.rel(generator)}")
+    if not manifest.is_file():
+        raise SystemExit(f"required boundary manifest is missing or not a file: {drift.rel(manifest)}")
     before = manifest.read_bytes()
     run([str(generator)])
+    if not manifest.is_file():
+        raise SystemExit(f"boundary manifest generator did not produce a file: {drift.rel(manifest)}")
     return manifest.read_bytes() != before
 
 

--- a/scripts/release/prepare_version_test.py
+++ b/scripts/release/prepare_version_test.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import io
 import json
 import subprocess
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
 import prepare_version
 
@@ -41,6 +45,177 @@ class RewriteSdkManifestsTests(unittest.TestCase):
                 text=True,
             )
             self.assertEqual(result.returncode, 0, f"{sdk_dir}: {result.stdout}{result.stderr}")
+
+
+class PublicDocsApiContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name)
+        self.manifest_path = self.root / "docs" / "public-docs.manifest.json"
+        self.source_path = self.root / "api" / "openapi" / "helm.openapi.yaml"
+        self.manifest_path.parent.mkdir(parents=True)
+        self.source_path.parent.mkdir(parents=True)
+        self.source_path.write_text("openapi: 3.1.0\ninfo:\n  version: 0.8.4\n", encoding="utf-8")
+        self.write_manifest()
+        root_patch = mock.patch.object(prepare_version, "ROOT", self.root)
+        root_patch.start()
+        self.addCleanup(root_patch.stop)
+        drift_root_patch = mock.patch.object(prepare_version.drift, "ROOT", self.root)
+        drift_root_patch.start()
+        self.addCleanup(drift_root_patch.stop)
+
+    def write_manifest(self, api_contract: object = None) -> None:
+        if api_contract is None:
+            api_contract = {
+                "schema_version": 1,
+                "source_path": "api/openapi/helm.openapi.yaml",
+                "content_sha256": "sha256:stale",
+                "git_blob_sha1": "stale",
+            }
+        self.manifest_path.write_text(json.dumps({"api_contract": api_contract}) + "\n", encoding="utf-8")
+
+    def test_refresh_updates_hashes_and_is_idempotent(self) -> None:
+        self.assertTrue(prepare_version.refresh_public_docs_api_contract())
+        contract = json.loads(self.manifest_path.read_text(encoding="utf-8"))["api_contract"]
+        expected_digest = hashlib.sha256(self.source_path.read_bytes()).hexdigest()
+        expected_blob = subprocess.run(
+            ["git", "hash-object", "api/openapi/helm.openapi.yaml"],
+            cwd=self.root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        self.assertEqual(contract["content_sha256"], f"sha256:{expected_digest}")
+        self.assertEqual(contract["git_blob_sha1"], expected_blob)
+        before = self.manifest_path.read_bytes()
+        self.assertFalse(prepare_version.refresh_public_docs_api_contract())
+        self.assertEqual(self.manifest_path.read_bytes(), before)
+
+    def test_missing_or_non_file_manifest_fails_closed(self) -> None:
+        self.manifest_path.unlink()
+        with self.assertRaisesRegex(SystemExit, "required public docs manifest"):
+            prepare_version.refresh_public_docs_api_contract()
+
+    def test_malformed_manifest_fails_closed(self) -> None:
+        for malformed in ("not JSON", "[]"):
+            with self.subTest(manifest=malformed):
+                self.manifest_path.write_text(malformed, encoding="utf-8")
+                with self.assertRaisesRegex(SystemExit, "required public docs manifest"):
+                    prepare_version.refresh_public_docs_api_contract()
+
+    def test_missing_or_malformed_api_contract_fails_closed(self) -> None:
+        for api_contract in ([], "not an object"):
+            with self.subTest(api_contract=api_contract):
+                self.write_manifest(api_contract)
+                with self.assertRaisesRegex(SystemExit, "api_contract must be a JSON object"):
+                    prepare_version.refresh_public_docs_api_contract()
+        self.manifest_path.write_text("{}\n", encoding="utf-8")
+        with self.assertRaisesRegex(SystemExit, "api_contract must be a JSON object"):
+            prepare_version.refresh_public_docs_api_contract()
+
+    def test_source_path_must_be_exact(self) -> None:
+        for source_path in (None, "api/openapi/other.yaml", "/tmp/helm.openapi.yaml"):
+            with self.subTest(source_path=source_path):
+                self.write_manifest({"source_path": source_path})
+                with self.assertRaisesRegex(SystemExit, "api_contract.source_path must be"):
+                    prepare_version.refresh_public_docs_api_contract()
+
+    def test_missing_source_file_fails_closed(self) -> None:
+        self.source_path.unlink()
+        with self.assertRaisesRegex(SystemExit, "required public docs API contract"):
+            prepare_version.refresh_public_docs_api_contract()
+
+
+class BoundaryManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.root = Path(self.temporary_directory.name)
+        self.generator = self.root / "tools" / "boundary" / "generate-manifest.sh"
+        self.manifest = self.root / "tools" / "boundary" / "protected.manifest"
+        self.generator.parent.mkdir(parents=True)
+        self.generator.write_text(
+            "#!/bin/sh\nset -eu\nprintf 'generated manifest\\n' > tools/boundary/protected.manifest\n",
+            encoding="utf-8",
+        )
+        self.generator.chmod(0o755)
+        self.manifest.write_text("stale manifest\n", encoding="utf-8")
+        root_patch = mock.patch.object(prepare_version, "ROOT", self.root)
+        root_patch.start()
+        self.addCleanup(root_patch.stop)
+        drift_root_patch = mock.patch.object(prepare_version.drift, "ROOT", self.root)
+        drift_root_patch.start()
+        self.addCleanup(drift_root_patch.stop)
+
+    def test_refresh_updates_manifest_and_is_idempotent(self) -> None:
+        self.assertTrue(prepare_version.refresh_boundary_manifest())
+        self.assertEqual(self.manifest.read_text(encoding="utf-8"), "generated manifest\n")
+        before = self.manifest.read_bytes()
+        self.assertFalse(prepare_version.refresh_boundary_manifest())
+        self.assertEqual(self.manifest.read_bytes(), before)
+
+    def test_missing_generator_fails_closed(self) -> None:
+        self.generator.unlink()
+        with self.assertRaisesRegex(SystemExit, "required boundary manifest generator"):
+            prepare_version.refresh_boundary_manifest()
+
+    def test_missing_manifest_fails_closed(self) -> None:
+        self.manifest.unlink()
+        with self.assertRaisesRegex(SystemExit, "required boundary manifest is missing"):
+            prepare_version.refresh_boundary_manifest()
+
+    def test_generator_failure_propagates(self) -> None:
+        self.generator.write_text("#!/bin/sh\nexit 7\n", encoding="utf-8")
+        with self.assertRaises(subprocess.CalledProcessError):
+            prepare_version.refresh_boundary_manifest()
+
+
+class MainOrderTests(unittest.TestCase):
+    def test_derived_manifests_refresh_before_drift_check(self) -> None:
+        events: list[str] = []
+
+        def record_run(command: list[str]) -> None:
+            events.append("run:" + " ".join(command))
+
+        with (
+            mock.patch.object(
+                prepare_version,
+                "parse_args",
+                return_value=prepare_version.argparse.Namespace(
+                    version="0.8.4", contract=Path("contract.json"), force=False
+                ),
+            ),
+            mock.patch.object(prepare_version.drift, "load_contract", return_value={"normalization_enabled": True}),
+            mock.patch.object(prepare_version, "rewrite_sdk_manifests", return_value=[]),
+            mock.patch.object(
+                prepare_version,
+                "refresh_public_docs_api_contract",
+                side_effect=lambda: events.append("public-docs") or False,
+            ),
+            mock.patch.object(
+                prepare_version,
+                "refresh_boundary_manifest",
+                side_effect=lambda: events.append("boundary") or False,
+            ),
+            mock.patch.object(
+                prepare_version,
+                "warn_missing_console_pin",
+                side_effect=lambda _version: events.append("console-pin"),
+            ),
+            mock.patch.object(prepare_version, "run", side_effect=record_run),
+        ):
+            self.assertEqual(prepare_version.main(), 0)
+
+        self.assertEqual(
+            events,
+            [
+                "public-docs",
+                "boundary",
+                "console-pin",
+                "run:python3 scripts/release/check_version_drift.py --expected-version 0.8.4 local",
+            ],
+        )
 
 
 class ConsolePinWarningTests(unittest.TestCase):


### PR DESCRIPTION
Preparing v0.8.4 failed two blocking gates in sequence, each discovered from a red CI run and fixed by hand. Both had the same cause: `prepare-version` rewrites files that feed verification manifests and refreshed none of them.

| Gate | Why it went red |
|---|---|
| `docs-truth` | `api/openapi/helm.openapi.yaml` bumped → `docs/public-docs.manifest.json` `api_contract` hashes stale |
| `boundary-manifest` | `protocols/specs/effects/openapi.yaml` bumped → it's a protected-surface file → `tools/boundary/protected.manifest` drifted |

Neither failure names the version bump as the cause, so both read as unrelated documentation or boundary defects.

## What changed

`prepare_version.py` now repins the docs manifest's `api_contract` hashes and reruns `tools/boundary/generate-manifest.sh`, printing what it touched next to the existing SDK-manifest repin.

`git_blob_sha1` is written from `git hash-object` on the working tree, which is the value the committed blob will carry. `check_documentation_truth` resolves it with `git rev-parse HEAD:<path>`, so it verifies against HEAD *after* the commit — meaning a content filter that made the two diverge would still surface there rather than pass silently.

The Console pin stays a **warning**, deliberately. It names a reviewed Console commit and a provenance tag, which is a decision rather than a derivation, so it can't be generated here.

## Verified

Ran `make prepare-version PREPARE_VERSION=0.8.5` on a scratch branch off current main, committed, and ran the two gates that were red for 0.8.4 — with no manual fixes:

```
repinned docs/public-docs.manifest.json api_contract hashes
regenerated tools/boundary/protected.manifest
NOTE: release/console-local-sidecar-pins.json has no row for v0.8.5; add one before tagging …

docs-truth         passed
boundary-manifest  passed
```

The scratch bump was discarded; this PR contains only the script change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fail-closed follow-up

Linear: [HELM-230](https://linear.app/mindburn-labs/issue/HELM-230)

The follow-up commit makes both derived-manifest refreshes required: missing or malformed public-docs contract inputs and missing or invalid boundary inputs now terminate preparation with a non-zero status. Focused tests cover successful refresh, idempotence, malformed and missing inputs, generator failure, and release-step ordering.

Local proof at 0f208b046e08e2f9c26a6d80f3f923cd337d9636: 15 prepare-version tests, version-drift, verify-boundary, docs-truth, and quality-pr passed. Two isolated missing-input CLI runs failed closed. A synthetic v0.8.5 preparation run twice produced byte-identical diff SHA-256 e6b7da1583a129fe0ae30d2f83a6747176fd8de86df00a2f9cc678ce200ba276 across the intended 43-file closure.