### PR TITLE
fix: align quickstart console dry-run preflight

### DIFF
--- a/core/cmd/helm-ai-kernel/local_console_test.go
+++ b/core/cmd/helm-ai-kernel/local_console_test.go
@@ -567,20 +567,56 @@ func TestQuickstartConsoleFailsBeforeMutationForExternalOverrideOrMissingBundle(
 	t.Cleanup(func() { localConsoleExecutable = original })
 	dataDir := filepath.Join(dir, "quickstart-data")
 	var stdout, stderr bytes.Buffer
+	if code := runQuickstartCmdWithReady([]string{"--console", "--dry-run", "--data-dir", dataDir}, &stdout, &stderr, nil); code != 1 {
+		t.Fatalf("dry-run exit code = %d, stdout = %s stderr = %s", code, stdout.String(), stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("dry-run wrote stdout = %s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Console-including packaged layout") {
+		t.Fatalf("missing bundle error = %s", stderr.String())
+	}
+	if _, statErr := os.Stat(dataDir); !os.IsNotExist(statErr) {
+		t.Fatalf("missing bundle dry-run mutated %q: %v", dataDir, statErr)
+	}
+}
+
+func TestQuickstartConsoleDryRunSucceedsWithTrustedBundleWithoutMutation(t *testing.T) {
+	target, err := localConsoleTarget()
+	if err != nil {
+		t.Skip(err)
+	}
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "bin", "helm-ai-kernel")
+	if err := os.MkdirAll(filepath.Dir(executable), 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executable, []byte("kernel"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	setLocalConsoleReleaseBuildInfo(t, "0.8.0", "")
+	_, manifestDigest := writeTrustedLocalConsoleRelease(t, executable, target)
+	consoleLocalSidecarManifestSHA256 = manifestDigest
+	originalExecutable := localConsoleExecutable
+	localConsoleExecutable = func() (string, error) { return executable, nil }
+	t.Cleanup(func() { localConsoleExecutable = originalExecutable })
+
+	dataDir := filepath.Join(dir, "quickstart-data")
+	var stdout, stderr bytes.Buffer
 	if code := runQuickstartCmdWithReady([]string{"--console", "--dry-run", "--data-dir", dataDir}, &stdout, &stderr, nil); code != 0 {
 		t.Fatalf("dry-run exit code = %d, stdout = %s stderr = %s", code, stdout.String(), stderr.String())
 	}
 	if stderr.Len() != 0 {
-		t.Fatalf("dry-run wrote stderr = %s", stderr.String())
+		t.Fatalf("unexpected dry-run stderr = %s", stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "\"operation\":\"preview\"") {
 		t.Fatalf("missing preview summary = %s", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "Console-including packaged layout") {
-		t.Fatalf("missing Console layout warning = %s", stdout.String())
+	if !strings.Contains(stdout.String(), "\"console\":true") {
+		t.Fatalf("missing console preview flag = %s", stdout.String())
 	}
 	if _, statErr := os.Stat(dataDir); !os.IsNotExist(statErr) {
-		t.Fatalf("missing bundle dry-run mutated %q: %v", dataDir, statErr)
+		t.Fatalf("trusted bundle dry-run mutated %q: %v", dataDir, statErr)
 	}
 }
 

--- a/core/cmd/helm-ai-kernel/quickstart_cmd.go
+++ b/core/cmd/helm-ai-kernel/quickstart_cmd.go
@@ -90,6 +90,11 @@ func runQuickstartCmdWithReady(args []string, stdout, stderr io.Writer, onReady 
 			writeQuickstartError(logger, logFormat, stderr, err, "")
 			return 1
 		}
+		planned, err = preflightQuickstartConsole(opts, planned)
+		if err != nil {
+			writeQuickstartError(logger, logFormat, stderr, err, "")
+			return 1
+		}
 		_ = json.NewEncoder(stdout).Encode(planned.summary("preview"))
 		return 0
 	}
@@ -332,12 +337,9 @@ func prepareQuickstart(opts quickstartOptions) (quickstartPrepared, error) {
 	if err != nil {
 		return quickstartPrepared{}, err
 	}
-	if opts.Console {
-		bundle, err := discoverLocalConsoleBundle()
-		if err != nil {
-			return quickstartPrepared{}, err
-		}
-		prepared.ConsoleBundle = bundle
+	prepared, err = preflightQuickstartConsole(opts, prepared)
+	if err != nil {
+		return quickstartPrepared{}, err
 	}
 	if opts.Reset {
 		if err := os.RemoveAll(opts.DataDir); err != nil {
@@ -381,6 +383,18 @@ func prepareQuickstart(opts quickstartOptions) (quickstartPrepared, error) {
 	prepared.PolicyPath = policyPath
 	prepared.Runtime = runtime
 	prepared.LocalSessionCredentialPath = credentialPath
+	return prepared, nil
+}
+
+func preflightQuickstartConsole(opts quickstartOptions, prepared quickstartPrepared) (quickstartPrepared, error) {
+	if !opts.Console {
+		return prepared, nil
+	}
+	bundle, err := discoverLocalConsoleBundle()
+	if err != nil {
+		return quickstartPrepared{}, err
+	}
+	prepared.ConsoleBundle = bundle
 	return prepared, nil
 }
 


### PR DESCRIPTION
## Summary
- reuse one non-mutating console preflight helper in both `quickstart --dry-run --console` and the real `prepareQuickstart` path
- fail dry-run previews with the same actionable packaged-console error the real startup already returns
- add regression coverage for both missing-bundle failure and trusted-bundle success without mutating the data dir

## Validation
- `GOWORK=off go test ./cmd/helm-ai-kernel -run 'TestQuickstartConsole|TestPrepareQuickstartConsole' -count=1`
- `GOWORK=off go test ./cmd/helm-ai-kernel -count=1`
- `GOWORK=off go test ./cmd/helm-ai-kernel -run 'TestQuickstartConsole|TestPrepareQuickstartConsole' -race -count=1`
- `GOWORK=off SHELL=/opt/homebrew/bin/bash make quality-pr`

## Sequencing
- Do not merge before #842. This is intended to land immediately after #842 in the release sequence.
