### PR TITLE
ci: guard release publication authority

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,80 @@ jobs:
             exit 1
           fi
 
+  release-authority:
+    # This is the one human authority boundary for the v* publication train.
+    # The release-production environment must exist, require the designated
+    # conductor's approval, and disallow administrator bypass before this
+    # workflow is enabled. GitHub auto-creates unknown environments without
+    # protection rules, so this job also requires an environment-scoped arming
+    # variable before any publication path may proceed. Validation remains
+    # outside the environment so an invalid candidate fails before asking for
+    # human approval.
+    runs-on: ubuntu-latest
+    needs:
+      - release-preflight
+      - validate
+      - deployment-smoke
+      - kind-smoke
+      - release-smoke
+      - reproducibility-check
+      - benchmark-pin
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_type == 'tag' &&
+      github.actor == 'mindburnlabs' &&
+      github.triggering_actor == 'mindburnlabs' &&
+      github.run_attempt == 1
+    environment:
+      name: release-production
+    permissions:
+      contents: read
+    steps:
+      - name: Bind this run to the live immutable annotated tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}
+          EXPECTED_TAG_OBJECT: ${{ github.event.after }}
+          EXPECTED_COMMIT: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]; then
+            echo "::error::release-production environment is not armed. Set environment-scoped HELM_RELEASE_AUTHORITY_ARMED=release-production and keep required reviewers plus administrator-bypass disabled before enabling Release."
+            exit 1
+          fi
+          if ! [[ "${EXPECTED_TAG_OBJECT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Push event after value is not a full Git object SHA: ${EXPECTED_TAG_OBJECT}"
+            exit 1
+          fi
+          if ! [[ "${EXPECTED_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Workflow commit is not a full Git commit SHA: ${EXPECTED_COMMIT}"
+            exit 1
+          fi
+
+          ref_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${GITHUB_REF_NAME}")"
+          ref_type="$(jq -er '.object.type' <<<"${ref_json}")"
+          live_tag_object="$(jq -er '.object.sha' <<<"${ref_json}")"
+          if [ "${ref_type}" != "tag" ]; then
+            echo "::error::Release ref ${GITHUB_REF_NAME} is ${ref_type}, not an annotated tag object."
+            exit 1
+          fi
+          if [ "${live_tag_object}" != "${EXPECTED_TAG_OBJECT}" ]; then
+            echo "::error::Release tag object moved: event=${EXPECTED_TAG_OBJECT}, live=${live_tag_object}."
+            exit 1
+          fi
+          tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${live_tag_object}")"
+          target_type="$(jq -er '.object.type' <<<"${tag_json}")"
+          target_commit="$(jq -er '.object.sha' <<<"${tag_json}")"
+          if [ "${target_type}" != "commit" ]; then
+            echo "::error::Annotated release tag points to ${target_type}, not a commit."
+            exit 1
+          fi
+          if [ "${target_commit}" != "${EXPECTED_COMMIT}" ]; then
+            echo "::error::Annotated release tag resolves to ${target_commit}, not workflow commit ${EXPECTED_COMMIT}."
+            exit 1
+          fi
+
   validate:
     runs-on: ubuntu-latest
     needs: release-preflight
@@ -185,7 +259,7 @@ jobs:
     # only its aggregate keyless manifest and an exact source pin committed in
     # the Kernel release source; it never accepts a mutable Console main build.
     runs-on: ubuntu-latest
-    needs: validate
+    needs: [validate, release-authority]
     outputs:
       manifest_sha256: ${{ steps.console-verify.outputs.manifest_sha256 }}
     permissions:
@@ -316,7 +390,7 @@ jobs:
 
   binaries:
     runs-on: ubuntu-latest
-    needs: [validate, deployment-smoke, kind-smoke, release-smoke]
+    needs: [validate, deployment-smoke, kind-smoke, release-smoke, release-authority]
     env:
       HELM_RELEASE_EVIDENCE_PROFILE: ${{ vars.HELM_RELEASE_EVIDENCE_PROFILE }}
       HELM_RELEASE_EVIDENCE_ANCHOR_TYPE: ${{ vars.HELM_RELEASE_EVIDENCE_ANCHOR_TYPE }}
@@ -376,7 +450,7 @@ jobs:
     runs-on: ubuntu-latest
     # Keyless signatures are externally visible release evidence. Do not create
     # them until both release authorities have closed successfully.
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     permissions:
       actions: read
       contents: read
@@ -445,7 +519,7 @@ jobs:
     runs-on: ubuntu-latest
     # Public registry publication starts only after the EvidencePack-backed
     # release assets and the exact Console source closure both succeed.
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     permissions:
       contents: read
       id-token: write
@@ -508,7 +582,7 @@ jobs:
 
   cosign-container:
     runs-on: ubuntu-latest
-    needs: container
+    needs: [container, release-authority]
     permissions:
       contents: read
       id-token: write
@@ -536,7 +610,9 @@ jobs:
     # a green CI (ci.yml) run for the sha, then builds, pushes, and
     # cosign-signs ghcr.io/mindburn-labs/helm-ai-kernel:sha-<sha>. The v* tag
     # pipeline above is untouched; it skips on dispatch (version-contract
-    # gate) and this job skips on tag pushes.
+    # gate) and this job skips on tag pushes. This deliberately does not depend
+    # on release-authority: it is a SHA-addressed, dev-grade QA dispatch lane,
+    # not a version-tag release publisher.
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     # One publish in flight per sha: the tag is deterministic, so two
@@ -650,7 +726,7 @@ jobs:
 
   homebrew:
     runs-on: ubuntu-latest
-    needs: github-release
+    needs: [github-release, release-authority]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
@@ -731,7 +807,7 @@ jobs:
 
   chart:
     runs-on: ubuntu-latest
-    needs: [validate, deployment-smoke, kind-smoke, container, cosign-container]
+    needs: [validate, deployment-smoke, kind-smoke, container, cosign-container, release-authority]
     permissions:
       contents: read
       id-token: write
@@ -784,7 +860,7 @@ jobs:
 
   artifacthub-repo:
     runs-on: ubuntu-latest
-    needs: chart
+    needs: [chart, release-authority]
     permissions:
       contents: read
       packages: write
@@ -810,7 +886,7 @@ jobs:
 
   go-sdk-tag:
     runs-on: ubuntu-latest
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     permissions:
       contents: write
     steps:
@@ -857,7 +933,7 @@ jobs:
 
   npm-sdk:
     runs-on: ubuntu-latest
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     environment: npm-production
     permissions:
       contents: read
@@ -907,7 +983,7 @@ jobs:
 
   python-sdk:
     runs-on: ubuntu-latest
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     environment: pypi-production
     permissions:
       contents: read
@@ -980,7 +1056,7 @@ jobs:
 
   crates-sdk:
     runs-on: ubuntu-latest
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     environment: crates-production
     permissions:
       contents: read
@@ -1045,7 +1121,7 @@ jobs:
 
   maven-sdk:
     runs-on: ubuntu-latest
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     environment: maven-central
     permissions:
       contents: read
@@ -1177,7 +1253,7 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
-    needs: [release-preflight, binaries, container, cosign-binaries, cosign-container, reproducibility-check, benchmark-pin, chart, artifacthub-repo, npm-sdk, python-sdk, crates-sdk, maven-sdk, version-status, deployment-smoke, kind-smoke, release-smoke, console-release-assets]
+    needs: [release-preflight, release-authority, binaries, container, cosign-binaries, cosign-container, reproducibility-check, benchmark-pin, chart, artifacthub-repo, npm-sdk, python-sdk, crates-sdk, maven-sdk, version-status, deployment-smoke, kind-smoke, release-smoke, console-release-assets]
     permissions:
       actions: read
       contents: write
@@ -1221,7 +1297,7 @@ jobs:
     # v0.8.0 includes the local Console. Build and verify every Console asset
     # before the one public GitHub release step consumes this artifact.
     runs-on: ubuntu-latest
-    needs: [binaries, console-local-sidecar]
+    needs: [binaries, console-local-sidecar, release-authority]
     permissions:
       actions: read
       contents: read
@@ -1363,7 +1439,7 @@ jobs:
           if-no-files-found: error
 
   slsa-provenance:
-    needs: [binaries, github-release]
+    needs: [binaries, github-release, release-authority]
     permissions:
       actions: read
       contents: write
@@ -1377,7 +1453,7 @@ jobs:
 
   post-release-version-drift:
     runs-on: ubuntu-latest
-    needs: [github-release, slsa-provenance, homebrew, go-sdk-tag, console-release-assets]
+    needs: [github-release, slsa-provenance, homebrew, go-sdk-tag, console-release-assets, release-authority]
     if: >-
       always() &&
       needs.github-release.result == 'success' &&

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Guard tag-release provenance and no-fanout workflow invariants.
+"""Guard tag-release authority, provenance, and no-fanout invariants.
 
 quantum_posture: this text-level contract test checks classical cosign and
 checksum workflow wiring; it implements no cryptographic control or
@@ -16,20 +16,183 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 VERSION_SURFACES = ROOT / "release" / "version-surfaces.yaml"
 
+TAG_RELEASE_MUTATION_JOBS = frozenset(
+    {
+        "artifacthub-repo",
+        "binaries",
+        "chart",
+        "console-local-sidecar",
+        "console-release-assets",
+        "container",
+        "cosign-binaries",
+        "cosign-container",
+        "crates-sdk",
+        "github-release",
+        "go-sdk-tag",
+        "homebrew",
+        "maven-sdk",
+        "npm-sdk",
+        "post-release-version-drift",
+        "python-sdk",
+        "slsa-provenance",
+    }
+)
+
+# container-sha publishes a dev-grade image for one exact, green-CI commit via
+# workflow_dispatch. It is intentionally not a v-tag release job and therefore
+# must not be coupled to the annotated-tag release authority boundary.
+NON_RELEASE_MUTATION_JOB_EXEMPTIONS = frozenset({"container-sha"})
+
+# These source markers classify every current externally mutating job. Keeping
+# the classification here makes a new publisher fail closed until its authority
+# dependency is deliberately reviewed (or it is documented as a non-release
+# exemption above).
+EXTERNAL_MUTATION_MARKERS = (
+    "actions/attest-build-provenance@",
+    "cosign sign",
+    "gh release upload ",
+    "gh workflow run ",
+    "git push ",
+    "helm push ",
+    "mvn --batch-mode deploy",
+    "npm publish ",
+    "oras push ",
+    "push: true",
+    "pypa/gh-action-pypi-publish@",
+    "run: cargo publish",
+    "slsa-framework/slsa-github-generator/",
+    "softprops/action-gh-release@",
+)
+
+RELEASE_AUTHORITY_GUARD_CLAUSES = (
+    "github.event_name == 'push'",
+    "github.ref_type == 'tag'",
+    "github.actor == 'mindburnlabs'",
+    "github.triggering_actor == 'mindburnlabs'",
+    "github.run_attempt == 1",
+)
+
 
 class ReleaseWorkflowContractTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.workflow = WORKFLOW.read_text()
+        cls.workflow = WORKFLOW.read_text(encoding="utf-8")
+        cls.job_blocks = {
+            match.group("name"): match.group("body")
+            for match in re.finditer(
+                r"^  (?P<name>[A-Za-z0-9_-]+):\n"
+                r"(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+                cls.workflow,
+                re.MULTILINE | re.DOTALL,
+            )
+        }
 
     def job(self, name: str) -> str:
+        self.assertIn(name, self.job_blocks, f"missing {name} job")
+        return self.job_blocks[name]
+
+    def job_needs(self, name: str) -> set[str]:
+        lines = self.job(name).splitlines()
+        for index, line in enumerate(lines):
+            if not line.startswith("    needs:"):
+                continue
+            value = line.removeprefix("    needs:").strip()
+            if value.startswith("[") and value.endswith("]"):
+                return {item.strip() for item in value[1:-1].split(",") if item.strip()}
+            if value:
+                return {value}
+
+            needs: set[str] = set()
+            for child in lines[index + 1 :]:
+                if child.startswith("      - "):
+                    needs.add(child.removeprefix("      - ").strip())
+                    continue
+                break
+            return needs
+        return set()
+
+    def job_if(self, name: str) -> str:
         match = re.search(
-            rf"^  {re.escape(name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
-            self.workflow,
-            re.MULTILINE | re.DOTALL,
+            r"^    if:\s*(?P<inline>[^\n]*)\n(?P<block>(?:      [^\n]*\n)*)",
+            self.job(name),
+            re.MULTILINE,
         )
-        self.assertIsNotNone(match, f"missing {name} job")
-        return match.group("body")  # type: ignore[union-attr]
+        self.assertIsNotNone(match, f"missing job-level if for {name}")
+        assert match is not None
+        return "\n".join((match.group("inline"), match.group("block")))
+
+    def external_mutation_jobs(self) -> set[str]:
+        return {
+            name
+            for name, body in self.job_blocks.items()
+            if any(marker in body for marker in EXTERNAL_MUTATION_MARKERS)
+        }
+
+    def test_release_authority_is_human_gated_armed_and_binds_the_live_tag_object(self) -> None:
+        authority = self.job("release-authority")
+        self.assertEqual(
+            self.job_needs("release-authority"),
+            {
+                "benchmark-pin",
+                "deployment-smoke",
+                "kind-smoke",
+                "release-preflight",
+                "release-smoke",
+                "reproducibility-check",
+                "validate",
+            },
+        )
+        self.assertIn("environment:\n      name: release-production", authority)
+        for clause in RELEASE_AUTHORITY_GUARD_CLAUSES:
+            self.assertIn(clause, self.job_if("release-authority"))
+
+        self.assertIn("RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}", authority)
+        self.assertIn(
+            'if [ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]; then',
+            authority,
+        )
+        # The guard binds the event-carried SHA to the live annotated tag
+        # object, then separately verifies the peeled commit.
+        self.assertIn("EXPECTED_TAG_OBJECT: ${{ github.event.after }}", authority)
+        self.assertIn("EXPECTED_COMMIT: ${{ github.sha }}", authority)
+        self.assertIn(
+            'if [ "${live_tag_object}" != "${EXPECTED_TAG_OBJECT}" ]; then',
+            authority,
+        )
+        self.assertIn(
+            'gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${GITHUB_REF_NAME}"',
+            authority,
+        )
+        self.assertIn('if [ "${ref_type}" != "tag" ]; then', authority)
+        self.assertIn(
+            'gh api "repos/${GITHUB_REPOSITORY}/git/tags/${live_tag_object}"',
+            authority,
+        )
+        self.assertIn('if [ "${target_type}" != "commit" ]; then', authority)
+        self.assertIn(
+            'if [ "${target_commit}" != "${EXPECTED_COMMIT}" ]; then',
+            authority,
+        )
+
+    def test_every_tag_release_mutation_requires_fresh_conductor_authority(self) -> None:
+        detected = self.external_mutation_jobs()
+        self.assertEqual(
+            detected,
+            TAG_RELEASE_MUTATION_JOBS | NON_RELEASE_MUTATION_JOB_EXEMPTIONS,
+            "external mutation classification changed; review the new job before publication",
+        )
+
+        for job_name in sorted(TAG_RELEASE_MUTATION_JOBS):
+            with self.subTest(job=job_name):
+                self.assertIn("release-authority", self.job_needs(job_name))
+
+    def test_container_sha_remains_the_separate_exact_sha_qa_lane(self) -> None:
+        container_sha = self.job("container-sha")
+        self.assertEqual(NON_RELEASE_MUTATION_JOB_EXEMPTIONS, {"container-sha"})
+        self.assertNotIn("release-authority", self.job_needs("container-sha"))
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", container_sha)
+        self.assertIn("No successful CI (ci.yml) run for ${SOURCE_SHA}", container_sha)
+        self.assertIn("dev.mindburn.build-grade=dev", container_sha)
 
     def test_tag_release_is_main_only_and_catalog_is_presynced(self) -> None:
         preflight = self.job("release-preflight")
@@ -72,7 +235,10 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
 
     def test_release_creation_requires_prebuilt_console_assets(self) -> None:
         binaries = self.job("binaries")
-        self.assertIn("needs: [validate, deployment-smoke, kind-smoke, release-smoke]", binaries)
+        self.assertIn(
+            "needs: [validate, deployment-smoke, kind-smoke, release-smoke, release-authority]",
+            binaries,
+        )
         self.assertIn("HELM_RELEASE_EVIDENCE_PROFILE: ${{ vars.HELM_RELEASE_EVIDENCE_PROFILE }}", binaries)
         self.assertIn("HELM_RELEASE_EVIDENCE_ANCHOR_TYPE: ${{ vars.HELM_RELEASE_EVIDENCE_ANCHOR_TYPE }}", binaries)
         self.assertIn("HELM_RELEASE_EVIDENCE_ANCHOR_URI: ${{ vars.HELM_RELEASE_EVIDENCE_ANCHOR_URI }}", binaries)
@@ -103,16 +269,16 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             "console-release-assets",
         ):
             self.assertIn(
-                "needs: [binaries, console-local-sidecar]",
+                "needs: [binaries, console-local-sidecar, release-authority]",
                 self.job(publisher),
                 publisher,
             )
 
-        self.assertIn("needs: container", self.job("cosign-container"))
+        self.assertIn("needs: [container, release-authority]", self.job("cosign-container"))
         self.assertIn("container", self.job("chart"))
         self.assertIn("cosign-container", self.job("chart"))
-        self.assertIn("needs: chart", self.job("artifacthub-repo"))
-        self.assertIn("needs: github-release", self.job("homebrew"))
+        self.assertIn("needs: [chart, release-authority]", self.job("artifacthub-repo"))
+        self.assertIn("needs: [github-release, release-authority]", self.job("homebrew"))
 
         reproducibility = self.job("reproducibility-check")
         self.assertIn("needs: validate", reproducibility)
@@ -137,7 +303,10 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
 
     def test_console_assets_are_verified_before_publication(self) -> None:
         console_assets = self.job("console-release-assets")
-        self.assertIn("needs: [binaries, console-local-sidecar]", console_assets)
+        self.assertIn(
+            "needs: [binaries, console-local-sidecar, release-authority]",
+            console_assets,
+        )
         self.assertNotIn("github-release", console_assets)
         self.assertNotIn("always()", console_assets)
         self.assertIn("make release-binaries-reproducible", console_assets)
@@ -171,7 +340,7 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
 
         post_release = self.job("post-release-version-drift")
         self.assertIn(
-            "needs: [github-release, slsa-provenance, homebrew, go-sdk-tag, console-release-assets]",
+            "needs: [github-release, slsa-provenance, homebrew, go-sdk-tag, console-release-assets, release-authority]",
             post_release,
         )
         self.assertIn("always()", post_release)


### PR DESCRIPTION
## Summary
- add a single `release-authority` gate for all externally mutating v-tag release jobs
- require the `release-production` environment to be explicitly armed before publication
- bind the run to the live annotated tag object and peeled commit
- keep `container-sha` as the separate exact-SHA QA lane
- simplify downstream publisher guards so authority is enforced by the workflow graph instead of duplicated `if` clauses

## Why
HELM-366 approved controlled recovery for the reviewed release-authority guard, but the local diff still had two problems:
- repeated per-job actor/run-attempt guards made the publication graph harder to audit than necessary
- the authority job had drifted into treating `github.event.after` like the pushed commit, which weakens annotated-tag binding and can reject the wrong thing

This change keeps the authority boundary fail-closed while making the workflow easier to reason about.

## Validation
- `python3 scripts/ci/release_workflow_contract_test.py`
- `python3 scripts/ci/quality.py run --gate release-workflow-contract`
- `python3 scripts/ci/quality.py self-test`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

## Recovery boundary
- no workflow enablement
- no tag deletion/recreation
- no release publication
- no package publish

Refs: HELM-366
