### PR TITLE
docs: govern privileged HELM operations

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -79,7 +79,8 @@ monorepo jobs do not look for a nonexistent root `go.sum`.
 Tag-triggered release jobs treat the repository `VERSION` file as release
 truth. The first release job fails when `GITHUB_REF_NAME` is not exactly
 `v$(cat VERSION)`. Before any release publication, the preflight also requires
-the tag's peeled commit to equal current `origin/main` and the Kernel OpenAPI
+the tag's peeled commit to be reachable from current `origin/main` (equal to it
+or one of its ancestors) and the Kernel OpenAPI
 blob to exactly match `Mindburn-Labs/contracts-catalog` `main`. The workflow
 never creates a downstream catalog PR; sync and merge that catalog change
 before tagging. `DOWNSTREAM_FANOUT_TOKEN` is retained only as a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,4 @@ Welcome to the **helm-ai-kernel** repository. This is the core, open-source exec
 2. Maintain strict zero-dependency boundaries on volatile commercial components.
 3. Every functional path must maintain green unit/integration tests and high coverage metrics.
 4. Treat RLM outputs as input evidence only. They become Kernel truth only when represented through existing verdict, receipt, ProofGraph, EvidencePack, contract, conformance, or verifier paths; do not add a separate RLM proof universe.
+5. Treat `mindburnlabs` and `peycheff-com` as Ivan's human GitHub accounts and preserve both as Mindburn-Labs organization owners/admins. Before any GitHub Actions state mutation, release/tag/package/artifact mutation, production promotion, or organization/repository access or settings mutation, read and follow `/helm-privileged-ops`; obtain exact single-use human approval and verify the authoritative readback.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,6 +1,6 @@
 ---
 title: Publishing
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-11
 ---
 
 # Publishing
@@ -93,8 +93,9 @@ Before tagging a release:
 9. after publication, run or confirm `make version-drift-published`
 
 Tag-triggered release workflows fail if the tag `v<version>` does not match
-the checked-in `VERSION` file, the tag's peeled commit is not current Kernel
-`main`, or the catalog OpenAPI differs from the tagged Kernel OpenAPI. The
+the checked-in `VERSION` file, the tag's peeled commit is not reachable from
+current `origin/main` (equal to it or one of its ancestors), or the catalog
+OpenAPI differs from the tagged Kernel OpenAPI. The
 preflight reads catalog `main` with `DOWNSTREAM_FANOUT_TOKEN`; it never opens
 or merges a downstream catalog PR. The chart and SDK package manifests are not
 patched in CI; source-controlled release metadata is the authority.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -136,13 +136,17 @@ The release workflow attaches these assets:
 - `sample-policy-material.tar`
 - `helm-ai-kernel-launchpad-data.tar`
 - `helm-ai-kernel.mcpb`
+- `helm-console-local-sidecar-*`
+- `helm-ai-kernel-*-console.tar.gz`
+- `CONSOLE-SHA256SUMS.txt`
 - `helm-ai-kernel.rb`
 - `v0.8.4.json`
 - matching `*.cosign.bundle` files for every primary asset
 
 `sample-policy-material.tar` includes the sample policy and its referenced EU
-AI Act high-risk reference pack. Browser UI bundles are not Kernel release
-assets and are not installed by the Homebrew formula.
+AI Act high-risk reference pack. The local Console sidecars and standalone
+browser UI layouts are Kernel release assets; the Homebrew formula does not
+install them.
 The retained release workflow attaches a `helm-ai-kernel.rb` formula asset for version `0.8.4`
 and publishes the same version to `mindburnlabs/homebrew-tap`;
 `version-status.json` must include a passing `homebrew-tap` surface before


### PR DESCRIPTION
## Summary
- require `/helm-privileged-ops` before privileged Actions, release, production, access, or settings mutations
- preserve `mindburnlabs` and `peycheff-com` as Ivan's human organization owners/admins
- align publishing docs with the release preflight's ancestry rule
- list the Console sidecars and standalone browser layouts that the Kernel release workflow actually publishes, while retaining the Homebrew-install limitation

## Validation
- `python3 scripts/ci/release_workflow_contract_test.py` (10/10)
- `make docs-coverage docs-truth`
- `git diff --check`
- independent exact-head review requested after the source-truth correction

Relates to HELM-366 and HELM-448.

This PR changes source instructions and documentation only. It does not mutate Actions state, tags, releases, packages, environments, settings, deployment, or runtime state.