### PR TITLE
docs(riskscan): correct scan EvidencePack claims

### DIFF
--- a/docs/reference/agent-risk-scan.md
+++ b/docs/reference/agent-risk-scan.md
@@ -197,14 +197,18 @@ The verifier checks:
   non-collection fields;
 - the pack-to-envelope IDs and hashes, plus every declared artifact path and
   SHA-256 hash;
-- the exact supported layout, rejecting missing, unexpected, unsupported, or
-  hash-mismatched files and unsafe archive entries.
+- the supported final extracted-file layout, rejecting missing, unexpected,
+  unsupported, or hash-mismatched files and unsafe archive paths, entry types,
+  and sizes; duplicate normalized archive member paths are not rejected, so
+  this check does not establish archive-entry uniqueness.
 
 A signature or signer in this local risk-scan pack is rejected as unsupported:
-the scan has no independently trusted signer. `VERIFIED` therefore means local
-artifact integrity only. It does not prove that execution occurred or was
-governed or authorized, nor does it establish runtime provenance or live
-posture.
+the scan has no independently trusted signer. `VERIFIED` therefore means
+structural validation and internal hash consistency for the final extracted
+file set. Because the expected hashes are stored in the same unsigned archive,
+it does not establish artifact integrity against an actor who can rewrite that
+archive. It also does not prove that execution occurred or was governed or
+authorized, nor does it establish runtime provenance or live posture.
 
 ## Upload Contract
 

--- a/docs/reference/agent-risk-scan.md
+++ b/docs/reference/agent-risk-scan.md
@@ -184,8 +184,9 @@ helm-ai-kernel verify-scan --bundle out/risk-scan-pack.tar --json
 
 The verifier checks:
 
-- the generic EvidencePack required fields and required
-  `attestation.pack_hash`, including its JCS-computed contract hash;
+- the generic EvidencePack validator's required identifiers and status fields,
+  required `attestation.pack_hash`, and its JCS-computed contract hash; this
+  path does not independently apply the complete EvidencePack JSON Schema;
 - the canonical RiskEnvelope representation, content hash, schema, and privacy
   non-collection fields;
 - the pack-to-envelope IDs and hashes, plus every declared artifact path and

--- a/docs/reference/agent-risk-scan.md
+++ b/docs/reference/agent-risk-scan.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Risk Scan
-last_reviewed: 2026-08-03
+last_reviewed: 2026-08-11
 ---
 
 # Agent Risk Scan
@@ -37,6 +37,7 @@ After running `scan`, you can show:
 | Markdown preview | `--preview out.md` |
 | HTML preview | `--preview out.html` |
 | Evidence pack tar | `--evidence-pack pack.tar` |
+| Offline evidence-pack verification | `helm-ai-kernel verify-scan --bundle pack.tar` |
 | Explicit upload | `--upload --upload-url <url> --yes` |
 | Receipt projection | `--from-receipts <dir>` |
 | Local salt | `--salt-file <path>` |
@@ -163,15 +164,40 @@ These values are not exported:
 - secret values;
 - local salts.
 
-The evidence pack contains only:
+The evidence-pack tar contains exactly:
 
+- `evidence-pack.json`, using the generic `contracts.EvidencePack` contract;
 - `risk-envelope.json`;
-- `schema-validation.json`;
-- `privacy-manifest.json`;
-- `source-pack-hash.json`;
-- requested previews.
+- zero or more requested `.md` or `.html` previews under `previews/`.
 
-The raw source pack, raw config files, and raw receipts stay local.
+It adds no independent archive index, seal, signature, or trust format. The raw
+source pack, raw config files, and raw receipts stay local.
+
+## Offline Verification
+
+Verify an archive without uploading it:
+
+```bash
+helm-ai-kernel verify-scan --bundle out/risk-scan-pack.tar
+helm-ai-kernel verify-scan --bundle out/risk-scan-pack.tar --json
+```
+
+The verifier checks:
+
+- the generic EvidencePack required fields and required
+  `attestation.pack_hash`, including its JCS-computed contract hash;
+- the canonical RiskEnvelope representation, content hash, schema, and privacy
+  non-collection fields;
+- the pack-to-envelope IDs and hashes, plus every declared artifact path and
+  SHA-256 hash;
+- the exact supported layout, rejecting missing, unexpected, unsupported, or
+  hash-mismatched files and unsafe archive entries.
+
+A signature or signer in this local risk-scan pack is rejected as unsupported:
+the scan has no independently trusted signer. `VERIFIED` therefore means local
+artifact integrity only. It does not prove that execution occurred or was
+governed or authorized, nor does it establish runtime provenance or live
+posture.
 
 ## Upload Contract
 

--- a/docs/reference/agent-risk-scan.md
+++ b/docs/reference/agent-risk-scan.md
@@ -185,11 +185,14 @@ helm-ai-kernel verify-scan --bundle out/risk-scan-pack.tar --json
 The verifier checks:
 
 - the generic EvidencePack validator's required identifiers and status fields
-  and required `attestation.pack_hash`; it recomputes that hash over a legacy
-  JCS projection that omits `correlation_id`, `threat_scan`,
-  `security_findings`, `network_logs`, `secret_events`, `port_exposures`,
-  `git_diffs`, and `replay_manifest`; this path does not independently apply
-  the complete EvidencePack JSON Schema or bind those omitted fields;
+  and required `attestation.pack_hash`, comparing that stored hash with a
+  legacy JCS projection; the projection excludes the entire `attestation`
+  object, including `attestation.kernel_version`, and also omits
+  `correlation_id`, `threat_scan`, `security_findings`, `network_logs`,
+  `secret_events`, `port_exposures`, `git_diffs`, and `replay_manifest`;
+  `verify-scan` separately rejects `attestation.signature` and
+  `attestation.signer_id`, but this path does not independently apply the
+  complete EvidencePack JSON Schema or bind those omitted fields;
 - the canonical RiskEnvelope representation, content hash, schema, and privacy
   non-collection fields;
 - the pack-to-envelope IDs and hashes, plus every declared artifact path and

--- a/docs/reference/agent-risk-scan.md
+++ b/docs/reference/agent-risk-scan.md
@@ -184,9 +184,12 @@ helm-ai-kernel verify-scan --bundle out/risk-scan-pack.tar --json
 
 The verifier checks:
 
-- the generic EvidencePack validator's required identifiers and status fields,
-  required `attestation.pack_hash`, and its JCS-computed contract hash; this
-  path does not independently apply the complete EvidencePack JSON Schema;
+- the generic EvidencePack validator's required identifiers and status fields
+  and required `attestation.pack_hash`; it recomputes that hash over a legacy
+  JCS projection that omits `correlation_id`, `threat_scan`,
+  `security_findings`, `network_logs`, `secret_events`, `port_exposures`,
+  `git_diffs`, and `replay_manifest`; this path does not independently apply
+  the complete EvidencePack JSON Schema or bind those omitted fields;
 - the canonical RiskEnvelope representation, content hash, schema, and privacy
   non-collection fields;
 - the pack-to-envelope IDs and hashes, plus every declared artifact path and


### PR DESCRIPTION
## Summary

- replace three nonexistent scan-archive members with the actual generic EvidencePack inventory
- document `verify-scan` contract, artifact-binding, and fail-closed layout checks
- state the integrity-only trust boundary and explicitly deny execution, authorization, runtime-provenance, and live-posture proof

Closes HELM-226.

## Validation

```bash
/usr/bin/python3 scripts/check_documentation_truth.py
git diff --check
GOROOT=<mise-go-1.25.12> GOWORK=off go test ./pkg/riskscan ./cmd/helm-ai-kernel
```

`make docs-truth` was attempted, but the local wrapper stopped at mise's untrusted-worktree prompt; its exact underlying checker passed directly.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes.
- [ ] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. (Not applicable.)
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path.
- [ ] Release version surfaces are lockstep (`make version-drift`) when touching `VERSION`, release workflows, chart metadata, SDK manifests, OpenAPI, or publishing docs. (Not applicable.)
- [x] Security-sensitive material is not included in the PR.
- [ ] Breaking public interface changes are called out in `CHANGELOG.md`. (Not applicable.)
- [x] Advisory quality warnings are acknowledged or tracked when relevant.
