### PR TITLE
fix(cli): preserve failure exit codes in JSON output (HELM-482)

### DIFF
--- a/core/cmd/helm-ai-kernel/boundary_surface_cmd.go
+++ b/core/cmd/helm-ai-kernel/boundary_surface_cmd.go
@@ -51,6 +51,14 @@ func writeSurfaceJSON(w io.Writer, value any) int {
 	return 0
 }
 
+func writeSurfaceJSONResult(w io.Writer, value any, successful bool) int {
+	_ = writeSurfaceJSON(w, value)
+	if !successful {
+		return 1
+	}
+	return 0
+}
+
 func writeLocalMCPReceipt(id, kind string, value any) string {
 	path := localMCPReceiptPath(id)
 	dir := filepath.Dir(path)
@@ -215,7 +223,7 @@ func runBoundaryVerify(args []string, registry *boundarypkg.SurfaceRegistry, std
 	}
 	result := registry.VerifyRecord(*recordID)
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, result)
+		return writeSurfaceJSONResult(stdout, result, result.Verified)
 	}
 	fmt.Fprintf(stdout, "Boundary verification %s: %s\n", result.RecordID, result.Verdict)
 	if !result.Verified {
@@ -354,7 +362,7 @@ func runAuthzCheck(args []string, registry *boundarypkg.SurfaceRegistry, stdout,
 		return 2
 	}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, sealed)
+		return writeSurfaceJSONResult(stdout, sealed, sealed.Decision)
 	}
 	fmt.Fprintf(stdout, "Authz decision=%t snapshot=%s hash=%s\n", sealed.Decision, sealed.SnapshotID, sealed.SnapshotHash)
 	if !sealed.Decision {
@@ -564,7 +572,7 @@ func runApprovalsAssert(args []string, registry *boundarypkg.SurfaceRegistry, st
 		return 1
 	}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, approval)
+		return writeSurfaceJSONResult(stdout, approval, approval.State == contracts.ApprovalCeremonyAllowed)
 	}
 	fmt.Fprintf(stdout, "Approval %s state=%s method=%s\n", approval.ApprovalID, approval.State, approval.AuthMethod)
 	if approval.State != contracts.ApprovalCeremonyAllowed {
@@ -860,7 +868,7 @@ func runMCPGet(args []string, stdout, stderr io.Writer) int {
 	}
 	record := map[string]any{"server_id": *serverID, "state": "not_found", "dispatch_ready": false}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, record)
+		return writeSurfaceJSONResult(stdout, record, false)
 	}
 	fmt.Fprintf(stdout, "MCP server %s is not registered in this local CLI registry\n", *serverID)
 	return 1
@@ -1039,7 +1047,7 @@ func runMCPAuthProfileVerify(args []string, registry *boundarypkg.SurfaceRegistr
 		}
 	}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, result)
+		return writeSurfaceJSONResult(stdout, result, result["verified"] == true)
 	}
 	fmt.Fprintf(stdout, "MCP auth profile %s verified=%t\n", *profileID, result["verified"])
 	if result["verified"] != true {
@@ -1326,7 +1334,7 @@ func runSandboxGet(args []string, stdout, stderr io.Writer) int {
 	}
 	result := map[string]any{"grant_id": *grantID, "state": "not_found", "verified": false}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, result)
+		return writeSurfaceJSONResult(stdout, result, false)
 	}
 	fmt.Fprintf(stdout, "Sandbox grant %s is not recorded in this local CLI registry\n", *grantID)
 	return 1
@@ -1354,7 +1362,7 @@ func runSandboxVerify(args []string, stdout, stderr io.Writer) int {
 		result.Findings = []string{"grant hash is required for offline verification"}
 	}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, result)
+		return writeSurfaceJSONResult(stdout, result, result.Verdict == contracts.VerdictAllow)
 	}
 	fmt.Fprintf(stdout, "Sandbox verify verdict=%s grant=%s\n", result.Verdict, result.GrantID)
 	if result.Verdict != contracts.VerdictAllow {
@@ -1498,7 +1506,7 @@ func runEvidenceEnvelopeGet(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, result)
+		return writeSurfaceJSONResult(stdout, result, false)
 	}
 	fmt.Fprintf(stdout, "Envelope manifest %s is not recorded in this local CLI registry\n", *manifestID)
 	return 1
@@ -1576,7 +1584,7 @@ func runEvidenceEnvelopeVerify(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	if *jsonOutput {
-		return writeSurfaceJSON(stdout, result)
+		return writeSurfaceJSONResult(stdout, result, result.Verified)
 	}
 	fmt.Fprintf(stdout, "Evidence envelope verify manifest=%s verified=%t\n", result.ManifestID, result.Verified)
 	if !result.Verified {

--- a/core/cmd/helm-ai-kernel/cli_exit_contract_test.go
+++ b/core/cmd/helm-ai-kernel/cli_exit_contract_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	boundarypkg "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/boundary"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/store"
+)
+
+type surfaceCommand func([]string, io.Writer, io.Writer) int
+
+func TestFailingSurfaceCommandsKeepJSONExitStatus(t *testing.T) {
+	t.Setenv("HELM_DATA_DIR", t.TempDir())
+
+	tests := []struct {
+		name string
+		args []string
+		run  surfaceCommand
+	}{
+		{"boundary verify", []string{"--record-id", "missing"}, func(args []string, stdout, stderr io.Writer) int {
+			return runBoundaryVerify(args, boundarypkg.NewSurfaceRegistry(time.Now), stdout, stderr)
+		}},
+		{"authz check", []string{"--stale"}, func(args []string, stdout, stderr io.Writer) int {
+			return runAuthzCheck(args, boundarypkg.NewSurfaceRegistry(time.Now), stdout, stderr)
+		}},
+		{"mcp get", []string{"--server-id", "missing"}, runMCPGet},
+		{"mcp auth-profile verify", []string{"--profile-id", "missing"}, func(args []string, stdout, stderr io.Writer) int {
+			return runMCPAuthProfileVerify(args, boundarypkg.NewSurfaceRegistry(time.Now), stdout, stderr)
+		}},
+		{"sandbox get", []string{"--grant-id", "missing"}, runSandboxGet},
+		{"sandbox verify", nil, runSandboxVerify},
+		{"evidence envelope get", []string{"--manifest-id", "missing"}, runEvidenceEnvelopeGet},
+		{"evidence envelope verify", nil, runEvidenceEnvelopeVerify},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var textOut, textErr bytes.Buffer
+			textCode := test.run(test.args, &textOut, &textErr)
+
+			var jsonOut, jsonErr bytes.Buffer
+			jsonCode := test.run(append(append([]string{}, test.args...), "--json"), &jsonOut, &jsonErr)
+
+			if textCode != 1 || jsonCode != textCode {
+				t.Fatalf("failing exit drifted: text=%d json=%d\ntext=%s\njson=%s", textCode, jsonCode, textOut.String(), jsonOut.String())
+			}
+			var payload any
+			if err := json.Unmarshal(jsonOut.Bytes(), &payload); err != nil {
+				t.Fatalf("JSON failure output is not parseable: %v\n%s", err, jsonOut.String())
+			}
+		})
+	}
+}
+
+type acceptingApprovalAssertionVerifier struct{}
+
+func (acceptingApprovalAssertionVerifier) VerifyApprovalAssertion(contracts.ApprovalWebAuthnChallenge, contracts.ApprovalWebAuthnAssertion) error {
+	return nil
+}
+
+func TestApprovalsAssertKeepsJSONExitStatusWhileQuorumIsPending(t *testing.T) {
+	run := func(jsonOutput bool) (int, string) {
+		registry := boundarypkg.NewSurfaceRegistry(time.Now)
+		now := time.Now().UTC()
+		_, err := registry.PutApproval(contracts.ApprovalCeremony{
+			ApprovalID:  "approval-quorum",
+			Subject:     "deploy",
+			Action:      "approve",
+			State:       contracts.ApprovalCeremonyPending,
+			RequestedBy: "agent:requester",
+			Quorum:      2,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		registry.SetApprovalAssertionVerifier(acceptingApprovalAssertionVerifier{})
+		challenge, err := registry.CreateApprovalChallenge("approval-quorum", "passkey", time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+		args := []string{
+			"--challenge-id", challenge.ChallengeID,
+			"--actor", "user:reviewer",
+			"--assertion", "verified-assertion",
+			"--receipt-id", "receipt-review",
+		}
+		if jsonOutput {
+			args = append(args, "--json")
+		}
+		var stdout, stderr bytes.Buffer
+		return runApprovalsAssert(args, registry, &stdout, &stderr), stdout.String()
+	}
+
+	textCode, _ := run(false)
+	jsonCode, jsonOut := run(true)
+	if textCode != 1 || jsonCode != textCode {
+		t.Fatalf("pending quorum exit drifted: text=%d json=%d\njson=%s", textCode, jsonCode, jsonOut)
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(jsonOut), &payload); err != nil {
+		t.Fatalf("JSON approval output is not parseable: %v\n%s", err, jsonOut)
+	}
+}
+
+func TestReportChainFailureReturnsNonzeroInEveryOutputMode(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "broken-chain.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts, err := store.NewSQLiteReceiptStore(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, id := range []string{"receipt-a", "receipt-b"} {
+		if err := receipts.Store(context.Background(), &contracts.Receipt{
+			ReceiptID:    id,
+			DecisionID:   "decision-" + id,
+			EffectID:     "effect-" + id,
+			Status:       "ALLOW",
+			LamportClock: 1,
+			Timestamp:    time.Unix(int64(i+1), 0).UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "report.txt")
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"text", []string{"--db", dbPath}},
+		{"json", []string{"--db", dbPath, "--json"}},
+		{"file", []string{"--db", dbPath, "--output", outputPath}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := runReportCmd(test.args, &stdout, &stderr); code != 1 {
+				t.Fatalf("broken chain exit=%d, want 1\nstdout=%s\nstderr=%s", code, stdout.String(), stderr.String())
+			}
+		})
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("FAILED")) {
+		t.Fatalf("file report does not expose the chain failure: %s", data)
+	}
+}

--- a/core/cmd/helm-ai-kernel/report_cmd.go
+++ b/core/cmd/helm-ai-kernel/report_cmd.go
@@ -1,5 +1,9 @@
 package main
 
+// quantum_posture: reports describe existing classical Ed25519 receipt
+// verification; this command adds no cryptographic control and makes no
+// post-quantum assurance claim.
+
 import (
 	"context"
 	"database/sql"

--- a/core/cmd/helm-ai-kernel/report_cmd.go
+++ b/core/cmd/helm-ai-kernel/report_cmd.go
@@ -133,6 +133,9 @@ func runReportCmd(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "%s✅ Report generated%s → %s\n", ColorBold+ColorGreen, ColorReset, outputPath)
 	}
 
+	if !report.ChainIntegrity.Verified {
+		return 1
+	}
 	return 0
 }
 


### PR DESCRIPTION
## Summary
- preserve operational failure exits when boundary/surface commands emit JSON
- return exit 1 after report output when receipt-chain integrity fails
- cover eight reproduced surface failures, the pending approval-quorum path, and report stdout/JSON/file modes

## Validation
- focused exit-contract regression: pass
- make test-cli: pass
- make test: pass
- make verify-boundary: pass
- go vet ./cmd/helm-ai-kernel: pass
- gofmt check: pass
- specialist diff review: no findings

## Scope
Source and tests only. No docs, SDK schemas, dependencies, releases, workflows, deployment, or production state changed.

Linear: HELM-482