### PR TITLE
fix(release): preserve the passing version receipt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1483,6 +1483,8 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Wait for published version convergence
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
@@ -1502,6 +1504,8 @@ jobs:
           exit 1
       - name: Check full published version status
         if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           python3 scripts/release/check_version_drift.py \
@@ -1509,7 +1513,7 @@ jobs:
             --write-status version-status.json \
             published
       - name: Replace release version status with full post-release status
-        if: always()
+        if: success()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "${GITHUB_REF_NAME}" version-status.json --clobber

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -128,6 +128,38 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             if any(marker in body for marker in EXTERNAL_MUTATION_MARKERS)
         }
 
+    def step(self, job: str, name: str) -> str:
+        match = re.search(
+            rf"^      - name: {re.escape(name)}\n"
+            r"(?P<body>.*?)(?=^      - (?:name:|uses:)|\Z)",
+            job,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match, f"missing {name} step")
+        assert match is not None
+        return match.group("body")
+
+    def assert_post_release_status_safety(self, post_release: str) -> None:
+        for step_name in (
+            "Wait for published version convergence",
+            "Check full published version status",
+        ):
+            self.assertIn(
+                "GITHUB_TOKEN: ${{ github.token }}",
+                self.step(post_release, step_name),
+                f"{step_name} must use authenticated GitHub API requests",
+            )
+
+        upload = self.step(
+            post_release,
+            "Replace release version status with full post-release status",
+        )
+        self.assertRegex(
+            upload,
+            r"(?m)^        if: success\(\)$",
+            "failed convergence must not clobber the passing release receipt",
+        )
+
     def test_release_authority_is_human_gated_armed_and_binds_the_live_tag_object(self) -> None:
         authority = self.job("release-authority")
         self.assertEqual(
@@ -357,7 +389,34 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             post_release.index("- name: Check full published version status"),
         )
         self.assertRegex(post_release, r"- name: Check full published version status\n\s+if: always\(\)")
-        self.assertRegex(post_release, r"- name: Replace release version status with full post-release status\n\s+if: always\(\)")
+        self.assert_post_release_status_safety(post_release)
+
+    def test_post_release_status_safety_rejects_unsafe_mutations(self) -> None:
+        post_release = self.job("post-release-version-drift")
+        token = "GITHUB_TOKEN: ${{ github.token }}"
+        wait_step = self.step(post_release, "Wait for published version convergence")
+        status_step = self.step(post_release, "Check full published version status")
+
+        mutations = {
+            "unauthenticated convergence polling": post_release.replace(
+                wait_step,
+                wait_step.replace(token, "", 1),
+                1,
+            ),
+            "unauthenticated final status check": post_release.replace(
+                status_step,
+                status_step.replace(token, "", 1),
+                1,
+            ),
+            "failed status clobbers passing receipt": post_release.replace(
+                "- name: Replace release version status with full post-release status\n        if: success()",
+                "- name: Replace release version status with full post-release status\n        if: always()",
+                1,
+            ),
+        }
+        for mutation, workflow in mutations.items():
+            with self.subTest(mutation=mutation), self.assertRaises(AssertionError):
+                self.assert_post_release_status_safety(workflow)
 
     def test_console_dispatch_uses_an_immutable_ref_bound_to_the_source_pin(self) -> None:
         console_sidecar = self.job("console-local-sidecar")

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -209,20 +209,34 @@ def http_headers(url: str, extra: dict[str, str] | None = None) -> dict[str, str
     return headers
 
 
+def http_request(
+    url: str,
+    *,
+    method: str | None = None,
+    extra: dict[str, str] | None = None,
+) -> urllib.request.Request:
+    headers = http_headers(url, extra)
+    authorization = headers.pop("Authorization", None)
+    request = urllib.request.Request(url, method=method, headers=headers)
+    if authorization:
+        request.add_unredirected_header("Authorization", authorization)
+    return request
+
+
 def request_json(url: str) -> Any:
-    req = urllib.request.Request(url, headers=http_headers(url))
+    req = http_request(url)
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         return json.loads(response.read().decode("utf-8"))
 
 
 def request_bytes(url: str) -> bytes:
-    req = urllib.request.Request(url, headers=http_headers(url, {"Accept": "application/octet-stream, */*"}))
+    req = http_request(url, extra={"Accept": "application/octet-stream, */*"})
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         return response.read()
 
 
 def request_text(url: str) -> str:
-    req = urllib.request.Request(url, headers=http_headers(url, {"Accept": "text/plain, text/html, application/xml, */*"}))
+    req = http_request(url, extra={"Accept": "text/plain, text/html, application/xml, */*"})
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         return response.read().decode("utf-8")
 
@@ -415,7 +429,7 @@ def ghcr_tags(repository: str) -> list[str]:
     token_url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
     token = request_json(token_url)["token"]
     url = f"https://ghcr.io/v2/{repository}/tags/list"
-    req = urllib.request.Request(url, headers=http_headers(url, {"Authorization": f"Bearer {token}"}))
+    req = http_request(url, extra={"Authorization": f"Bearer {token}"})
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         payload = json.loads(response.read().decode("utf-8"))
     return payload.get("tags") or []
@@ -425,10 +439,10 @@ def ghcr_manifest_status(repository: str, tag: str) -> int:
     token_url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
     token = request_json(token_url)["token"]
     url = f"https://ghcr.io/v2/{repository}/manifests/{tag}"
-    req = urllib.request.Request(
+    req = http_request(
         url,
         method="HEAD",
-        headers=http_headers(url, {"Authorization": f"Bearer {token}", "Accept": GHCR_MANIFEST_ACCEPT}),
+        extra={"Authorization": f"Bearer {token}", "Accept": GHCR_MANIFEST_ACCEPT},
     )
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
@@ -450,7 +464,7 @@ def check_ghcr_tags(surface: dict[str, Any], version: str) -> SurfaceResult:
 
 def check_http_exists(surface: dict[str, Any], version: str) -> SurfaceResult:
     url = fmt(surface["url"], version)
-    req = urllib.request.Request(url, method="HEAD", headers=http_headers(url))
+    req = http_request(url, method="HEAD")
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
             code = response.status

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -13,6 +13,7 @@ import socket
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -197,10 +198,11 @@ def check_local(contract: dict[str, Any], version: str, tag: str | None) -> list
     return results
 
 
-def http_headers(extra: dict[str, str] | None = None) -> dict[str, str]:
+def http_headers(url: str, extra: dict[str, str] | None = None) -> dict[str, str]:
     headers = {"Accept": "application/json", "User-Agent": "MindburnLabs-VersionDriftGuard/1.0"}
     token = os.environ.get("GITHUB_TOKEN")
-    if token:
+    parsed = urllib.parse.urlsplit(url)
+    if token and parsed.scheme == "https" and parsed.hostname == "api.github.com":
         headers["Authorization"] = f"Bearer {token}"
     if extra:
         headers.update(extra)
@@ -208,19 +210,19 @@ def http_headers(extra: dict[str, str] | None = None) -> dict[str, str]:
 
 
 def request_json(url: str) -> Any:
-    req = urllib.request.Request(url, headers=http_headers())
+    req = urllib.request.Request(url, headers=http_headers(url))
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         return json.loads(response.read().decode("utf-8"))
 
 
 def request_bytes(url: str) -> bytes:
-    req = urllib.request.Request(url, headers=http_headers({"Accept": "application/octet-stream, */*"}))
+    req = urllib.request.Request(url, headers=http_headers(url, {"Accept": "application/octet-stream, */*"}))
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         return response.read()
 
 
 def request_text(url: str) -> str:
-    req = urllib.request.Request(url, headers=http_headers({"Accept": "text/plain, text/html, application/xml, */*"}))
+    req = urllib.request.Request(url, headers=http_headers(url, {"Accept": "text/plain, text/html, application/xml, */*"}))
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         return response.read().decode("utf-8")
 
@@ -412,7 +414,8 @@ def check_homebrew_formula(surface: dict[str, Any], version: str) -> SurfaceResu
 def ghcr_tags(repository: str) -> list[str]:
     token_url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
     token = request_json(token_url)["token"]
-    req = urllib.request.Request(f"https://ghcr.io/v2/{repository}/tags/list", headers=http_headers({"Authorization": f"Bearer {token}"}))
+    url = f"https://ghcr.io/v2/{repository}/tags/list"
+    req = urllib.request.Request(url, headers=http_headers(url, {"Authorization": f"Bearer {token}"}))
     with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
         payload = json.loads(response.read().decode("utf-8"))
     return payload.get("tags") or []
@@ -421,10 +424,11 @@ def ghcr_tags(repository: str) -> list[str]:
 def ghcr_manifest_status(repository: str, tag: str) -> int:
     token_url = f"https://ghcr.io/token?scope=repository:{repository}:pull&service=ghcr.io"
     token = request_json(token_url)["token"]
+    url = f"https://ghcr.io/v2/{repository}/manifests/{tag}"
     req = urllib.request.Request(
-        f"https://ghcr.io/v2/{repository}/manifests/{tag}",
+        url,
         method="HEAD",
-        headers=http_headers({"Authorization": f"Bearer {token}", "Accept": GHCR_MANIFEST_ACCEPT}),
+        headers=http_headers(url, {"Authorization": f"Bearer {token}", "Accept": GHCR_MANIFEST_ACCEPT}),
     )
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
@@ -446,7 +450,7 @@ def check_ghcr_tags(surface: dict[str, Any], version: str) -> SurfaceResult:
 
 def check_http_exists(surface: dict[str, Any], version: str) -> SurfaceResult:
     url = fmt(surface["url"], version)
-    req = urllib.request.Request(url, method="HEAD", headers=http_headers())
+    req = urllib.request.Request(url, method="HEAD", headers=http_headers(url))
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
             code = response.status

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -6,11 +6,37 @@ import base64
 import hashlib
 import json
 import unittest
+from unittest import mock
 
 import check_version_drift as drift
 
 
 class VersionDriftMonitorTests(unittest.TestCase):
+    def test_http_headers_scope_ambient_github_token_to_github_api(self) -> None:
+        with mock.patch.dict(drift.os.environ, {"GITHUB_TOKEN": "repo-token"}):
+            self.assertEqual(
+                drift.http_headers("https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel")["Authorization"],
+                "Bearer repo-token",
+            )
+
+            for url in (
+                "http://api.github.com/repos/Mindburn-Labs/helm-ai-kernel",
+                "https://api.github.com.evil.test/repos/Mindburn-Labs/helm-ai-kernel",
+                "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/download/v0.8.4/asset",
+                "https://registry.npmjs.org/@mindburn/helm-ai-kernel",
+                "https://helm.docs.mindburn.org/version.json",
+            ):
+                with self.subTest(url=url):
+                    self.assertNotIn("Authorization", drift.http_headers(url))
+
+            self.assertEqual(
+                drift.http_headers(
+                    "https://ghcr.io/v2/mindburn-labs/helm-ai-kernel/tags/list",
+                    {"Authorization": "Bearer ghcr-token"},
+                )["Authorization"],
+                "Bearer ghcr-token",
+            )
+
     def test_published_contract_covers_release_channels(self) -> None:
         contract = drift.load_contract(drift.DEFAULT_CONTRACT)
         ids = {surface["id"] for surface in contract["published_surfaces"]}

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -18,6 +18,13 @@ class VersionDriftMonitorTests(unittest.TestCase):
                 drift.http_headers("https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel")["Authorization"],
                 "Bearer repo-token",
             )
+            self.assertEqual(
+                drift.http_headers(
+                    "https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel",
+                    {"Authorization": "Bearer explicit-token"},
+                )["Authorization"],
+                "Bearer explicit-token",
+            )
 
             for url in (
                 "http://api.github.com/repos/Mindburn-Labs/helm-ai-kernel",
@@ -36,6 +43,42 @@ class VersionDriftMonitorTests(unittest.TestCase):
                 )["Authorization"],
                 "Bearer ghcr-token",
             )
+
+    def test_http_request_does_not_forward_authorization_on_redirect(self) -> None:
+        with mock.patch.dict(drift.os.environ, {"GITHUB_TOKEN": "repo-token"}):
+            requests = (
+                (
+                    drift.http_request("https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel"),
+                    "Bearer repo-token",
+                ),
+                (
+                    drift.http_request(
+                        "https://ghcr.io/v2/mindburn-labs/helm-ai-kernel/tags/list",
+                        extra={"Authorization": "Bearer ghcr-token"},
+                    ),
+                    "Bearer ghcr-token",
+                ),
+            )
+
+        handler = drift.urllib.request.HTTPRedirectHandler()
+        for initial, expected_authorization in requests:
+            with self.subTest(url=initial.full_url):
+                self.assertEqual(initial.get_header("Authorization"), expected_authorization)
+                self.assertNotIn("Authorization", initial.headers)
+
+                redirected = handler.redirect_request(
+                    initial,
+                    None,
+                    302,
+                    "Found",
+                    {},
+                    "https://third-party.example/redirected",
+                )
+                self.assertIsNotNone(redirected)
+                assert redirected is not None
+                self.assertIsNone(redirected.get_header("Authorization"))
+                self.assertEqual(redirected.get_header("Accept"), initial.get_header("Accept"))
+                self.assertEqual(redirected.get_header("User-Agent"), initial.get_header("User-Agent"))
 
     def test_published_contract_covers_release_channels(self) -> None:
         contract = drift.load_contract(drift.DEFAULT_CONTRACT)


### PR DESCRIPTION
## Summary

- authenticate both post-release published-surface checks with the job-scoped GitHub token
- upload the final version-status asset only when convergence and the full status check succeed
- add negative mutation coverage for missing authentication and unsafe always-clobber behavior

## Why

HELM-531 exposed a circular recovery failure: an unauthenticated GitHub API rate-limit error could make the final status check fail, while the always-run upload step replaced the already passing bootstrap receipt with that failed status. This keeps the last proven passing receipt intact until a complete post-release status also passes.

## Validation

- actionlint `.github/workflows/release.yml`
- `python3 -m unittest -v scripts.ci.release_workflow_contract_test` (11/11)
- `python3 -m unittest -v scripts.release.check_version_drift_test` (15/15)
- `make version-drift`
- pinned-toolchain `make quality-pr`
- `git diff --check`
- independent review: GO, no P0-P2 findings

No Release workflow dispatch/rerun, tag, release asset, package, deployment, settings, or Linear mutation is part of this PR.