### PR TITLE
fix(release): report unreadable drift surfaces as unknown, not drift (HELM-541)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,7 +69,9 @@ surface for the `helm-ai-kernel` project.
   checksum-covered assets already attached to a published release. Normal tag
   releases generate SLSA provenance from `release.yml`.
 - `version-drift.yml` runs the published registry drift check daily and opens or
-  updates one issue when any public channel falls behind `VERSION`.
+  updates one issue when any public channel falls behind `VERSION`. A channel
+  that could not be read after the bounded rate-limit retries is reported as
+  unknown: it does not open a drift issue and does not close an open one.
 
 Pinned first-party setup actions should stay on Node 24-capable majors
 (`checkout` v5, `setup-go` v6, `setup-python` v6, `setup-node` v6, and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1486,13 +1486,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          set +e
           VERSION="${GITHUB_REF_NAME#v}"
+          status=0
           for attempt in $(seq 1 40); do
-            if python3 scripts/release/check_version_drift.py \
+            python3 scripts/release/check_version_drift.py \
               --expected-version "$VERSION" \
               published \
-              --surface-timeout 10; then
+              --surface-timeout 10 \
+              --rate-limit-retries 1
+            status=$?
+            if [ "$status" -eq 0 ]; then
               exit 0
             fi
             if [ "$attempt" -lt 40 ]; then
@@ -1500,6 +1505,10 @@ jobs:
               sleep 30
             fi
           done
+          if [ "$status" -eq 75 ]; then
+            echo "::warning::Published version surfaces stayed unreadable within the bounded retry budget (rate limited); reporting unknown rather than drift."
+            exit 0
+          fi
           echo "::error::Published version surfaces did not converge within the bounded retry budget."
           exit 1
       - name: Check full published version status
@@ -1507,11 +1516,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
+          set -uo pipefail
+          set +e
           VERSION="${GITHUB_REF_NAME#v}"
           python3 scripts/release/check_version_drift.py \
             --expected-version "$VERSION" \
             --write-status version-status.json \
             published
+          status=$?
+          if [ "$status" -eq 75 ]; then
+            echo "::warning::At least one published surface could not be read (rate limited); version-status.json records it as unknown, not drift."
+            exit 0
+          fi
+          exit "$status"
       - name: Replace release version status with full post-release status
         if: success()
         env:

--- a/.github/workflows/version-drift.yml
+++ b/.github/workflows/version-drift.yml
@@ -38,9 +38,10 @@ jobs:
           if status.get("schema_version") != "mindburn.version_status.v1":
               raise SystemExit("unrecognised version-status schema")
           verdict = status.get("status")
-          if verdict not in {"pass", "fail"}:
+          if verdict not in {"pass", "fail", "unknown"}:
               raise SystemExit(f"unrecognised version-status verdict: {verdict!r}")
           print(f"drift={'true' if verdict == 'fail' else 'false'}")
+          print(f"unknown={'true' if verdict == 'unknown' else 'false'}")
           PY
       - name: Upload version status
         if: always()
@@ -68,8 +69,10 @@ jobs:
           expected = status.get("expected_version", "unknown")
           generated_at = status.get("generated_at", "unknown")
           registries = status.get("registry_versions", [])
-          failing = [item for item in registries if item.get("status") != "pass" and item.get("blocking", True)]
-          advisory = [item for item in registries if item.get("status") != "pass" and not item.get("blocking", True)]
+          drifted = [item for item in registries if item.get("status") not in {"pass", "unknown"}]
+          failing = [item for item in drifted if item.get("blocking", True)]
+          advisory = [item for item in drifted if not item.get("blocking", True)]
+          unreadable = [item for item in registries if item.get("status") == "unknown"]
           passing = [item for item in registries if item.get("status") == "pass"]
 
           def value_text(value):
@@ -114,6 +117,18 @@ jobs:
           else:
               print("- None")
           print()
+          print("## Unreadable published channels (not drift)")
+          print()
+          if unreadable:
+              for item in unreadable:
+                  detail = item.get("detail")
+                  suffix = f" ({detail})" if detail else ""
+                  print(f"- `{item.get('id', 'unknown')}`: could not be read, so its published version is unknown{suffix}")
+                  if item.get("url"):
+                      print(f"  {item['url']}")
+          else:
+              print("- None")
+          print()
           print("## Passing published channels")
           print()
           if passing:
@@ -141,7 +156,7 @@ jobs:
               --label release-blocker
           fi
       - name: Close resolved drift issue
-        if: steps.verdict.outputs.drift == 'false'
+        if: steps.verdict.outputs.drift == 'false' && steps.verdict.outputs.unknown == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -22,6 +22,30 @@ specific GitHub release attached a matching asset.
 | `check_version_drift.py` | Checks local source versions and published release channels with bounded per-surface requests. | `make version-drift`, `make version-drift-published`, scheduled monitor. |
 | `check_version_drift_test.py` | Self-test for required published-channel coverage and drift-monitor error shaping. | Manual validation for release monitor edits. |
 
+## Drift, unknown, and exit codes
+
+`check_version_drift.py` separates "the published version is wrong" from "the
+published version could not be read". A host that answers with a rate limit
+(HTTP 429, or HTTP 403 carrying `x-ratelimit-remaining: 0`, `retry-after`, or a
+rate-limit reason) is retried with bounded backoff; `--rate-limit-retries`
+sets the attempts per request. A surface that stays unreadable is reported as
+`UNKNOWN` with an explicit unreadable detail, never as a version mismatch, and
+`version-status.json` records `"status": "unknown"` for it. An unreadable
+blocking surface also makes the run verdict `unknown`; an advisory one does not,
+exactly as advisory failures do not fail a run. A plain HTTP 403 is not a rate
+limit, is not retried, and keeps its existing failure or expected-status
+handling.
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Every checked surface matched the expected version. |
+| `1` | A blocking surface drifted. Real drift still fails the caller. |
+| `75` | Nothing drifted, but at least one surface stayed unreadable. |
+
+Release and monitor callers treat `75` as a warning rather than drift, except
+the pre-release lockstep gate in `release.yml`, which still refuses to publish a
+GitHub Release on a verdict it could not verify.
+
 ## Validation
 
 ```bash

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -292,6 +292,7 @@ def rate_limit_backoff(exc: urllib.error.HTTPError, attempt: int) -> float:
         try:
             delay = float(retry_after)
         except ValueError:
+            # Invalid Retry-After value; keep the computed exponential backoff.
             pass
     return max(0.0, min(delay, RATE_LIMIT_MAX_BACKOFF_SECONDS))
 

--- a/scripts/release/check_version_drift.py
+++ b/scripts/release/check_version_drift.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Check release version drift across local source and published surfaces."""
+"""Check release version drift across local source and published surfaces.
+
+Exit codes: 0 when every checked surface matches, 1 when a blocking surface
+drifted, and 75 when nothing drifted but at least one surface stayed unreadable
+after the bounded rate-limit retry budget. An unreadable surface is reported as
+unknown so a throttled read never masquerades as a version mismatch.
+"""
 from __future__ import annotations
 
 import argparse
@@ -12,6 +18,7 @@ import re
 import socket
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -24,6 +31,14 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONTRACT = ROOT / "release" / "version-surfaces.yaml"
 REQUEST_TIMEOUT_SECONDS = 30.0
+RATE_LIMIT_RETRY_ATTEMPTS = 3
+RATE_LIMIT_BACKOFF_SECONDS = 2.0
+RATE_LIMIT_MAX_BACKOFF_SECONDS = 30.0
+# A surface the checker could not read. It is not a drift verdict: the published
+# value is unknown, so it must never be reported as a version mismatch.
+STATUS_UNKNOWN = "unknown"
+# EX_TEMPFAIL. Nothing drifted, but at least one surface could not be read.
+EXIT_UNKNOWN = 75
 SEMVER_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
 SEMVER_TAG_RE = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+$")
 REJECT_TOKEN_SUFFIX_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789.+-"
@@ -35,6 +50,21 @@ GHCR_MANIFEST_ACCEPT = ", ".join(
         "application/vnd.docker.distribution.manifest.v2+json",
     ]
 )
+
+
+class SurfaceUnreadable(Exception):
+    """A surface stayed unreadable after the bounded rate-limit retry budget.
+
+    Raised only for transport-level refusals to serve the response (rate
+    limiting), never for a response that carried a version. Callers turn it into
+    an ``unknown`` surface result so a throttled read is never counted as drift.
+    """
+
+    def __init__(self, url: str, attempts: int, cause: Exception) -> None:
+        super().__init__(f"could not read {url} after {attempts} attempt(s): {type(cause).__name__}: {cause}")
+        self.url = url
+        self.attempts = attempts
+        self.cause = cause
 
 
 @dataclass
@@ -223,27 +253,109 @@ def http_request(
     return request
 
 
+def header_value(exc: urllib.error.HTTPError, name: str) -> str:
+    headers = getattr(exc, "headers", None) or {}
+    getter = getattr(headers, "get", None)
+    if getter is None:
+        return ""
+    value = getter(name)
+    if value is None and isinstance(headers, dict):
+        lowered = name.lower()
+        value = next((item for key, item in headers.items() if str(key).lower() == lowered), None)
+    return "" if value is None else str(value).strip()
+
+
+def is_rate_limited(exc: urllib.error.HTTPError) -> bool:
+    """Report whether a response is a refusal to serve rather than an answer.
+
+    GitHub answers an exhausted quota with 403 plus `x-ratelimit-remaining: 0`,
+    and a secondary limit with 403 plus `retry-after`; other hosts use 429. A
+    plain 403 stays a normal result, so surfaces that treat 403 as an expected
+    status keep their current behaviour and cost no retries.
+    """
+    if exc.code == 429:
+        return True
+    if exc.code != 403:
+        return False
+    if header_value(exc, "x-ratelimit-remaining") == "0":
+        return True
+    if header_value(exc, "retry-after"):
+        return True
+    reason = str(getattr(exc, "reason", "") or "").lower()
+    return "rate limit" in reason or "too many requests" in reason
+
+
+def rate_limit_backoff(exc: urllib.error.HTTPError, attempt: int) -> float:
+    retry_after = header_value(exc, "retry-after")
+    delay = RATE_LIMIT_BACKOFF_SECONDS * (2 ** (attempt - 1))
+    if retry_after:
+        try:
+            delay = float(retry_after)
+        except ValueError:
+            pass
+    return max(0.0, min(delay, RATE_LIMIT_MAX_BACKOFF_SECONDS))
+
+
+def urlopen_with_retry(request: urllib.request.Request) -> Any:
+    """Open a request, retrying rate-limit refusals with bounded backoff.
+
+    Raises SurfaceUnreadable when the host keeps refusing; every other error
+    propagates unchanged so real failures keep their existing handling.
+    """
+    attempts = max(1, RATE_LIMIT_RETRY_ATTEMPTS)
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_SECONDS)
+        except urllib.error.HTTPError as exc:
+            if not is_rate_limited(exc):
+                raise
+            if attempt >= attempts:
+                raise SurfaceUnreadable(request.full_url, attempts, exc) from exc
+            delay = rate_limit_backoff(exc, attempt)
+            print(
+                f"rate limited by {urllib.parse.urlsplit(request.full_url).hostname} "
+                f"(HTTP {exc.code}); retrying in {delay:g}s ({attempt}/{attempts - 1})",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+
 def request_json(url: str) -> Any:
     req = http_request(url)
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+    with urlopen_with_retry(req) as response:
         return json.loads(response.read().decode("utf-8"))
 
 
 def request_bytes(url: str) -> bytes:
     req = http_request(url, extra={"Accept": "application/octet-stream, */*"})
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+    with urlopen_with_retry(req) as response:
         return response.read()
 
 
 def request_text(url: str) -> str:
     req = http_request(url, extra={"Accept": "text/plain, text/html, application/xml, */*"})
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+    with urlopen_with_retry(req) as response:
         return response.read().decode("utf-8")
 
 
 def published_error(surface: dict[str, Any], version: str, exc: Exception) -> SurfaceResult:
     detail = f"{type(exc).__name__}: {exc}"
     return SurfaceResult(surface["id"], "fail", version, None, url=fmt(surface.get("human_url") or surface.get("url", ""), version), detail=detail, blocking=is_blocking(surface))
+
+
+def published_unknown(surface: dict[str, Any], version: str, exc: SurfaceUnreadable) -> SurfaceResult:
+    detail = f"surface unreadable, not drift: {exc}"
+    return SurfaceResult(
+        surface["id"],
+        STATUS_UNKNOWN,
+        version,
+        None,
+        url=fmt(surface.get("human_url") or surface.get("url", ""), version),
+        detail=detail,
+        blocking=is_blocking(surface),
+    )
 
 
 def check_github_release(surface: dict[str, Any], version: str) -> SurfaceResult:
@@ -430,7 +542,7 @@ def ghcr_tags(repository: str) -> list[str]:
     token = request_json(token_url)["token"]
     url = f"https://ghcr.io/v2/{repository}/tags/list"
     req = http_request(url, extra={"Authorization": f"Bearer {token}"})
-    with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+    with urlopen_with_retry(req) as response:
         payload = json.loads(response.read().decode("utf-8"))
     return payload.get("tags") or []
 
@@ -445,7 +557,7 @@ def ghcr_manifest_status(repository: str, tag: str) -> int:
         extra={"Authorization": f"Bearer {token}", "Accept": GHCR_MANIFEST_ACCEPT},
     )
     try:
-        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        with urlopen_with_retry(req) as response:
             return response.status
     except urllib.error.HTTPError as exc:
         return exc.code
@@ -466,7 +578,7 @@ def check_http_exists(surface: dict[str, Any], version: str) -> SurfaceResult:
     url = fmt(surface["url"], version)
     req = http_request(url, method="HEAD")
     try:
-        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT_SECONDS) as response:
+        with urlopen_with_retry(req) as response:
             code = response.status
     except urllib.error.HTTPError as exc:
         code = exc.code
@@ -619,6 +731,8 @@ def check_published(contract: dict[str, Any], version: str, skip: set[str], only
             continue
         try:
             results.append(checker(surface, version))
+        except SurfaceUnreadable as exc:
+            results.append(published_unknown(surface, version, exc))
         except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, socket.timeout, KeyError, ValueError, ET.ParseError, json.JSONDecodeError) as exc:
             results.append(published_error(surface, version, exc))
     return results
@@ -631,12 +745,34 @@ def should_fail(results: list[SurfaceResult], mode: str) -> bool:
     return False
 
 
+def has_blocking_unknown(results: list[SurfaceResult]) -> bool:
+    return any(result.status == STATUS_UNKNOWN and result.blocking for result in results)
+
+
+def exit_code(status: str) -> int:
+    """Map an overall verdict to a process exit code.
+
+    Drift keeps exit 1. An unreadable surface gets its own code so callers can
+    tell "the release is wrong" from "we could not look".
+    """
+    if status == "fail":
+        return 1
+    if status == STATUS_UNKNOWN:
+        return EXIT_UNKNOWN
+    return 0
+
+
 def status_payload(mode: str, version: str, results: list[SurfaceResult], source_results: list[SurfaceResult], registry_results: list[SurfaceResult]) -> dict[str, Any]:
     try:
         commit = subprocess.check_output(["git", "-C", str(ROOT), "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, text=True).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         commit = "unknown"
-    overall = "fail" if should_fail(results, mode) else "pass"
+    if should_fail(results, mode):
+        overall = "fail"
+    elif has_blocking_unknown(results):
+        overall = STATUS_UNKNOWN
+    else:
+        overall = "pass"
     return {
         "schema_version": "mindburn.version_status.v1",
         "mode": mode,
@@ -651,9 +787,19 @@ def status_payload(mode: str, version: str, results: list[SurfaceResult], source
     }
 
 
+def result_marker(result: SurfaceResult) -> str:
+    if result.status == "pass":
+        return "OK"
+    if result.status == "skipped":
+        return "SKIP"
+    if result.status == STATUS_UNKNOWN:
+        return "UNKNOWN"
+    return "FAIL" if result.blocking else "WARN"
+
+
 def print_results(results: list[SurfaceResult]) -> None:
     for result in results:
-        marker = "OK" if result.status == "pass" else "SKIP" if result.status == "skipped" else "FAIL" if result.blocking else "WARN"
+        marker = result_marker(result)
         location = result.path or result.url or ""
         scope = "blocking" if result.blocking else "advisory"
         print(f"{marker} {result.id} [{scope}]: expected={result.expected!r} actual={result.actual!r} {location}")
@@ -679,17 +825,26 @@ def parse_args() -> argparse.Namespace:
     published.add_argument("--skip", action="append", default=[], help="published surface id to skip; can be passed more than once")
     published.add_argument("--only", action="append", default=[], help="published surface id to check; when passed, all other published surfaces are skipped")
     published.add_argument("--surface-timeout", type=float, default=REQUEST_TIMEOUT_SECONDS, help="timeout in seconds for each public surface request")
+    published.add_argument(
+        "--rate-limit-retries",
+        type=int,
+        default=RATE_LIMIT_RETRY_ATTEMPTS,
+        help="attempts per request when a host answers with a rate limit; a surface that stays unreadable is reported unknown, not drift",
+    )
     return parser.parse_args()
 
 
 def main() -> int:
-    global REQUEST_TIMEOUT_SECONDS
+    global REQUEST_TIMEOUT_SECONDS, RATE_LIMIT_RETRY_ATTEMPTS
     args = parse_args()
     contract = load_contract(args.contract)
     version = expected_version(contract, args.expected_version)
     if getattr(args, "surface_timeout", REQUEST_TIMEOUT_SECONDS) <= 0:
         raise SystemExit("--surface-timeout must be greater than 0")
     REQUEST_TIMEOUT_SECONDS = float(getattr(args, "surface_timeout", REQUEST_TIMEOUT_SECONDS))
+    if getattr(args, "rate_limit_retries", RATE_LIMIT_RETRY_ATTEMPTS) < 1:
+        raise SystemExit("--rate-limit-retries must be at least 1")
+    RATE_LIMIT_RETRY_ATTEMPTS = int(getattr(args, "rate_limit_retries", RATE_LIMIT_RETRY_ATTEMPTS))
 
     if args.mode == "local":
         source_results = check_local(contract, version, args.tag)
@@ -708,7 +863,7 @@ def main() -> int:
     print_results(results)
     if args.report:
         return 0
-    return 1 if payload["status"] == "fail" else 0
+    return exit_code(payload["status"])
 
 
 if __name__ == "__main__":

--- a/scripts/release/check_version_drift_test.py
+++ b/scripts/release/check_version_drift_test.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
+import io
 import json
 import unittest
 from unittest import mock
@@ -424,6 +426,139 @@ class VersionDriftMonitorTests(unittest.TestCase):
         self.assertEqual(result.actual["missing"], ["io.github.mindburnlabs:helm-sdk:0.5.10"])
         self.assertEqual(result.actual["rejected_found"], ["io.github.mindburnlabs:helm-sdk:0.5.2"])
 
+    def test_rate_limited_read_retries_then_reports_unknown_instead_of_drift(self) -> None:
+        sleeps: list[float] = []
+        attempts: list[str] = []
+
+        def always_rate_limited(request, timeout=None):
+            attempts.append(request.full_url)
+            raise rate_limited_error(request.full_url)
+
+        with captured_stderr() as notices, mock.patch.object(
+            drift.urllib.request, "urlopen", always_rate_limited
+        ), mock.patch.object(drift.time, "sleep", sleeps.append):
+            results = drift.check_published(github_release_contract(), "0.8.4", set())
+
+        self.assertEqual(len(attempts), drift.RATE_LIMIT_RETRY_ATTEMPTS)
+        self.assertEqual(sleeps, [2.0, 4.0])
+        self.assertIn("rate limited by api.github.com (HTTP 403); retrying in 2s", notices.getvalue())
+
+        result = results[0]
+        self.assertEqual(result.status, drift.STATUS_UNKNOWN)
+        self.assertTrue(result.blocking)
+        self.assertIsNone(result.actual)
+        self.assertIn("could not read", result.detail or "")
+        self.assertIn("rate limit exceeded", result.detail or "")
+        self.assertEqual(drift.result_marker(result), "UNKNOWN")
+
+        payload = drift.status_payload("published", "0.8.4", results, [], results)
+        self.assertFalse(drift.should_fail(results, "published"))
+        self.assertEqual(payload["status"], drift.STATUS_UNKNOWN)
+        self.assertEqual(payload["registry_versions"][0]["status"], drift.STATUS_UNKNOWN)
+        self.assertEqual(drift.exit_code(payload["status"]), drift.EXIT_UNKNOWN)
+        self.assertNotEqual(drift.EXIT_UNKNOWN, 0)
+
+    def test_rate_limited_read_recovers_within_the_retry_budget(self) -> None:
+        sleeps: list[float] = []
+        responses = [rate_limited_error("https://api.github.com/releases/tags/v0.8.4")]
+
+        def flaky(request, timeout=None):
+            if responses:
+                raise responses.pop()
+            return fake_response(json.dumps({"tag_name": "v0.8.4"}).encode())
+
+        with captured_stderr(), mock.patch.object(drift.urllib.request, "urlopen", flaky), mock.patch.object(
+            drift.time, "sleep", sleeps.append
+        ):
+            results = drift.check_published(github_release_contract(), "0.8.4", set())
+
+        self.assertEqual(sleeps, [2.0])
+        self.assertEqual(results[0].status, "pass")
+        self.assertEqual(results[0].actual, "v0.8.4")
+        self.assertEqual(drift.exit_code(drift.status_payload("published", "0.8.4", results, [], results)["status"]), 0)
+
+    def test_rate_limit_backoff_honours_retry_after_within_the_cap(self) -> None:
+        secondary = rate_limited_error("https://api.github.com", code=403, headers={"Retry-After": "7"})
+        self.assertTrue(drift.is_rate_limited(secondary))
+        self.assertEqual(drift.rate_limit_backoff(secondary, 1), 7.0)
+
+        excessive = rate_limited_error("https://api.github.com", code=429, headers={"Retry-After": "3600"})
+        self.assertEqual(drift.rate_limit_backoff(excessive, 1), drift.RATE_LIMIT_MAX_BACKOFF_SECONDS)
+
+        exhausted = rate_limited_error("https://api.github.com", headers={"x-ratelimit-remaining": "0"}, reason="Forbidden")
+        self.assertTrue(drift.is_rate_limited(exhausted))
+        self.assertEqual(drift.rate_limit_backoff(exhausted, 3), 8.0)
+
+    def test_plain_forbidden_is_not_retried_and_still_reports_drift(self) -> None:
+        sleeps: list[float] = []
+        attempts: list[str] = []
+
+        def forbidden(request, timeout=None):
+            attempts.append(request.full_url)
+            raise drift.urllib.error.HTTPError(request.full_url, 403, "Forbidden", {}, None)
+
+        with mock.patch.object(drift.urllib.request, "urlopen", forbidden), mock.patch.object(
+            drift.time, "sleep", sleeps.append
+        ):
+            results = drift.check_published(github_release_contract(), "0.8.4", set())
+
+        self.assertEqual(len(attempts), 1)
+        self.assertEqual(sleeps, [])
+        self.assertEqual(results[0].status, "fail")
+        self.assertTrue(results[0].blocking)
+        self.assertIn("HTTPError", results[0].detail or "")
+
+    def test_version_mismatch_still_fails_when_another_surface_is_unknown(self) -> None:
+        mismatch = drift.SurfaceResult("npm-sdk", "fail", "0.8.4", "0.8.3", url="https://example.test/npm")
+        unreadable = drift.published_unknown(
+            {"id": "github-release", "url": "https://api.example.test/releases/tags/v0.8.4"},
+            "0.8.4",
+            drift.SurfaceUnreadable("https://api.example.test/releases/tags/v0.8.4", 3, TimeoutError("rate limit exceeded")),
+        )
+        results = [mismatch, unreadable]
+
+        payload = drift.status_payload("published", "0.8.4", results, [], results)
+        self.assertTrue(drift.should_fail(results, "published"))
+        self.assertEqual(payload["status"], "fail")
+        self.assertEqual(drift.exit_code(payload["status"]), 1)
+        self.assertEqual(drift.result_marker(mismatch), "FAIL")
+        self.assertEqual(drift.result_marker(unreadable), "UNKNOWN")
+
+    def test_advisory_unknown_does_not_move_the_overall_verdict(self) -> None:
+        advisory = drift.published_unknown(
+            {"id": "optional-docs-cache", "url": "https://example.test/cache", "blocking": False},
+            "0.8.4",
+            drift.SurfaceUnreadable("https://example.test/cache", 3, TimeoutError("rate limit exceeded")),
+        )
+        passing = drift.SurfaceResult("npm-sdk", "pass", "0.8.4", "0.8.4", url="https://example.test/npm")
+
+        payload = drift.status_payload("published", "0.8.4", [passing, advisory], [], [passing, advisory])
+        self.assertEqual(payload["status"], "pass")
+        self.assertEqual(payload["registry_versions"][1]["status"], drift.STATUS_UNKNOWN)
+        self.assertFalse(payload["registry_versions"][1]["blocking"])
+        self.assertEqual(drift.exit_code(payload["status"]), 0)
+
+    def test_successful_read_is_unchanged_by_the_retry_path(self) -> None:
+        sleeps: list[float] = []
+        calls: list[str] = []
+
+        def ok(request, timeout=None):
+            calls.append(request.full_url)
+            return fake_response(json.dumps({"tag_name": "v0.8.4"}).encode())
+
+        with mock.patch.object(drift.urllib.request, "urlopen", ok), mock.patch.object(
+            drift.time, "sleep", sleeps.append
+        ):
+            results = drift.check_published(github_release_contract(), "0.8.4", set())
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(sleeps, [])
+        self.assertEqual(results[0].status, "pass")
+        payload = drift.status_payload("published", "0.8.4", results, [], results)
+        self.assertEqual(payload["status"], "pass")
+        self.assertEqual(drift.exit_code(payload["status"]), 0)
+        self.assertEqual(drift.result_marker(results[0]), "OK")
+
     def test_http_contains_does_not_reject_version_prefix_matches(self) -> None:
         original = drift.request_text
         drift.request_text = lambda _url: (
@@ -454,6 +589,54 @@ class VersionDriftMonitorTests(unittest.TestCase):
 
         self.assertEqual(result.status, "pass")
         self.assertEqual(result.actual["rejected_found"], [])
+
+
+def github_release_contract() -> dict[str, list[dict[str, str]]]:
+    return {
+        "published_surfaces": [
+            {
+                "id": "github-release",
+                "kind": "github_release",
+                "url": "https://api.github.com/repos/Mindburn-Labs/helm-ai-kernel/releases/tags/v{version}",
+                "human_url": "https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v{version}",
+            }
+        ]
+    }
+
+
+def rate_limited_error(
+    url: str,
+    code: int = 403,
+    headers: dict[str, str] | None = None,
+    reason: str = "rate limit exceeded",
+) -> drift.urllib.error.HTTPError:
+    return drift.urllib.error.HTTPError(url, code, reason, headers or {"x-ratelimit-remaining": "0"}, None)
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, status: int = 200) -> None:
+        self._body = body
+        self.status = status
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, *_exc: object) -> bool:
+        return False
+
+
+def fake_response(body: bytes, status: int = 200) -> FakeResponse:
+    return FakeResponse(body, status)
+
+
+@contextlib.contextmanager
+def captured_stderr():
+    buffer = io.StringIO()
+    with contextlib.redirect_stderr(buffer):
+        yield buffer
 
 
 def release_surface() -> dict[str, str]:


### PR DESCRIPTION
Closes the first half of [HELM-541](https://linear.app/mindburn/issue/HELM-541): the release drift checker. The docs-site content update (`helm.docs.mindburn.org`) is the other half of that issue and is deliberately **not** in this PR — different surface, different owner.

## Problem

In the v0.8.4 release run ([31410230782](https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/31410230782), job `94186648601`), `post-release-version-drift` reported five findings that were not drift:

```
FAIL github-release [blocking]: expected='0.8.4' actual=None .../releases/tag/v0.8.4
  HTTPError: HTTP Error 403: rate limit exceeded
```

…and the same for `github-release-notes`, `github-release-slsa-provenance`, `github-release-console-local-sidecar` and `github-release-slsa-subjects`. The release object demonstrably existed — 62 signed assets, published `2026-08-12T16:33:16Z`. `check_version_drift.py` had no retry on the GitHub API and turned a failure to *read* a surface into a blocking drift finding, so a good release went red. A job that cries wolf gets ignored.

## Change

`scripts/release/check_version_drift.py`:

- **Retry with bounded backoff on rate limits.** `urlopen_with_retry` retries HTTP 429, and HTTP 403 that carries `x-ratelimit-remaining: 0`, `retry-after`, or a rate-limit reason (GitHub's primary and secondary limits). `Retry-After` is honoured up to a 30s cap, otherwise 2s exponential. `--rate-limit-retries` sets the attempts per request.
- **Unreadable is `unknown`, not drift.** A surface that stays unreadable raises `SurfaceUnreadable` and is reported as `UNKNOWN` with an explicit detail, never as a version mismatch. `version-status.json` records `"status": "unknown"` for it, and for the run when the surface is blocking.
- **Real drift is untouched.** A blocking mismatch is still `FAIL`, still exits 1, still fails the job — including when an unreadable surface is present in the same run. Unreadable-only runs exit `75` (EX_TEMPFAIL), so callers can tell "the release is wrong" from "we could not look".
- **No weakening of the other surfaces.** A plain HTTP 403 is not a rate limit, is not retried, and keeps its existing handling, so surfaces where 403 is an expected status (`http_exists`) behave exactly as before. Timeouts, URL errors, parse errors and every other failure keep reporting `FAIL` as they do today. Only rate-limit refusals become `unknown`.

Callers:

- `release.yml` — the convergence wait and the full-status step treat exit 75 as a `::warning::` instead of a red job. The **pre-release** lockstep gate (`version-status` job) is deliberately left strict: it still refuses to publish a GitHub Release on a verdict it could not verify.
- `version-drift.yml` — the daily monitor accepts the `unknown` verdict, lists unreadable channels in their own section of the drift issue rather than under "failing", and no longer closes an open drift issue on a verdict it could not read.
- `scripts/release/README.md`, `.github/workflows/README.md` — document the statuses and the exit-code contract.

## Verification

`python3 scripts/release/check_version_drift_test.py` — 24 tests, all pass (17 pre-existing, 7 new):

```
test_rate_limited_read_retries_then_reports_unknown_instead_of_drift ... ok
test_rate_limited_read_recovers_within_the_retry_budget ... ok
test_rate_limit_backoff_honours_retry_after_within_the_cap ... ok
test_plain_forbidden_is_not_retried_and_still_reports_drift ... ok
test_version_mismatch_still_fails_when_another_surface_is_unknown ... ok
test_advisory_unknown_does_not_move_the_overall_verdict ... ok
test_successful_read_is_unchanged_by_the_retry_path ... ok
----------------------------------------------------------------------
Ran 24 tests in 0.206s

OK
```

End-to-end through `main()` with a faked transport, showing the four cases and their exit codes:

```
===== a) GitHub rate-limited, npm correct =====
UNKNOWN github-release [blocking]: expected='0.8.4' actual=None .../releases/tag/v0.8.4
  surface unreadable, not drift: could not read https://api.github.com/... after 3 attempt(s): HTTPError: HTTP Error 403: rate limit exceeded
OK npm-sdk [blocking]: expected='0.8.4' actual='0.8.4' https://www.npmjs.com/package/@mindburn/helm-ai-kernel
--> exit code 75; version-status.json status='unknown'

===== b) genuine mismatch (npm behind), GitHub fine =====
FAIL npm-sdk [blocking]: expected='0.8.4' actual='0.8.3' https://www.npmjs.com/package/@mindburn/helm-ai-kernel
--> exit code 1; version-status.json status='fail'

===== c) everything published correctly =====
--> exit code 0; version-status.json status='pass'

===== d) rate-limited AND genuine mismatch =====
UNKNOWN github-release [blocking]: ...
FAIL npm-sdk [blocking]: expected='0.8.4' actual='0.8.3' ...
--> exit code 1; version-status.json status='fail'
```

Live read-only run of the patched checker against the real v0.8.4 surfaces (`--report --expected-version 0.8.4 published`): all five previously-false-failing GitHub surfaces read `OK` (the release was always there), every registry — GHCR image and chart, ArtifactHub, npm, PyPI, crates.io, Maven Central, homebrew-tap, Go proxy, pkg.go.dev — reads `OK`, and the three genuine docs-site failures still report `FAIL` as blocking drift:

```
FAIL docs-site-developer-journey [blocking]: ... missing: ['io.github.mindburnlabs:helm-sdk:0.8.4', ...] https://helm.docs.mindburn.org/developer-journey
FAIL docs-site-sdk-index [blocking]: ... https://helm.docs.mindburn.org/sdks
FAIL docs-site-examples [blocking]: ... https://helm.docs.mindburn.org/examples
```

Those three are HELM-541's second half (stale docs site) and remain red on purpose.

Also run: `python3 scripts/release/check_version_drift.py local` (clean), `make docs-coverage` / `docs-truth` equivalents (`check_documentation_coverage.py`, `check_documentation_truth.py` — both pass), YAML parse and `bash -n` of the edited workflow steps, and `compile()` of both embedded Python heredocs in `version-drift.yml`.

## Not done here

No workflow was triggered, re-run, enabled, disabled or cancelled; no tag, release or release asset was created, moved or deleted. Only files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
