### PR TITLE
fix(mcp): preserve synthetic lifecycle events for system principal

### DIFF
--- a/core/cmd/helm-ai-kernel/route_auth.go
+++ b/core/cmd/helm-ai-kernel/route_auth.go
@@ -182,7 +182,7 @@ func requireRuntimeService(handler http.HandlerFunc) http.HandlerFunc {
 
 		principal := &helmauth.BasePrincipal{
 			ID:       servicePrincipalID,
-			TenantID: "system",
+			TenantID: helmauth.SystemTenantID,
 			Roles:    []string{"service"},
 		}
 		handler(w, r.WithContext(helmauth.WithPrincipal(r.Context(), principal)))

--- a/core/pkg/auth/apikey.go
+++ b/core/pkg/auth/apikey.go
@@ -22,6 +22,8 @@ import (
 const (
 	// AdminAPIKeyEnv is the environment variable used by standalone OSS admin authentication.
 	AdminAPIKeyEnv = "HELM_ADMIN_API_KEY"
+	// SystemTenantID identifies HELM's non-customer admin/service boundary.
+	SystemTenantID = "system"
 
 	systemAdminPrincipalID = "system-admin"
 )
@@ -96,7 +98,7 @@ func AdminPrincipalFromRequest(r *http.Request, adminKey string) (*BasePrincipal
 
 	return &BasePrincipal{
 		ID:       systemAdminPrincipalID,
-		TenantID: "system",
+		TenantID: SystemTenantID,
 		Roles:    []string{"admin"},
 	}, "", true
 }

--- a/core/pkg/mcp/lifecycle_event_test.go
+++ b/core/pkg/mcp/lifecycle_event_test.go
@@ -411,6 +411,34 @@ func TestGovernanceFirewallLifecyclePublicationHonorsTrustedEnvironment(t *testi
 			t.Fatal("tenant-bearing request was published as synthetic")
 		}
 	})
+
+	t.Run("system pseudo-tenant remains synthetic", func(t *testing.T) {
+		t.Setenv("HELM_ENV", events.EnvSynthetic)
+		capture := &lifecycleCapture{}
+		fw := NewGovernanceFirewall(
+			lifecycleEvaluator{decision: &contracts.DecisionRecord{
+				ID: "decision-system", Action: "EXECUTE_TOOL", Resource: "read",
+				Verdict: string(contracts.VerdictAllow),
+			}},
+			readOnlyCatalog(t),
+			WithLifecyclePublisher(capture.publish),
+		)
+		ctx := auth.WithPrincipal(context.Background(), &auth.BasePrincipal{TenantID: auth.SystemTenantID})
+		_, err := fw.WrapToolHandler(func(context.Context, ToolExecutionRequest) (ToolExecutionResponse, error) {
+			return ToolExecutionResponse{Content: "ok"}, nil
+		})(ctx, ToolExecutionRequest{ToolName: "read", SessionID: "synthetic-session"})
+		if err != nil {
+			t.Fatalf("system request failed: %v", err)
+		}
+		if len(capture.events) == 0 {
+			t.Fatal("system pseudo-tenant suppressed synthetic lifecycle publication")
+		}
+		for _, event := range capture.events {
+			if event.Meta.Env != events.EnvSynthetic {
+				t.Fatalf("system event env = %q, want %q", event.Meta.Env, events.EnvSynthetic)
+			}
+		}
+	})
 }
 
 func TestGovernanceFirewallUsesExplicitCatalogClassification(t *testing.T) {

--- a/core/pkg/mcp/server.go
+++ b/core/pkg/mcp/server.go
@@ -416,9 +416,11 @@ func lifecycleContext(ctx context.Context, req ToolExecutionRequest, lifecycleEn
 		lifecycleEnv = events.EnvProduction
 	}
 	if lifecycleEnv == events.EnvSynthetic {
-		if tenantID, err := auth.GetTenantID(ctx); err == nil && tenantID != "" {
+		if tenantID, err := auth.GetTenantID(ctx); err == nil && tenantID != "" && tenantID != auth.SystemTenantID {
 			// A tenant-bearing request is not synthetic even when the process
-			// was started with the synthetic switch; do not relabel it.
+			// was started with the synthetic switch; do not relabel it. HELM's
+			// own system pseudo-tenant carries no customer tenancy and remains
+			// eligible for the explicitly enabled synthetic lane.
 			lifecycleEnv = events.EnvCustomerHosted
 		}
 	}


### PR DESCRIPTION
## Summary

- define the kernel internal `system` tenant ID once and reuse it for admin/service principals
- keep that non-customer pseudo-tenant in the explicitly enabled synthetic lifecycle lane
- preserve fail-closed suppression for every real tenant/customer-hosted request
- add the deployed-auth-path regression case

## Root cause

The deployed `/mcp` route authenticates its admin principal with `TenantID=system`. `lifecycleContext` treated every non-empty tenant as customer-hosted, so the real synthetic MCP path suppressed all lifecycle events even though package-level tests passed.

## Validation

- `env -u GOROOT -u GOTOOLDIR /usr/local/go/bin/go test ./pkg/auth ./pkg/mcp ./cmd/helm-ai-kernel -count=1`
- `env -u GOROOT -u GOTOOLDIR PATH=/usr/local/go/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin make lint`
- `env -u GOROOT -u GOTOOLDIR /usr/local/go/bin/go test ./... -count=1`
- `env -u GOROOT -u GOTOOLDIR PATH=/usr/local/go/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin make build`
- local real MCP `file_read` emitted received/classified/policy/decision/completed with one correlation ID and synthetic data class; this is local producer proof, not ClickHouse/deployed proof

Related: HELM-462