### PR TITLE
HELM-462: enable synthetic lifecycle telemetry in chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          repo-token: ${{ github.token }}
+      - name: Install pinned protoc
+        run: bash scripts/ci/install_protoc.sh
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ github.token }}
@@ -130,9 +129,8 @@ jobs:
         with:
           go-version: "1.25.12"
           cache-dependency-path: "**/go.sum"
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          repo-token: ${{ github.token }}
+      - name: Install pinned protoc
+        run: bash scripts/ci/install_protoc.sh
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ github.token }}
@@ -269,10 +267,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "34.1"
-          repo-token: ${{ github.token }}
+      - name: Install pinned protoc
+        run: bash scripts/ci/install_protoc.sh
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,10 +181,8 @@ jobs:
           distribution: temurin
           java-version: "21"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
-        with:
-          version: "34.1"
-          repo-token: ${{ github.token }}
+      - name: Install pinned protoc
+        run: bash scripts/ci/install_protoc.sh
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1
         with:
           github_token: ${{ github.token }}

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -104,6 +104,7 @@ flowchart TD
 | `helm.metrics.enabled` | `false` | Enables `/metrics` on `service.metricsPort`. |
 | `helm.metrics.serviceMonitor.enabled` | `false` | Emits a Prometheus Operator `ServiceMonitor`. |
 | `telemetry.enabled` | `false` | Renders the OTLP variables into the kernel container. Enable per stand, never in a chart default. |
+| `telemetry.syntheticLifecycleEvents` | `false` | Renders `HELM_ENV=synthetic` so the kernel publishes governed lifecycle events from a synthetic stand. Requires `telemetry.enabled=true`; never enable for pilot or customer namespaces. |
 | `telemetry.endpoint` | empty | OTLP gRPC target, e.g. `http://telemetry-gateway.telemetry-system.svc.cluster.local:4317`. Required when `telemetry.enabled=true`; keep the `http://` prefix. |
 | `telemetry.serviceName` | empty | `service.name` on exported spans, rendered as `OTEL_SERVICE_NAME` when `telemetry.enabled=true`. Empty renders nothing and the kernel reports `helm-sovereign-os`. No leading or trailing whitespace. |
 

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -54,6 +54,9 @@
 {{- if and .Values.helm.emergencyStop.enabled .Values.helm.emergencyStop.commandReplayKeyringSecretKey (not .Values.helm.emergencyStop.existingSecret) -}}
 {{- fail "helm.emergencyStop.commandReplayKeyringSecretKey requires helm.emergencyStop.existingSecret" -}}
 {{- end -}}
+{{- if and .Values.telemetry.syntheticLifecycleEvents (not .Values.telemetry.enabled) -}}
+{{- fail "telemetry.syntheticLifecycleEvents=true requires telemetry.enabled=true" -}}
+{{- end -}}
 {{- if not (regexMatch "^.+@sha256:[0-9a-f]{64}$" .Values.runtimeInit.image) -}}
 {{- fail "runtimeInit.image must be pinned by immutable sha256 digest" -}}
 {{- end -}}
@@ -211,6 +214,10 @@ spec:
             {{- with .Values.telemetry.serviceName }}
             - name: OTEL_SERVICE_NAME
               value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.telemetry.syntheticLifecycleEvents }}
+            - name: HELM_ENV
+              value: "synthetic"
             {{- end }}
             {{- end }}
             - name: HELM_LIMIT_GLOBAL_RPS

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -828,6 +828,11 @@
           "default": false,
           "description": "Export traces to telemetry.endpoint. A stand handed an endpoint starts exporting the moment it boots, so keep this false until the stand is meant to report."
         },
+        "syntheticLifecycleEvents": {
+          "type": "boolean",
+          "default": false,
+          "description": "Publish governed lifecycle events from a synthetic stand by rendering HELM_ENV=synthetic. Requires telemetry.enabled=true so lifecycle events remain joinable to exported traces. Never enable for pilot or customer namespaces."
+        },
         "endpoint": {
           "type": "string",
           "description": "OTLP gRPC target of the in-cluster gateway, e.g. http://telemetry-gateway.telemetry-system.svc.cluster.local:4317. Required when enabled is true. Keep the http:// prefix: the kernel strips the scheme before dialing and uses its presence to select an insecure connection, and the gateway does not terminate TLS in-cluster."

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -286,6 +286,10 @@ helm:
 # exporting the moment it boots. Enabled per stand, never in a chart default.
 telemetry:
   enabled: false
+  # Publish governed lifecycle events only from a synthetic stand. This maps
+  # to the kernel's fail-closed HELM_ENV=synthetic publisher gate and requires
+  # telemetry.enabled so the events remain joinable to exported traces.
+  syntheticLifecycleEvents: false
   # In-cluster gateway. Plaintext on purpose: TLS terminates at the central
   # frontdoor, not inside the cluster. Example:
   #   http://telemetry-gateway.telemetry-system.svc.cluster.local:4317

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -108,6 +108,7 @@ assert_not_contains "$default_rendered" "configmap-reload"
 assert_not_contains "$default_rendered" "kind: CustomResourceDefinition"
 assert_not_contains "$default_rendered" "HelmPolicyBundle"
 assert_not_contains "$default_rendered" "policy-reader"
+assert_not_contains "$default_rendered" "HELM_ENV"
 assert_contains "$default_rendered" "name: prepare-authority-state"
 assert_contains "$default_rendered" "HELM_AUTHORITY_DATA_DIR"
 assert_contains "$default_rendered" "/var/run/helm-signing-key"
@@ -156,6 +157,24 @@ if helm_runner template "$RELEASE" "$CHART" \
     exit 1
 fi
 assert_contains "$runtime_init_fail_log" "runtimeInit.image"
+
+synthetic_telemetry_rendered="$RENDER_DIR/rendered-synthetic-telemetry.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set telemetry.enabled=true \
+    --set telemetry.syntheticLifecycleEvents=true \
+    --set telemetry.endpoint=http://telemetry-gateway.telemetry-system.svc.cluster.local:4317 >"$synthetic_telemetry_rendered"
+assert_contains "$synthetic_telemetry_rendered" "HELM_ENV"
+assert_contains "$synthetic_telemetry_rendered" 'value: "synthetic"'
+
+synthetic_without_telemetry_log="$RENDER_DIR/synthetic-without-telemetry.log"
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set telemetry.syntheticLifecycleEvents=true >"$RENDER_DIR/synthetic-without-telemetry.yaml" 2>"$synthetic_without_telemetry_log"; then
+    echo "::error::synthetic lifecycle publication without telemetry unexpectedly rendered"
+    exit 1
+fi
+assert_contains "$synthetic_without_telemetry_log" "telemetry.syntheticLifecycleEvents=true requires telemetry.enabled=true"
 
 authority_identity_rendered="$RENDER_DIR/rendered-authority-identity.yaml"
 helm_runner template "$RELEASE" "$CHART" \

--- a/scripts/ci/install_protoc.sh
+++ b/scripts/ci/install_protoc.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="34.1"
+sha256="af27ea66cd26938fe48587804ca7d4817457a08350021a1c6e23a27ccc8c6904"
+
+if [ "$(uname -s)" != "Linux" ] || [ "$(uname -m)" != "x86_64" ]; then
+    echo "::error::install_protoc.sh supports the Linux x86_64 GitHub runner only"
+    exit 1
+fi
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${GITHUB_PATH:?GITHUB_PATH is required}"
+
+download_dir="$(mktemp -d "${RUNNER_TEMP}/protoc-download.XXXXXX")"
+archive="${download_dir}/protoc-${version}-linux-x86_64.zip"
+install_dir="${RUNNER_TEMP}/protoc-${version}"
+trap 'rm -rf "$download_dir"' EXIT
+
+curl -fsSL --retry 5 --retry-all-errors \
+    -o "$archive" \
+    "https://github.com/protocolbuffers/protobuf/releases/download/v${version}/protoc-${version}-linux-x86_64.zip"
+printf '%s  %s\n' "$sha256" "$archive" | sha256sum --check --strict -
+mkdir -p "$install_dir"
+unzip -oq "$archive" -d "$install_dir"
+printf '%s\n' "$install_dir/bin" >>"$GITHUB_PATH"
+"$install_dir/bin/protoc" --version


### PR DESCRIPTION
## Summary
- add a default-off `telemetry.syntheticLifecycleEvents` chart value
- render only `HELM_ENV=synthetic`, guarded by `telemetry.enabled=true`
- cover default silence, enabled rendering, and invalid half-enabled configuration
- replace the deprecated protoc setup action with a shared SHA-256-verified protoc 34.1 installer after the required gates reproduced its Node 24 failure

## Why
The f718 QA stand exported OTLP traces but emitted no governed lifecycle events because the chart never configured the kernel lifecycle publisher. This closes that chart/runtime seam without allowing pilot or customer publication.

The first CI attempt and failed-job rerun both stopped before repository commands in `arduino/setup-protoc`; even the job explicitly pinned to 34.1 reported `unable to get latest version` while GitHub forced the unmaintained Node 20 action onto Node 24. The replacement downloads the exact official Linux x86_64 asset and verifies `af27ea66cd26938fe48587804ca7d4817457a08350021a1c6e23a27ccc8c6904` before extraction.

## Validation
- `bash scripts/ci/helm_chart_smoke.sh`
- `go test ./pkg/mcp ./pkg/events`
- `make lint`
- `bash -n scripts/ci/install_protoc.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- `git diff --check`

Linear: HELM-462