### PR TITLE
HELM-462: propagate correlation at daemon edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,13 @@ are causal-chain-bound projections, and the listing does not prove
 completeness. Canonical rows fail closed if any filter projection differs from
 the hash-verified receipt envelope.
 
+### Fixed — daemon correlation propagation
+
+The shared HTTP edge now adopts or mints `X-Helm-Correlation-ID`, echoes the
+canonical value, carries it into governed MCP lifecycle events, and stamps it
+on the active server span. This closes the deployed daemon path that bypasses
+the embedded API server's equivalent correlation edge.
+
 ## [0.8.4] - pending tag
 
 Release target for the receipt tenant-isolation fix, the corrected EU AI Act

--- a/core/pkg/auth/auth_behavior_coverage_test.go
+++ b/core/pkg/auth/auth_behavior_coverage_test.go
@@ -132,6 +132,8 @@ func TestCORSMiddlewareDefaultDeniesOrigin(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	assert.Empty(t, rr.Header().Get("Access-Control-Allow-Origin"))
 	assert.Contains(t, rr.Header().Get("Access-Control-Allow-Headers"), "X-Helm-Tenant-ID")
+	assert.Contains(t, rr.Header().Get("Access-Control-Allow-Headers"), "X-Helm-Correlation-ID")
+	assert.Contains(t, rr.Header().Get("Access-Control-Expose-Headers"), "X-Helm-Correlation-ID")
 }
 
 func TestCORSMiddlewarePreflightReturns204(t *testing.T) {

--- a/core/pkg/auth/cors.go
+++ b/core/pkg/auth/cors.go
@@ -34,8 +34,8 @@ func CORSMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {
 			}
 
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Idempotency-Key, X-Operator-ID, X-Helm-Tenant-ID, X-Helm-Principal-ID")
-			w.Header().Set("Access-Control-Expose-Headers", "Retry-After, X-Request-ID")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Idempotency-Key, X-Operator-ID, X-Helm-Tenant-ID, X-Helm-Principal-ID, X-Helm-Correlation-ID")
+			w.Header().Set("Access-Control-Expose-Headers", "Retry-After, X-Request-ID, X-Helm-Correlation-ID")
 			w.Header().Set("Access-Control-Max-Age", "86400")
 
 			// Handle preflight

--- a/core/pkg/tracing/edgehandler.go
+++ b/core/pkg/tracing/edgehandler.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/correlation"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
@@ -92,12 +93,34 @@ import (
 // The same mechanism is why the daemon's chain in cmd/helm-ai-kernel keeps this
 // wrapper BELOW RequestIDMiddleware, which copies the request the same way.
 func WrapEdgeHandler(h http.Handler, operation string) http.Handler {
-	return otelhttp.NewHandler(withRouteAttribute(dropRemoteSpanContext(h)), operation,
+	return otelhttp.NewHandler(withRouteAttribute(dropRemoteSpanContext(withCorrelationIdentity(h))), operation,
 		otelhttp.WithPropagators(propagation.TraceContext{}),
 		otelhttp.WithPublicEndpointFn(func(*http.Request) bool { return true }),
 		otelhttp.WithSpanNameFormatter(edgeSpanName),
 		otelhttp.WithMetricAttributesFn(edgeMetricAttributes),
 	)
+}
+
+// withCorrelationIdentity establishes the product request identity after the
+// server span exists and before any routed handler runs. The daemon registers
+// routes directly on its own mux, so this shared edge wrapper — not api.Server
+// — is the one place that covers the daemon, proxy, and embedded API server.
+//
+// The canonical value is written back to the request header so a nested edge
+// adopts the same ID instead of minting a second one. Updating the request in
+// place preserves http.ServeMux's route stamp for the outer otelhttp wrapper.
+func withCorrelationIdentity(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		corr, _ := correlation.AdoptOrMint(r.Header)
+		ctx := correlation.With(r.Context(), corr)
+		correlation.Inject(ctx, r.Header)
+		correlation.Inject(ctx, w.Header())
+		*r = *r.WithContext(ctx)
+		oteltrace.SpanFromContext(ctx).SetAttributes(
+			attribute.String("helm.correlation_id", string(corr)),
+		)
+		next.ServeHTTP(w, r)
+	})
 }
 
 // dropRemoteSpanContext removes the extracted caller context only when the

--- a/core/pkg/tracing/edgehandler_test.go
+++ b/core/pkg/tracing/edgehandler_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/correlation"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/tracing"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/baggage"
@@ -17,6 +18,50 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
+
+func TestWrapEdgeHandlerAdoptsAndStampsCorrelation(t *testing.T) {
+	sr := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(context.Background())
+	})
+
+	const inbound = "bf7171d9-4965-4c81-acf0-6dfe3042caa0"
+	var inner correlation.ID
+	h := tracing.WrapEdgeHandler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		inner, _ = correlation.From(r.Context())
+		if got := r.Header.Get(correlation.Header); got != inbound {
+			t.Errorf("downstream correlation header = %q, want %q", got, inbound)
+		}
+	}), "test.edge")
+	req := httptest.NewRequest(http.MethodPost, "/mcp/v1/execute", nil)
+	req.Header.Set(correlation.Header, inbound)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if string(inner) != inbound {
+		t.Errorf("downstream correlation = %q, want %q", inner, inbound)
+	}
+	if got := rec.Header().Get(correlation.Header); got != inbound {
+		t.Errorf("response correlation header = %q, want %q", got, inbound)
+	}
+	spans := sr.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("recorded %d server spans, want 1", len(spans))
+	}
+	for _, attr := range spans[0].Attributes() {
+		if string(attr.Key) == "helm.correlation_id" {
+			if got := attr.Value.AsString(); got != inbound {
+				t.Errorf("span correlation = %q, want %q", got, inbound)
+			}
+			return
+		}
+	}
+	t.Error("server span has no helm.correlation_id attribute")
+}
 
 func TestWrapEdgeHandlerRootsInboundTraceAndLinksRemote(t *testing.T) {
 	sr := tracetest.NewSpanRecorder()


### PR DESCRIPTION
## Outcome

The shared HTTP edge now adopts or mints X-Helm-Correlation-ID before routed handlers run, echoes the canonical ID, preserves it for nested edges, and stamps it on the active server span. The daemon CORS contract now permits and exposes the same header.

This fixes the live QA finding where MCP lifecycle events and traces joined internally but ignored the caller-provided correlation because the daemon bypasses api.Server.

## Validation

- full core test target equivalent: go test ./pkg/... ./cmd/release-permit-verify/... ./cmd/receipt_verify/... -count=1
- go test ./pkg/auth ./pkg/tracing ./pkg/api ./cmd/helm-ai-kernel
- go vet ./...
- go mod tidy check: 12 modules tidy
- docs coverage and docs truth
- git diff --check

HELM-462 remains Active until a released kernel is deployed and ALLOW, DENY, ESCALATE, and unclosed-request paths have live joined proof.