### PR TITLE
HELM-462: add governed live-proof controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,13 @@ reference pack for governed bootstrap and synthetic-stand policy proof. The
 default remains an empty fail-closed rule list; production deployments should
 prefer a signed control-plane or CRD policy source.
 
+### Added — daemon semantic escalation threshold
+
+The daemon and Helm chart can configure the Guardian's existing semantic
+threat escalation threshold in basis points. Zero remains advisory-only;
+positive thresholds return ESCALATE before dispatch when semantic assessment
+is unavailable, truncated, or meets the configured score.
+
 ### Added — tenant-scoped receipt query predicates
 
 `GET /api/v1/receipts` can filter the authenticated tenant's V5 receipts by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ Keep research scaffolds and hardware-backed enforcement language out of the
 public changelog until a tagged release ships source-owned tests, verifier
 evidence, and release artifacts for that exact capability.
 
+### Added — chart-managed mounted-file runtime rules
+
+The Helm chart can render explicit `helm.policy.runtimeActions` into its
+reference pack for governed bootstrap and synthetic-stand policy proof. The
+default remains an empty fail-closed rule list; production deployments should
+prefer a signed control-plane or CRD policy source.
+
 ### Added — tenant-scoped receipt query predicates
 
 `GET /api/v1/receipts` can filter the authenticated tenant's V5 receipts by

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -274,6 +274,10 @@ func runServerWithOptions(opts serverOptions) error {
 	if logConfigErr != nil {
 		return logConfigErr
 	}
+	semanticEscalationBP, semanticConfigErr := semanticThreatEscalationBPFromEnv()
+	if semanticConfigErr != nil {
+		return semanticConfigErr
+	}
 	// Consume the Desktop launch secret before any optional runtime setup can
 	// spawn a subprocess. The route retains only the in-memory copy below.
 	desktopReadyToken := takeDesktopReadyToken()
@@ -521,6 +525,9 @@ func runServerWithOptions(opts serverOptions) error {
 
 	// Guardian
 	guardianOpts := []guardian.GuardianOption{guardian.WithClock(runtimeClock)}
+	if semanticEscalationBP > 0 {
+		guardianOpts = append(guardianOpts, guardian.WithSemanticThreatEscalation(semanticEscalationBP))
+	}
 	if policyStore != nil {
 		guardianOpts = append(guardianOpts, guardian.WithPolicySnapshots(policyStore, policyScope))
 	}
@@ -785,6 +792,18 @@ func envInt(key string, fallback int) int {
 		return fallback
 	}
 	return parsed
+}
+
+func semanticThreatEscalationBPFromEnv() (int, error) {
+	value := strings.TrimSpace(os.Getenv("HELM_SEMANTIC_THREAT_ESCALATION_BP"))
+	if value == "" {
+		return 0, nil
+	}
+	threshold, err := strconv.Atoi(value)
+	if err != nil || threshold < 0 || threshold > 10000 {
+		return 0, fmt.Errorf("HELM_SEMANTIC_THREAT_ESCALATION_BP must be an integer from 0 to 10000")
+	}
+	return threshold, nil
 }
 
 // buildAPIHandler assembles the daemon's request pipeline.

--- a/core/cmd/helm-ai-kernel/main_test.go
+++ b/core/cmd/helm-ai-kernel/main_test.go
@@ -362,6 +362,29 @@ func TestEnvIntFallback(t *testing.T) {
 	assert.Equal(t, 60, envInt("HELM_LIMIT_GLOBAL_RPS", 60))
 }
 
+func TestSemanticThreatEscalationBPFromEnv(t *testing.T) {
+	for _, test := range []struct {
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{value: "", want: 0},
+		{value: "0", want: 0},
+		{value: "1", want: 1},
+		{value: "10000", want: 10000},
+		{value: "-1", wantErr: true},
+		{value: "10001", wantErr: true},
+		{value: "invalid", wantErr: true},
+	} {
+		t.Run(test.value, func(t *testing.T) {
+			t.Setenv("HELM_SEMANTIC_THREAT_ESCALATION_BP", test.value)
+			got, err := semanticThreatEscalationBPFromEnv()
+			assert.Equal(t, test.wantErr, err != nil)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
 func TestConfigurePostgresPoolFromEnv(t *testing.T) {
 	db, _, err := sqlmock.New()
 	if err != nil {

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -90,6 +90,7 @@ flowchart TD
 | `helm.limits.actor.burst` | `120` | Actor/resource burst. |
 | `helm.limits.concurrency.max` | `0` | Process in-flight request cap; `0` disables. |
 | `helm.limits.loadShed.enabled` | `false` | Enable low-priority load shedding. |
+| `helm.guardian.semanticThreatEscalationBP` | `0` | Semantic ESCALATE threshold in basis points; `0` is advisory-only, while a positive value fails closed when assessment is unavailable or truncated. |
 | `helm.policy.source.kind` | `mountedFile` | `controlplane`, `crd`, or `mountedFile`; Kubernetes delivery is not policy truth. |
 | `helm.policy.source.pollInterval` | `10s` | Runtime reconciler polling interval. Lost hints are recovered by polling. |
 | `helm.policy.failClosed.onInvalidUpdate` | `keepLastKnownGood` | Retain only a snapshot with a fresh successful source verification after a fault, or `deny` to invalidate immediately. |

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -97,6 +97,7 @@ flowchart TD
 | `helm.policy.signature.required` | `false` | Rejects unsigned policy heads during reconciliation when enabled. |
 | `helm.policy.signature.publicKey` | empty | 64-char hex Ed25519 public key for canonical policy bundle signatures. |
 | `helm.policy.signature.existingSecret` | empty | Existing secret containing `HELM_POLICY_TRUST_PUBLIC_KEY`. |
+| `helm.policy.runtimeActions` | `[]` | Explicit mounted-file rules compiled into the chart-managed reference pack; empty remains fail-closed. Prefer signed control-plane/CRD policy in production. |
 | `helm.policy.reloadHints.httpWakeEndpoint` | `/internal/policy/reconcile` | Wake-only internal endpoint for sidecars/operators. |
 | `helm.policy.reloadHints.configReloaderSidecar.enabled` | `false` | Optional mounted-file wake hint; disabled by default. |
 | `persistence.enabled` | `true` | Creates or uses a PVC for `/data`. |

--- a/deploy/helm-chart/templates/configmap.yaml
+++ b/deploy/helm-chart/templates/configmap.yaml
@@ -32,7 +32,7 @@ data:
       "pack_id": {{ .Values.helm.policy.referencePackID | quote }},
       "label": {{ .Values.helm.policy.referencePackLabel | quote }},
       "version": 1,
-      "runtime_actions": []
+      "runtime_actions": {{ .Values.helm.policy.runtimeActions | toJson }}
     }
 
   helm.yaml: |

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -234,6 +234,10 @@ spec:
               value: {{ ternary "1" "0" .Values.helm.limits.loadShed.enabled | quote }}
             - name: HELM_LOAD_SHED_LOW_PRIORITY_MAX
               value: {{ .Values.helm.limits.loadShed.lowPriorityMax | quote }}
+            {{- if gt (int .Values.helm.guardian.semanticThreatEscalationBP) 0 }}
+            - name: HELM_SEMANTIC_THREAT_ESCALATION_BP
+              value: {{ .Values.helm.guardian.semanticThreatEscalationBP | quote }}
+            {{- end }}
             - name: HELM_POLICY_SOURCE_KIND
               value: {{ .Values.helm.policy.source.kind | quote }}
             - name: HELM_POLICY_POLL_INTERVAL

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -577,6 +577,20 @@
             }
           }
         },
+        "guardian": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Guardian verdict-authority configuration.",
+          "properties": {
+            "semanticThreatEscalationBP": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 10000,
+              "default": 0,
+              "description": "Semantic ESCALATE threshold in basis points. Zero keeps semantic assessment advisory-only; a positive threshold fails closed to ESCALATE when the configured assessment is unavailable or truncated."
+            }
+          }
+        },
         "policy": {
           "type": "object",
           "additionalProperties": true,

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -813,6 +813,22 @@
             "referencePackLabel": {
               "type": "string",
               "description": "Human-readable label for the reference pack."
+            },
+            "runtimeActions": {
+              "type": "array",
+              "default": [],
+              "description": "Explicit mounted-file runtime rules compiled into the chart-managed reference pack. Empty remains fail-closed; use a signed control-plane or CRD source for production policy.",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["action"],
+                "properties": {
+                  "action": { "type": "string", "minLength": 1 },
+                  "enabled": { "type": "boolean", "default": true },
+                  "expression": { "type": "string" },
+                  "description": { "type": "string" }
+                }
+              }
             }
           }
         }

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -199,6 +199,12 @@ helm:
       enabled: false
       lowPriorityMax: 0
 
+  guardian:
+    # 0 keeps semantic assessment advisory-only. A positive basis-point
+    # threshold makes unavailable, truncated, or matching semantic assessment
+    # return ESCALATE before dispatch.
+    semanticThreatEscalationBP: 0
+
   # Policy configuration
   policy:
     # Kubernetes delivery is a policy-source backend, not runtime truth.

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -280,6 +280,9 @@ helm:
     referencePackFileName: "reference-pack.json"
     referencePackID: "helm-chart-reference-pack"
     referencePackLabel: "HELM chart default fail-closed reference pack"
+    # Explicit mounted-file rules compiled by the runtime reconciler. Empty is
+    # fail-closed. Prefer signed control-plane/CRD policy for production.
+    runtimeActions: []
 
 # Telemetry (HELM-453). Off by default and it must stay that way: the
 # Application Readiness Gate is closed, and a stand handed an endpoint starts

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -109,6 +109,7 @@ assert_not_contains "$default_rendered" "kind: CustomResourceDefinition"
 assert_not_contains "$default_rendered" "HelmPolicyBundle"
 assert_not_contains "$default_rendered" "policy-reader"
 assert_not_contains "$default_rendered" "HELM_ENV"
+assert_contains "$default_rendered" '"runtime_actions": []'
 assert_contains "$default_rendered" "name: prepare-authority-state"
 assert_contains "$default_rendered" "HELM_AUTHORITY_DATA_DIR"
 assert_contains "$default_rendered" "/var/run/helm-signing-key"
@@ -175,6 +176,12 @@ if helm_runner template "$RELEASE" "$CHART" \
     exit 1
 fi
 assert_contains "$synthetic_without_telemetry_log" "telemetry.syntheticLifecycleEvents=true requires telemetry.enabled=true"
+
+runtime_actions_rendered="$RENDER_DIR/rendered-runtime-actions.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set-json 'helm.policy.runtimeActions=[{"action":"file_read","expression":"input.path == \"/etc/hostname\""}]' >"$runtime_actions_rendered"
+assert_contains "$runtime_actions_rendered" '"runtime_actions": [{"action":"file_read","expression":"input.path == \"/etc/hostname\""}]'
 
 authority_identity_rendered="$RENDER_DIR/rendered-authority-identity.yaml"
 helm_runner template "$RELEASE" "$CHART" \

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -109,6 +109,7 @@ assert_not_contains "$default_rendered" "kind: CustomResourceDefinition"
 assert_not_contains "$default_rendered" "HelmPolicyBundle"
 assert_not_contains "$default_rendered" "policy-reader"
 assert_not_contains "$default_rendered" "HELM_ENV"
+assert_not_contains "$default_rendered" "HELM_SEMANTIC_THREAT_ESCALATION_BP"
 assert_contains "$default_rendered" '"runtime_actions": []'
 assert_contains "$default_rendered" "name: prepare-authority-state"
 assert_contains "$default_rendered" "HELM_AUTHORITY_DATA_DIR"
@@ -182,6 +183,20 @@ helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set-json 'helm.policy.runtimeActions=[{"action":"file_read","expression":"input.path == \"/etc/hostname\""}]' >"$runtime_actions_rendered"
 assert_contains "$runtime_actions_rendered" '"runtime_actions": [{"action":"file_read","expression":"input.path == \"/etc/hostname\""}]'
+
+semantic_escalation_rendered="$RENDER_DIR/rendered-semantic-escalation.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.guardian.semanticThreatEscalationBP=7000 >"$semantic_escalation_rendered"
+assert_contains "$semantic_escalation_rendered" "HELM_SEMANTIC_THREAT_ESCALATION_BP"
+assert_contains "$semantic_escalation_rendered" 'value: "7000"'
+
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.guardian.semanticThreatEscalationBP=10001 >"$RENDER_DIR/rendered-invalid-semantic-escalation.yaml" 2>&1; then
+    echo "::error::out-of-range semantic escalation threshold unexpectedly rendered"
+    exit 1
+fi
 
 authority_identity_rendered="$RENDER_DIR/rendered-authority-identity.yaml"
 helm_runner template "$RELEASE" "$CHART" \


### PR DESCRIPTION
## Summary

- render explicit, default-empty mounted-file runtime actions through the existing reconciled reference pack
- wire the Guardian semantic escalation threshold into the daemon and Helm chart
- reject invalid thresholds before server startup; keep both controls disabled by default

These controls provide bounded QA stimuli for HELM-462 ALLOW, ESCALATE, and killed/unclosed-request evidence without adding a parallel policy path.

## Validation

- Go 1.25.12: go test ./... -count=1
- make helm-chart-smoke
- make lint with pinned Go/Python PATH
- focused daemon, Guardian, and MCP tests
- git diff --check; JSON schema parse

HELM-462 remains Active until the merged source is published/deployed and all live evidence trees are captured.