### PR TITLE
HELM-462: close ingress lifecycle gaps and wire GitHub receipt runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,15 @@ Keep research scaffolds and hardware-backed enforcement language out of the
 public changelog until a tagged release ships source-owned tests, verifier
 evidence, and release artifacts for that exact capability.
 
+### Fixed — governed MCP lifecycle closure and GitHub dispatch wiring
+
+Governed MCP calls rejected at the REST or JSON-RPC ingress boundary now emit
+one `helm.request.received.v1` and one `helm.request.failed.v1` event without
+reaching policy evaluation or a tool handler. The Helm chart can also activate
+the existing signed-permit GitHub effects runtime through an existing Secret;
+raw GitHub tokens are never accepted as chart values, and the default remains
+off.
+
 ### Added — offline Kernel receipt.v5 file verify (Building)
 
 Evaluate persist writes a copyable `receipt.v5` JSON file under

--- a/core/pkg/mcp/gateway.go
+++ b/core/pkg/mcp/gateway.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
@@ -299,9 +300,11 @@ func (g *Gateway) handleExecute(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(MCPToolCallResponse{Error: "invalid request body"})
 		return
 	}
+	execReq := toolExecutionRequestFromHTTP(r, req.Method, req.Params)
 
 	tool, ok := findToolRef(g.catalog, req.Method)
 	if !ok {
+		g.recordGovernedIngressFailure(r.Context(), execReq, string(contracts.ReasonNoPolicy))
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(MCPToolCallResponse{
@@ -310,7 +313,9 @@ func (g *Gateway) handleExecute(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	execReq.RequiredScopes = append([]string(nil), tool.RequiredScopes...)
 	if !g.hasRequiredScopes(r.Context(), tool) {
+		g.recordGovernedIngressFailure(r.Context(), execReq, "MCP.OAUTH.INSUFFICIENT_SCOPE")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
 		_ = json.NewEncoder(w).Encode(MCPToolCallResponse{
@@ -323,6 +328,7 @@ func (g *Gateway) handleExecute(w http.ResponseWriter, r *http.Request) {
 	// 1. Validate and canonicalize args via PEP boundary
 	argsHash, err := ValidateToolArguments(tool, req.Params)
 	if err != nil {
+		g.recordGovernedIngressFailure(r.Context(), execReq, string(contracts.ReasonSchemaViolation))
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(MCPToolCallResponse{
@@ -336,28 +342,6 @@ func (g *Gateway) handleExecute(w http.ResponseWriter, r *http.Request) {
 	resp := MCPToolCallResponse{ArgsHash: argsHash}
 
 	if g.exec != nil {
-		// Build execution request with delegation context from headers.
-		execReq := ToolExecutionRequest{
-			ToolName:       req.Method,
-			Arguments:      req.Params,
-			SessionID:      fmt.Sprintf("mcp-http-%s-%p", r.RemoteAddr, r),
-			RequiredScopes: append([]string(nil), tool.RequiredScopes...),
-		}
-		if auth, ok := OAuthAuthorizationFromContext(r.Context()); ok {
-			execReq.OAuthScopes = append([]string(nil), auth.Scopes...)
-			execReq.OAuthResources = append([]string(nil), auth.Resources...)
-		}
-		if delegationID := r.Header.Get("X-HELM-Delegation-Session-ID"); delegationID != "" {
-			execReq.DelegationSessionID = delegationID
-			execReq.DelegationVerifier = r.Header.Get("X-HELM-Delegation-Verifier")
-			if allowedCSV := r.Header.Get("X-HELM-Delegation-Allowed-Tools"); allowedCSV != "" {
-				for _, t := range strings.Split(allowedCSV, ",") {
-					if trimmed := strings.TrimSpace(t); trimmed != "" {
-						execReq.DelegationAllowedTools = append(execReq.DelegationAllowedTools, trimmed)
-					}
-				}
-			}
-		}
 		execResp, execErr := g.exec(r.Context(), execReq)
 		if execErr != nil {
 			w.Header().Set("Content-Type", "application/json")
@@ -524,30 +508,25 @@ func (g *Gateway) handleJSONRPCRequest(ctx context.Context, id any, method strin
 		if err := json.Unmarshal(params, &req); err != nil {
 			return writeError(-32602, "invalid tools/call params")
 		}
+		execReq := newToolExecutionRequest(ctx, req.Name, req.Arguments, "mcp-http-jsonrpc")
 		tool, ok := findToolRef(g.catalog, req.Name)
 		if !ok {
+			g.recordGovernedIngressFailure(ctx, execReq, string(contracts.ReasonNoPolicy))
 			return writeError(-32602, fmt.Sprintf("tool %q not found", req.Name))
 		}
+		execReq.RequiredScopes = append([]string(nil), tool.RequiredScopes...)
 		if !g.hasRequiredScopes(ctx, tool) {
+			g.recordGovernedIngressFailure(ctx, execReq, "MCP.OAUTH.INSUFFICIENT_SCOPE")
 			return writeError(-32001, fmt.Sprintf("tool %q requires OAuth scopes: %s", req.Name, strings.Join(tool.RequiredScopes, ", ")))
 		}
 		if _, err := ValidateToolArguments(tool, req.Arguments); err != nil {
+			g.recordGovernedIngressFailure(ctx, execReq, string(contracts.ReasonSchemaViolation))
 			return writeError(-32602, fmt.Sprintf("PEP validation failed: %v", err))
 		}
 		if g.exec == nil {
 			return writeError(-32603, "tool executor is not configured")
 		}
 
-		execReq := ToolExecutionRequest{
-			ToolName:       req.Name,
-			Arguments:      req.Arguments,
-			SessionID:      "mcp-http-jsonrpc",
-			RequiredScopes: append([]string(nil), tool.RequiredScopes...),
-		}
-		if auth, ok := OAuthAuthorizationFromContext(ctx); ok {
-			execReq.OAuthScopes = append([]string(nil), auth.Scopes...)
-			execReq.OAuthResources = append([]string(nil), auth.Resources...)
-		}
 		execResp, err := g.exec(ctx, execReq)
 		if err != nil {
 			return writeError(-32603, err.Error())
@@ -556,6 +535,39 @@ func (g *Gateway) handleJSONRPCRequest(ctx context.Context, id any, method strin
 		return response, true, http.StatusOK
 	default:
 		return writeError(-32601, fmt.Sprintf("method %q not found", method))
+	}
+}
+
+func newToolExecutionRequest(ctx context.Context, toolName string, arguments map[string]any, sessionID string) ToolExecutionRequest {
+	req := ToolExecutionRequest{ToolName: toolName, Arguments: arguments, SessionID: sessionID}
+	if auth, ok := OAuthAuthorizationFromContext(ctx); ok {
+		req.OAuthScopes = append([]string(nil), auth.Scopes...)
+		req.OAuthResources = append([]string(nil), auth.Resources...)
+	}
+	return req
+}
+
+func toolExecutionRequestFromHTTP(r *http.Request, toolName string, arguments map[string]any) ToolExecutionRequest {
+	req := newToolExecutionRequest(r.Context(), toolName, arguments, fmt.Sprintf("mcp-http-%s-%p", r.RemoteAddr, r))
+	if delegationID := r.Header.Get("X-HELM-Delegation-Session-ID"); delegationID != "" {
+		req.DelegationSessionID = delegationID
+		req.DelegationVerifier = r.Header.Get("X-HELM-Delegation-Verifier")
+		for _, tool := range strings.Split(r.Header.Get("X-HELM-Delegation-Allowed-Tools"), ",") {
+			if tool = strings.TrimSpace(tool); tool != "" {
+				req.DelegationAllowedTools = append(req.DelegationAllowedTools, tool)
+			}
+		}
+	}
+	return req
+}
+
+func (g *Gateway) recordGovernedIngressFailure(ctx context.Context, req ToolExecutionRequest, reasonCode string) {
+	if !g.governed || g.exec == nil {
+		return
+	}
+	req.ingressFailureReasonCode = reasonCode
+	if _, err := g.exec(ctx, req); err != nil {
+		slog.Warn("mcp_gateway: lifecycle ingress rejection publication failed", "reason_code", reasonCode)
 	}
 }
 

--- a/core/pkg/mcp/gateway_protocol_test.go
+++ b/core/pkg/mcp/gateway_protocol_test.go
@@ -14,12 +14,102 @@ import (
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/budget"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/crypto"
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/events"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/guardian"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/prg"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/proofgraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGatewayGovernedIngressRejectionsPublishClosedLifecycle(t *testing.T) {
+	t.Setenv("HELM_ENV", events.EnvSynthetic)
+	transportCatalog := NewInMemoryCatalog()
+	for _, tool := range []ToolRef{
+		{
+			Name: "read",
+			Schema: map[string]any{
+				"type":       "object",
+				"properties": map[string]any{"path": map[string]any{"type": "string"}},
+				"required":   []string{"path"},
+			},
+		},
+		{Name: "scoped", Schema: map[string]any{"type": "object"}, RequiredScopes: []string{"mcp:tool:scoped"}},
+	} {
+		require.NoError(t, transportCatalog.Register(context.Background(), tool))
+	}
+
+	governanceCatalog := NewToolCatalog()
+	for _, name := range []string{"read", "scoped"} {
+		require.NoError(t, governanceCatalog.Register(context.Background(), ToolRef{
+			Name: name, EffectClass: "E0", RiskTier: contracts.RiskTierLow,
+		}))
+	}
+	capture := &lifecycleCapture{}
+	evaluatorCalls := 0
+	handlerCalls := 0
+	firewall := NewGovernanceFirewall(
+		lifecycleEvaluator{calls: &evaluatorCalls, decision: &contracts.DecisionRecord{Verdict: string(contracts.VerdictAllow)}},
+		governanceCatalog,
+		WithLifecyclePublisher(capture.publish),
+	)
+	gateway := NewGateway(
+		transportCatalog,
+		GatewayConfig{AuthMode: "oauth"},
+		WithGovernedExecutor(firewall.GovernedExecutor(func(context.Context, ToolExecutionRequest) (ToolExecutionResponse, error) {
+			handlerCalls++
+			return ToolExecutionResponse{Content: "unexpected"}, nil
+		})),
+	)
+	mux := http.NewServeMux()
+	gateway.RegisterRoutes(mux)
+
+	tests := []struct {
+		name       string
+		tool       string
+		arguments  map[string]any
+		reasonCode string
+		status     int
+	}{
+		{name: "unknown", tool: "missing", reasonCode: string(contracts.ReasonNoPolicy), status: http.StatusNotFound},
+		{name: "schema", tool: "read", arguments: map[string]any{}, reasonCode: string(contracts.ReasonSchemaViolation), status: http.StatusBadRequest},
+		{name: "scope", tool: "scoped", reasonCode: "MCP.OAUTH.INSUFFICIENT_SCOPE", status: http.StatusForbidden},
+	}
+	for _, transport := range []string{"rest", "jsonrpc"} {
+		for _, tt := range tests {
+			t.Run(transport+"/"+tt.name, func(t *testing.T) {
+				start := len(capture.events)
+				if transport == "rest" {
+					body, err := json.Marshal(MCPToolCallRequest{Method: tt.tool, Params: tt.arguments})
+					require.NoError(t, err)
+					req := httptest.NewRequest(http.MethodPost, "/mcp/v1/execute", bytes.NewReader(body))
+					rec := httptest.NewRecorder()
+					mux.ServeHTTP(rec, req)
+					require.Equal(t, tt.status, rec.Code)
+				} else {
+					rec := performJSONRPCRequest(t, mux, http.MethodPost, "/mcp", map[string]any{
+						"jsonrpc": "2.0",
+						"id":      42,
+						"method":  "tools/call",
+						"params":  map[string]any{"name": tt.tool, "arguments": tt.arguments},
+					}, nil)
+					require.Equal(t, http.StatusOK, rec.Code)
+					require.Contains(t, rec.Body.String(), "error")
+				}
+
+				sequence := capture.events[start:]
+				require.NoError(t, events.ValidateRequestSequence(sequence))
+				require.Equal(t, 1, countEvent(sequence, events.RequestReceived))
+				require.Equal(t, 1, countEvent(sequence, events.RequestFailed))
+				require.Zero(t, countEvent(sequence, events.RequestClassified))
+				require.Equal(t, "ingress", fieldString(sequence, events.RequestFailed, "failure_class"))
+				require.Equal(t, tt.reasonCode, fieldString(sequence, events.RequestFailed, "reason_code"))
+			})
+		}
+	}
+	require.Zero(t, evaluatorCalls)
+	require.Zero(t, handlerCalls)
+}
 
 func TestGateway_StreamableInitializeNegotiatesProtocol(t *testing.T) {
 	mux := newProtocolTestMux(t, GatewayConfig{}, nil)

--- a/core/pkg/mcp/mcp_additional_coverage_test.go
+++ b/core/pkg/mcp/mcp_additional_coverage_test.go
@@ -86,18 +86,23 @@ func TestCatalog_ConcurrentRegisterAndSearch(t *testing.T) {
 // ── Session TTL Boundary ────────────────────────────────────
 
 func TestSessionStore_AccessRefreshesTTL(t *testing.T) {
-	s := NewSessionStore(100 * time.Millisecond)
+	ttl := 250 * time.Millisecond
+	s := NewSessionStore(ttl)
 	defer s.Stop()
 	id, _ := s.Create("v1", "c")
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(ttl / 3)
 	session := s.Get(id) // should refresh LastAccess
 	if session == nil {
 		t.Fatal("session should still be alive after refresh")
 	}
-	time.Sleep(60 * time.Millisecond)
+	firstRefresh := session.LastAccess
+	time.Sleep(ttl / 3)
 	session = s.Get(id) // refresh again
 	if session == nil {
 		t.Fatal("session should still be alive after second refresh within TTL")
+	}
+	if !session.LastAccess.After(firstRefresh) {
+		t.Fatal("session access should advance LastAccess")
 	}
 }
 

--- a/core/pkg/mcp/server.go
+++ b/core/pkg/mcp/server.go
@@ -34,6 +34,12 @@ type ToolExecutionRequest struct {
 	RequiredScopes []string `json:"required_scopes,omitempty"`
 	OAuthScopes    []string `json:"oauth_scopes,omitempty"`
 	OAuthResources []string `json:"oauth_resources,omitempty"`
+
+	// ingressFailureReasonCode is set only by the trusted Gateway after it has
+	// rejected a syntactically valid tool call before policy evaluation. Keeping
+	// it private prevents callers from bypassing governance through the wire
+	// contract while allowing the lifecycle wrapper to close the request.
+	ingressFailureReasonCode string
 }
 
 // ToolExecutionResponse represents the result of a tool execution.
@@ -280,6 +286,10 @@ func (f *GovernanceFirewall) WrapToolHandler(handler ToolHandler) ToolHandler {
 				Tool:     req.ToolName,
 			},
 		))
+		if req.ingressFailureReasonCode != "" {
+			emitFailure(req.ingressFailureReasonCode, "ingress")
+			return deniedResponse(fmt.Errorf("MCP ingress rejected: %s", req.ingressFailureReasonCode)), nil
+		}
 		decisionCtx, preflightErr := f.prepareToolExecution(req)
 		if preflightErr != nil {
 			emitFailure(string(preflightReasonCode(f, req)), "preflight")

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -48,6 +48,7 @@ flowchart TD
   snapshot --> pod["helm-ai-kernel serve pod"]
   signing["signing-key Secret"] --> pod
   auth["admin/service API-key Secret"] --> pod
+  github["optional GitHub token Secret"] --> pod
   pvc["data volume"] --> pod
   pod --> service["ClusterIP Service"]
   service --> ingress["optional Ingress"]
@@ -74,6 +75,9 @@ flowchart TD
 | `helm.auth.adminAPIKey` | empty | Admin API key written to the generated auth secret. |
 | `helm.auth.serviceAPIKey` | empty | Service API key written to the generated auth secret. |
 | `helm.auth.existingSecret` | empty | Existing secret containing auth key entries. |
+| `helm.githubEffects.existingSecret` | empty | Existing Secret containing the GitHub token; non-empty activates the shipped signed-permit `github.*` runtime. |
+| `helm.githubEffects.tokenSecretKey` | `HELM_GITHUB_TOKEN` | Key inside the GitHub effects Secret. Raw tokens are not accepted in chart values. |
+| `helm.githubEffects.apiURL` | empty | Optional GitHub-compatible API base URL; requires `existingSecret`. Empty uses github.com. |
 | `helm.auth.tenantID` | `default` | Server-bound tenant for tenant-scoped runtime routes; request tenant headers must match. |
 | `helm.auth.principalID` | `system-admin` | Server-bound principal for tenant-scoped runtime routes; request principal headers must match. |
 | `helm.emergencyStop.commandReplayKeyring` | empty | Optional strict JSON FENCE replay-authority keyring. Use only during a deliberate command key/audience rotation. |
@@ -140,6 +144,11 @@ flowchart TD
   provide a companion `serve-policy.toml.sig` file in the same volume.
 - Keep connector credentials in Kubernetes Secrets or an external secret
   manager. Policy bundles should reference credentials, not embed raw secrets.
+- Set `helm.githubEffects.existingSecret` only when the release should register
+  the shipped `github.*` tools. Read operations dispatch under signed,
+  single-use permits and return authoritative execution receipts; bounded
+  writes remain fail-closed and do not dispatch in this runtime. Use `apiURL`
+  only for an explicitly trusted GitHub-compatible endpoint.
 - Use a persistent volume or external PostgreSQL for durable receipts and
   evidence.
 - Keep `serviceAccount.automountServiceAccountToken=false` unless CRD mode is

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -57,6 +57,9 @@
 {{- if and .Values.telemetry.syntheticLifecycleEvents (not .Values.telemetry.enabled) -}}
 {{- fail "telemetry.syntheticLifecycleEvents=true requires telemetry.enabled=true" -}}
 {{- end -}}
+{{- if and .Values.helm.githubEffects.apiURL (not .Values.helm.githubEffects.existingSecret) -}}
+{{- fail "helm.githubEffects.apiURL requires helm.githubEffects.existingSecret" -}}
+{{- end -}}
 {{- if not (regexMatch "^.+@sha256:[0-9a-f]{64}$" .Values.runtimeInit.image) -}}
 {{- fail "runtimeInit.image must be pinned by immutable sha256 digest" -}}
 {{- end -}}
@@ -344,6 +347,17 @@ spec:
                 secretKeyRef:
                   name: {{ include "helm-ai-kernel.authSecretName" . }}
                   key: {{ .Values.helm.auth.serviceAPIKeySecretKey }}
+            {{- end }}
+            {{- if .Values.helm.githubEffects.existingSecret }}
+            - name: HELM_GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.helm.githubEffects.existingSecret }}
+                  key: {{ required "helm.githubEffects.tokenSecretKey is required when helm.githubEffects.existingSecret is set" .Values.helm.githubEffects.tokenSecretKey }}
+            {{- if .Values.helm.githubEffects.apiURL }}
+            - name: HELM_GITHUB_API_URL
+              value: {{ .Values.helm.githubEffects.apiURL | quote }}
+            {{- end }}
             {{- end }}
             - name: HELM_RUNTIME_TENANT_ID
               value: {{ .Values.helm.auth.tenantID | quote }}

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -359,6 +359,30 @@
             }
           }
         },
+        "githubEffects": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Secret-backed activation of the shipped governed GitHub effects runtime. Reads dispatch under signed single-use permits and produce authoritative execution receipts; bounded writes remain fail-closed in this runtime.",
+          "properties": {
+            "existingSecret": {
+              "type": "string",
+              "default": "",
+              "description": "Existing Secret containing the GitHub token. Empty keeps github.* tools unregistered."
+            },
+            "tokenSecretKey": {
+              "type": "string",
+              "minLength": 1,
+              "default": "HELM_GITHUB_TOKEN",
+              "description": "Key inside existingSecret containing HELM_GITHUB_TOKEN."
+            },
+            "apiURL": {
+              "type": "string",
+              "default": "",
+              "pattern": "^$|^https?://[^\\s]+$",
+              "description": "Optional GitHub-compatible API base URL rendered as HELM_GITHUB_API_URL. Empty uses github.com."
+            }
+          }
+        },
         "emergencyStop": {
           "type": "object",
           "additionalProperties": false,

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -125,6 +125,15 @@ helm:
     # scoped emergency-stop fence is enabled.
     workspaceID: "default"
 
+  # Governed GitHub effects. Supplying an existing Secret arms the shipped
+  # signed-permit connector; an empty Secret name keeps every github.* tool
+  # unregistered. Raw tokens are never accepted through chart values.
+  githubEffects:
+    existingSecret: ""
+    tokenSecretKey: "HELM_GITHUB_TOKEN"
+    # Optional GitHub-compatible API base URL. Leave empty for github.com.
+    apiURL: ""
+
   # Internal Kernel fence only. This remains disabled until the Control Plane
   # has the shared command/ack contract plus its own durable command ledger
   # and reconciliation worker. It fences newly governed dispatches and does

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -110,6 +110,8 @@ assert_not_contains "$default_rendered" "HelmPolicyBundle"
 assert_not_contains "$default_rendered" "policy-reader"
 assert_not_contains "$default_rendered" "HELM_ENV"
 assert_not_contains "$default_rendered" "HELM_SEMANTIC_THREAT_ESCALATION_BP"
+assert_not_contains "$default_rendered" "HELM_GITHUB_TOKEN"
+assert_not_contains "$default_rendered" "HELM_GITHUB_API_URL"
 assert_contains "$default_rendered" '"runtime_actions": []'
 assert_contains "$default_rendered" "name: prepare-authority-state"
 assert_contains "$default_rendered" "HELM_AUTHORITY_DATA_DIR"
@@ -177,6 +179,26 @@ if helm_runner template "$RELEASE" "$CHART" \
     exit 1
 fi
 assert_contains "$synthetic_without_telemetry_log" "telemetry.syntheticLifecycleEvents=true requires telemetry.enabled=true"
+
+github_effects_rendered="$RENDER_DIR/rendered-github-effects.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.githubEffects.existingSecret=helm-github-effects \
+    --set helm.githubEffects.apiURL=http://github-api.qa.svc.cluster.local >"$github_effects_rendered"
+assert_contains "$github_effects_rendered" "HELM_GITHUB_TOKEN"
+assert_contains "$github_effects_rendered" "name: helm-github-effects"
+assert_contains "$github_effects_rendered" "key: HELM_GITHUB_TOKEN"
+assert_contains "$github_effects_rendered" "HELM_GITHUB_API_URL"
+assert_contains "$github_effects_rendered" "http://github-api.qa.svc.cluster.local"
+
+github_effects_missing_secret_log="$RENDER_DIR/github-effects-missing-secret.log"
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.githubEffects.apiURL=http://github-api.qa.svc.cluster.local >"$RENDER_DIR/github-effects-missing-secret.yaml" 2>"$github_effects_missing_secret_log"; then
+    echo "::error::GitHub effects API URL without a token Secret unexpectedly rendered"
+    exit 1
+fi
+assert_contains "$github_effects_missing_secret_log" "helm.githubEffects.apiURL requires helm.githubEffects.existingSecret"
 
 runtime_actions_rendered="$RENDER_DIR/rendered-runtime-actions.yaml"
 helm_runner template "$RELEASE" "$CHART" \


### PR DESCRIPTION
## Summary
- emit closed lifecycle sequences for governed MCP ingress rejections on REST and JSON-RPC surfaces
- keep dispatch completed receipt-gated and expose the existing signed GitHub effects runtime through Secret-backed chart wiring
- add focused gateway and chart smoke coverage
- harden the session TTL refresh check with a wider timing margin and an explicit LastAccess advancement assertion

## Validation
- go test ./core/pkg/mcp -count=1
- go test ./core/cmd/helm-ai-kernel -count=1
- bash scripts/ci/helm_chart_smoke.sh
- go test ./core/pkg/mcp -run TestSessionStore_AccessRefreshesTTL -count=20
- make test
- make test-cli
- make lint
- make build
- make quality-pr
- git diff --check 318ec6f8d051055bfdf70409c8a0f6d05b89ad3f...HEAD

## Deployment boundary
Source only. No image publication, chart upgrade, QA deployment, credential mutation, or live runtime readback was performed.
