### PR TITLE
test(launchpad): wait for teardown convergence

### DIFF
--- a/scripts/ci/launchpad_k8s_smoke.sh
+++ b/scripts/ci/launchpad_k8s_smoke.sh
@@ -250,6 +250,7 @@ if [ "$CLUSTER_MODE" = "minikube" ]; then
             --driver="${LAUNCHPAD_SMOKE_DRIVER:-docker}"
     fi
     kubectl config use-context "$PROFILE"
+    kubectl -n kube-system rollout status daemonset/calico-node --timeout=8m
 else
     if [ -n "$KUBE_CONTEXT" ]; then
         kubectl config use-context "$KUBE_CONTEXT"
@@ -497,6 +498,11 @@ cleanup_ad_hoc_runtime_secrets
 
 # Leak audit (k8s analogue of GAP #17): after uninstall, no launchpad-app or
 # kernel resources should remain in the smoke namespace.
+# Helm waits for its direct resources, but their Pods may still be completing
+# the normal termination grace period. Observe that bounded grace before
+# treating a terminating Pod as a leak; a genuinely stuck Pod still fails.
+kubectl -n "$NAMESPACE" wait --for=delete pod \
+    -l app.kubernetes.io/part-of=helm-ai-kernel --timeout=120s
 leftover="$(kubectl -n "$NAMESPACE" get all -l app.kubernetes.io/part-of=helm-ai-kernel --no-headers 2>/dev/null || true)"
 if [ -n "$leftover" ]; then
     echo "::error::leftover resources detected after helm uninstall:"


### PR DESCRIPTION
## Summary

- wait for the minikube Calico DaemonSet before installing HELM workloads
- give terminating HELM Pods a bounded 120-second convergence window after uninstall
- retain the existing fail-closed label audit for any real leftover resource

## Why

HELM-462 source CI reached and passed every intended negative launchpad assertion, then failed because the leak audit queried immediately after Helm uninstall while a Pod was still in normal Terminating state. Local reproduction also showed minikube can return before its selected Calico CNI is ready.

Failed source run: https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/32372145772

## Validation

- `bash -n scripts/ci/launchpad_k8s_smoke.sh`
- `git diff --check`
- `bash scripts/ci/helm_chart_smoke.sh`
- `make lint`
- isolated negative minikube smoke reached the expected OpenClaw non-ready and Hermes Failed assertions; the retained local probe then failed closed on a Docker image-pull/sidecar teardown defect, and its exact minikube profile was deleted

Linear: HELM-462
