### PR TITLE
HELM-462: execute the chart policy expression in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ flows now include `--profile dev-local --allow-self-attested`; this accepts
 internal consistency without claiming provenance. The demos also execute that
 CLI verification before printing completion.
 
+### Fixed — executable mounted-policy chart example
+
+The Helm chart smoke fixture now scopes `file_read` through the runtime CEL
+path `input.effect.params.path`. The deployed gateway regression test executes
+that same path-scoped rule and keeps other paths and tools fail-closed.
+
 ### Fixed — governed MCP lifecycle closure and GitHub dispatch wiring
 
 Governed MCP calls rejected at the REST or JSON-RPC ingress boundary now emit

--- a/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -153,7 +154,7 @@ func TestDeployedMCPGatewayEnforcesReconciledSnapshot(t *testing.T) {
 		"version": 1,
 		"runtime_actions": []map[string]any{{
 			"action":     "file_read",
-			"expression": `input.effect.params.path == "` + target + `"`,
+			"expression": "input.effect.params.path == " + strconv.Quote(target),
 		}},
 	})
 	if err != nil {

--- a/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
@@ -144,13 +144,22 @@ func TestMountedPackRuntimeActionsReconcileIntoAllowRules(t *testing.T) {
 // tools outside the pack stay fail-closed.
 func TestDeployedMCPGatewayEnforcesReconciledSnapshot(t *testing.T) {
 	dir := t.TempDir()
-	policyPath, _ := writeMountedServePolicyFixture(t, dir, `{
-  "pack_id": "runtime-pack",
-  "version": 1,
-  "runtime_actions": [
-    {"action": "file_read", "expression": "true"}
-  ]
-}`)
+	target := filepath.Join(dir, "allowed.txt")
+	if err := os.WriteFile(target, []byte("helm-362-allow"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pack, err := json.Marshal(map[string]any{
+		"pack_id": "runtime-pack",
+		"version": 1,
+		"runtime_actions": []map[string]any{{
+			"action":     "file_read",
+			"expression": `input.effect.params.path == "` + target + `"`,
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policyPath, _ := writeMountedServePolicyFixture(t, dir, string(pack))
 
 	source := policyreconcile.NewMountedFileSource(policyPath, policyreconcile.DefaultScope)
 	store := policyreconcile.NewAtomicSnapshotStore()
@@ -190,13 +199,18 @@ func TestDeployedMCPGatewayEnforcesReconciledSnapshot(t *testing.T) {
 		return recorder.Body.String()
 	}
 
-	target := filepath.Join(dir, "allowed.txt")
-	if err := os.WriteFile(target, []byte("helm-362-allow"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	body := callTool(t, "file_read", map[string]any{"path": target})
 	if !strings.Contains(body, "helm-362-allow") || strings.Contains(body, "Access Denied") {
 		t.Fatalf("pack-allowed file_read did not reach ALLOW: %s", body)
+	}
+
+	deniedTarget := filepath.Join(dir, "not-allowed.txt")
+	if err := os.WriteFile(deniedTarget, []byte("must-stay-denied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	body = callTool(t, "file_read", map[string]any{"path": deniedTarget})
+	if !strings.Contains(body, "Access Denied") {
+		t.Fatalf("file_read path outside the rule was not fail-closed: %s", body)
 	}
 
 	body = callTool(t, "file_write", map[string]any{"path": filepath.Join(dir, "denied.txt"), "content": "x"})

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -203,8 +203,8 @@ assert_contains "$github_effects_missing_secret_log" "helm.githubEffects.apiURL 
 runtime_actions_rendered="$RENDER_DIR/rendered-runtime-actions.yaml"
 helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
-    --set-json 'helm.policy.runtimeActions=[{"action":"file_read","expression":"input.path == \"/etc/hostname\""}]' >"$runtime_actions_rendered"
-assert_contains "$runtime_actions_rendered" '"runtime_actions": [{"action":"file_read","expression":"input.path == \"/etc/hostname\""}]'
+    --set-json 'helm.policy.runtimeActions=[{"action":"file_read","expression":"input.effect.params.path == \"/etc/hostname\""}]' >"$runtime_actions_rendered"
+assert_contains "$runtime_actions_rendered" '"runtime_actions": [{"action":"file_read","expression":"input.effect.params.path == \"/etc/hostname\""}]'
 
 semantic_escalation_rendered="$RENDER_DIR/rendered-semantic-escalation.yaml"
 helm_runner template "$RELEASE" "$CHART" \


### PR DESCRIPTION
## Outcome

Fixes the runtime-action example exposed by the HELM-462 QA ALLOW proof. The Guardian PRG input places tool arguments under `input.effect.params`; the chart smoke fixture used `input.path`, which rendered successfully but failed closed at runtime with `PRG_EVALUATION_ERROR`.

## Changes

- render the path-scoped chart rule as `input.effect.params.path == "/etc/hostname"`
- execute the same context path in the deployed MCP gateway regression
- prove a different path of the same tool and a different tool both remain fail-closed
- record the correction in the unreleased changelog

## Validation

- `go test ./core/cmd/helm-ai-kernel -run 'TestDeployedMCPGatewayEnforcesReconciledSnapshot|TestMountedPackRuntimeActionsReconcileIntoAllowRules' -count=1`
- `go test ./core/cmd/helm-ai-kernel -count=1`
- `bash scripts/ci/helm_chart_smoke.sh`
- `make lint`
- `git diff --check`

All passed with Go 1.25.12.

## QA boundary

The single approved QA proof was not retried. It produced a closed DENY lifecycle with `PRG_EVALUATION_ERROR`, then the transaction restored `runtimeActions=[]` at Helm revision 3 and runtime reconciliation confirmed the active fail-closed reference-pack digest. A separately approved retry is required after this source correction lands.

Linear: HELM-462
