### PR TITLE
fix(mcp): preserve deployed github effects runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,9 @@ Governed MCP calls rejected at the REST or JSON-RPC ingress boundary now emit
 one `helm.request.received.v1` and one `helm.request.failed.v1` event without
 reaching policy evaluation or a tool handler. The Helm chart can also activate
 the existing signed-permit GitHub effects runtime through an existing Secret;
-raw GitHub tokens are never accepted as chart values, and the default remains
-off.
+the deployed snapshot-bound gateway now registers those configured tools
+instead of dropping the effects runtime. Raw GitHub tokens are never accepted
+as chart values, and the default remains off.
 
 ### Added — offline Kernel receipt.v5 file verify (Building)
 

--- a/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
+++ b/core/cmd/helm-ai-kernel/mcp_gateway_policy_test.go
@@ -481,6 +481,68 @@ func TestGovernedDeployedMCPGatewayRequiresReceiptComponents(t *testing.T) {
 	}
 }
 
+func TestDeployedMCPGatewayRegistersConfiguredGitHubEffects(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv(githubEffectsTokenEnv, "inert-test-token")
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gateway, err := newDeployedMCPGateway(&Services{
+		DataDir:       dataDir,
+		Guardian:      &guardian.Guardian{},
+		ReceiptStore:  &captureReceiptStore{},
+		ReceiptSigner: signer,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	gateway.RegisterRoutes(mux)
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("tools/list status = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	for _, tool := range []string{"github.list_prs", "github.read_pr", "github.create_issue", "github.add_comment"} {
+		if !strings.Contains(recorder.Body.String(), `"name":"`+tool+`"`) {
+			t.Fatalf("configured deployed gateway did not register %s: %s", tool, recorder.Body.String())
+		}
+	}
+}
+
+func TestDeployedMCPGatewayLeavesGitHubEffectsDisabledWithoutToken(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv(githubEffectsTokenEnv, "")
+	signer, err := loadOrGenerateSignerWithDataDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gateway, err := newDeployedMCPGateway(&Services{
+		DataDir:       dataDir,
+		Guardian:      &guardian.Guardian{},
+		ReceiptStore:  &captureReceiptStore{},
+		ReceiptSigner: signer,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux := http.NewServeMux()
+	gateway.RegisterRoutes(mux)
+
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("tools/list status = %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), `"name":"github.`) {
+		t.Fatalf("unconfigured deployed gateway widened tool surface: %s", recorder.Body.String())
+	}
+}
+
 func TestUnavailableMCPGatewayLogsWarning(t *testing.T) {
 	previousLogger := slog.Default()
 	var output bytes.Buffer

--- a/core/cmd/helm-ai-kernel/mcp_runtime.go
+++ b/core/cmd/helm-ai-kernel/mcp_runtime.go
@@ -153,7 +153,11 @@ func newConfiguredLocalMCPGatewayWithSigner(cfg mcppkg.GatewayConfig, signer hel
 // governance evaluator (typically the kernel Guardian bound to the reconciled
 // policy snapshot store).
 func newLocalMCPGatewayWithEvaluator(cfg mcppkg.GatewayConfig, evaluator mcppkg.PolicyEvaluator) (*mcppkg.Gateway, error) {
-	catalog, executor, err := newLocalMCPRuntimeWithEvaluator(evaluator)
+	return newLocalMCPGatewayWithEvaluatorAndEffects(cfg, evaluator, nil)
+}
+
+func newLocalMCPGatewayWithEvaluatorAndEffects(cfg mcppkg.GatewayConfig, evaluator mcppkg.PolicyEvaluator, githubEffects *githubEffectsRuntime) (*mcppkg.Gateway, error) {
+	catalog, executor, err := newLocalMCPRuntimeWithEvaluatorAndEffects(evaluator, githubEffects)
 	if err != nil {
 		return nil, err
 	}

--- a/core/cmd/helm-ai-kernel/subsystems.go
+++ b/core/cmd/helm-ai-kernel/subsystems.go
@@ -343,7 +343,11 @@ func newDeployedMCPGateway(svc *Services) (*mcppkg.Gateway, error) {
 	case svc.Guardian != nil:
 		// Bind the reconciled policy authority and receipt every decision.
 		evaluator := &receiptPersistingEvaluator{svc: svc, inner: svc.Guardian}
-		return newLocalMCPGatewayWithEvaluator(mcppkg.GatewayConfig{}, evaluator)
+		githubEffects, err := newGitHubEffectsRuntimeFromEnv(svc.DataDir)
+		if err != nil {
+			return nil, err
+		}
+		return newLocalMCPGatewayWithEvaluatorAndEffects(mcppkg.GatewayConfig{}, evaluator, githubEffects)
 	case svc.ReceiptSigner != nil:
 		return newConfiguredLocalMCPGatewayWithSigner(mcppkg.GatewayConfig{}, svc.ReceiptSigner)
 	default:


### PR DESCRIPTION
## Summary
- wire the deployed Guardian-backed MCP gateway through the existing optional GitHub effects runtime instead of always dropping it
- keep the fail-closed default by loading deployed GitHub effects only when the existing environment contract is satisfied
- add deployed gateway tests for both configured registration and default-off behavior

## Validation
- go test ./core/cmd/helm-ai-kernel -run "TestGovernedDeployedMCPGatewayRequiresReceiptComponents|TestDeployedMCPGatewayRegistersConfiguredGitHubEffects|TestDeployedMCPGatewayLeavesGitHubEffectsDisabledWithoutToken" -count=1
