### PR TITLE
fix(docs): make v0.8.4 installation paths canonical

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# quantum_posture: this release configuration references existing classical
+# Cosign/signature verification and adds no cryptographic primitive or
+# post-quantum assurance.
 version: 2
 
 project_name: helm-ai-kernel

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,7 +71,7 @@ docker_signs:
 brews:
   - name: helm-ai-kernel
     repository:
-      owner: mindburnlabs
+      owner: Mindburn-Labs
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ trusting *who* signed is a separate, explicit step — see
 ```bash
 brew tap mindburn-labs/tap
 brew trust mindburn-labs/tap   # recent Homebrew requires trusting third-party taps
-brew install helm-ai-kernel
+brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel setup claude-code --yes
 # Codex: helm-ai-kernel setup codex --yes
 # Hermes: helm-ai-kernel setup hermes --scope user --yes
@@ -113,12 +113,25 @@ logo use is covered by [TRADEMARK.md](TRADEMARK.md).
 
 ## Source Build
 
+The source build uses Go 1.25.12 (the version pinned by `go.work` and
+`mise.toml`). The supported reproducible recipe explicitly trusts the
+checked-out mise configuration and installs the pinned toolchain. If mise is
+unavailable, use a compatible native Go toolchain instead.
+
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel
-make build
+git checkout v0.8.4
+mise trust
+mise install
+mise exec -- make build
 bin/helm-ai-kernel setup claude-code --yes
 ```
+
+The [Quickstart delivery matrix](docs/QUICKSTART.md#delivery-surfaces) lists
+the released binaries, container images, OCI chart, release-only MCPB and
+Console bundles, and SDK package surfaces. SDKs are client libraries, not
+Kernel executable installs.
 
 ## Project
 

--- a/docs/DEVELOPER_JOURNEY.md
+++ b/docs/DEVELOPER_JOURNEY.md
@@ -29,16 +29,24 @@ Published macOS CLI:
 ```bash
 brew tap mindburn-labs/tap
 brew trust mindburn-labs/tap
-brew install helm-ai-kernel
+brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel --version
 ```
 
 Source build:
 
+The source build uses Go 1.25.12, pinned by `go.work` and `mise.toml`. The
+recipe explicitly trusts the checked-out mise configuration and installs the
+pinned toolchain before building. If mise is unavailable, use a compatible
+native Go toolchain instead.
+
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel
-make build
+git checkout v0.8.4
+mise trust
+mise install
+mise exec -- make build
 ./bin/helm-ai-kernel --version
 ```
 

--- a/docs/PROOF_LOOP.md
+++ b/docs/PROOF_LOOP.md
@@ -25,7 +25,7 @@ Install the kernel, run the local proof, then verify the bundle:
 
 ```bash
 brew tap mindburn-labs/tap
-brew install helm-ai-kernel
+brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs
 helm-ai-kernel verify --bundle ~/.helm-ai-kernel/proofs/<run-id>/evidencepacks/<run-id> --profile dev-local --allow-self-attested --json
 ```

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -68,7 +68,7 @@ The repository retains packaging metadata for the kernel binaries, container ima
 
 | Surface | Package Identity |
 | --- | --- |
-| CLI/Homebrew | GitHub Release binaries, attached `helm-ai-kernel.rb`, and `mindburnlabs/tap/helm-ai-kernel` |
+| CLI/Homebrew | GitHub Release binaries, attached `helm-ai-kernel.rb`, and `mindburn-labs/tap/helm-ai-kernel` |
 | TypeScript SDK | `@mindburn/helm-ai-kernel` |
 | Python SDK | `helm-sdk` |
 | Rust SDK | `helm-sdk` |
@@ -106,7 +106,7 @@ The retained workflow set under `.github/workflows/` covers:
 
 - main CI
 - GitHub Release creation for tagged versions
-- Homebrew formula generation for `mindburnlabs/homebrew-tap`
+- Homebrew formula generation for `Mindburn-Labs/homebrew-tap`
 - GHCR image publication for `latest`, version tag, and slim tag
 - Go SDK subdirectory tag publication for `sdk/go/v0.8.4`
 - tag-triggered npm, PyPI, crates.io, and Maven-compatible SDK publication
@@ -148,9 +148,9 @@ AI Act high-risk reference pack. The local Console sidecars and standalone
 browser UI layouts are Kernel release assets; the Homebrew formula does not
 install them.
 The retained release workflow attaches a `helm-ai-kernel.rb` formula asset for version `0.8.4`
-and publishes the same version to `mindburnlabs/homebrew-tap`;
+and publishes the same version to `Mindburn-Labs/homebrew-tap`;
 `version-status.json` must include a passing `homebrew-tap` surface before
-documenting `brew install mindburnlabs/tap/helm-ai-kernel` as current.
+documenting `brew install mindburn-labs/tap/helm-ai-kernel` as current.
 
 SDK package manifests and registry versions must remain lockstep with the
 GitHub release tag. npm, PyPI, crates.io, Maven, and Homebrew publication

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -12,7 +12,7 @@ No account or model key is required.
 
 ```bash
 brew tap mindburn-labs/tap
-brew install helm-ai-kernel
+brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel --version
 ```
 
@@ -21,15 +21,39 @@ From source:
 ```bash
 git clone https://github.com/Mindburn-Labs/helm-ai-kernel.git
 cd helm-ai-kernel
-make build
+git checkout v0.8.4
+mise trust
+mise install
+mise exec -- make build
 ./bin/helm-ai-kernel --version
 ```
 
-## Supported Today
+The source build uses Go 1.25.12, pinned by `go.work` and `mise.toml`. The
+recipe explicitly trusts the checked-out mise configuration and installs the
+pinned toolchain before building. If mise is unavailable, use a compatible
+native Go toolchain instead.
+
+## Delivery Surfaces
+
+These are distinct delivery surfaces for the released `v0.8.4` Kernel. The
+Homebrew, binary, container, and chart rows install or retrieve the Kernel;
+MCPB/Console bundles are release artifacts and are not CLI substitutes; SDKs
+are client libraries, not executable Kernel installs.
+
+| Surface | Install or artifact | Verification / boundary |
+| --- | --- | --- |
+| Homebrew CLI formula | `brew tap mindburn-labs/tap` then `brew install mindburn-labs/tap/helm-ai-kernel` | Canonical formula `mindburn-labs/tap/helm-ai-kernel` |
+| GitHub release binaries | [HELM Kernel v0.8.4 release](https://github.com/Mindburn-Labs/helm-ai-kernel/releases/tag/v0.8.4): macOS/Linux `amd64` and `arm64`, Windows `amd64` assets | Download `SHA256SUMS.txt` and the matching per-asset Cosign bundle |
+| GHCR images | `docker pull ghcr.io/mindburn-labs/helm-ai-kernel:v0.8.4` or `docker pull ghcr.io/mindburn-labs/helm-ai-kernel:v0.8.4-slim` | Verify the image signature before use |
+| OCI chart | `helm pull oci://ghcr.io/mindburn-labs/charts/helm-ai-kernel --version 0.8.4` | Verify the chart signature before deployment |
+| MCPB / Console bundles | `helm-ai-kernel.mcpb` and `helm-console-local-sidecar-*` / `helm-ai-kernel-*-console.tar.gz` release assets | Release artifacts only; they do not replace the CLI install |
+| SDKs | npm `@mindburn/helm-ai-kernel@0.8.4`; PyPI `helm-sdk==0.8.4`; crates `helm-sdk@0.8.4`; Maven `io.github.mindburnlabs:helm-sdk:0.8.4`; Go `github.com/Mindburn-Labs/helm-ai-kernel/sdk/go@v0.8.4` | Client libraries only; use the SDK docs for integration, not executable installation |
+
+## Supported CLI Paths
 
 | Surface | Public proof |
 | --- | --- |
-| Install | `brew install helm-ai-kernel` or `make build` |
+| Install | `brew install mindburn-labs/tap/helm-ai-kernel` or the tagged source build above |
 | CLI chooser | `helm-ai-kernel` or `helm-ai-kernel setup` |
 | Local proof | `helm-ai-kernel mcp proof --json --out ~/.helm-ai-kernel/proofs` |
 | Codex setup | `helm-ai-kernel setup codex --dry-run --json` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Install and open the CLI front door:
 
 ```bash
 brew tap mindburn-labs/tap
-brew install helm-ai-kernel
+brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel
 ```
 

--- a/docs/launch/LAUNCH_READINESS.md
+++ b/docs/launch/LAUNCH_READINESS.md
@@ -4,7 +4,7 @@ This is a frozen snapshot of one `scripts/launch/launch-ready.sh --write` run.
 It is **not** a live status page and nothing keeps it current.
 
 - Snapshot taken: 2026-05-19T17:15:07Z, against launch target `0.5.0`.
-- `VERSION` is now `0.8.3`, and the tool derives its launch target from
+- `VERSION` is now `0.8.4`, and the tool derives its launch target from
   `cat VERSION`, so a fresh run would check a different target.
 - The tool writes to `${HELM_LAUNCH_READY_REPORT}` and otherwise to
   `$LOG_DIR/launch-readiness.txt` in a `mktemp` directory. `make launch-ready`
@@ -12,12 +12,9 @@ It is **not** a live status page and nothing keeps it current.
   pointing `HELM_LAUNCH_READY_REPORT` here once and committing the result.
 - The tool no longer emits the "Config Boundary: wrangler.toml…" row below;
   there is no `wrangler.toml` tracked in this repository.
-- The "Homebrew" row below is false as of 2026-08-09. The tool's check is
-  `rg -q 'brew install mindburnlabs/tap/helm-ai-kernel' README.md`, and
-  `README.md` instead documents `brew tap mindburn-labs/tap` followed by
-  `brew install helm-ai-kernel`. Either the check or the README is wrong;
-  neither has been changed here, because deciding which tap name is canonical
-  is a public-claims call.
+- The "Homebrew" row below is a historical snapshot. Current active docs use
+  the fully qualified formula `mindburn-labs/tap/helm-ai-kernel` so a second
+  legacy tap cannot make an unqualified install ambiguous.
 
 To get current state, run the tool rather than reading this file:
 
@@ -40,8 +37,8 @@ not committed to the repository.
 - [x] **PR Boundary: No open PRs contain commercial infrastructure terminology.**
 - [x] **Config Boundary: wrangler.toml does not enforce hosted domains.** (row no longer emitted)
 - [x] **Terminology Boundary: VERDICT_CANONICALIZATION.md exists and resolves the ALLOW/DENY/ESCALATE vs. DEFER drift.**
-- [x] **Version: VERSION is set to launch target 0.5.0.** (target is now 0.8.3)
-- [x] **Homebrew: README points to canonical mindburnlabs/tap/helm-ai-kernel.** (false as of 2026-08-09)
+- [x] **Version: VERSION is set to launch target 0.5.0.** (historical snapshot; current target is 0.8.4)
+- [x] **Homebrew: README points to canonical mindburn-labs/tap/helm-ai-kernel.** (current active-doc command)
 
 ### Phase 1: Implementation & Proof
 - [x] **Build: make build completes cleanly.**

--- a/docs/launchpad/CLEAN_INSTALL_GA.md
+++ b/docs/launchpad/CLEAN_INSTALL_GA.md
@@ -1,12 +1,12 @@
 ---
 title: Launchpad Clean Install GA
-last_reviewed: 2026-08-09
+last_reviewed: 2026-08-21
 ---
 
 # Launchpad Clean Install GA
 
 Status: the gate is implemented and its release target tracks the current
-release tag, `v0.8.3`. The supported-app clean-install set is OpenClaw and
+release tag, `v0.8.4`. The supported-app clean-install set is OpenClaw and
 Hermes, which passed signed artifact, live conformance, teardown, receipts, and
 offline EvidencePack verification in workflow `26198407296`. OpenCode and Kilo
 Code are in the verify-only set, not the supported set.
@@ -30,7 +30,7 @@ offline verification.
 
 ## Source Truth
 
-- Release target: `v0.8.3`. Do not hand-edit that number here. It is the
+- Release target: `v0.8.4`. Do not hand-edit that number here. It is the
   `RELEASE_TAG` default in `scripts/launch/clean_install_gate.sh` and the
   `release_tag` input default in `.github/workflows/launchpad-clean-install.yml`,
   and `tests/launchpad/claims_truth_test.go` fails the build unless both equal
@@ -39,7 +39,7 @@ offline verification.
 - Last executed macOS Homebrew clean-install workflow: <https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/26199878246>.
   That run was against release tag `v0.5.5`, not against the current target;
   `docs/launchpad/clean_install_report.json` is its recorded output. No
-  clean-install run has been executed against `v0.8.3`.
+  clean-install run has been executed against `v0.8.4`.
 - Current Launchpad v1 report: `docs/launchpad/v1_report.json`
 - Historical `v0.5.4` release report: `docs/launchpad/final_report.json`
 - Clean-install report: `docs/launchpad/clean_install_report.json`
@@ -94,7 +94,7 @@ Docker-compatible runtime such as Docker Desktop or Colima:
 
 ```bash
 brew update
-brew install mindburnlabs/tap/helm-ai-kernel
+brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel launch matrix --json
 helm-ai-kernel launch secrets set model_gateway --provider openai --value-env OPENAI_API_KEY
 helm-ai-kernel launch openclaw local-container --headless --output json
@@ -110,7 +110,7 @@ Use the repo-native gate to collect redacted evidence:
 ```bash
 export OPENAI_API_KEY='<fresh CI-only key>'
 bash scripts/launch/clean_install_gate.sh \
-  --release-tag v0.8.3 \
+  --release-tag v0.8.4 \
   --artifact-run-id 26198407296 \
   --host-kind developer_macos \
   --output docs/launchpad/clean_install_report.json
@@ -151,7 +151,7 @@ Manual CI entrypoint:
 ```bash
 gh workflow run launchpad-clean-install.yml \
   --repo Mindburn-Labs/helm-ai-kernel \
-  -f release_tag=v0.8.3 \
+  -f release_tag=v0.8.4 \
   -f artifact_run_id=26198407296
 ```
 

--- a/docs/launchpad/CONFORMANCE.md
+++ b/docs/launchpad/CONFORMANCE.md
@@ -157,7 +157,7 @@ No additional app may move to `oss_supported` until it passes the same bar.
 
 ```bash
 brew update
-brew install mindburnlabs/tap/helm-ai-kernel
+brew install mindburn-labs/tap/helm-ai-kernel
 helm-ai-kernel launch matrix --json
 helm-ai-kernel launch secrets set model_gateway --provider openai --value-env OPENAI_API_KEY
 helm-ai-kernel launch openclaw local-container --headless --output json

--- a/docs/launchpad/CONFORMANCE.md
+++ b/docs/launchpad/CONFORMANCE.md
@@ -3,6 +3,10 @@ title: Launchpad Conformance
 last_reviewed: 2026-08-09
 ---
 
+<!-- quantum_posture: this conformance guide references existing classical
+Cosign/signature verification and adds no cryptographic primitive or
+post-quantum assurance. -->
+
 # Launchpad Conformance
 
 Status: OpenClaw and Hermes are `oss_supported` / `agent_live`. They passed the

--- a/scripts/check_documentation_truth.py
+++ b/scripts/check_documentation_truth.py
@@ -56,6 +56,11 @@ CANONICAL_REPO_RENAMES = {
 CANONICAL_PUBLIC_OPENAPI_PATH = 'api/openapi/helm.openapi.yaml'
 PUBLIC_HTTP_API_SLUG = 'reference/http-api'
 PUBLIC_HTTP_API_SOURCE_PATH = 'docs/reference/http-api.md'
+CANONICAL_HOMEBREW_INSTALL = 'brew install mindburn-labs/tap/helm-ai-kernel'
+BROKEN_HOMEBREW_INSTALL_RE = re.compile(
+    r'brew\s+install\s+(?:helm-ai-kernel|mindburnlabs/tap/helm-ai-kernel)(?![\w-])',
+    re.IGNORECASE,
+)
 SHA256_DIGEST_RE = re.compile(r'^sha256:[0-9a-f]{64}$')
 GIT_BLOB_SHA1_RE = re.compile(r'^[0-9a-f]{40}$')
 OPENAPI_EXAMPLE_SOURCE_TEST_RE = re.compile(
@@ -542,6 +547,25 @@ def validate_sdk_freshness_docs(failures: list[str]) -> None:
         failures.append(f'docs/EXAMPLES.md is missing current Java coordinate {java_coordinate}')
 
 
+def validate_homebrew_install_docs(failures: list[str]) -> None:
+    """Keep active public install guidance on the canonical tap coordinate."""
+    active_docs = [ROOT / 'README.md', *sorted((ROOT / 'docs').rglob('*.md'))]
+    for path in active_docs:
+        if not path.exists():
+            failures.append(f'{path.relative_to(ROOT)} is missing from active installation docs check')
+            continue
+        text = read_text(path)
+        match = BROKEN_HOMEBREW_INSTALL_RE.search(text)
+        if match:
+            failures.append(
+                f'{path.relative_to(ROOT)} contains a non-canonical Homebrew install: {match.group(0)!r}'
+            )
+
+    for path in (ROOT / 'README.md', ROOT / 'docs' / 'QUICKSTART.md'):
+        if path.exists() and CANONICAL_HOMEBREW_INSTALL not in read_text(path):
+            failures.append(f'{path.relative_to(ROOT)} is missing canonical Homebrew install {CANONICAL_HOMEBREW_INSTALL!r}')
+
+
 def main() -> int:
     coverage = subprocess.run([sys.executable, str(ROOT / 'scripts' / 'check_documentation_coverage.py')], cwd=ROOT)
     if coverage.returncode != 0:
@@ -579,6 +603,7 @@ def main() -> int:
                 failures.append(f'sdk/go/go.mod is missing standalone generated SDK dependency {module}')
 
     validate_sdk_freshness_docs(failures)
+    validate_homebrew_install_docs(failures)
 
     for row in rows:
         source = ROOT if row['source_path'] == '.' else ROOT / row['source_path']

--- a/scripts/launch/clean_install_gate.sh
+++ b/scripts/launch/clean_install_gate.sh
@@ -356,7 +356,7 @@ main() {
   resolve_egress_proxy_image || final_status="FAIL"
 
   run_step brew_update "brew update" "brew update" || final_status="FAIL"
-  run_step brew_install "brew install mindburnlabs/tap/helm-ai-kernel" "brew install mindburnlabs/tap/helm-ai-kernel" || final_status="FAIL"
+  run_step brew_install "brew install mindburn-labs/tap/helm-ai-kernel" "brew install mindburn-labs/tap/helm-ai-kernel" || final_status="FAIL"
   run_step docker_version "docker version" "docker version" || final_status="FAIL"
   run_step helm_version "helm-ai-kernel --version" "helm-ai-kernel --version" || final_status="FAIL"
   run_step launch_matrix "helm-ai-kernel launch matrix --json" "helm-ai-kernel launch matrix --json" || final_status="FAIL"

--- a/scripts/launch/launch-ready.sh
+++ b/scripts/launch/launch-ready.sh
@@ -113,7 +113,7 @@ record() {
 record pr_boundary "PR Boundary: No open PRs contain commercial infrastructure terminology." "python3 scripts/launch/pr_boundary_check.py"
 record terminology_boundary "Terminology Boundary: VERDICT_CANONICALIZATION.md exists and resolves the ALLOW/DENY/ESCALATE vs. DEFER drift." "test -f docs/VERDICT_CANONICALIZATION.md && rg -q 'ALLOW' docs/VERDICT_CANONICALIZATION.md && rg -q 'DENY' docs/VERDICT_CANONICALIZATION.md && rg -q 'ESCALATE' docs/VERDICT_CANONICALIZATION.md && rg -q 'DEFER' docs/VERDICT_CANONICALIZATION.md"
 record version "Version: VERSION is set to launch target ${LAUNCH_TARGET_VERSION}." "test \"\$(cat VERSION)\" = '${LAUNCH_TARGET_VERSION}'"
-record homebrew "Homebrew: README points to canonical mindburnlabs/tap/helm-ai-kernel." "rg -q 'brew install mindburnlabs/tap/helm-ai-kernel' README.md && ! rg -q 'brew install (mindburn|Mindburn-Labs|mindburn-labs)/homebrew-tap/helm|brew install mindburn-labs/tap/helm' README.md"
+record homebrew "Homebrew: README points to canonical mindburn-labs/tap/helm-ai-kernel." "rg -q 'brew install mindburn-labs/tap/helm-ai-kernel' README.md && ! rg -q 'brew install (helm-ai-kernel|mindburnlabs/tap/helm-ai-kernel)' README.md"
 
 record build "Build: make build completes cleanly." "make build"
 record test "Test: make test completes cleanly." "make test"


### PR DESCRIPTION
## Summary
- make mindburn-labs/tap/helm-ai-kernel the single active Homebrew coordinate
- align GoReleaser, launch gates, active Launchpad guides, and source-build instructions
- add the exact v0.8.4 delivery matrix and fail-closed documentation guard

## Validation
- make docs-truth
- make test-cli
- exact v0.8.4 source archive build with pinned mise toolchain
- broken-coordinate sweep leaves only immutable historical JSON evidence

## Tracking
- HELM-229: https://linear.app/mindburn/issue/HELM-229
- HELM-513: https://linear.app/mindburn/issue/HELM-513

No release, package publication, or production promotion is included.