### PR TITLE
Fail closed on boundary registry persistence

### DIFF
--- a/core/cmd/helm-ai-kernel/services.go
+++ b/core/cmd/helm-ai-kernel/services.go
@@ -262,14 +262,9 @@ func NewServices(ctx context.Context, db *sql.DB, artStore artifacts.Store, logg
 			}
 		})
 	}
-	surfaces, surfaceErr := boundary.NewSQLSurfaceRegistry(ctx, db, time.Now)
+	surfaces, surfaceErr := boundary.NewSQLSurfaceRegistry(ctx, db, databaseMode, time.Now)
 	if surfaceErr != nil {
-		logger.Warn("Boundary surface registry persistence disabled", "error", surfaceErr)
-		surfaces, surfaceErr = boundary.NewFileBackedSurfaceRegistry(defaultBoundaryRegistryPath(), time.Now)
-		if surfaceErr != nil {
-			logger.Warn("Boundary surface file fallback disabled", "error", surfaceErr)
-			surfaces = boundary.NewSurfaceRegistry(time.Now)
-		}
+		return nil, fmt.Errorf("boundary surface registry persistence: %w", surfaceErr)
 	}
 	s.BoundarySurfaces = surfaces
 	logger.Info("subsystem ready", "component", " Boundary Perimeter Enforcer initialized")

--- a/core/pkg/boundary/surface_registry.go
+++ b/core/pkg/boundary/surface_registry.go
@@ -128,12 +128,33 @@ func NewFileBackedSurfaceRegistry(path string, now func() time.Time) (*SurfaceRe
 // Postgres database as the OSS runtime. It stores a versioned snapshot in one
 // row so API, Console, and SDK surfaces share durable state without becoming a
 // second policy authority.
-func NewSQLSurfaceRegistry(ctx context.Context, db *sql.DB, now func() time.Time) (*SurfaceRegistry, error) {
+func NewSQLSurfaceRegistry(ctx context.Context, db *sql.DB, databaseMode string, now func() time.Time) (*SurfaceRegistry, error) {
 	if db == nil {
 		return NewSurfaceRegistry(now), nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	var eventTableDDL string
+	switch strings.ToLower(strings.TrimSpace(databaseMode)) {
+	case "sqlite", "sqlite3":
+		eventTableDDL = `CREATE TABLE IF NOT EXISTS boundary_surface_events (
+			sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+			event_kind TEXT NOT NULL,
+			object_id TEXT NOT NULL,
+			object_json TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`
+	case "postgres", "postgresql":
+		eventTableDDL = `CREATE TABLE IF NOT EXISTS boundary_surface_events (
+			sequence BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+			event_kind TEXT NOT NULL,
+			object_id TEXT NOT NULL,
+			object_json TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`
+	default:
+		return nil, fmt.Errorf("init boundary surface registry: unsupported database mode %q", databaseMode)
 	}
 	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS boundary_surface_snapshots (
 		id TEXT PRIMARY KEY,
@@ -142,13 +163,7 @@ func NewSQLSurfaceRegistry(ctx context.Context, db *sql.DB, now func() time.Time
 	)`); err != nil {
 		return nil, fmt.Errorf("init boundary surface table: %w", err)
 	}
-	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS boundary_surface_events (
-		sequence INTEGER PRIMARY KEY AUTOINCREMENT,
-		event_kind TEXT NOT NULL,
-		object_id TEXT NOT NULL,
-		object_json TEXT NOT NULL,
-		created_at TEXT NOT NULL
-	)`); err != nil {
+	if _, err := db.ExecContext(ctx, eventTableDDL); err != nil {
 		return nil, fmt.Errorf("init boundary surface event table: %w", err)
 	}
 	if _, err := db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS boundary_records_index (

--- a/core/pkg/boundary/surface_registry_coverage_test.go
+++ b/core/pkg/boundary/surface_registry_coverage_test.go
@@ -68,7 +68,7 @@ func TestSurfaceRegistryStorageBackendsAndConstructors(t *testing.T) {
 		t.Fatal("directory path should fail as unreadable registry snapshot")
 	}
 
-	if registry, err := NewSQLSurfaceRegistry(context.Background(), nil, func() time.Time { return now }); err != nil || registry.StorageBackend() != "memory" {
+	if registry, err := NewSQLSurfaceRegistry(context.Background(), nil, "sqlite", func() time.Time { return now }); err != nil || registry.StorageBackend() != "memory" {
 		t.Fatalf("nil SQL registry = (%v,%v), want memory,nil", registry, err)
 	}
 	db, err := sql.Open("sqlite", filepath.Join(dir, "boundary.db"))
@@ -76,7 +76,10 @@ func TestSurfaceRegistryStorageBackendsAndConstructors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	sqlRegistry, err := NewSQLSurfaceRegistry(nil, db, func() time.Time { return now })
+	if _, err := NewSQLSurfaceRegistry(nil, db, "mysql", func() time.Time { return now }); err == nil {
+		t.Fatal("unsupported SQL database mode should fail registry init")
+	}
+	sqlRegistry, err := NewSQLSurfaceRegistry(nil, db, "sqlite", func() time.Time { return now })
 	if err != nil {
 		t.Fatalf("NewSQLSurfaceRegistry() error = %v", err)
 	}
@@ -606,7 +609,7 @@ func TestSurfaceRegistryPersistenceFailureBranches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	registry, err := NewSQLSurfaceRegistry(context.Background(), db, func() time.Time { return now })
+	registry, err := NewSQLSurfaceRegistry(context.Background(), db, "sqlite", func() time.Time { return now })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -630,7 +633,7 @@ func TestSurfaceRegistryPersistenceFailureBranches(t *testing.T) {
 	if err := closedDB.Close(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := NewSQLSurfaceRegistry(context.Background(), closedDB, func() time.Time { return now }); err == nil {
+	if _, err := NewSQLSurfaceRegistry(context.Background(), closedDB, "sqlite", func() time.Time { return now }); err == nil {
 		t.Fatal("closed SQL db should fail registry init")
 	}
 	canceled, cancel := context.WithCancel(context.Background())
@@ -640,7 +643,7 @@ func TestSurfaceRegistryPersistenceFailureBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer canceledDB.Close()
-	if _, err := NewSQLSurfaceRegistry(canceled, canceledDB, func() time.Time { return now }); err == nil {
+	if _, err := NewSQLSurfaceRegistry(canceled, canceledDB, "sqlite", func() time.Time { return now }); err == nil {
 		t.Fatal("canceled context should fail registry init")
 	}
 
@@ -655,7 +658,7 @@ func TestSurfaceRegistryPersistenceFailureBranches(t *testing.T) {
 	if _, err := invalidDB.Exec(`INSERT INTO boundary_surface_snapshots (id, snapshot_json, updated_at) VALUES ('default', '{bad-json', 'now')`); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := NewSQLSurfaceRegistry(context.Background(), invalidDB, func() time.Time { return now }); err == nil {
+	if _, err := NewSQLSurfaceRegistry(context.Background(), invalidDB, "sqlite", func() time.Time { return now }); err == nil {
 		t.Fatal("invalid SQL snapshot should fail registry load")
 	}
 
@@ -685,7 +688,7 @@ func TestSurfaceRegistryPersistenceFailureBranches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	eventRegistry, err := NewSQLSurfaceRegistry(context.Background(), eventDB, func() time.Time { return now })
+	eventRegistry, err := NewSQLSurfaceRegistry(context.Background(), eventDB, "sqlite", func() time.Time { return now })
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/core/pkg/boundary/surface_registry_test.go
+++ b/core/pkg/boundary/surface_registry_test.go
@@ -5,12 +5,15 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/contracts"
+	"github.com/lib/pq"
 	_ "modernc.org/sqlite"
 )
 
@@ -401,7 +404,7 @@ func TestSQLSurfaceRegistryPersistsRecords(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	registry, err := NewSQLSurfaceRegistry(context.Background(), db, func() time.Time { return now })
+	registry, err := NewSQLSurfaceRegistry(context.Background(), db, "sqlite", func() time.Time { return now })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +420,7 @@ func TestSQLSurfaceRegistryPersistsRecords(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	reloaded, err := NewSQLSurfaceRegistry(context.Background(), db, func() time.Time { return now })
+	reloaded, err := NewSQLSurfaceRegistry(context.Background(), db, "sqlite", func() time.Time { return now })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -445,5 +448,72 @@ func TestSQLSurfaceRegistryPersistsRecords(t *testing.T) {
 	verify := reloaded.VerifyCheckpoint(reloaded.ListCheckpoints()[0].CheckpointID)
 	if verify["verified"] != true {
 		t.Fatalf("checkpoint verification failed: %+v", verify)
+	}
+}
+
+func TestSQLSurfaceRegistryPersistsRecordsOnPostgres(t *testing.T) {
+	postgresURL := strings.TrimSpace(os.Getenv("HELM_TEST_POSTGRES_URL"))
+	if postgresURL == "" {
+		t.Skip("set HELM_TEST_POSTGRES_URL to run the Postgres boundary registry proof")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	schema := fmt.Sprintf("helm_boundary_%d", time.Now().UnixNano())
+	adminDB, err := sql.Open("postgres", postgresURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adminDB.Close()
+	if _, err := adminDB.ExecContext(ctx, `CREATE SCHEMA `+pq.QuoteIdentifier(schema)); err != nil {
+		t.Fatalf("create boundary test schema: %v", err)
+	}
+	defer func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cleanupCancel()
+		_, _ = adminDB.ExecContext(cleanupCtx, `DROP SCHEMA IF EXISTS `+pq.QuoteIdentifier(schema)+` CASCADE`)
+	}()
+
+	parsed, err := url.Parse(postgresURL)
+	if err != nil || parsed.Scheme == "" {
+		t.Fatalf("HELM_TEST_POSTGRES_URL must be a URL-style Postgres DSN: %v", err)
+	}
+	query := parsed.Query()
+	query.Set("search_path", schema)
+	parsed.RawQuery = query.Encode()
+	db, err := sql.Open("postgres", parsed.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	now := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	registry, err := NewSQLSurfaceRegistry(ctx, db, "postgres", func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := registry.PutRecord(contracts.ExecutionBoundaryRecord{
+		RecordID:    "rec-postgres",
+		Verdict:     contracts.VerdictDeny,
+		ReasonCode:  contracts.ReasonPDPError,
+		PolicyEpoch: "epoch-1",
+		ToolName:    "tool.exec",
+		CreatedAt:   now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sequence int64
+	if err := db.QueryRowContext(ctx, `SELECT sequence FROM boundary_surface_events WHERE object_id = $1`, record.RecordID).Scan(&sequence); err != nil {
+		t.Fatal(err)
+	}
+	if sequence <= 0 {
+		t.Fatalf("Postgres identity sequence = %d, want positive", sequence)
+	}
+	reloaded, err := NewSQLSurfaceRegistry(ctx, db, "postgres", func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := reloaded.GetRecord(record.RecordID); !ok || got.RecordHash != record.RecordHash {
+		t.Fatalf("Postgres reload = (%+v, %v), want record hash %s", got, ok, record.RecordHash)
 	}
 }


### PR DESCRIPTION
## Summary
- use dialect-correct event identity DDL for SQLite and PostgreSQL
- refuse Kernel startup when the shared SQL boundary registry cannot initialize
- add a source-owned real-PostgreSQL persistence/reload proof

## Validation
- `make test-platform`
- `make lint`
- `make quantum-crypto-inventory`
- `make openapi-breaking`
- `go test ./cmd/helm-ai-kernel -count=1`
- `go build ./...`
- PostgreSQL 16 `TestSQLSurfaceRegistryPersistsRecordsOnPostgres`
- golangci-lint + gosec on new diff: 0 issues

HELM-191

This closes a source fail-open path; it does not assert production deployment or GDPR completion.