### PR TITLE
Enforce regulated privacy profile prerequisites

### DIFF
--- a/core/pkg/conform/gates/g9_jurisdiction.go
+++ b/core/pkg/conform/gates/g9_jurisdiction.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
+	helmconfig "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/config"
 	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
 )
 
@@ -75,6 +77,64 @@ func (g *G9Jurisdiction) Run(ctx *conform.RunContext) *conform.GateResult {
 		}
 	}
 
+	enforceRegionalPrivacyPrerequisites(ctx, result)
 	result.EvidencePaths = append(result.EvidencePaths, "04_EXPORTS/jurisdictions/")
 	return result
+}
+
+// enforceRegionalPrivacyPrerequisites checks declared source configuration
+// only. Passing it does not prove provider terms, processing location, or a
+// deployed GDPR control; those require separate external and runtime evidence.
+func enforceRegionalPrivacyPrerequisites(ctx *conform.RunContext, result *conform.GateResult) {
+	definition := conform.Profiles()[ctx.Profile]
+	if definition == nil {
+		return
+	}
+	strictErasure, _ := definition.Overrides["privacy_erasure_strict"].(bool)
+	requireRetention, _ := definition.Overrides["retention_policy_required"].(bool)
+	requireResidency, _ := definition.Overrides["tape_residency_enforced"].(bool)
+	if !strictErasure && !requireRetention && !requireResidency {
+		return
+	}
+
+	deny := func(reason string) {
+		result.Pass = false
+		result.Reasons = append(result.Reasons, reason)
+	}
+	jurisdiction := strings.ToLower(strings.TrimSpace(ctx.Jurisdiction))
+	if jurisdiction == "" || strings.ContainsAny(jurisdiction, `/\\`) {
+		if strictErasure {
+			deny(conform.ReasonPrivacyErasureRequired)
+		}
+		if requireRetention {
+			deny(conform.ReasonRetentionPolicyMissing)
+		}
+		if requireResidency {
+			deny(conform.ReasonTapeResidencyViolation)
+		}
+		return
+	}
+
+	profile, err := helmconfig.LoadProfile(filepath.Join(ctx.ProjectRoot, "core", "pkg", "config", "profiles"), jurisdiction)
+	if err != nil {
+		if strictErasure {
+			deny(conform.ReasonPrivacyErasureRequired)
+		}
+		if requireRetention {
+			deny(conform.ReasonRetentionPolicyMissing)
+		}
+		if requireResidency {
+			deny(conform.ReasonTapeResidencyViolation)
+		}
+		return
+	}
+	if strictErasure && (!profile.RightToErasure || !profile.Retention.RightToErasure) {
+		deny(conform.ReasonPrivacyErasureRequired)
+	}
+	if requireRetention && (profile.Retention.MaxDays <= 0 || profile.Retention.PIIRetentionDays <= 0) {
+		deny(conform.ReasonRetentionPolicyMissing)
+	}
+	if requireResidency && strings.TrimSpace(profile.DataResidency) == "" {
+		deny(conform.ReasonTapeResidencyViolation)
+	}
 }

--- a/core/pkg/conform/gates/g9_jurisdiction_test.go
+++ b/core/pkg/conform/gates/g9_jurisdiction_test.go
@@ -1,0 +1,93 @@
+package gates
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/conform"
+)
+
+func TestG9JurisdictionRegulatedHealthRequiresRegionalPrivacyProfile(t *testing.T) {
+	evidenceDir := t.TempDir()
+	setupJurisdictionEvidence(t, evidenceDir)
+	result := (&G9Jurisdiction{}).Run(&conform.RunContext{
+		Profile:     conform.ProfileRegulatedHealth,
+		EvidenceDir: evidenceDir,
+		ProjectRoot: t.TempDir(),
+	})
+
+	if result.Pass {
+		t.Fatal("regulated health passed without a jurisdiction profile")
+	}
+	for _, want := range []string{
+		conform.ReasonPrivacyErasureRequired,
+		conform.ReasonRetentionPolicyMissing,
+		conform.ReasonTapeResidencyViolation,
+	} {
+		if !reasonContains(result.Reasons, want) {
+			t.Fatalf("missing reason %q in %v", want, result.Reasons)
+		}
+	}
+}
+
+func TestG9JurisdictionRegulatedHealthRejectsIncompleteRegionalPrivacyProfile(t *testing.T) {
+	evidenceDir := t.TempDir()
+	projectRoot := t.TempDir()
+	setupJurisdictionEvidence(t, evidenceDir)
+	writeRegionalPrivacyProfile(t, projectRoot, `
+name: "European Union"
+code: "eu"
+data_residency: "eu-west-1"
+retention:
+  max_days: 365
+  audit_log_days: 1825
+`)
+
+	result := (&G9Jurisdiction{}).Run(&conform.RunContext{
+		Profile:      conform.ProfileRegulatedHealth,
+		Jurisdiction: "EU",
+		EvidenceDir:  evidenceDir,
+		ProjectRoot:  projectRoot,
+	})
+	if result.Pass || !reasonContains(result.Reasons, conform.ReasonPrivacyErasureRequired) ||
+		!reasonContains(result.Reasons, conform.ReasonRetentionPolicyMissing) {
+		t.Fatalf("incomplete privacy profile result = %+v", result)
+	}
+	if reasonContains(result.Reasons, conform.ReasonTapeResidencyViolation) {
+		t.Fatalf("configured residency was rejected: %v", result.Reasons)
+	}
+}
+
+func TestG9JurisdictionRegulatedHealthAcceptsStrictRegionalPrivacyProfile(t *testing.T) {
+	evidenceDir := t.TempDir()
+	projectRoot := t.TempDir()
+	setupJurisdictionEvidence(t, evidenceDir)
+	writeRegionalPrivacyProfile(t, projectRoot, `
+name: "European Union"
+code: "eu"
+data_residency: "eu-west-1"
+right_to_erasure: true
+retention:
+  max_days: 365
+  audit_log_days: 1825
+  pii_retention_days: 30
+  right_to_erasure: true
+`)
+
+	result := (&G9Jurisdiction{}).Run(&conform.RunContext{
+		Profile:      conform.ProfileRegulatedHealth,
+		Jurisdiction: "EU",
+		EvidenceDir:  evidenceDir,
+		ProjectRoot:  projectRoot,
+	})
+	if !result.Pass {
+		t.Fatalf("strict regional privacy profile failed: %v", result.Reasons)
+	}
+}
+
+func writeRegionalPrivacyProfile(t *testing.T, projectRoot, raw string) {
+	t.Helper()
+	path := filepath.Join(projectRoot, "core", "pkg", "config", "profiles", "profile_eu.yaml")
+	mkdirGate(t, filepath.Dir(path))
+	writeGateFile(t, path, []byte(raw))
+}

--- a/core/pkg/conform/reason_codes.go
+++ b/core/pkg/conform/reason_codes.go
@@ -22,6 +22,8 @@ const (
 
 	// --- Tape ---
 	ReasonTapeResidencyViolation = "TAPE_RESIDENCY_VIOLATION" // taped payload violates jurisdiction/data handling
+	ReasonPrivacyErasureRequired = "PRIVACY_ERASURE_REQUIRED" // strict profile requires right-to-erasure support
+	ReasonRetentionPolicyMissing = "RETENTION_POLICY_MISSING" // strict profile requires an explicit retention policy
 
 	// --- Policy ---
 	ReasonPolicyDecisionMissing  = "POLICY_DECISION_MISSING"
@@ -108,6 +110,8 @@ func AllReasonCodes() []string {
 		ReasonReplayHashDivergence,
 		ReasonReplayTapeMiss,
 		ReasonTapeResidencyViolation,
+		ReasonPrivacyErasureRequired,
+		ReasonRetentionPolicyMissing,
 		ReasonPolicyDecisionMissing,
 		ReasonSchemaValidationFailed,
 		ReasonBudgetExhausted,


### PR DESCRIPTION
## Summary
- fail regulated-health G9 when jurisdiction or regional privacy configuration is missing
- require declared erasure support, bounded PII retention, and data residency for strict profiles
- add stable denial reason codes and focused negative/pass coverage

## Scope truth
This validates source-declared prerequisites only. It does not claim provider DPA/SCC/no-training terms, deployed residency, production operation, or GDPR compliance. Those remain separate external/runtime gates.

## Validation
- `make test-platform`
- `make lint quantum-crypto-inventory`
- `go build ./...`
- `make openapi-breaking`
- golangci-lint + gosec on new conformance diff: 0 issues

Canonical upstream replacement for closed mirrored Enterprise PR #283.

HELM-191