### PR TITLE
HELM-641: harden generated-spec approval runtime

### DIFF
--- a/core/cmd/helm-ai-kernel/approval_consumption_runtime.go
+++ b/core/cmd/helm-ai-kernel/approval_consumption_runtime.go
@@ -209,7 +209,7 @@ func validEffectReconciliationCandidatesResource(value string) bool {
 		parsed.Path == effectReconciliationCandidatesPath
 }
 
-func newApprovalConsumptionRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops *kernel.ScopedStopStore) (*approvalConsumptionRuntime, error) {
+func newApprovalConsumptionRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops kernel.ScopedStopReader) (*approvalConsumptionRuntime, error) {
 	config, enabled, err := approvalConsumptionConfigFromEnv()
 	if err != nil || !enabled {
 		return nil, err

--- a/core/cmd/helm-ai-kernel/approval_consumption_runtime.go
+++ b/core/cmd/helm-ai-kernel/approval_consumption_runtime.go
@@ -209,7 +209,7 @@ func validEffectReconciliationCandidatesResource(value string) bool {
 		parsed.Path == effectReconciliationCandidatesPath
 }
 
-func newApprovalConsumptionRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops kernel.ScopedStopReader) (*approvalConsumptionRuntime, error) {
+func newApprovalConsumptionRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops *kernel.ScopedStopStore) (*approvalConsumptionRuntime, error) {
 	config, enabled, err := approvalConsumptionConfigFromEnv()
 	if err != nil || !enabled {
 		return nil, err

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_runtime.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_runtime.go
@@ -169,7 +169,7 @@ func validateGeneratedSpecApprovalRuntimeConfig(cfg generatedSpecApprovalRuntime
 	return nil
 }
 
-func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops *kernel.ScopedStopStore) (*generatedSpecApprovalRuntime, error) {
+func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops kernel.ScopedStopReader) (*generatedSpecApprovalRuntime, error) {
 	cfg, enabled, err := generatedSpecApprovalRuntimeConfigFromEnv()
 	if err != nil || !enabled {
 		return nil, err

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_runtime.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_runtime.go
@@ -7,6 +7,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -33,6 +35,7 @@ const (
 	generatedSpecApprovalSourceURLEnv             = "HELM_GENERATED_SPEC_APPROVAL_SOURCE_URL"
 	generatedSpecApprovalSourceTokenEnv           = "HELM_GENERATED_SPEC_APPROVAL_SOURCE_TOKEN"
 	generatedSpecApprovalJWKSURLEnv               = "HELM_GENERATED_SPEC_APPROVAL_JWKS_URL"
+	generatedSpecApprovalOutboundCAFileEnv        = "HELM_GENERATED_SPEC_APPROVAL_OUTBOUND_CA_BUNDLE_FILE"
 	generatedSpecApprovalIssuerEnv                = "HELM_GENERATED_SPEC_APPROVAL_ISSUER"
 	generatedSpecApprovalAudienceEnv              = "HELM_GENERATED_SPEC_APPROVAL_AUDIENCE"
 	generatedSpecApprovalResourceEnv              = "HELM_GENERATED_SPEC_APPROVAL_RESOURCE"
@@ -66,6 +69,7 @@ type generatedSpecApprovalRuntimeConfig struct {
 	SourceURL            string
 	SourceToken          string
 	JWKSURL              string
+	OutboundCAFile       string
 	Issuer               string
 	Audience             string
 	Resource             string
@@ -96,7 +100,8 @@ func generatedSpecApprovalRuntimeConfigFromEnv() (generatedSpecApprovalRuntimeCo
 	}
 	cfg := generatedSpecApprovalRuntimeConfig{
 		SourceURL: strings.TrimSpace(os.Getenv(generatedSpecApprovalSourceURLEnv)), SourceToken: strings.TrimSpace(os.Getenv(generatedSpecApprovalSourceTokenEnv)),
-		JWKSURL: strings.TrimSpace(os.Getenv(generatedSpecApprovalJWKSURLEnv)), Issuer: strings.TrimSpace(os.Getenv(generatedSpecApprovalIssuerEnv)),
+		JWKSURL: strings.TrimSpace(os.Getenv(generatedSpecApprovalJWKSURLEnv)), OutboundCAFile: strings.TrimSpace(os.Getenv(generatedSpecApprovalOutboundCAFileEnv)),
+		Issuer:   strings.TrimSpace(os.Getenv(generatedSpecApprovalIssuerEnv)),
 		Audience: strings.TrimSpace(os.Getenv(generatedSpecApprovalAudienceEnv)), Resource: strings.TrimSpace(os.Getenv(generatedSpecApprovalResourceEnv)),
 		ControlScope: strings.TrimSpace(os.Getenv(generatedSpecApprovalControlScopeEnv)), ConsumerScope: strings.TrimSpace(os.Getenv(generatedSpecApprovalConsumerScopeEnv)),
 		MaxTokenTTL: defaultGeneratedSpecApprovalMaxTokenTTL, MinHoldDuration: defaultGeneratedSpecApprovalMinHoldDuration,
@@ -164,7 +169,7 @@ func validateGeneratedSpecApprovalRuntimeConfig(cfg generatedSpecApprovalRuntime
 	return nil
 }
 
-func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops kernel.ScopedStopReader) (*generatedSpecApprovalRuntime, error) {
+func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMode string, signer helmcrypto.Signer, stops *kernel.ScopedStopStore) (*generatedSpecApprovalRuntime, error) {
 	cfg, enabled, err := generatedSpecApprovalRuntimeConfigFromEnv()
 	if err != nil || !enabled {
 		return nil, err
@@ -184,7 +189,11 @@ func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMo
 	if err := store.Init(ctx); err != nil {
 		return nil, fmt.Errorf("initialize generated spec approval ceremony store: %w", err)
 	}
-	source, err := newGeneratedSpecApprovalSourceClient(cfg.SourceURL, cfg.SourceToken, nil, false)
+	outboundClient, err := newGeneratedSpecApprovalOutboundClient(cfg.OutboundCAFile)
+	if err != nil {
+		return nil, err
+	}
+	source, err := newGeneratedSpecApprovalSourceClient(cfg.SourceURL, cfg.SourceToken, outboundClient, false)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +210,7 @@ func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMo
 	if err != nil {
 		return nil, fmt.Errorf("initialize generated spec approval service: %w", err)
 	}
-	validatorConfig := mcppkg.JWKSConfig{JWKSURL: cfg.JWKSURL, Issuer: cfg.Issuer, Audience: cfg.Audience, Resource: cfg.Resource}
+	validatorConfig := mcppkg.JWKSConfig{JWKSURL: cfg.JWKSURL, Issuer: cfg.Issuer, Audience: cfg.Audience, Resource: cfg.Resource, HTTPClient: outboundClient}
 	validatorConfig.Scopes = []string{cfg.ControlScope}
 	controlValidator := mcppkg.NewJWKSValidator(validatorConfig)
 	validatorConfig.Scopes = []string{cfg.ConsumerScope}
@@ -210,6 +219,23 @@ func newGeneratedSpecApprovalRuntime(ctx context.Context, db *sql.DB, databaseMo
 		service: service, controlValidator: controlValidator, consumerValidator: consumerValidator,
 		audience: cfg.Audience, maxTokenTTL: cfg.MaxTokenTTL,
 	}, nil
+}
+
+func newGeneratedSpecApprovalOutboundClient(caFile string) (*http.Client, error) {
+	if caFile == "" {
+		return nil, nil
+	}
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read generated spec approval outbound CA: %w", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		return nil, errors.New("generated spec approval outbound CA is invalid")
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots}
+	return &http.Client{Transport: transport, Timeout: generatedSpecApprovalSourceTimeout}, nil
 }
 
 type generatedSpecApprovalSourceClient struct {

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_runtime_test.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_runtime_test.go
@@ -1,3 +1,5 @@
+// quantum_posture: these tests exercise classical X.509/TLS and JWK trust
+// wiring only; no post-quantum cryptographic control or assurance is added.
 package main
 
 import (

--- a/core/cmd/helm-ai-kernel/generated_spec_approval_runtime_test.go
+++ b/core/cmd/helm-ai-kernel/generated_spec_approval_runtime_test.go
@@ -1,11 +1,17 @@
 package main
 
 import (
+	"context"
+	"crypto/x509"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +50,15 @@ func TestGeneratedSpecApprovalConfigIsExplicitAndFailClosed(t *testing.T) {
 	t.Setenv(generatedSpecApprovalSourceURLEnv, "http://control.example.test")
 	if _, _, err := generatedSpecApprovalRuntimeConfigFromEnv(); err == nil {
 		t.Fatal("HTTP source URL was accepted")
+	}
+}
+
+func TestGeneratedSpecApprovalRuntimeRequiresEmergencyStopCoordination(t *testing.T) {
+	generatedSpecApprovalTestEnv(t)
+	setCompleteGeneratedSpecApprovalEnv(t)
+	_, err := newGeneratedSpecApprovalRuntime(context.Background(), new(sql.DB), "postgres", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "emergency-stop scope coordination") {
+		t.Fatalf("missing stop coordination error = %v", err)
 	}
 }
 
@@ -105,6 +120,33 @@ func TestGeneratedSpecApprovalSourceClientPinsBindingAndAuthority(t *testing.T) 
 	}
 }
 
+func TestGeneratedSpecApprovalOutboundClientTrustsConfiguredCA(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+	certificate, err := x509.ParseCertificate(server.Certificate().Raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate.Raw}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	client, err := newGeneratedSpecApprovalOutboundClient(caFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status=%d", response.StatusCode)
+	}
+}
+
 func TestGeneratedSpecApprovalVerifierErrorsRemainActionable(t *testing.T) {
 	for _, test := range []struct {
 		name string
@@ -130,7 +172,7 @@ func generatedSpecApprovalTestEnv(t *testing.T) {
 	t.Helper()
 	for _, name := range []string{
 		generatedSpecApprovalEnabledEnv, generatedSpecApprovalSourceURLEnv, generatedSpecApprovalSourceTokenEnv,
-		generatedSpecApprovalJWKSURLEnv, generatedSpecApprovalIssuerEnv, generatedSpecApprovalAudienceEnv,
+		generatedSpecApprovalJWKSURLEnv, generatedSpecApprovalOutboundCAFileEnv, generatedSpecApprovalIssuerEnv, generatedSpecApprovalAudienceEnv,
 		generatedSpecApprovalResourceEnv, generatedSpecApprovalControlScopeEnv, generatedSpecApprovalConsumerScopeEnv,
 		generatedSpecApprovalMaxTokenTTLEnv, generatedSpecApprovalMinHoldDurationEnv, generatedSpecApprovalChallengeTTLEnv,
 		generatedSpecApprovalMaxChallengeLifetimeEnv, generatedSpecApprovalGrantTTLEnv, generatedSpecApprovalMaxAssertionsEnv,

--- a/core/pkg/boundary/generatedspecapprovalceremony/postgres_store.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/postgres_store.go
@@ -34,12 +34,11 @@ created_at, updated_at, expires_at, consumed_at, consumed_by, version
 type PostgresStore struct {
 	db                   *sql.DB
 	verifier             GrantSignatureVerifier
-	clock                func() time.Time
 	maxChallengeLifetime time.Duration
 }
 
 func NewPostgresStore(db *sql.DB, verifier GrantSignatureVerifier) *PostgresStore {
-	return &PostgresStore{db: db, verifier: verifier, clock: time.Now}
+	return &PostgresStore{db: db, verifier: verifier}
 }
 
 func (s *PostgresStore) setMaxChallengeLifetime(value time.Duration) {
@@ -591,11 +590,8 @@ func (s *PostgresStore) requireReady() error {
 	return nil
 }
 
-func (s *PostgresStore) transitionTime(fallback time.Time) time.Time {
-	if s == nil || s.clock == nil {
-		return fallback.UTC().Truncate(time.Microsecond)
-	}
-	return s.clock().UTC().Truncate(time.Microsecond)
+func (s *PostgresStore) transitionTime(requestedAt time.Time) time.Time {
+	return requestedAt.UTC().Truncate(time.Microsecond)
 }
 
 func requireGeneratedSpecApprovalUnfencedScope(ctx context.Context, tx *sql.Tx, tenantID, workspaceID string) error {

--- a/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
+++ b/core/pkg/boundary/generatedspecapprovalceremony/postgres_store_test.go
@@ -338,7 +338,6 @@ func TestPostgresLifecycleSingleIssueConsumeAndFence(t *testing.T) {
 		t.Fatalf("connect runtime role: %v", err)
 	}
 	store := NewPostgresStore(runtimeDB, fixture.verifier)
-	store.clock = func() time.Time { return fixture.now }
 	service, err := newService(
 		store,
 		bindingStub{binding: fixture.binding},

--- a/core/pkg/mcp/jwks.go
+++ b/core/pkg/mcp/jwks.go
@@ -100,7 +100,7 @@ func NewJWKSValidator(config JWKSConfig) *JWKSValidator {
 	return &JWKSValidator{
 		config: config,
 		client: &clientCopy,
-		keys: make(map[string]*rsa.PublicKey),
+		keys:   make(map[string]*rsa.PublicKey),
 	}
 }
 

--- a/core/pkg/mcp/jwks.go
+++ b/core/pkg/mcp/jwks.go
@@ -54,6 +54,7 @@ type JWKSConfig struct {
 	Resource              string   // HELM_OAUTH_RESOURCE — expected RFC 8707 resource indicator
 	Scopes                []string // HELM_OAUTH_SCOPES — required scopes
 	AllowInsecureLoopback bool     // test/dev-only allowance for httptest loopback JWKS endpoints
+	HTTPClient            *http.Client
 }
 
 // OAuthTokenClaims contains validated token claims needed by MCP authorization.
@@ -88,11 +89,17 @@ const jwksRefreshInterval = 5 * time.Minute
 
 // NewJWKSValidator creates a validator with the given config.
 func NewJWKSValidator(config JWKSConfig) *JWKSValidator {
+	client := config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	clientCopy := *client
+	if clientCopy.Timeout <= 0 {
+		clientCopy.Timeout = 10 * time.Second
+	}
 	return &JWKSValidator{
 		config: config,
-		client: &http.Client{
-			Timeout: 10 * time.Second,
-		},
+		client: &clientCopy,
 		keys: make(map[string]*rsa.PublicKey),
 	}
 }


### PR DESCRIPTION
## Summary
- trust the configured private CA for GeneratedSpec source and JWKS reads
- preserve the service-verified approval consumption timestamp across PostgreSQL persistence
- require durable emergency-stop coordination without narrowing the existing stop-reader contract

## Validation
- `GOWORK=off go test ./cmd/helm-ai-kernel ./pkg/boundary/generatedspecapprovalceremony ./pkg/mcp`
- `GOWORK=off make test lint`

Part of HELM-641.