### PR TITLE
fix(conform): preserve downstream profile gates

### DIFF
--- a/core/pkg/conform/engine.go
+++ b/core/pkg/conform/engine.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -21,17 +22,19 @@ import (
 // It enumerates gates, runs them deterministically, emits an EvidencePack,
 // and signs the final report.
 type Engine struct {
-	gates   map[string]Gate
-	ordered []string // gate execution order
-	clock   func() time.Time
+	gates             map[string]Gate
+	ordered           []string // gate execution order
+	profileExtensions map[ProfileID][]string
+	clock             func() time.Time
 }
 
 // NewEngine creates a new conformance engine.
 func NewEngine() *Engine {
 	return &Engine{
-		gates:   make(map[string]Gate),
-		ordered: make([]string, 0),
-		clock:   time.Now,
+		gates:             make(map[string]Gate),
+		ordered:           make([]string, 0),
+		profileExtensions: make(map[ProfileID][]string),
+		clock:             time.Now,
 	}
 }
 
@@ -49,6 +52,19 @@ func (e *Engine) RegisterGate(g Gate) {
 		e.ordered = append(e.ordered, id)
 	}
 	e.gates[id] = g
+}
+
+// RegisterGateForProfiles registers a gate and appends it to each built-in
+// profile without requiring the Kernel profile registry to know downstream
+// gate implementations.
+func (e *Engine) RegisterGateForProfiles(g Gate, profiles ...ProfileID) {
+	e.RegisterGate(g)
+	id := g.ID()
+	for _, profile := range profiles {
+		if !slices.Contains(e.profileExtensions[profile], id) {
+			e.profileExtensions[profile] = append(e.profileExtensions[profile], id)
+		}
+	}
 }
 
 // ConformanceReport is the top-level result of a conformance run.
@@ -204,8 +220,11 @@ func (e *Engine) resolveGates(opts *RunOptions) []string {
 	}
 
 	// Intersect profile gates with registered gates, preserving registration order
-	required := make(map[string]bool, len(profileGates))
+	required := make(map[string]bool, len(profileGates)+len(e.profileExtensions[opts.Profile]))
 	for _, g := range profileGates {
+		required[g] = true
+	}
+	for _, g := range e.profileExtensions[opts.Profile] {
 		required[g] = true
 	}
 

--- a/core/pkg/conform/engine_test.go
+++ b/core/pkg/conform/engine_test.go
@@ -61,6 +61,29 @@ func TestEngine_RegisterAndRun(t *testing.T) {
 	require.Equal(t, 2, found)
 }
 
+func TestEngine_RegisterGateForProfiles(t *testing.T) {
+	withEngineEvidenceDataDir(t)
+	e := NewEngine()
+	e.RegisterGate(&fakeGate{id: "G0", name: "Build Identity", pass: true})
+	extension := &fakeGate{id: "EXT_TENANT", name: "Extended Tenant Gate", pass: true}
+	e.RegisterGateForProfiles(extension, ProfileCore)
+	e.RegisterGateForProfiles(extension, ProfileCore)
+
+	dir := t.TempDir()
+	report, err := e.Run(&RunOptions{
+		Profile:     ProfileCore,
+		ProjectRoot: dir,
+		OutputDir:   filepath.Join(dir, "evidence"),
+	})
+	require.NoError(t, err)
+
+	gateIDs := make([]string, 0, len(report.GateResults))
+	for _, result := range report.GateResults {
+		gateIDs = append(gateIDs, result.GateID)
+	}
+	require.Equal(t, []string{"G0", "EXT_TENANT"}, gateIDs)
+}
+
 func TestEngine_FailingGate(t *testing.T) {
 	withEngineEvidenceDataDir(t)
 	e := NewEngine()


### PR DESCRIPTION
## Summary

- add an explicit Kernel conformance API that registers downstream gates against selected built-in profiles
- preserve deterministic registration order and deduplicate repeated profile attachments
- prevent Enterprise L3/regulated profile runs from silently omitting tenant, KMS, audit, and connector gates after the canonical Kernel sync

## Root cause

`ProfileL3` became an explicit built-in profile. `Engine.resolveGates` therefore intersected registered gates with only Kernel-owned profile IDs, silently dropping downstream Enterprise gates even though `CommercialEngine` registered them.

## Validation

- `go test ./pkg/conform`
- `make quality-pr` (all blocking gates passed, including Go, command tests, boundary, Python/TS/Rust/Java SDKs, JSON schemas, reason codes, and OpenAPI compatibility)

## Scope

This adds an extension point to the existing Kernel engine; it does not add a parallel conformance runtime or encode commercial gate IDs in Kernel.