### PR TITLE
fix: keep SQL surface snapshot stable on restart

### DIFF
--- a/core/pkg/boundary/surface_registry.go
+++ b/core/pkg/boundary/surface_registry.go
@@ -236,6 +236,7 @@ CREATE TABLE IF NOT EXISTS boundary_records_index (
 
 func loadSQLSurfaceRegistry(ctx context.Context, db *sql.DB, now func() time.Time) (*SurfaceRegistry, error) {
 	r := newSurfaceRegistry(now)
+	seeded := false
 	var snapshotJSON string
 	err := db.QueryRowContext(ctx, `SELECT snapshot_json FROM boundary_surface_snapshots WHERE id = $1`, "default").Scan(&snapshotJSON)
 	if err == nil {
@@ -244,16 +245,19 @@ func loadSQLSurfaceRegistry(ctx context.Context, db *sql.DB, now func() time.Tim
 		}
 	} else if err == sql.ErrNoRows {
 		r.seed()
+		seeded = true
 	} else {
 		return nil, fmt.Errorf("read boundary surface snapshot: %w", err)
 	}
 	r.db = db
 	r.ctx = ctx
-	r.mu.Lock()
-	err = r.persistLocked()
-	r.mu.Unlock()
-	if err != nil {
-		return nil, err
+	if seeded {
+		r.mu.Lock()
+		err = r.persistLocked()
+		r.mu.Unlock()
+		if err != nil {
+			return nil, err
+		}
 	}
 	return r, nil
 }

--- a/core/pkg/boundary/surface_registry_test.go
+++ b/core/pkg/boundary/surface_registry_test.go
@@ -419,10 +419,21 @@ func TestSQLSurfaceRegistryPersistsRecords(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	var snapshotUpdatedAt string
+	if err := db.QueryRow(`SELECT updated_at FROM boundary_surface_snapshots WHERE id = 'default'`).Scan(&snapshotUpdatedAt); err != nil {
+		t.Fatal(err)
+	}
 
-	reloaded, err := NewSQLSurfaceRegistry(context.Background(), db, "sqlite", func() time.Time { return now })
+	reloaded, err := NewSQLSurfaceRegistry(context.Background(), db, "sqlite", func() time.Time { return now.Add(time.Hour) })
 	if err != nil {
 		t.Fatal(err)
+	}
+	var reloadedSnapshotUpdatedAt string
+	if err := db.QueryRow(`SELECT updated_at FROM boundary_surface_snapshots WHERE id = 'default'`).Scan(&reloadedSnapshotUpdatedAt); err != nil {
+		t.Fatal(err)
+	}
+	if reloadedSnapshotUpdatedAt != snapshotUpdatedAt {
+		t.Fatalf("SQL registry reload rewrote snapshot updated_at: %s != %s", reloadedSnapshotUpdatedAt, snapshotUpdatedAt)
 	}
 	got, ok := reloaded.GetRecord(record.RecordID)
 	if !ok {


### PR DESCRIPTION
Closes the merged-head R3 recovery preflight defect found under HELM-658.

The SQL-backed boundary registry rewrote an unchanged snapshot on every open, updating `boundary_surface_snapshots.updated_at` during Kernel restart and invalidating the process-only recovery invariant. Persist the seed only when no snapshot exists, matching the existing file-backed behavior.

Validation:
- focused SQLite regression
- real Postgres reload test
- `go test -race ./pkg/boundary -count=1`
- `make test`
- seven-component no-effect stack recovery at pinned source heads
- offline Ed25519 receipt verification (receipt SHA-256: `92a822e04f344906109520be2578b1965559f41ba74e1156cf91a3391d5d849d`)
