### PR TITLE
HELM-658: keep unchanged boundary snapshots recovery-stable

### DIFF
--- a/core/pkg/boundary/surface_registry.go
+++ b/core/pkg/boundary/surface_registry.go
@@ -1443,7 +1443,8 @@ func (r *SurfaceRegistry) persistLocked() error {
 		}
 		_, err := r.db.ExecContext(ctx, `INSERT INTO boundary_surface_snapshots (id, snapshot_json, updated_at)
 			VALUES ($1, $2, $3)
-			ON CONFLICT(id) DO UPDATE SET snapshot_json = excluded.snapshot_json, updated_at = excluded.updated_at`,
+			ON CONFLICT(id) DO UPDATE SET snapshot_json = excluded.snapshot_json, updated_at = excluded.updated_at
+			WHERE boundary_surface_snapshots.snapshot_json != excluded.snapshot_json`,
 			"default", string(data), r.now().UTC().Format(time.RFC3339Nano))
 		if err != nil {
 			return fmt.Errorf("persist boundary surface snapshot: %w", err)

--- a/core/pkg/boundary/surface_registry_test.go
+++ b/core/pkg/boundary/surface_registry_test.go
@@ -419,10 +419,22 @@ func TestSQLSurfaceRegistryPersistsRecords(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	var persistedAt string
+	if err := db.QueryRow(`SELECT updated_at FROM boundary_surface_snapshots WHERE id = ?`, "default").Scan(&persistedAt); err != nil {
+		t.Fatal(err)
+	}
+	now = now.Add(time.Hour)
 
 	reloaded, err := NewSQLSurfaceRegistry(context.Background(), db, "sqlite", func() time.Time { return now })
 	if err != nil {
 		t.Fatal(err)
+	}
+	var reloadedAt string
+	if err := db.QueryRow(`SELECT updated_at FROM boundary_surface_snapshots WHERE id = ?`, "default").Scan(&reloadedAt); err != nil {
+		t.Fatal(err)
+	}
+	if reloadedAt != persistedAt {
+		t.Fatalf("unchanged SQL snapshot updated_at changed on reload: %s != %s", reloadedAt, persistedAt)
 	}
 	got, ok := reloaded.GetRecord(record.RecordID)
 	if !ok {


### PR DESCRIPTION
## Summary

- avoid rewriting `boundary_surface_snapshots.updated_at` when the canonical snapshot JSON is unchanged
- preserve normal snapshot updates for real boundary state changes
- prove an unchanged SQL registry reload leaves the persisted timestamp stable

## End-to-end finding

The exact seven-component OrganizationRuntime started healthy, but its recovery proof failed closed with `recovery invariant changed: postgres`. The only logical row changed by the restart was the Kernel boundary snapshot timestamp; the snapshot payload was unchanged.

## Validation

- focused unchanged-reload SQLite regression: passed
- full `pkg/boundary` suite: passed
- real PostgreSQL boundary persistence test: passed
- full Kernel Core `go test ./...`: passed

Local/no-effect runtime proof only; no deployment or production promotion is included.