### PR TITLE
HELM-191: require immutable production Kernel image digests

### DIFF
--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -28,6 +28,7 @@ the pinned containerized Helm runner.
 ```bash
 helm install helm-ai-kernel deploy/helm-chart \
   --values ./production-network-policy.yaml \
+  --set image.digest="$KERNEL_IMAGE_DIGEST" \
   --set helm.production=true \
   --set helm.signing.key=<64-char-ed25519-seed-hex> \
   --set helm.auth.adminAPIKey=<admin-api-key> \
@@ -37,6 +38,10 @@ helm install helm-ai-kernel deploy/helm-chart \
 ```
 
 Review `values.yaml` before use in a real environment.
+
+`KERNEL_IMAGE_DIGEST` must be the promoted release's immutable
+`sha256:<64-lowercase-hex>` digest. `helm.production=true` refuses mutable tag-
+only Kernel images; when a digest is set, `image.tag` is ignored.
 
 `production-network-policy.yaml` must set `networkPolicy.enabled=true` and
 provide explicit ingress and egress rules. Production rendering rejects empty
@@ -69,6 +74,7 @@ flowchart TD
 | --- | --- | --- |
 | `image.repository` | `ghcr.io/mindburn-labs/helm-ai-kernel` | Container image repository. |
 | `image.tag` | chart `appVersion` | Container image tag. |
+| `image.digest` | empty | Immutable `sha256` digest; required in production and takes precedence over `image.tag`. |
 | `imagePullSecrets` | `[]` | Pull secrets applied to the kernel and optional launchpad app Pods/Jobs/test Pod. |
 | `networkPolicy.enabled` | `false` | Renders the Kernel Pod NetworkPolicy; required in production. |
 | `networkPolicy.ingress` | `[]` | Explicit production ingress peers and ports. Empty or broad selectors fail production rendering. |

--- a/deploy/helm-chart/templates/_helpers.tpl
+++ b/deploy/helm-chart/templates/_helpers.tpl
@@ -66,8 +66,17 @@ Create the name of the service account to use
 Return the image name
 */}}
 {{- define "helm-ai-kernel.image" -}}
+{{- if .Values.image.digest -}}
+{{- if not (regexMatch "^sha256:[0-9a-f]{64}$" .Values.image.digest) -}}
+{{- fail "image.digest must be a sha256 digest with 64 lowercase hex characters" -}}
+{{- end -}}
+{{- printf "%s@%s" .Values.image.repository .Values.image.digest -}}
+{{- else if .Values.helm.production -}}
+{{- fail "helm.production=true requires image.digest pinned by immutable sha256 digest" -}}
+{{- else -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag -}}
-{{- printf "%s:%s" .Values.image.repository $tag }}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -28,11 +28,16 @@
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"],
           "default": "IfNotPresent",
-          "description": "Kubernetes image pull policy. Use IfNotPresent for pinned tags and Always when consuming the floating :latest tag."
+          "description": "Kubernetes image pull policy. Use IfNotPresent for digest-pinned images and release tags; use Always only for floating tags."
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^(|sha256:[0-9a-f]{64})$",
+          "description": "Immutable sha256 image digest including the `sha256:` prefix. Required when helm.production=true; when set, the rendered image uses repository@digest and ignores tag."
         },
         "tag": {
           "type": "string",
-          "description": "Overrides the image tag. Leave empty to inherit the chart's appVersion. Set explicitly when pinning to a digest-resolved release or to a development build."
+          "description": "Overrides the image tag. Leave empty to inherit the chart's appVersion. Ignored when image.digest is set."
         }
       }
     },

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -7,6 +7,9 @@ replicaCount: 1
 image:
   repository: ghcr.io/mindburn-labs/helm-ai-kernel
   pullPolicy: IfNotPresent
+  # Immutable sha256 digest. Required when helm.production=true and preferred
+  # over tag whenever set.
+  digest: ""
   # Overrides the image tag whose default is the chart appVersion
   tag: ""
 

--- a/scripts/ci/check_helm_smoke_hardening.py
+++ b/scripts/ci/check_helm_smoke_hardening.py
@@ -51,6 +51,9 @@ def check_kind_smoke(path: Path) -> None:
         "kind-${CLUSTER}",
         "-control-plane:6443",
         "pod-security.kubernetes.io/enforce=restricted",
+        "ctr --namespace k8s.io images inspect",
+        "ctr --namespace k8s.io images tag --force",
+        "--set image.digest=",
     ]
     for token in required:
         if token not in text:
@@ -60,6 +63,12 @@ def check_kind_smoke(path: Path) -> None:
 def check_chart_smoke(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
     require_digest_default(path, text)
+    for token in [
+        "PRODUCTION_IMAGE_DIGEST",
+        "requires image.digest pinned by immutable sha256 digest",
+        "--set image.digest=",
+    ]:
+        require(text, token, path)
 
 
 def check_authority_state_chart(path: Path) -> None:

--- a/scripts/ci/check_helm_smoke_hardening.py
+++ b/scripts/ci/check_helm_smoke_hardening.py
@@ -71,6 +71,18 @@ def check_chart_smoke(path: Path) -> None:
         require(text, token, path)
 
 
+def check_launchpad_smoke(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    for token in [
+        "--container-runtime=containerd",
+        "ctr --namespace k8s.io images inspect",
+        "ctr --namespace k8s.io images tag --force",
+        'crictl inspecti "$KERNEL_IMAGE_DIGEST_REF"',
+        '--set "image.digest=${KERNEL_IMAGE_DIGEST}"',
+    ]:
+        require(text, token, path)
+
+
 def check_authority_state_chart(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
     required = [
@@ -111,6 +123,7 @@ def check_authority_state_chart(path: Path) -> None:
 def main() -> None:
     check_kind_smoke(ROOT / "scripts/ci/kind_smoke.sh")
     check_chart_smoke(ROOT / "scripts/ci/helm_chart_smoke.sh")
+    check_launchpad_smoke(ROOT / "scripts/ci/launchpad_k8s_smoke.sh")
     check_authority_state_chart(ROOT / "deploy/helm-chart/templates/deployment.yaml")
     print("Helm smoke hardening checks passed.")
 

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -16,6 +16,7 @@ ADMIN_KEY="${HELM_SMOKE_ADMIN_KEY:-helm-admin-smoke}"
 SERVICE_KEY="${HELM_SMOKE_SERVICE_KEY:-helm-service-smoke}"
 TENANT_ID="${HELM_SMOKE_TENANT_ID:-tenant-smoke}"
 AGENT_ID="${HELM_SMOKE_AGENT_ID:-agent.smoke}"
+PRODUCTION_IMAGE_DIGEST="${HELM_CHART_SMOKE_IMAGE_DIGEST:-sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}"
 REPLAY_KEYRING='{"keyring_version":"emergency-stop-fence-command-replay-keyring.v1","keys":[{"command_key_id":"cp-stop-before-rotation","command_audience":"kernel-before-rotation","command_public_key":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}'
 RENDER_DIR="${HELM_CHART_RENDER_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/helm-ai-kernel-chart.XXXXXX")}"
 
@@ -79,7 +80,9 @@ assert_not_contains() {
 PRODUCTION_NETWORK_POLICY_VALUES="scripts/ci/helm_production_network_policy_values.yaml"
 
 production_helm_runner() {
-    helm_runner "$@" --values "$PRODUCTION_NETWORK_POLICY_VALUES"
+    helm_runner "$@" \
+        --values "$PRODUCTION_NETWORK_POLICY_VALUES" \
+        --set image.digest="$PRODUCTION_IMAGE_DIGEST"
 }
 
 default_rendered="$RENDER_DIR/rendered-default.yaml"
@@ -90,6 +93,7 @@ helm_runner template "$RELEASE" "$CHART" \
     --set image.pullPolicy=IfNotPresent >"$default_rendered"
 
 assert_contains "$default_rendered" "kind: Deployment"
+assert_contains "$default_rendered" 'image: "ghcr.io/mindburn-labs/helm-ai-kernel:local"'
 assert_contains "$default_rendered" "HELM_POLICY_SOURCE_KIND"
 assert_contains "$default_rendered" "mountedFile"
 assert_contains "$default_rendered" "HELM_POLICY_ON_INVALID_UPDATE"
@@ -370,13 +374,40 @@ if production_helm_runner template "$RELEASE" "$CHART" \
 fi
 assert_contains "$fail_log" "requires helm.signing.key"
 
+image_digest_fail_log="$RENDER_DIR/production-missing-image-digest.log"
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --values "$PRODUCTION_NETWORK_POLICY_VALUES" \
+    --set helm.production=true \
+    --set helm.signing.key="$SIGNING_KEY" \
+    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set helm.auth.tenantID="$TENANT_ID" \
+    --set helm.auth.principalID="$AGENT_ID" >"$RENDER_DIR/production-missing-image-digest.yaml" 2>"$image_digest_fail_log"; then
+    echo "::error::production render without an immutable Kernel image digest unexpectedly succeeded"
+    exit 1
+fi
+assert_contains "$image_digest_fail_log" "requires image.digest pinned by immutable sha256 digest"
+
+image_digest_invalid_log="$RENDER_DIR/invalid-image-digest.log"
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set image.digest=sha256:not-a-digest >"$RENDER_DIR/invalid-image-digest.yaml" 2>"$image_digest_invalid_log"; then
+    echo "::error::render with a malformed Kernel image digest unexpectedly succeeded"
+    exit 1
+fi
+assert_contains "$image_digest_invalid_log" "image.digest"
+
 network_policy_disabled_log="$RENDER_DIR/production-network-policy-disabled.log"
 if helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
     --set helm.auth.adminAPIKey="$ADMIN_KEY" \
-    --set helm.auth.serviceAPIKey="$SERVICE_KEY" >"$RENDER_DIR/production-network-policy-disabled.yaml" 2>"$network_policy_disabled_log"; then
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set helm.auth.tenantID="$TENANT_ID" \
+    --set helm.auth.principalID="$AGENT_ID" \
+    --set image.digest="$PRODUCTION_IMAGE_DIGEST" >"$RENDER_DIR/production-network-policy-disabled.yaml" 2>"$network_policy_disabled_log"; then
     echo "::error::production render without a kernel NetworkPolicy unexpectedly succeeded"
     exit 1
 fi
@@ -491,7 +522,6 @@ production_helm_runner lint "$CHART" \
     --set helm.auth.tenantID="$TENANT_ID" \
     --set helm.auth.principalID="$AGENT_ID" \
     --set image.repository=ghcr.io/mindburn-labs/helm-ai-kernel \
-    --set image.tag=local \
     --set image.pullPolicy=IfNotPresent >/dev/null
 
 rendered="$RENDER_DIR/rendered.yaml"
@@ -504,10 +534,10 @@ production_helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.tenantID="$TENANT_ID" \
     --set helm.auth.principalID="$AGENT_ID" \
     --set image.repository=ghcr.io/mindburn-labs/helm-ai-kernel \
-    --set image.tag=local \
     --set image.pullPolicy=IfNotPresent >"$rendered"
 
 assert_contains "$rendered" "kind: Deployment"
+assert_contains "$rendered" "image: \"ghcr.io/mindburn-labs/helm-ai-kernel@${PRODUCTION_IMAGE_DIGEST}\""
 assert_contains "$rendered" "serve"
 assert_contains "$rendered" "--policy"
 assert_contains "$rendered" "/etc/helm-ai-kernel/policy/serve-policy.toml"

--- a/scripts/ci/kind_smoke.sh
+++ b/scripts/ci/kind_smoke.sh
@@ -130,6 +130,20 @@ kubectl cluster-info --context "kind-${CLUSTER}" >/dev/null
 kubectl config use-context "kind-${CLUSTER}" >/dev/null
 
 kind load docker-image "$IMAGE" --name "$CLUSTER"
+IMAGE_DIGEST="$(
+    docker exec "${CLUSTER}-control-plane" \
+        ctr --namespace k8s.io images inspect "$IMAGE" \
+        | sed -nE 's/.*@(sha256:[0-9a-f]{64}).*/\1/p' \
+        | sed -n '1p'
+)"
+if [[ ! "$IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "::error::could not resolve the loaded Kernel image to an immutable sha256 digest"
+    exit 1
+fi
+IMAGE_REPOSITORY="${IMAGE%:*}"
+IMAGE_DIGEST_REF="${IMAGE_REPOSITORY}@${IMAGE_DIGEST}"
+docker exec "${CLUSTER}-control-plane" \
+    ctr --namespace k8s.io images tag --force "$IMAGE" "$IMAGE_DIGEST_REF" >/dev/null
 kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
 kubectl label namespace "$NAMESPACE" \
     pod-security.kubernetes.io/enforce=restricted \
@@ -145,8 +159,8 @@ helm_runner upgrade --install "$RELEASE" deploy/helm-chart \
     --set helm.auth.serviceAPIKey="${HELM_SMOKE_SERVICE_KEY:-helm-service-smoke}" \
     --set helm.auth.tenantID="$TENANT_ID" \
     --set helm.auth.principalID="$AGENT_ID" \
-    --set image.repository="${IMAGE%:*}" \
-    --set image.tag="${IMAGE##*:}" \
+    --set image.repository="$IMAGE_REPOSITORY" \
+    --set image.digest="$IMAGE_DIGEST" \
     --set image.pullPolicy=IfNotPresent \
     --set persistence.enabled=true \
     --wait --timeout 180s

--- a/scripts/ci/launchpad_k8s_smoke.sh
+++ b/scripts/ci/launchpad_k8s_smoke.sh
@@ -56,7 +56,7 @@ Environment overrides:
   LAUNCHPAD_SMOKE_PROFILE       minikube profile name (default launchpad-smoke)
   LAUNCHPAD_SMOKE_NAMESPACE     release namespace (default helm-launchpad-smoke)
   LAUNCHPAD_SMOKE_RELEASE       helm release name (default kernel)
-  LAUNCHPAD_SMOKE_KERNEL_IMAGE  kernel image to load into minikube (default ghcr.io/mindburn-labs/helm-ai-kernel:local)
+  LAUNCHPAD_SMOKE_KERNEL_IMAGE  kernel image to load into minikube; reuse clusters require repo@sha256 (default ghcr.io/mindburn-labs/helm-ai-kernel:local)
   LAUNCHPAD_SMOKE_KEEP_CLUSTER  set to 1 to skip the final minikube delete
   LAUNCHPAD_SMOKE_FRESH_CLUSTER set to 0 to reuse an existing minikube profile (assumes the cluster is already running and kernel image is loaded)
   LAUNCHPAD_SMOKE_MANAGE_NAMESPACE set to 0 when the namespace already exists and the kubeconfig has namespace-scoped RBAC only
@@ -247,6 +247,7 @@ if [ "$CLUSTER_MODE" = "minikube" ]; then
             --disk-size="${LAUNCHPAD_SMOKE_DISK:-20g}" \
             --kubernetes-version="${LAUNCHPAD_SMOKE_K8S_VERSION:-v1.30.0}" \
             --cni=calico \
+            --container-runtime=containerd \
             --driver="${LAUNCHPAD_SMOKE_DRIVER:-docker}"
     fi
     kubectl config use-context "$PROFILE"
@@ -265,6 +266,14 @@ fi
 echo "::endgroup::"
 
 echo "::group::stage 2 — local kernel image + optional launchpad image debug"
+KERNEL_IMAGE_REPOSITORY="${KERNEL_IMAGE%%@*}"
+KERNEL_IMAGE_DIGEST=""
+if [[ "$KERNEL_IMAGE" == *@* ]]; then
+    KERNEL_IMAGE_DIGEST="${KERNEL_IMAGE##*@}"
+elif [[ "${KERNEL_IMAGE##*/}" == *:* ]]; then
+    KERNEL_IMAGE_REPOSITORY="${KERNEL_IMAGE%:*}"
+fi
+
 if [ "$CLUSTER_MODE" = "minikube" ]; then
     # Kernel image: built locally by the caller (CI step or developer make target).
     # Skip the load if it is already inside minikube (common when the caller built
@@ -276,8 +285,30 @@ if [ "$CLUSTER_MODE" = "minikube" ]; then
     else
         echo "::warning::kernel image $KERNEL_IMAGE not in local docker; relying on imagePullPolicy=IfNotPresent against registry"
     fi
+
+    if [ -z "$KERNEL_IMAGE_DIGEST" ]; then
+        KERNEL_IMAGE_DIGEST="$(
+            minikube -p "$PROFILE" ssh -- \
+                sudo ctr --namespace k8s.io images inspect "$KERNEL_IMAGE" \
+                | tr -d '\r' \
+                | sed -nE 's/.*@(sha256:[0-9a-f]{64}).*/\1/p' \
+                | sed -n '1p'
+        )"
+        if [[ ! "$KERNEL_IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::could not resolve the loaded Kernel image to an immutable sha256 digest" >&2
+            exit 1
+        fi
+        KERNEL_IMAGE_DIGEST_REF="${KERNEL_IMAGE_REPOSITORY}@${KERNEL_IMAGE_DIGEST}"
+        minikube -p "$PROFILE" ssh -- \
+            sudo ctr --namespace k8s.io images tag --force "$KERNEL_IMAGE" "$KERNEL_IMAGE_DIGEST_REF" >/dev/null
+        minikube -p "$PROFILE" ssh -- sudo crictl inspecti "$KERNEL_IMAGE_DIGEST_REF" >/dev/null
+    fi
 else
     echo "reused-cluster mode: kubelet must pull kernel image $KERNEL_IMAGE from a registry or node cache"
+fi
+if [[ ! "$KERNEL_IMAGE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+    echo "::error::LAUNCHPAD_SMOKE_KERNEL_IMAGE must be repo@sha256 for reused clusters" >&2
+    exit 1
 fi
 
 if [ "$PRE_LOAD_LAUNCHPAD_IMAGES" = "1" ] && [ "$MODE" != "baseline" ]; then
@@ -334,8 +365,8 @@ helm_args=(
     --set "helm.signing.key=${SIGNING_KEY}"
     --set "helm.auth.adminAPIKey=${ADMIN_KEY}"
     --set "helm.auth.serviceAPIKey=${SERVICE_KEY}"
-    --set "image.repository=${KERNEL_IMAGE%:*}"
-    --set "image.tag=${KERNEL_IMAGE##*:}"
+    --set "image.repository=${KERNEL_IMAGE_REPOSITORY}"
+    --set "image.digest=${KERNEL_IMAGE_DIGEST}"
     --set "image.pullPolicy=IfNotPresent"
     --set "persistence.enabled=${PERSISTENCE_ENABLED}"
 )

--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -610,6 +610,7 @@
         "deploy/helm-chart/values.schema.json",
         "scripts/ci/kind_smoke.sh",
         "scripts/ci/helm_chart_smoke.sh",
+        "scripts/ci/launchpad_k8s_smoke.sh",
         "scripts/ci/check_helm_smoke_hardening.py",
         "scripts/ci/quality-gates.json"
       ]


### PR DESCRIPTION
## Summary
- require a valid sha256 Kernel image digest whenever `helm.production=true`
- render the Kernel container as `repository@digest` while preserving tag-based development installs
- keep kind smoke production-realistic by resolving and aliasing the locally loaded OCI index by digest
- document and statically guard the immutable-image contract

## Security impact
Production chart rendering now fails closed before Pod creation when the Kernel image is mutable or the digest is malformed. This closes image-tag drift at the Kernel execution boundary.

## Validation
- `make helm-chart-smoke`
- `python3 scripts/ci/check_helm_smoke_hardening.py`
- `make kind-smoke` with Go 1.25.13
- `make lint`
- `QUALITY_CHANGED_FILES=<7 owned paths> make quality-pr`

Tracks HELM-191.