### PR TITLE
Require rotating authentication for managed policy sources

### DIFF
--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -1078,14 +1078,62 @@ func policySourceFromEnv(policyPath string, scope policyreconcile.PolicyScope) (
 		if err := policyreconcile.ValidateControlPlaneURL(baseURL); err != nil {
 			return nil, "controlplane", err
 		}
+		bearerToken, bearerTokenFile, err := policyControlPlaneAuthFromEnv()
+		if err != nil {
+			return nil, "controlplane", err
+		}
 		source := policyreconcile.NewControlPlaneSource(baseURL, scope)
-		source.BearerToken = os.Getenv("HELM_POLICY_BEARER_TOKEN")
+		source.BearerToken = bearerToken
+		source.BearerTokenFile = bearerTokenFile
 		return source, "controlplane", nil
 	case "crd":
 		return nil, "crd", fmt.Errorf("HELM_POLICY_SOURCE_KIND=crd requires a CRD source implementation in the runtime build; this OSS binary only ships the chart CRD/RBAC contract")
 	default:
 		return nil, kind, fmt.Errorf("unsupported HELM_POLICY_SOURCE_KIND %q", kind)
 	}
+}
+
+func policyControlPlaneAuthFromEnv() (string, string, error) {
+	authMode := strings.TrimSpace(os.Getenv("HELM_POLICY_CONTROLPLANE_AUTH_MODE"))
+	if authMode == "" && strings.TrimSpace(os.Getenv("HELM_POLICY_BEARER_TOKEN")) != "" {
+		authMode = "bearerToken"
+	}
+
+	var token string
+	var tokenFile string
+	switch strings.ToLower(authMode) {
+	case "bearertoken", "bearer-token", "bearer_token":
+		token = os.Getenv("HELM_POLICY_BEARER_TOKEN")
+	case "serviceaccountjwt", "service-account-jwt", "service_account_jwt":
+		tokenFile = strings.TrimSpace(os.Getenv("HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE"))
+		if tokenFile == "" {
+			tokenFile = "/var/run/secrets/helm-policy/token"
+		}
+		if !filepath.IsAbs(tokenFile) {
+			return "", "", fmt.Errorf("HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE must be an absolute path")
+		}
+		data, err := os.ReadFile(filepath.Clean(tokenFile))
+		if err != nil {
+			return "", "", fmt.Errorf("read projected policy service account token: %w", err)
+		}
+		token = string(data)
+	case "":
+		return "", "", fmt.Errorf("HELM_POLICY_CONTROLPLANE_AUTH_MODE is required when HELM_POLICY_SOURCE_KIND=controlplane")
+	default:
+		return "", "", fmt.Errorf("HELM_POLICY_CONTROLPLANE_AUTH_MODE must be serviceAccountJWT or bearerToken")
+	}
+
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", "", fmt.Errorf("controlplane policy authentication token is empty")
+	}
+	if len(token) > 64*1024 || strings.ContainsAny(token, "\r\n") {
+		return "", "", fmt.Errorf("controlplane policy authentication token is invalid")
+	}
+	if tokenFile != "" {
+		return "", tokenFile, nil
+	}
+	return token, "", nil
 }
 
 func policySignatureVerifierFromEnv(sourceKind string) (policyreconcile.SignatureVerifier, bool, error) {

--- a/core/cmd/helm-ai-kernel/policy_source_test.go
+++ b/core/cmd/helm-ai-kernel/policy_source_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +37,7 @@ func TestPolicySourceFromEnvControlPlaneRequiresURL(t *testing.T) {
 func TestPolicySourceFromEnvControlPlaneUsesBearerToken(t *testing.T) {
 	t.Setenv("HELM_POLICY_SOURCE_KIND", "controlplane")
 	t.Setenv("HELM_POLICY_CONTROLPLANE_URL", "https://controlplane.example")
+	t.Setenv("HELM_POLICY_CONTROLPLANE_AUTH_MODE", "bearerToken")
 	t.Setenv("HELM_POLICY_BEARER_TOKEN", "token-1")
 	source, kind, err := policySourceFromEnv("/tmp/policy.toml", policyreconcile.DefaultScope)
 	if err != nil {
@@ -55,6 +58,8 @@ func TestPolicySourceFromEnvControlPlaneUsesBearerToken(t *testing.T) {
 func TestPolicySourceFromEnvControlPlaneAllowsLoopbackHTTP(t *testing.T) {
 	t.Setenv("HELM_POLICY_SOURCE_KIND", "controlplane")
 	t.Setenv("HELM_POLICY_CONTROLPLANE_URL", "http://127.0.0.1:18080")
+	t.Setenv("HELM_POLICY_CONTROLPLANE_AUTH_MODE", "bearerToken")
+	t.Setenv("HELM_POLICY_BEARER_TOKEN", "local-token")
 	source, kind, err := policySourceFromEnv("/tmp/policy.toml", policyreconcile.DefaultScope)
 	if err != nil {
 		t.Fatalf("source from env: %v", err)
@@ -64,6 +69,55 @@ func TestPolicySourceFromEnvControlPlaneAllowsLoopbackHTTP(t *testing.T) {
 	}
 	if _, ok := source.(*policyreconcile.ControlPlaneSource); !ok {
 		t.Fatalf("expected ControlPlaneSource, got %T", source)
+	}
+}
+
+func TestPolicySourceFromEnvControlPlaneUsesProjectedServiceAccountJWT(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("projected-jwt\n"), 0o600); err != nil {
+		t.Fatalf("write projected token: %v", err)
+	}
+	t.Setenv("HELM_POLICY_SOURCE_KIND", "controlplane")
+	t.Setenv("HELM_POLICY_CONTROLPLANE_URL", "https://controlplane.example")
+	t.Setenv("HELM_POLICY_CONTROLPLANE_AUTH_MODE", "serviceAccountJWT")
+	t.Setenv("HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE", tokenPath)
+
+	source, kind, err := policySourceFromEnv("/tmp/policy.toml", policyreconcile.DefaultScope)
+	if err != nil {
+		t.Fatalf("source from env: %v", err)
+	}
+	cp, ok := source.(*policyreconcile.ControlPlaneSource)
+	if kind != "controlplane" || !ok || cp.BearerToken != "" || cp.BearerTokenFile != tokenPath {
+		t.Fatalf("projected service account token not configured: kind=%s source=%+v", kind, source)
+	}
+}
+
+func TestPolicySourceFromEnvControlPlaneAuthFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		mode      string
+		token     string
+		tokenFile string
+		want      string
+	}{
+		{name: "missing mode", want: "AUTH_MODE is required"},
+		{name: "empty bearer", mode: "bearerToken", want: "token is empty"},
+		{name: "missing projected token", mode: "serviceAccountJWT", tokenFile: filepath.Join(t.TempDir(), "missing"), want: "read projected"},
+		{name: "unknown mode", mode: "anonymous", want: "must be serviceAccountJWT or bearerToken"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("HELM_POLICY_SOURCE_KIND", "controlplane")
+			t.Setenv("HELM_POLICY_CONTROLPLANE_URL", "https://controlplane.example")
+			t.Setenv("HELM_POLICY_CONTROLPLANE_AUTH_MODE", tc.mode)
+			t.Setenv("HELM_POLICY_BEARER_TOKEN", tc.token)
+			if tc.tokenFile != "" {
+				t.Setenv("HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE", tc.tokenFile)
+			}
+			_, _, err := policySourceFromEnv("/tmp/policy.toml", policyreconcile.DefaultScope)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+		})
 	}
 }
 

--- a/core/pkg/policy/reconcile/reconcile.go
+++ b/core/pkg/policy/reconcile/reconcile.go
@@ -835,6 +835,9 @@ type ControlPlaneSource struct {
 	HTTPClient  *http.Client
 	Scope       PolicyScope
 	BearerToken string
+	// BearerTokenFile is re-read for every request so projected Kubernetes
+	// ServiceAccount token rotation takes effect without restarting Kernel.
+	BearerTokenFile string
 }
 
 func NewControlPlaneSource(baseURL string, scope PolicyScope) *ControlPlaneSource {
@@ -899,7 +902,9 @@ func (s *ControlPlaneSource) Load(ctx context.Context, scope PolicyScope, epoch 
 	if err != nil {
 		return nil, err
 	}
-	s.authorize(req)
+	if err := s.authorize(req); err != nil {
+		return nil, err
+	}
 	resp, err := s.client().Do(req)
 	if err != nil {
 		return nil, err
@@ -937,7 +942,9 @@ func (s *ControlPlaneSource) getJSON(ctx context.Context, endpoint string, out a
 	if err != nil {
 		return err
 	}
-	s.authorize(req)
+	if err := s.authorize(req); err != nil {
+		return err
+	}
 	resp, err := s.client().Do(req)
 	if err != nil {
 		return err
@@ -956,10 +963,39 @@ func (s *ControlPlaneSource) client() *http.Client {
 	return http.DefaultClient
 }
 
-func (s *ControlPlaneSource) authorize(req *http.Request) {
-	if strings.TrimSpace(s.BearerToken) != "" {
-		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(s.BearerToken))
+func (s *ControlPlaneSource) authorize(req *http.Request) error {
+	token, err := s.currentBearerToken()
+	if err != nil {
+		return err
 	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return nil
+}
+
+func (s *ControlPlaneSource) currentBearerToken() (string, error) {
+	token := s.BearerToken
+	tokenFile := strings.TrimSpace(s.BearerTokenFile)
+	if tokenFile != "" {
+		if strings.TrimSpace(token) != "" {
+			return "", fmt.Errorf("controlplane policy authentication must use either a bearer token or a token file")
+		}
+		if !filepath.IsAbs(tokenFile) {
+			return "", fmt.Errorf("controlplane policy authentication token file must be an absolute path")
+		}
+		data, err := os.ReadFile(filepath.Clean(tokenFile))
+		if err != nil {
+			return "", fmt.Errorf("read controlplane policy authentication token: %w", err)
+		}
+		token = string(data)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", fmt.Errorf("controlplane policy authentication token is empty")
+	}
+	if len(token) > 64*1024 || strings.ContainsAny(token, "\r\n") {
+		return "", fmt.Errorf("controlplane policy authentication token is invalid")
+	}
+	return token, nil
 }
 
 // StaticSource is useful for tests and bootstrap code.

--- a/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
+++ b/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
@@ -162,6 +162,7 @@ func TestControlPlaneSourceErrorAndHeaderBranches(t *testing.T) {
 	}))
 	defer errorServer.Close()
 	source = NewControlPlaneSource(errorServer.URL, scope)
+	source.BearerToken = "token-1"
 	if _, err := source.Head(context.Background(), scope); err == nil {
 		t.Fatal("expected controlplane head status error")
 	}
@@ -174,8 +175,49 @@ func TestControlPlaneSourceErrorAndHeaderBranches(t *testing.T) {
 	}))
 	defer invalidJSON.Close()
 	source = NewControlPlaneSource(invalidJSON.URL, scope)
+	source.BearerToken = "token-1"
 	if _, err := source.Head(context.Background(), scope); err == nil {
 		t.Fatal("expected controlplane decode error")
+	}
+}
+
+func TestControlPlaneSourceReloadsProjectedBearerToken(t *testing.T) {
+	tokenPath := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(tokenPath, []byte("token-1"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	scope := PolicyScope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+	bundle := []byte("policy")
+	head := PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(bundle)}
+	var authorizations []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorizations = append(authorizations, r.Header.Get("Authorization"))
+		if r.URL.Path == "/api/v1/policy/head" {
+			_ = json.NewEncoder(w).Encode(head)
+			return
+		}
+		_, _ = w.Write(bundle)
+	}))
+	defer server.Close()
+
+	source := NewControlPlaneSource(server.URL, scope)
+	source.BearerTokenFile = tokenPath
+	if _, err := source.Head(context.Background(), scope); err != nil {
+		t.Fatalf("head with projected token: %v", err)
+	}
+	if err := os.WriteFile(tokenPath, []byte("token-2"), 0o600); err != nil {
+		t.Fatalf("rotate token: %v", err)
+	}
+	if _, err := source.Load(context.Background(), scope, 1); err != nil {
+		t.Fatalf("load with rotated token: %v", err)
+	}
+	if len(authorizations) != 2 || authorizations[0] != "Bearer token-1" || authorizations[1] != "Bearer token-2" {
+		t.Fatalf("projected token rotation was not observed: %v", authorizations)
+	}
+
+	source.BearerToken = "static-token"
+	if _, err := source.Head(context.Background(), scope); err == nil || !strings.Contains(err.Error(), "either a bearer token or a token file") {
+		t.Fatalf("expected conflicting credential error, got %v", err)
 	}
 }
 

--- a/core/pkg/policy/reconcile/reconcile_test.go
+++ b/core/pkg/policy/reconcile/reconcile_test.go
@@ -171,6 +171,7 @@ func TestControlPlaneSourcePublishesPolicyToReconciler(t *testing.T) {
 	defer server.Close()
 
 	source := NewControlPlaneSource(server.URL, scope)
+	source.BearerToken = "policy-reader-token"
 	store := NewAtomicSnapshotStore()
 	reconciler, err := NewReconciler(ReconcilerConfig{
 		Source:            source,

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -113,6 +113,9 @@ flowchart TD
 | `helm.limits.loadShed.enabled` | `false` | Enable low-priority load shedding. |
 | `helm.guardian.semanticThreatEscalationBP` | `0` | Semantic ESCALATE threshold in basis points; `0` is advisory-only, while a positive value fails closed when assessment is unavailable or truncated. |
 | `helm.policy.source.kind` | `mountedFile` | `controlplane`, `crd`, or `mountedFile`; Kubernetes delivery is not policy truth. |
+| `helm.policy.source.controlplane.auth.mode` | `serviceAccountJWT` | `serviceAccountJWT` uses a rotating projected token; `bearerToken` requires explicit static Secret material. |
+| `helm.policy.source.controlplane.auth.serviceAccountJWT.audience` | `helm-control-plane` | Audience required from the policy authority's Kubernetes TokenReview verifier. |
+| `helm.policy.source.controlplane.auth.serviceAccountJWT.expirationSeconds` | `600` | Projected token TTL, constrained to 600–3600 seconds. |
 | `helm.policy.source.pollInterval` | `10s` | Runtime reconciler polling interval. Lost hints are recovered by polling. |
 | `helm.policy.failClosed.onInvalidUpdate` | `keepLastKnownGood` | Retain only a snapshot with a fresh successful source verification after a fault, or `deny` to invalidate immediately. |
 | `helm.policy.failClosed.lastKnownGoodMaxAge` | `10m` | Positive maximum age since the last successful source verification after a source fault. |
@@ -145,6 +148,11 @@ flowchart TD
 - Set `helm.auth.tenantID` and `helm.auth.principalID` to the runtime identity
   expected by tenant-scoped API clients. Caller-supplied tenant and principal
   headers are accepted only when they match these server-bound values.
+- For a `controlplane` policy source, prefer `serviceAccountJWT`. The chart
+  keeps general ServiceAccount automount disabled and projects only a
+  short-lived, audience-bound token into the Kernel container. The policy
+  authority must verify that token and bind its namespace/ServiceAccount to the
+  requested tenant and workspace.
 - Keep `helm.emergencyStop.commandReplayKeyring` empty unless the Control Plane
   has queued signed FENCE envelopes across a deliberate key or audience
   rotation. Prefer `helm.emergencyStop.existingSecret` plus

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -6,8 +6,17 @@
 {{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "controlplane") (not .Values.helm.policy.source.controlplane.url) -}}
 {{- fail "helm.production=true with helm.policy.source.kind=controlplane requires helm.policy.source.controlplane.url" -}}
 {{- end -}}
-{{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.controlplane.auth.mode "bearerToken") (not (or .Values.helm.policy.source.controlplane.auth.bearerToken .Values.helm.policy.source.controlplane.auth.existingSecret)) -}}
-{{- fail "helm.production=true with controlplane bearerToken auth requires helm.policy.source.controlplane.auth.bearerToken or existingSecret" -}}
+{{- if and (eq .Values.helm.policy.source.kind "controlplane") (not (or (eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT") (eq .Values.helm.policy.source.controlplane.auth.mode "bearerToken"))) -}}
+{{- fail "controlplane auth mode must be serviceAccountJWT or bearerToken" -}}
+{{- end -}}
+{{- if and (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT") (not .Values.helm.policy.source.controlplane.auth.serviceAccountJWT.audience) -}}
+{{- fail "controlplane serviceAccountJWT auth requires a non-empty audience" -}}
+{{- end -}}
+{{- if and (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT") (or .Values.helm.policy.source.controlplane.auth.bearerToken .Values.helm.policy.source.controlplane.auth.existingSecret) -}}
+{{- fail "controlplane serviceAccountJWT auth cannot also configure a static bearer token" -}}
+{{- end -}}
+{{- if and (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.controlplane.auth.mode "bearerToken") (not (or .Values.helm.policy.source.controlplane.auth.bearerToken .Values.helm.policy.source.controlplane.auth.existingSecret)) -}}
+{{- fail "controlplane bearerToken auth requires helm.policy.source.controlplane.auth.bearerToken or existingSecret" -}}
 {{- end -}}
 {{- if and .Values.helm.policy.signature.publicKey (not (regexMatch "^[0-9a-fA-F]{64}$" .Values.helm.policy.signature.publicKey)) -}}
 {{- fail "helm.policy.signature.publicKey must be a 64-character hex Ed25519 public key" -}}
@@ -302,6 +311,10 @@ spec:
               value: {{ .Values.helm.policy.source.controlplane.url | quote }}
             - name: HELM_POLICY_CONTROLPLANE_AUTH_MODE
               value: {{ .Values.helm.policy.source.controlplane.auth.mode | quote }}
+            {{- if eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT" }}
+            - name: HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE
+              value: "/var/run/secrets/helm-policy/token"
+            {{- end }}
             {{- if or .Values.helm.policy.source.controlplane.auth.bearerToken .Values.helm.policy.source.controlplane.auth.existingSecret }}
             - name: HELM_POLICY_BEARER_TOKEN
               valueFrom:
@@ -440,6 +453,11 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- if and (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT") }}
+            - name: policy-service-account-token
+              mountPath: /var/run/secrets/helm-policy
+              readOnly: true
+            {{- end }}
         {{- if and .Values.helm.policy.reloadHints.enabled .Values.helm.policy.reloadHints.configReloaderSidecar.enabled }}
         - name: config-reloader
           image: {{ .Values.helm.policy.reloadHints.configReloaderSidecar.image | quote }}
@@ -479,6 +497,16 @@ spec:
           {{- end }}
         - name: tmp
           emptyDir: {}
+        {{- if and (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT") }}
+        - name: policy-service-account-token
+          projected:
+            defaultMode: 256
+            sources:
+              - serviceAccountToken:
+                  audience: {{ required "helm.policy.source.controlplane.auth.serviceAccountJWT.audience is required" .Values.helm.policy.source.controlplane.auth.serviceAccountJWT.audience | quote }}
+                  expirationSeconds: {{ .Values.helm.policy.source.controlplane.auth.serviceAccountJWT.expirationSeconds }}
+                  path: token
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -697,6 +697,24 @@
                           "default": "serviceAccountJWT",
                           "description": "serviceAccountJWT (recommended) projects the pod's Kubernetes ServiceAccount token; bearerToken uses a static token from existingSecret."
                         },
+                        "serviceAccountJWT": {
+                          "type": "object",
+                          "additionalProperties": false,
+                          "description": "Short-lived projected Kubernetes ServiceAccount token settings.",
+                          "properties": {
+                            "audience": {
+                              "type": "string",
+                              "minLength": 1,
+                              "default": "helm-control-plane"
+                            },
+                            "expirationSeconds": {
+                              "type": "integer",
+                              "minimum": 600,
+                              "maximum": 3600,
+                              "default": 600
+                            }
+                          }
+                        },
                         "bearerToken": {
                           "type": "string",
                           "description": "Static bearer token. Prefer existingSecret over inline values; required only when mode=bearerToken."

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -237,6 +237,9 @@ helm:
         url: ""
         auth:
           mode: "serviceAccountJWT" # serviceAccountJWT | bearerToken
+          serviceAccountJWT:
+            audience: "helm-control-plane"
+            expirationSeconds: 600
           bearerToken: ""
           existingSecret: ""
           existingSecretKey: "HELM_POLICY_BEARER_TOKEN"

--- a/docs/RUNTIME_POLICY_RECONCILIATION.md
+++ b/docs/RUNTIME_POLICY_RECONCILIATION.md
@@ -11,7 +11,12 @@ verification, compile, validation, and atomic snapshot swap.
 
 - `HELM_POLICY_SOURCE_KIND`: `mountedFile` (default), `controlplane`, or `crd`.
 - `HELM_POLICY_CONTROLPLANE_URL`: required when `HELM_POLICY_SOURCE_KIND=controlplane`.
-- `HELM_POLICY_BEARER_TOKEN`: optional bearer token for the control-plane source.
+- `HELM_POLICY_CONTROLPLANE_AUTH_MODE`: required for a control-plane source;
+  choose `serviceAccountJWT` or `bearerToken`.
+- `HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE`: projected token path for
+  `serviceAccountJWT`; defaults to `/var/run/secrets/helm-policy/token` and is
+  re-read before every request so kubelet rotation takes effect.
+- `HELM_POLICY_BEARER_TOKEN`: required when auth mode is `bearerToken`.
 - `HELM_POLICY_SIGNATURE_REQUIRED`: when true, unsigned bundles fail closed.
 - `HELM_POLICY_TRUST_PUBLIC_KEY`: hex Ed25519 public key used when signatures are required.
 - `HELM_POLICY_ON_INVALID_UPDATE`: `keepLastKnownGood` (default) or `deny`.

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -618,11 +618,42 @@ assert_contains "$controlplane_rendered" "HELM_POLICY_SOURCE_KIND"
 assert_contains "$controlplane_rendered" "controlplane"
 assert_contains "$controlplane_rendered" "HELM_POLICY_CONTROLPLANE_URL"
 assert_contains "$controlplane_rendered" "https://helm-controlplane.example.internal"
+assert_contains "$controlplane_rendered" "HELM_POLICY_CONTROLPLANE_AUTH_MODE"
+assert_contains "$controlplane_rendered" "serviceAccountJWT"
+assert_contains "$controlplane_rendered" "HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE"
+assert_contains "$controlplane_rendered" "/var/run/secrets/helm-policy/token"
+assert_contains "$controlplane_rendered" "name: policy-service-account-token"
+assert_contains "$controlplane_rendered" "audience: \"helm-control-plane\""
+assert_contains "$controlplane_rendered" "expirationSeconds: 600"
+assert_contains "$controlplane_rendered" "automountServiceAccountToken: false"
+assert_not_contains "$controlplane_rendered" "HELM_POLICY_BEARER_TOKEN"
 assert_contains "$controlplane_rendered" "HELM_POLICY_SIGNATURE_REQUIRED"
 assert_contains "$controlplane_rendered" "HELM_POLICY_TRUST_PUBLIC_KEY"
 assert_not_contains "$controlplane_rendered" "configmap-reload"
 assert_not_contains "$controlplane_rendered" "kind: CustomResourceDefinition"
 assert_not_contains "$controlplane_rendered" "policy-reader"
+
+controlplane_bearer_rendered="$RENDER_DIR/rendered-controlplane-bearer.yaml"
+production_helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.production=true \
+    --set helm.signing.key="$SIGNING_KEY" \
+    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set helm.policy.source.kind=controlplane \
+    --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.source.controlplane.auth.mode=bearerToken \
+    --set helm.policy.source.controlplane.auth.existingSecret=policy-reader \
+    --set helm.policy.signature.required=true \
+    --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" \
+    --set image.repository=ghcr.io/mindburn-labs/helm-ai-kernel \
+    --set image.tag=local \
+    --set image.pullPolicy=IfNotPresent >"$controlplane_bearer_rendered"
+
+assert_contains "$controlplane_bearer_rendered" "HELM_POLICY_BEARER_TOKEN"
+assert_contains "$controlplane_bearer_rendered" "name: policy-reader"
+assert_not_contains "$controlplane_bearer_rendered" "policy-service-account-token"
+assert_not_contains "$controlplane_bearer_rendered" "HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE"
 
 crd_rendered="$RENDER_DIR/rendered-crd.yaml"
 production_helm_runner template "$RELEASE" "$CHART" \


### PR DESCRIPTION
## Summary

- fail closed when a Control Plane policy source has no explicit authentication
- support a rotating audience-bound projected Kubernetes ServiceAccount JWT and reload it before every policy request
- keep static bearer authentication as an explicit Secret-backed compatibility path
- render only the dedicated token projection while general ServiceAccount token automount remains disabled
- validate mutually exclusive credentials, token shape, audience, and bounded token lifetime

## Validation

- go test ./core/cmd/helm-ai-kernel ./core/pkg/policy/reconcile -count=1
- bash scripts/ci/helm_chart_smoke.sh
- python scripts/ci/check_helm_smoke_hardening.py
- CONTRACT_BASE_SHA=origin/main make quality-pr

## Production boundary

This PR does not deploy or publish a Kernel release and does not establish GDPR compliance by itself. The Control Plane must still provide authenticated Kubernetes TokenReview verification with tenant/workspace binding, signed immutable policy head/bundle endpoints, and a trusted TLS path before production activation.