### PR TITLE
HELM-658: bind OpenClaw smoke to OpenRouter

### DIFF
--- a/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
+++ b/deploy/helm-chart/templates/launchpad-apps/openclaw-deployment.yaml
@@ -57,19 +57,23 @@ spec:
               drop:
                 - ALL
           command:
-            - openclaw
-            - gateway
-            - run
-            - --port
-            - {{ $cfg.gatewayPort | quote }}
-            - --allow-unconfigured
-            - --auth
-            - none
-            - --bind
-            - loopback
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              openclaw models set "$OPENCLAW_MODEL"
+              exec openclaw gateway run \
+                --port "$OPENCLAW_GATEWAY_PORT" \
+                --allow-unconfigured \
+                --auth none \
+                --bind loopback
           env:
             - name: HOME
               value: /opt/openclaw/.openclaw
+            - name: OPENCLAW_MODEL
+              value: {{ required "launchpadApps.openclaw.model is required" $cfg.model | quote }}
+            - name: OPENCLAW_GATEWAY_PORT
+              value: {{ $cfg.gatewayPort | quote }}
             # No HTTP_PROXY/HTTPS_PROXY: egress is enforced transparently by the
             # egress-init iptables REDIRECT, not by the workload honoring proxy env.
             # HELM_EGRESS_TRANSPARENT tells helm-launchpad-openrouter-check that
@@ -78,22 +82,6 @@ spec:
             - name: HELM_EGRESS_TRANSPARENT
               value: "1"
             - name: OPENROUTER_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.openrouter.apiKeySecretRef.name | quote }}
-                  key: {{ .Values.openrouter.apiKeySecretRef.key | quote }}
-            # Route openclaw's OpenAI-compatible agent calls through OpenRouter —
-            # the only host the egress allowlist permits. openclaw's built-in agent
-            # model defaults to the `openai/*` provider, which dials api.openai.com
-            # directly; under the transparent-egress REDIRECT that connection is
-            # dropped ("stream disconnected before completion"), so the embedded
-            # agent fails. OpenRouter is OpenAI-API-compatible, so pointing
-            # OPENAI_BASE_URL at it (authenticated with the same OpenRouter key)
-            # makes those calls leave through the allowed host. Mirrors hermes,
-            # which already runs `--provider openrouter`.
-            - name: OPENAI_BASE_URL
-              value: "https://openrouter.ai/api/v1"
-            - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.openrouter.apiKeySecretRef.name | quote }}

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -1188,6 +1188,12 @@
           "maximum": 65535,
           "description": "TCP port the workload's gateway binds inside the container. With `--bind loopback` this is reachable only via `kubectl exec`, never via a Service."
         },
+        "model": {
+          "type": "string",
+          "pattern": "^openrouter/.+",
+          "default": "openrouter/auto",
+          "description": "OpenClaw provider/model reference. The provider must remain openrouter because the chart projects only an OpenRouter credential and allows only the OpenRouter egress origin."
+        },
         "tmpfsSize": {
           "type": "string",
           "description": "Size limit for the tmpfs-backed emptyDir mounted at /tmp."

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -1191,7 +1191,7 @@
         "model": {
           "type": "string",
           "pattern": "^openrouter/.+",
-          "default": "openrouter/auto",
+          "default": "openrouter/openai/gpt-4o-mini",
           "description": "OpenClaw provider/model reference. The provider must remain openrouter because the chart projects only an OpenRouter credential and allows only the OpenRouter egress origin."
         },
         "tmpfsSize": {

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -444,7 +444,7 @@ launchpadApps:
     gatewayPort: 18789
     # OpenClaw routes by provider/model prefix. Keep the provider explicit so
     # the workload uses the OpenRouter credential and allowed egress origin.
-    model: "openrouter/auto"
+    model: "openrouter/openai/gpt-4o-mini"
     tmpfsSize: "256Mi"
     appStateSize: "1Gi"
     # Resources sized for the ~6.36 GiB OCI image plus 8-plugin warm-up. Trim

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -442,6 +442,9 @@ launchpadApps:
       digest: "sha256:3c8c7069b9b8e69f584adc7de34b42a3f2b2721a19c069af342e1cbd7cf6d9af"
       pullPolicy: "IfNotPresent"
     gatewayPort: 18789
+    # OpenClaw routes by provider/model prefix. Keep the provider explicit so
+    # the workload uses the OpenRouter credential and allowed egress origin.
+    model: "openrouter/auto"
     tmpfsSize: "256Mi"
     appStateSize: "1Gi"
     # Resources sized for the ~6.36 GiB OCI image plus 8-plugin warm-up. Trim

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -320,8 +320,7 @@ assert_contains "$emergency_stop_missing_authority_log" "helm.emergencyStop.comm
 openclaw_rendered="$RENDER_DIR/rendered-openclaw.yaml"
 helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
-    --set launchpadApps.openclaw.enabled=true \
-    --set-string launchpadApps.openclaw.model=openrouter/openai/gpt-4o-mini >"$openclaw_rendered"
+    --set launchpadApps.openclaw.enabled=true >"$openclaw_rendered"
 assert_contains "$openclaw_rendered" 'openclaw models set "$OPENCLAW_MODEL"'
 assert_contains "$openclaw_rendered" 'value: "openrouter/openai/gpt-4o-mini"'
 assert_contains "$openclaw_rendered" "OPENROUTER_API_KEY"

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -317,6 +317,27 @@ if helm_runner template "$RELEASE" "$CHART" \
 fi
 assert_contains "$emergency_stop_missing_authority_log" "helm.emergencyStop.commandPublicKeys"
 
+openclaw_rendered="$RENDER_DIR/rendered-openclaw.yaml"
+helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set launchpadApps.openclaw.enabled=true \
+    --set-string launchpadApps.openclaw.model=openrouter/openai/gpt-4o-mini >"$openclaw_rendered"
+assert_contains "$openclaw_rendered" 'openclaw models set "$OPENCLAW_MODEL"'
+assert_contains "$openclaw_rendered" 'value: "openrouter/openai/gpt-4o-mini"'
+assert_contains "$openclaw_rendered" "OPENROUTER_API_KEY"
+assert_not_contains "$openclaw_rendered" "OPENAI_API_KEY"
+assert_not_contains "$openclaw_rendered" "OPENAI_BASE_URL"
+
+openclaw_provider_fail_log="$RENDER_DIR/openclaw-invalid-provider.log"
+if helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set launchpadApps.openclaw.enabled=true \
+    --set-string launchpadApps.openclaw.model=openai/gpt-5.5 >"$RENDER_DIR/openclaw-invalid-provider.yaml" 2>"$openclaw_provider_fail_log"; then
+    echo "::error::OpenClaw render with a provider outside the OpenRouter egress boundary unexpectedly succeeded"
+    exit 1
+fi
+assert_contains "$openclaw_provider_fail_log" "launchpadApps.openclaw.model"
+
 hermes_job_rendered="$RENDER_DIR/rendered-hermes-job.yaml"
 helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \


### PR DESCRIPTION
## Summary
- select OpenRouter through OpenClaw's provider/model contract before gateway startup
- remove the ineffective OpenAI base-URL/key projection
- constrain chart values to `openrouter/*` and add positive/negative render coverage

## Root cause
Exact-head run https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/33271066206 proved the OpenRouter key itself was valid, then OpenClaw selected its baked `openai/gpt-5.5` default and dialed `api.openai.com`. OpenClaw routes by provider prefix; `OPENAI_BASE_URL` did not change that provider selection.

## Validation
- `/bin/bash -n scripts/ci/helm_chart_smoke.sh`
- `/usr/bin/jq empty deploy/helm-chart/values.schema.json`
- `/usr/bin/python3 scripts/ci/check_helm_smoke_hardening.py`
- `/bin/bash scripts/ci/helm_chart_smoke.sh`
