### PR TITLE
HELM-191: bind policy signatures to publication heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@ scaffolds, and hardware-backed enforcement language out of the public changelog
 until a tagged release ships source-owned tests, verifier evidence, and release
 artifacts for that exact capability.
 
+### Changed — policy-head signature source contract
+
+The unreleased `policy/reconcile.SignatureVerifier` source contract now verifies
+the complete versioned unsigned policy head through `VerifyPolicyHead`. Existing
+bundle-only signatures and `VerifyPolicyBundle` implementations must migrate
+before adopting this source revision. This entry does not claim a tagged release
+or production deployment.
+
 ## [0.8.5] - 2026-08-23
 
 Source-prepared v0.8.5 notes for the current Kernel tree. These entries do not

--- a/core/pkg/policy/reconcile/reconcile.go
+++ b/core/pkg/policy/reconcile/reconcile.go
@@ -55,6 +55,9 @@ var (
 	ErrPolicyNotReady          = errors.New("policy not ready")
 	ErrPolicyHashMismatch      = errors.New("policy hash mismatch")
 	ErrPolicySignatureInvalid  = errors.New("policy signature invalid")
+	ErrPolicyScopeMismatch     = errors.New("policy scope mismatch")
+	ErrPolicyEpochRollback     = errors.New("policy epoch rollback")
+	ErrPolicyEpochEquivocation = errors.New("policy epoch equivocation")
 	ErrEmergencyCapsuleInvalid = errors.New("emergency capsule invalid")
 )
 
@@ -118,6 +121,7 @@ type EffectivePolicySnapshot struct {
 	WorkspaceID          string           `json:"workspace_id"`
 	PolicyEpoch          uint64           `json:"policy_epoch"`
 	PolicyHash           string           `json:"policy_hash"`
+	PolicyHeadHash       string           `json:"policy_head_hash,omitempty"`
 	P0CeilingsHash       string           `json:"p0_ceilings_hash,omitempty"`
 	P1BundleHash         string           `json:"p1_bundle_hash,omitempty"`
 	P2OverlayHashes      []string         `json:"p2_overlay_hashes,omitempty"`
@@ -151,9 +155,9 @@ type PolicySnapshotStore interface {
 // SnapshotCompiler turns verified policy bytes into an effective snapshot.
 type SnapshotCompiler func(ctx context.Context, head PolicyHead, bundle []byte) (*EffectivePolicySnapshot, error)
 
-// SignatureVerifier verifies optional policy signatures/provenance.
+// SignatureVerifier verifies the complete unsigned policy head.
 type SignatureVerifier interface {
-	VerifyPolicyBundle(ctx context.Context, head PolicyHead, bundle []byte) error
+	VerifyPolicyHead(ctx context.Context, head PolicyHead) error
 }
 
 // EmergencyCapsuleVerifier verifies hardware-quorum emergency capsules before
@@ -162,8 +166,8 @@ type EmergencyCapsuleVerifier interface {
 	VerifyEmergencyCapsule(ctx context.Context, head PolicyHead, capsule contracts.EmergencyCapsule) error
 }
 
-// Ed25519PolicyVerifier verifies policy bundles against an operator-provided
-// Ed25519 public key. Signatures are computed over exact canonical bundle bytes.
+// Ed25519PolicyVerifier verifies complete policy heads against an
+// operator-provided Ed25519 public key. PolicyHash binds the exact bundle bytes.
 type Ed25519PolicyVerifier struct {
 	PublicKeyHex string
 }
@@ -172,7 +176,7 @@ func NewEd25519PolicyVerifier(publicKeyHex string) *Ed25519PolicyVerifier {
 	return &Ed25519PolicyVerifier{PublicKeyHex: strings.TrimSpace(publicKeyHex)}
 }
 
-func (v *Ed25519PolicyVerifier) VerifyPolicyBundle(ctx context.Context, head PolicyHead, bundle []byte) error {
+func (v *Ed25519PolicyVerifier) VerifyPolicyHead(ctx context.Context, head PolicyHead) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -184,7 +188,10 @@ func (v *Ed25519PolicyVerifier) VerifyPolicyBundle(ctx context.Context, head Pol
 	if signature == "" {
 		return fmt.Errorf("%w: policy head has empty signature", ErrPolicySignatureInvalid)
 	}
-	material := PolicySignatureMaterial(head, bundle)
+	material, err := PolicyHeadSignatureMaterial(head)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrPolicySignatureInvalid, err)
+	}
 	ok, err := helmcrypto.Verify(publicKey, signature, material)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrPolicySignatureInvalid, err)
@@ -309,15 +316,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, scope PolicyScope) (Reconcil
 		status.Reason = err.Error()
 		return r.invalid(status, err)
 	}
-	head.Scope = head.Scope.Normalize()
-	if head.Scope.Key() != scope.Key() {
-		head.Scope = scope
-	}
 	status.DesiredPolicyHash = head.PolicyHash
 	status.DesiredPolicyEpoch = head.PolicyEpoch
 	status.BundleRef = head.BundleRef
 	status.SourceRefs = append([]string(nil), head.SourceRefs...)
 	status.AuditEvent = "policy_reconcile"
+	if head.Scope != scope {
+		err := fmt.Errorf("%w: requested %s got %s", ErrPolicyScopeMismatch, scope.Key(), head.Scope.Key())
+		status.Reason = err.Error()
+		return r.invalid(status, err)
+	}
+	headMaterial, err := PolicyHeadSignatureMaterial(head)
+	if err != nil {
+		status.Reason = err.Error()
+		return r.invalid(status, err)
+	}
+	desiredHeadHash := HashBytes(headMaterial)
+	if err := r.verifyPolicyHeadSignature(ctx, head); err != nil {
+		status.Reason = err.Error()
+		return r.invalid(status, err)
+	}
 
 	if installed, ok := r.store.Get(scope); ok {
 		status.PolicyHash = installed.PolicyHash
@@ -325,7 +343,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, scope PolicyScope) (Reconcil
 		status.InstalledPolicyHash = installed.PolicyHash
 		status.InstalledPolicyEpoch = installed.PolicyEpoch
 		status.SnapshotStatus = installed.Validation.Status
-		if installed.Validation.Status == StatusActive && installed.PolicyHash == head.PolicyHash && installed.PolicyEpoch == head.PolicyEpoch {
+		if head.PolicyEpoch < installed.PolicyEpoch {
+			err := fmt.Errorf("%w: installed epoch %d, desired epoch %d", ErrPolicyEpochRollback, installed.PolicyEpoch, head.PolicyEpoch)
+			status.Reason = err.Error()
+			return r.invalid(status, err)
+		}
+		if head.PolicyEpoch == installed.PolicyEpoch && installed.PolicyHash != head.PolicyHash {
+			err := fmt.Errorf("%w: epoch %d changed policy hash", ErrPolicyEpochEquivocation, head.PolicyEpoch)
+			status.Reason = err.Error()
+			return r.invalid(status, err)
+		}
+		if head.PolicyEpoch == installed.PolicyEpoch && installed.PolicyHeadHash != "" && installed.PolicyHeadHash != desiredHeadHash {
+			err := fmt.Errorf("%w: epoch %d changed signed head", ErrPolicyEpochEquivocation, head.PolicyEpoch)
+			status.Reason = err.Error()
+			return r.invalid(status, err)
+		}
+		if installed.Validation.Status == StatusActive && installed.PolicyHash == head.PolicyHash &&
+			installed.PolicyEpoch == head.PolicyEpoch && installed.PolicyHeadHash == desiredHeadHash {
 			refreshed := *installed
 			refreshed.LastVerifiedAt = r.now().UTC()
 			if err := r.store.Swap(scope, &refreshed); err != nil {
@@ -346,24 +380,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, scope PolicyScope) (Reconcil
 	if err := verifyExpectedPolicyHash(head, bundle); err != nil {
 		status.Reason = err.Error()
 		return r.invalid(status, err)
-	}
-	signature := strings.TrimSpace(head.Signature)
-	if signature == "" && r.requireSignature {
-		err := fmt.Errorf("%w: source head has empty signature", ErrPolicySignatureInvalid)
-		status.Reason = err.Error()
-		return r.invalid(status, err)
-	}
-	if signature != "" {
-		if r.verifier == nil {
-			err := fmt.Errorf("%w: no verifier configured for signed policy %s", ErrPolicySignatureInvalid, head.PolicyHash)
-			status.Reason = err.Error()
-			return r.invalid(status, err)
-		}
-		if err := r.verifier.VerifyPolicyBundle(ctx, head, bundle); err != nil {
-			err = fmt.Errorf("%w: %v", ErrPolicySignatureInvalid, err)
-			status.Reason = err.Error()
-			return r.invalid(status, err)
-		}
 	}
 	if head.EmergencyCapsule != nil {
 		if r.emergencyVerifier == nil {
@@ -391,6 +407,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, scope PolicyScope) (Reconcil
 		return r.invalid(status, err)
 	}
 	normalizeSnapshot(snapshot, head)
+	snapshot.PolicyHeadHash = desiredHeadHash
 	if err := validateSnapshot(snapshot); err != nil {
 		status.ReconcileStatus = StatusValidateError
 		status.Reason = err.Error()
@@ -411,6 +428,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, scope PolicyScope) (Reconcil
 	status.Updated = true
 	r.remember(status)
 	return status, nil
+}
+
+func (r *Reconciler) verifyPolicyHeadSignature(ctx context.Context, head PolicyHead) error {
+	signature := strings.TrimSpace(head.Signature)
+	if signature == "" && r.requireSignature {
+		return fmt.Errorf("%w: source head has empty signature", ErrPolicySignatureInvalid)
+	}
+	if signature == "" {
+		return nil
+	}
+	if r.verifier == nil {
+		return fmt.Errorf("%w: no verifier configured for signed policy %s", ErrPolicySignatureInvalid, head.PolicyHash)
+	}
+	if err := r.verifier.VerifyPolicyHead(ctx, head); err != nil {
+		return fmt.Errorf("%w: %v", ErrPolicySignatureInvalid, err)
+	}
+	return nil
 }
 
 func (r *Reconciler) Start(ctx context.Context, interval time.Duration) {
@@ -585,12 +619,26 @@ func PolicyHashWithSourceRefs(bundle []byte, sourceRefs []string) string {
 	return HashBytes(PolicyHashMaterial(bundle, sourceRefs))
 }
 
-func PolicySignatureMaterial(head PolicyHead, bundle []byte) []byte {
-	if strings.EqualFold(strings.TrimSpace(head.PolicyHash), PolicyHashWithSourceRefs(bundle, head.SourceRefs)) &&
-		!strings.EqualFold(strings.TrimSpace(head.PolicyHash), HashBytes(bundle)) {
-		return PolicyHashMaterial(bundle, head.SourceRefs)
+// PolicyHeadSignatureMaterial binds every policy-head field except Signature.
+// PolicyHash separately commits the exact bundle bytes.
+func PolicyHeadSignatureMaterial(head PolicyHead) ([]byte, error) {
+	unsigned := head
+	unsigned.Signature = ""
+	if unsigned.PolicyEpoch == 0 || strings.TrimSpace(unsigned.Scope.TenantID) == "" ||
+		strings.TrimSpace(unsigned.Scope.WorkspaceID) == "" || strings.TrimSpace(unsigned.PolicyHash) == "" {
+		return nil, fmt.Errorf("%w: policy head signature fields are incomplete", ErrPolicyNotReady)
 	}
-	return bundle
+	return json.Marshal(struct {
+		Version string     `json:"version"`
+		Head    PolicyHead `json:"head"`
+	}{Version: "helm-policy-publication-signature.v1", Head: unsigned})
+}
+
+// PolicySignatureMaterial is retained for source compatibility. Bundle is
+// ignored because PolicyHash already binds its exact bytes.
+func PolicySignatureMaterial(head PolicyHead, _ []byte) []byte {
+	material, _ := PolicyHeadSignatureMaterial(head)
+	return material
 }
 
 func PolicyHashMaterial(bundle []byte, sourceRefs []string) []byte {
@@ -704,10 +752,13 @@ func (s *MountedFileSource) Head(ctx context.Context, scope PolicyScope) (Policy
 		return PolicyHead{}, err
 	}
 	sourceRefs := []string{s.Path}
-	if ref, err := mountedReferencePackSourceRef(s.Path, data); err != nil {
+	if ref, refEpoch, err := mountedReferencePackSourceRef(s.Path, data); err != nil {
 		return PolicyHead{}, err
 	} else if ref != "" {
 		sourceRefs = append(sourceRefs, ref)
+		if refEpoch > epoch {
+			epoch = refEpoch
+		}
 	}
 	policyHash := HashBytes(data)
 	if len(digestSourceRefs(sourceRefs)) > 0 {
@@ -778,26 +829,34 @@ type mountedPolicyRef struct {
 	ReferencePack string `toml:"reference_pack"`
 }
 
-func mountedReferencePackSourceRef(policyPath string, policyBytes []byte) (string, error) {
+func mountedReferencePackSourceRef(policyPath string, policyBytes []byte) (string, uint64, error) {
 	if strings.ToLower(filepath.Ext(policyPath)) != ".toml" {
-		return "", nil
+		return "", 0, nil
 	}
 	var ref mountedPolicyRef
 	if _, err := toml.Decode(string(policyBytes), &ref); err != nil {
-		return "", fmt.Errorf("decode mounted policy reference_pack: %w", err)
+		return "", 0, fmt.Errorf("decode mounted policy reference_pack: %w", err)
 	}
 	if strings.TrimSpace(ref.ReferencePack) == "" {
-		return "", nil
+		return "", 0, nil
 	}
 	refPath, err := ResolveReferencePackPath(policyPath, ref.ReferencePack)
 	if err != nil {
-		return "", err
+		return "", 0, err
 	}
 	refData, err := os.ReadFile(refPath)
 	if err != nil {
-		return "", fmt.Errorf("read reference_pack %s: %w", ref.ReferencePack, err)
+		return "", 0, fmt.Errorf("read reference_pack %s: %w", ref.ReferencePack, err)
 	}
-	return fmt.Sprintf("reference_pack:%s@%s", refPath, HashBytes(refData)), nil
+	info, err := os.Stat(refPath)
+	if err != nil {
+		return "", 0, fmt.Errorf("stat reference_pack %s: %w", ref.ReferencePack, err)
+	}
+	epoch := uint64(info.ModTime().UnixNano())
+	if epoch == 0 {
+		epoch = 1
+	}
+	return fmt.Sprintf("reference_pack:%s@%s", refPath, HashBytes(refData)), epoch, nil
 }
 
 func ResolveReferencePackPath(policyPath, referencePack string) (string, error) {
@@ -886,9 +945,6 @@ func (s *ControlPlaneSource) Head(ctx context.Context, scope PolicyScope) (Polic
 	var head PolicyHead
 	if err := s.getJSON(ctx, endpoint, &head); err != nil {
 		return PolicyHead{}, err
-	}
-	if head.Scope.Key() == DefaultScope.Key() {
-		head.Scope = scope.Normalize()
 	}
 	return head, nil
 }

--- a/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
+++ b/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
@@ -149,8 +149,8 @@ func TestControlPlaneSourceErrorAndHeaderBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("controlplane head: %v", err)
 	}
-	if gotHead.Scope.Key() != scope.Key() || !sawBearer {
-		t.Fatalf("head scope/header not normalized: %+v bearer=%v", gotHead, sawBearer)
+	if gotHead.Scope != DefaultScope || !sawBearer {
+		t.Fatalf("head scope was rewritten or authorization missing: %+v bearer=%v", gotHead, sawBearer)
 	}
 	loaded, err := source.Load(context.Background(), scope, 9)
 	if err != nil || string(loaded) != string(bundle) {

--- a/core/pkg/policy/reconcile/reconcile_test.go
+++ b/core/pkg/policy/reconcile/reconcile_test.go
@@ -61,7 +61,7 @@ func (s *mutableSource) Load(context.Context, PolicyScope, uint64) ([]byte, erro
 
 type rejectingVerifier struct{}
 
-func (rejectingVerifier) VerifyPolicyBundle(context.Context, PolicyHead, []byte) error {
+func (rejectingVerifier) VerifyPolicyHead(context.Context, PolicyHead) error {
 	return errors.New("bad signature")
 }
 
@@ -95,6 +95,19 @@ func testCompiler(_ context.Context, head PolicyHead, _ []byte) (*EffectivePolic
 		Validation:  ValidationStatus{Status: StatusActive},
 		Graph:       prg.NewGraph(),
 	}, nil
+}
+
+func signPolicyHead(t *testing.T, signer helmcrypto.Signer, head PolicyHead) PolicyHead {
+	t.Helper()
+	material, err := PolicyHeadSignatureMaterial(head)
+	if err != nil {
+		t.Fatalf("policy head material: %v", err)
+	}
+	head.Signature, err = signer.Sign(material)
+	if err != nil {
+		t.Fatalf("sign policy head: %v", err)
+	}
+	return head
 }
 
 func assertInvalidSnapshot(t *testing.T, snapshot *EffectivePolicySnapshot) {
@@ -260,6 +273,73 @@ func TestReconcilerRejectsHashMismatch(t *testing.T) {
 	}
 }
 
+func TestReconcilerRejectsCrossScopeHead(t *testing.T) {
+	requested := PolicyScope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+	bundle := []byte("policy")
+	source := &mutableSource{
+		head: PolicyHead{
+			Scope:       PolicyScope{TenantID: "tenant-b", WorkspaceID: "workspace-b"},
+			PolicyEpoch: 1,
+			PolicyHash:  HashBytes(bundle),
+		},
+		bundle: bundle,
+	}
+	store := NewAtomicSnapshotStore()
+	reconciler, err := NewReconciler(ReconcilerConfig{Source: source, Store: store, Compiler: testCompiler})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := reconciler.Reconcile(context.Background(), requested)
+	if !errors.Is(err, ErrPolicyScopeMismatch) {
+		t.Fatalf("expected scope mismatch, got status=%+v err=%v", status, err)
+	}
+	if _, ok := store.Get(requested); ok {
+		t.Fatal("cross-scope head installed a snapshot")
+	}
+}
+
+func TestReconcilerRejectsEpochRollbackAndEquivocation(t *testing.T) {
+	scope := DefaultScope
+	bundle := []byte("policy-v2")
+	source := &mutableSource{
+		head:   PolicyHead{Scope: scope, PolicyEpoch: 2, PolicyHash: HashBytes(bundle), SourceRefs: []string{"publication:2"}},
+		bundle: bundle,
+	}
+	store := NewAtomicSnapshotStore()
+	reconciler, err := NewReconciler(ReconcilerConfig{Source: source, Store: store, Compiler: testCompiler, KeepLastKnownGood: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reconciler.Reconcile(context.Background(), scope); err != nil {
+		t.Fatalf("install epoch 2: %v", err)
+	}
+
+	source.head = PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(bundle), SourceRefs: []string{"publication:1"}}
+	status, err := reconciler.Reconcile(context.Background(), scope)
+	if !errors.Is(err, ErrPolicyEpochRollback) {
+		t.Fatalf("expected epoch rollback, got status=%+v err=%v", status, err)
+	}
+
+	equivocatedBundle := []byte("policy-v2-equivocated")
+	source.head = PolicyHead{Scope: scope, PolicyEpoch: 2, PolicyHash: HashBytes(equivocatedBundle), SourceRefs: []string{"publication:2"}}
+	source.bundle = equivocatedBundle
+	status, err = reconciler.Reconcile(context.Background(), scope)
+	if !errors.Is(err, ErrPolicyEpochEquivocation) {
+		t.Fatalf("expected epoch equivocation, got status=%+v err=%v", status, err)
+	}
+
+	source.head = PolicyHead{Scope: scope, PolicyEpoch: 2, PolicyHash: HashBytes(bundle), SourceRefs: []string{"publication:2-mutated"}}
+	source.bundle = bundle
+	status, err = reconciler.Reconcile(context.Background(), scope)
+	if !errors.Is(err, ErrPolicyEpochEquivocation) {
+		t.Fatalf("expected signed-head equivocation, got status=%+v err=%v", status, err)
+	}
+	current, ok := store.Get(scope)
+	if !ok || current.PolicyEpoch != 2 || current.PolicyHash != HashBytes(bundle) || current.Validation.Status != StatusActive {
+		t.Fatalf("replay attempts replaced the installed snapshot: %+v", current)
+	}
+}
+
 func TestReconcilerRejectsInvalidSignature(t *testing.T) {
 	scope := DefaultScope
 	bundle := []byte("signed-policy")
@@ -311,12 +391,9 @@ func TestReconcilerInstallsValidEd25519Signature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new signer: %v", err)
 	}
-	signature, err := signer.Sign(bundle)
-	if err != nil {
-		t.Fatalf("sign bundle: %v", err)
-	}
+	head := signPolicyHead(t, signer, PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(bundle)})
 	source := &mutableSource{
-		head:   PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(bundle), Signature: signature},
+		head:   head,
 		bundle: bundle,
 	}
 	store := NewAtomicSnapshotStore()
@@ -340,7 +417,7 @@ func TestReconcilerInstallsValidEd25519Signature(t *testing.T) {
 	}
 }
 
-func TestReconcilerRequiresCompositeSignatureForDigestBoundPolicy(t *testing.T) {
+func TestReconcilerRequiresHeadBoundSignatureForDigestBoundPolicy(t *testing.T) {
 	scope := DefaultScope
 	bundle := []byte("signed-policy-with-reference")
 	sourceRefs := []string{"policy.toml", "reference_pack:/policy/reference.json@sha256:" + strings.Repeat("a", 64)}
@@ -372,14 +449,10 @@ func TestReconcilerRequiresCompositeSignatureForDigestBoundPolicy(t *testing.T) 
 		t.Fatalf("bundle-only signature installed digest-bound policy: %+v", status)
 	}
 
-	compositeSignature, err := signer.Sign(PolicyHashMaterial(bundle, sourceRefs))
-	if err != nil {
-		t.Fatalf("sign composite material: %v", err)
-	}
-	source.head.Signature = compositeSignature
+	source.head = signPolicyHead(t, signer, source.head)
 	status, err := reconciler.Reconcile(context.Background(), scope)
 	if err != nil {
-		t.Fatalf("composite signature rejected: status=%+v err=%v", status, err)
+		t.Fatalf("head-bound signature rejected: status=%+v err=%v", status, err)
 	}
 	if !status.Updated || status.InstalledPolicyHash != policyHash {
 		t.Fatalf("digest-bound policy not installed: %+v", status)
@@ -394,12 +467,10 @@ func TestReconcilerRejectsTamperedEd25519Signature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new signer: %v", err)
 	}
-	signature, err := signer.Sign(signedBundle)
-	if err != nil {
-		t.Fatalf("sign bundle: %v", err)
-	}
+	head := signPolicyHead(t, signer, PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(signedBundle)})
+	head.PolicyHash = HashBytes(loadedBundle)
 	source := &mutableSource{
-		head:   PolicyHead{Scope: scope, PolicyEpoch: 1, PolicyHash: HashBytes(loadedBundle), Signature: signature},
+		head:   head,
 		bundle: loadedBundle,
 	}
 	store := NewAtomicSnapshotStore()

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -120,7 +120,7 @@ flowchart TD
 | `helm.policy.failClosed.onInvalidUpdate` | `keepLastKnownGood` | Retain only a snapshot with a fresh successful source verification after a fault, or `deny` to invalidate immediately. |
 | `helm.policy.failClosed.lastKnownGoodMaxAge` | `10m` | Positive maximum age since the last successful source verification after a source fault. |
 | `helm.policy.signature.required` | `false` | Rejects unsigned policy heads during reconciliation when enabled. |
-| `helm.policy.signature.publicKey` | empty | 64-char hex Ed25519 public key for canonical policy bundle signatures. |
+| `helm.policy.signature.publicKey` | empty | 64-char hex Ed25519 public key for versioned complete policy-head signatures. |
 | `helm.policy.signature.existingSecret` | empty | Existing secret containing `HELM_POLICY_TRUST_PUBLIC_KEY`. |
 | `helm.policy.runtimeActions` | `[]` | Explicit mounted-file rules compiled into the chart-managed reference pack; empty remains fail-closed. Prefer signed control-plane/CRD policy in production. |
 | `helm.policy.reloadHints.httpWakeEndpoint` | `/internal/policy/reconcile` | Wake-only internal endpoint for sidecars/operators. |
@@ -169,8 +169,10 @@ flowchart TD
   the optional `HelmPolicyBundle` CRD and RBAC only in CRD mode.
 - `mountedFile` mode is retained for OSS/local/bootstrap/demo use. ConfigMap
   or Secret bytes are delivery backends only and the sidecar, when enabled,
-  only calls `/internal/policy/reconcile`. Signed mounted-file bundles can
-  provide a companion `serve-policy.toml.sig` file in the same volume.
+  only calls `/internal/policy/reconcile`. Signed mounted-file policies can
+  provide a companion `serve-policy.toml.sig`; it must sign the versioned
+  unsigned-head envelope returned by `PolicyHeadSignatureMaterial`, whose
+  `policy_hash` commits the exact policy bytes.
 - Keep connector credentials in Kubernetes Secrets or an external secret
   manager. Policy bundles should reference credentials, not embed raw secrets.
 - Set `helm.githubEffects.existingSecret` only when the release should register

--- a/docs/deployment/boundary-enforcement-profile.md
+++ b/docs/deployment/boundary-enforcement-profile.md
@@ -81,7 +81,8 @@ is **hash-bound** into the compile receipt (`policy_input_hash`).
 Signed-input status, stated precisely: no canonical *signed policy-bundle
 record contract* exists yet as a compiler input in this repository — existing
 bundle types are content-hash-verified, and `policy/reconcile`'s
-`Ed25519PolicyVerifier` verifies reconciler bundle signatures. When a signed
+`Ed25519PolicyVerifier` verifies versioned complete policy-head signatures
+whose `policy_hash` commits the exact bundle bytes. When a signed
 input envelope lands, its verification slots in ahead of `Compile`, binding
 to that verifier pattern, without changing the receipt format.
 

--- a/docs/design/sealed-boundary-appliance-profile.md
+++ b/docs/design/sealed-boundary-appliance-profile.md
@@ -136,8 +136,9 @@ integrity, not authenticity).
 3. Signed-input wording corrected: no canonical **signed policy-bundle record
    contract usable as compiler input** exists; existing bundles are
    content-hash-verified, and `policy/reconcile.Ed25519PolicyVerifier`
-   verifies reconciler bundle signatures — the future signed-input slot binds
-   to that pattern. The Slice A input is hash-bound (`policy_input_hash`).
+   verifies versioned complete policy-head signatures whose `policy_hash`
+   commits exact bundle bytes — the future signed-input slot binds to that
+   pattern. The Slice A input is hash-bound (`policy_input_hash`).
 4. No repo-wide mode-ladder enum exists; tiers (`observe|enforce`) validate
    locally to the package.
 5. Compile-time DNS resolution dropped: domains stay L7 gateway scope, with a


### PR DESCRIPTION
## Summary

- fail closed when a fetched policy head does not exactly match the requested tenant/workspace scope
- bind Ed25519 verification to the complete versioned unsigned policy head while `policy_hash` commits the exact bundle bytes
- reject epoch rollback and same-epoch equivocation without replacing the last known-good snapshot
- advance mounted-file epochs when a hash-bound reference pack changes
- document the breaking source migration from `VerifyPolicyBundle` to `VerifyPolicyHead` without claiming a release or production deployment

## Validation

```bash
env -u GOROOT PATH=/Users/ivan/.local/share/mise/installs/go/1.25.13/bin:$PATH GOWORK=off CONTRACT_BASE_SHA=origin/main make quality-pr
```

All applicable blocking gates passed twice, including docs truth, presentation/tracked-file hygiene, vet/gofmt, module tidiness, build, package tests, command tests, TCB isolation, quality self-test, and crypto inventory.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes.
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md` (not applicable; no Launchpad runtime change).
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path (not applicable).
- [x] Release version surfaces are lockstep when relevant (not applicable; no release/version surface changed).
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`.
- [x] Advisory quality warnings are acknowledged or tracked when relevant (none emitted).

This is source and test evidence only. It does not claim tagged release, deployment, production readback, or GDPR closure.