### PR TITLE
HELM-191: persist policy replay watermarks across Kernel restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@ Production policy reconciliation now persists private, atomic per-scope epoch
 and policy-head commitments before activating a snapshot, so restart does not
 erase rollback and equivocation detection. The chart requires a persistent data
 volume and one Kernel writer in production until this watermark uses a
-distributed transactional store. This entry does not claim a tagged release or
+distributed transactional store. Production rollouts use `Recreate` to avoid
+overlapping old and new writers. This entry does not claim a tagged release or
 production deployment.
 
 ## [0.8.5] - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,12 @@ and policy-head commitments before activating a snapshot, so restart does not
 erase rollback and equivocation detection. The chart requires a persistent data
 volume and one Kernel writer in production until this watermark uses a
 distributed transactional store. Production rollouts use `Recreate` to avoid
-overlapping old and new writers. This entry does not claim a tagged release or
-production deployment.
+overlapping old and new writers, restores the watermark's private mode after
+Kubernetes `fsGroup` processing, and retains the higher in-process replay floor
+when a post-rename directory sync cannot confirm durability. The shipped
+production runtime rejects `mountedFile`, whose filesystem timestamp is not a
+source-owned monotonic publication epoch. This entry does not claim a tagged
+release or production deployment.
 
 ## [0.8.5] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,15 @@ bundle-only signatures and `VerifyPolicyBundle` implementations must migrate
 before adopting this source revision. This entry does not claim a tagged release
 or production deployment.
 
+### Changed — production policy replay persistence
+
+Production policy reconciliation now persists private, atomic per-scope epoch
+and policy-head commitments before activating a snapshot, so restart does not
+erase rollback and equivocation detection. The chart requires a persistent data
+volume and one Kernel writer in production until this watermark uses a
+distributed transactional store. This entry does not claim a tagged release or
+production deployment.
+
 ## [0.8.5] - 2026-08-23
 
 Source-prepared v0.8.5 notes for the current Kernel tree. These entries do not

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -521,7 +521,14 @@ func runServerWithOptions(opts serverOptions) error {
 		if lkgConfigErr != nil {
 			return fmt.Errorf("configure last-known-good policy retention: %w", lkgConfigErr)
 		}
-		policyStore = policyreconcile.NewAtomicSnapshotStore()
+		if envBool("HELM_PRODUCTION") {
+			policyStore, err = policyreconcile.NewPersistentSnapshotStore(filepath.Join(dataDir, "policy-replay-watermarks.json"))
+			if err != nil {
+				return fmt.Errorf("open policy replay watermark store: %w", err)
+			}
+		} else {
+			policyStore = policyreconcile.NewAtomicSnapshotStore()
+		}
 		policyReconciler, err = policyreconcile.NewReconciler(policyreconcile.ReconcilerConfig{
 			Source:              policySource,
 			Store:               policyStore,

--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -1076,6 +1076,9 @@ func policySourceFromEnv(policyPath string, scope policyreconcile.PolicyScope) (
 	}
 	switch strings.ToLower(kind) {
 	case "mountedfile", "mounted-file", "mounted_file":
+		if envBool("HELM_PRODUCTION") {
+			return nil, "mountedFile", fmt.Errorf("HELM_PRODUCTION=1 rejects mountedFile policy sources because filesystem timestamps are not source-owned monotonic publication epochs; use controlplane")
+		}
 		return policyreconcile.NewMountedFileSource(policyPath, scope), "mountedFile", nil
 	case "controlplane", "control-plane", "control_plane":
 		baseURL := strings.TrimSpace(os.Getenv("HELM_POLICY_CONTROLPLANE_URL"))

--- a/core/cmd/helm-ai-kernel/policy_source_test.go
+++ b/core/cmd/helm-ai-kernel/policy_source_test.go
@@ -25,6 +25,15 @@ func TestPolicySourceFromEnvDefaultsToMountedFile(t *testing.T) {
 	}
 }
 
+func TestPolicySourceFromEnvRejectsMountedFileInProduction(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "true")
+	t.Setenv("HELM_POLICY_SOURCE_KIND", "mountedFile")
+	_, kind, err := policySourceFromEnv("/tmp/policy.toml", policyreconcile.DefaultScope)
+	if kind != "mountedFile" || err == nil || !strings.Contains(err.Error(), "source-owned monotonic publication epochs") {
+		t.Fatalf("expected production mountedFile rejection, got kind=%s err=%v", kind, err)
+	}
+}
+
 func TestPolicySourceFromEnvControlPlaneRequiresURL(t *testing.T) {
 	t.Setenv("HELM_POLICY_SOURCE_KIND", "controlplane")
 	t.Setenv("HELM_POLICY_CONTROLPLANE_URL", "")

--- a/core/pkg/policy/reconcile/persistent_store.go
+++ b/core/pkg/policy/reconcile/persistent_store.go
@@ -43,10 +43,12 @@ type policyReplayWatermark struct {
 // ponytail: file serialization is process-local; move this state to a
 // transactional shared store before running multiple Kernel writers.
 type PersistentSnapshotStore struct {
-	mu         sync.Mutex
-	path       string
-	memory     *AtomicSnapshotStore
-	watermarks map[string]policyReplayWatermark
+	mu                    sync.Mutex
+	path                  string
+	memory                *AtomicSnapshotStore
+	watermarks            map[string]policyReplayWatermark
+	writeWatermarks       func(string, map[string]policyReplayWatermark) (bool, error)
+	durabilityUnconfirmed bool
 }
 
 func NewPersistentSnapshotStore(path string) (*PersistentSnapshotStore, error) {
@@ -59,9 +61,10 @@ func NewPersistentSnapshotStore(path string) (*PersistentSnapshotStore, error) {
 		return nil, err
 	}
 	store := &PersistentSnapshotStore{
-		path:       path,
-		memory:     NewAtomicSnapshotStore(),
-		watermarks: watermarks,
+		path:            path,
+		memory:          NewAtomicSnapshotStore(),
+		watermarks:      watermarks,
+		writeWatermarks: writePolicyReplayWatermarks,
 	}
 	for _, watermark := range watermarks {
 		if err := store.memory.Swap(watermark.scope(), watermark.snapshot()); err != nil {
@@ -92,16 +95,30 @@ func (s *PersistentSnapshotStore) Swap(scope PolicyScope, snapshot *EffectivePol
 		(watermark.PolicyHash != existing.PolicyHash || watermark.PolicyHeadHash != existing.PolicyHeadHash) {
 		return fmt.Errorf("%w: epoch %d changed persisted policy head", ErrPolicyEpochEquivocation, watermark.PolicyEpoch)
 	}
-	if !ok || watermark != existing {
+	if !ok || watermark != existing || s.durabilityUnconfirmed {
 		next := make(map[string]policyReplayWatermark, len(s.watermarks)+1)
 		for storedKey, stored := range s.watermarks {
 			next[storedKey] = stored
 		}
 		next[key] = watermark
-		if err := writePolicyReplayWatermarks(s.path, next); err != nil {
+		committed, err := s.writeWatermarks(s.path, next)
+		if committed {
+			// Rename already made the higher floor visible. Retain it even when
+			// the following directory sync fails so this process cannot write a
+			// lower epoch while durability is retried.
+			s.watermarks = next
+		}
+		if err != nil {
+			if committed {
+				s.durabilityUnconfirmed = true
+			}
 			return fmt.Errorf("persist policy replay watermark: %w", err)
 		}
+		if !committed {
+			return errors.New("persist policy replay watermark: writer returned without committing state")
+		}
 		s.watermarks = next
+		s.durabilityUnconfirmed = false
 	}
 	return s.memory.Swap(scope, snapshot)
 }
@@ -182,9 +199,11 @@ func loadPolicyReplayWatermarks(path string) (map[string]policyReplayWatermark, 
 	return watermarks, nil
 }
 
-func writePolicyReplayWatermarks(path string, watermarks map[string]policyReplayWatermark) error {
+// writePolicyReplayWatermarks reports committed=true once rename makes the new
+// state visible, even if the following directory sync cannot confirm durability.
+func writePolicyReplayWatermarks(path string, watermarks map[string]policyReplayWatermark) (committed bool, err error) {
 	if len(watermarks) > maxPolicyReplayWatermarks {
-		return fmt.Errorf("%w: watermark count exceeds %d", ErrPolicyReplayStateInvalid, maxPolicyReplayWatermarks)
+		return false, fmt.Errorf("%w: watermark count exceeds %d", ErrPolicyReplayStateInvalid, maxPolicyReplayWatermarks)
 	}
 	state := policyReplayWatermarkState{Version: policyReplayWatermarkVersion}
 	state.Watermarks = make([]policyReplayWatermark, 0, len(watermarks))
@@ -196,25 +215,25 @@ func writePolicyReplayWatermarks(path string, watermarks map[string]policyReplay
 	})
 	data, err := json.Marshal(state)
 	if err != nil {
-		return err
+		return false, err
 	}
 	data = append(data, '\n')
 	if len(data) > maxPolicyReplayWatermarkBytes {
-		return fmt.Errorf("%w: watermark state exceeds %d bytes", ErrPolicyReplayStateInvalid, maxPolicyReplayWatermarkBytes)
+		return false, fmt.Errorf("%w: watermark state exceeds %d bytes", ErrPolicyReplayStateInvalid, maxPolicyReplayWatermarkBytes)
 	}
 
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
+		return false, err
 	}
 	if info, err := os.Lstat(path); err == nil && !info.Mode().IsRegular() {
-		return fmt.Errorf("%w: watermark target must be a regular file", ErrPolicyReplayStateInvalid)
+		return false, fmt.Errorf("%w: watermark target must be a regular file", ErrPolicyReplayStateInvalid)
 	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
+		return false, err
 	}
 	temporary, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*")
 	if err != nil {
-		return err
+		return false, err
 	}
 	temporaryPath := temporary.Name()
 	removeTemporary := true
@@ -225,27 +244,30 @@ func writePolicyReplayWatermarks(path string, watermarks map[string]policyReplay
 		}
 	}()
 	if err := temporary.Chmod(0o600); err != nil {
-		return err
+		return false, err
 	}
 	if _, err := temporary.Write(data); err != nil {
-		return err
+		return false, err
 	}
 	if err := temporary.Sync(); err != nil {
-		return err
+		return false, err
 	}
 	if err := temporary.Close(); err != nil {
-		return err
+		return false, err
 	}
 	if err := os.Rename(temporaryPath, path); err != nil {
-		return err
+		return false, err
 	}
 	removeTemporary = false
 	directory, err := os.Open(dir)
 	if err != nil {
-		return err
+		return true, err
 	}
 	defer func() { _ = directory.Close() }()
-	return directory.Sync()
+	if err := directory.Sync(); err != nil {
+		return true, err
+	}
+	return true, nil
 }
 
 func validatePolicyReplayWatermark(watermark policyReplayWatermark) error {

--- a/core/pkg/policy/reconcile/persistent_store.go
+++ b/core/pkg/policy/reconcile/persistent_store.go
@@ -1,0 +1,290 @@
+package reconcile
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	policyReplayWatermarkVersion   = 1
+	maxPolicyReplayWatermarkBytes  = 1 << 20
+	maxPolicyReplayWatermarks      = 10_000
+	persistedReplayWatermarkReason = "persisted replay watermark requires policy source revalidation"
+)
+
+var ErrPolicyReplayStateInvalid = errors.New("policy replay state invalid")
+
+type policyReplayWatermarkState struct {
+	Version    int                     `json:"version"`
+	Watermarks []policyReplayWatermark `json:"watermarks"`
+}
+
+type policyReplayWatermark struct {
+	TenantID       string `json:"tenant_id"`
+	WorkspaceID    string `json:"workspace_id"`
+	PolicyEpoch    uint64 `json:"policy_epoch"`
+	PolicyHash     string `json:"policy_hash"`
+	PolicyHeadHash string `json:"policy_head_hash"`
+}
+
+// PersistentSnapshotStore keeps active snapshots in memory and persists only
+// the minimum replay watermark needed to reject rollback after a restart.
+//
+// ponytail: file serialization is process-local; move this state to a
+// transactional shared store before running multiple Kernel writers.
+type PersistentSnapshotStore struct {
+	mu         sync.Mutex
+	path       string
+	memory     *AtomicSnapshotStore
+	watermarks map[string]policyReplayWatermark
+}
+
+func NewPersistentSnapshotStore(path string) (*PersistentSnapshotStore, error) {
+	if path == "" || path != strings.TrimSpace(path) {
+		return nil, fmt.Errorf("%w: watermark path is invalid", ErrPolicyReplayStateInvalid)
+	}
+	path = filepath.Clean(path)
+	watermarks, err := loadPolicyReplayWatermarks(path)
+	if err != nil {
+		return nil, err
+	}
+	store := &PersistentSnapshotStore{
+		path:       path,
+		memory:     NewAtomicSnapshotStore(),
+		watermarks: watermarks,
+	}
+	for _, watermark := range watermarks {
+		if err := store.memory.Swap(watermark.scope(), watermark.snapshot()); err != nil {
+			return nil, fmt.Errorf("%w: restore watermark: %v", ErrPolicyReplayStateInvalid, err)
+		}
+	}
+	return store, nil
+}
+
+func (s *PersistentSnapshotStore) Get(scope PolicyScope) (*EffectivePolicySnapshot, bool) {
+	return s.memory.Get(scope)
+}
+
+func (s *PersistentSnapshotStore) Swap(scope PolicyScope, snapshot *EffectivePolicySnapshot) error {
+	watermark, err := replayWatermarkFromSnapshot(scope, snapshot)
+	if err != nil {
+		return err
+	}
+	key := watermark.scope().Key()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	existing, ok := s.watermarks[key]
+	if ok && watermark.PolicyEpoch < existing.PolicyEpoch {
+		return fmt.Errorf("%w: persisted epoch %d, proposed epoch %d", ErrPolicyEpochRollback, existing.PolicyEpoch, watermark.PolicyEpoch)
+	}
+	if ok && watermark.PolicyEpoch == existing.PolicyEpoch &&
+		(watermark.PolicyHash != existing.PolicyHash || watermark.PolicyHeadHash != existing.PolicyHeadHash) {
+		return fmt.Errorf("%w: epoch %d changed persisted policy head", ErrPolicyEpochEquivocation, watermark.PolicyEpoch)
+	}
+	if !ok || watermark != existing {
+		next := make(map[string]policyReplayWatermark, len(s.watermarks)+1)
+		for storedKey, stored := range s.watermarks {
+			next[storedKey] = stored
+		}
+		next[key] = watermark
+		if err := writePolicyReplayWatermarks(s.path, next); err != nil {
+			return fmt.Errorf("persist policy replay watermark: %w", err)
+		}
+		s.watermarks = next
+	}
+	return s.memory.Swap(scope, snapshot)
+}
+
+func (s *PersistentSnapshotStore) Invalidate(scope PolicyScope, reason string) (*EffectivePolicySnapshot, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.memory.Invalidate(scope, reason)
+}
+
+func replayWatermarkFromSnapshot(scope PolicyScope, snapshot *EffectivePolicySnapshot) (policyReplayWatermark, error) {
+	if snapshot == nil {
+		return policyReplayWatermark{}, errors.New("nil policy snapshot")
+	}
+	scope = scope.Normalize()
+	if snapshot.Scope() != scope {
+		return policyReplayWatermark{}, fmt.Errorf("%w: store scope %s, snapshot scope %s", ErrPolicyScopeMismatch, scope.Key(), snapshot.Scope().Key())
+	}
+	watermark := policyReplayWatermark{
+		TenantID:       scope.TenantID,
+		WorkspaceID:    scope.WorkspaceID,
+		PolicyEpoch:    snapshot.PolicyEpoch,
+		PolicyHash:     snapshot.PolicyHash,
+		PolicyHeadHash: snapshot.PolicyHeadHash,
+	}
+	if err := validatePolicyReplayWatermark(watermark); err != nil {
+		return policyReplayWatermark{}, err
+	}
+	return watermark, nil
+}
+
+func loadPolicyReplayWatermarks(path string) (map[string]policyReplayWatermark, error) {
+	watermarks := make(map[string]policyReplayWatermark)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return watermarks, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load policy replay watermark: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("%w: watermark file must be a private regular file", ErrPolicyReplayStateInvalid)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("load policy replay watermark: %w", err)
+	}
+	defer func() { _ = file.Close() }()
+	data, err := io.ReadAll(io.LimitReader(file, maxPolicyReplayWatermarkBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("load policy replay watermark: %w", err)
+	}
+	if len(data) > maxPolicyReplayWatermarkBytes {
+		return nil, fmt.Errorf("%w: watermark file exceeds %d bytes", ErrPolicyReplayStateInvalid, maxPolicyReplayWatermarkBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var state policyReplayWatermarkState
+	if err := decoder.Decode(&state); err != nil {
+		return nil, fmt.Errorf("%w: decode watermark file: %v", ErrPolicyReplayStateInvalid, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%w: watermark file has trailing data", ErrPolicyReplayStateInvalid)
+	}
+	if state.Version != policyReplayWatermarkVersion || len(state.Watermarks) > maxPolicyReplayWatermarks {
+		return nil, fmt.Errorf("%w: unsupported watermark state", ErrPolicyReplayStateInvalid)
+	}
+	for _, watermark := range state.Watermarks {
+		if err := validatePolicyReplayWatermark(watermark); err != nil {
+			return nil, err
+		}
+		key := watermark.scope().Key()
+		if _, exists := watermarks[key]; exists {
+			return nil, fmt.Errorf("%w: duplicate scope %s", ErrPolicyReplayStateInvalid, key)
+		}
+		watermarks[key] = watermark
+	}
+	return watermarks, nil
+}
+
+func writePolicyReplayWatermarks(path string, watermarks map[string]policyReplayWatermark) error {
+	if len(watermarks) > maxPolicyReplayWatermarks {
+		return fmt.Errorf("%w: watermark count exceeds %d", ErrPolicyReplayStateInvalid, maxPolicyReplayWatermarks)
+	}
+	state := policyReplayWatermarkState{Version: policyReplayWatermarkVersion}
+	state.Watermarks = make([]policyReplayWatermark, 0, len(watermarks))
+	for _, watermark := range watermarks {
+		state.Watermarks = append(state.Watermarks, watermark)
+	}
+	sort.Slice(state.Watermarks, func(i, j int) bool {
+		return state.Watermarks[i].scope().Key() < state.Watermarks[j].scope().Key()
+	})
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if len(data) > maxPolicyReplayWatermarkBytes {
+		return fmt.Errorf("%w: watermark state exceeds %d bytes", ErrPolicyReplayStateInvalid, maxPolicyReplayWatermarkBytes)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil && !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: watermark target must be a regular file", ErrPolicyReplayStateInvalid)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	temporary, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0o600); err != nil {
+		return err
+	}
+	if _, err := temporary.Write(data); err != nil {
+		return err
+	}
+	if err := temporary.Sync(); err != nil {
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return err
+	}
+	removeTemporary = false
+	directory, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = directory.Close() }()
+	return directory.Sync()
+}
+
+func validatePolicyReplayWatermark(watermark policyReplayWatermark) error {
+	if watermark.TenantID == "" || watermark.TenantID != strings.TrimSpace(watermark.TenantID) ||
+		watermark.WorkspaceID == "" || watermark.WorkspaceID != strings.TrimSpace(watermark.WorkspaceID) ||
+		watermark.PolicyEpoch == 0 || !validPolicyReplayDigest(watermark.PolicyHash) ||
+		!validPolicyReplayDigest(watermark.PolicyHeadHash) {
+		return fmt.Errorf("%w: watermark fields are invalid", ErrPolicyReplayStateInvalid)
+	}
+	return nil
+}
+
+func validPolicyReplayDigest(value string) bool {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(value, prefix) || len(value) != len(prefix)+sha256.Size*2 {
+		return false
+	}
+	digest := strings.TrimPrefix(value, prefix)
+	if digest != strings.ToLower(digest) {
+		return false
+	}
+	_, err := hex.DecodeString(digest)
+	return err == nil
+}
+
+func (w policyReplayWatermark) scope() PolicyScope {
+	return PolicyScope{TenantID: w.TenantID, WorkspaceID: w.WorkspaceID}
+}
+
+func (w policyReplayWatermark) snapshot() *EffectivePolicySnapshot {
+	return &EffectivePolicySnapshot{
+		TenantID:       w.TenantID,
+		WorkspaceID:    w.WorkspaceID,
+		PolicyEpoch:    w.PolicyEpoch,
+		PolicyHash:     w.PolicyHash,
+		PolicyHeadHash: w.PolicyHeadHash,
+		Validation: ValidationStatus{
+			Status: StatusInvalid,
+			Reason: persistedReplayWatermarkReason,
+		},
+	}
+}

--- a/core/pkg/policy/reconcile/persistent_store_test.go
+++ b/core/pkg/policy/reconcile/persistent_store_test.go
@@ -131,6 +131,43 @@ func TestPersistentSnapshotStoreFailsClosedOnInvalidOrUnwritableState(t *testing
 		}
 	})
 
+	t.Run("post-rename failure retains replay floor", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "policy-replay-watermarks.json")
+		store, err := NewPersistentSnapshotStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		realWriter := store.writeWatermarks
+		firstWrite := true
+		store.writeWatermarks = func(path string, watermarks map[string]policyReplayWatermark) (bool, error) {
+			committed, err := realWriter(path, watermarks)
+			if err == nil && firstWrite {
+				firstWrite = false
+				return committed, errors.New("simulated directory sync failure")
+			}
+			return committed, err
+		}
+
+		scope := PolicyScope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+		epochTwo := replayTestSnapshot(scope, 2, "policy-v2", "head-v2")
+		if err := store.Swap(scope, epochTwo); err == nil {
+			t.Fatal("post-rename durability failure was accepted")
+		}
+		if _, ok := store.Get(scope); ok {
+			t.Fatal("unconfirmed watermark activated the policy snapshot")
+		}
+		if err := store.Swap(scope, replayTestSnapshot(scope, 1, "policy-v1", "head-v1")); !errors.Is(err, ErrPolicyEpochRollback) {
+			t.Fatalf("rollback after post-rename failure error=%v", err)
+		}
+		if err := store.Swap(scope, epochTwo); err != nil {
+			t.Fatalf("retry durability confirmation: %v", err)
+		}
+		active, ok := store.Get(scope)
+		if !ok || active.PolicyEpoch != 2 {
+			t.Fatalf("confirmed snapshot=%+v", active)
+		}
+	})
+
 	t.Run("oversized state", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "policy-replay-watermarks.json")
 		watermark := policyReplayWatermark{
@@ -140,7 +177,8 @@ func TestPersistentSnapshotStoreFailsClosedOnInvalidOrUnwritableState(t *testing
 			PolicyHash:     HashBytes([]byte("policy-v1")),
 			PolicyHeadHash: HashBytes([]byte("head-v1")),
 		}
-		if err := writePolicyReplayWatermarks(path, map[string]policyReplayWatermark{watermark.scope().Key(): watermark}); !errors.Is(err, ErrPolicyReplayStateInvalid) {
+		committed, err := writePolicyReplayWatermarks(path, map[string]policyReplayWatermark{watermark.scope().Key(): watermark})
+		if committed || !errors.Is(err, ErrPolicyReplayStateInvalid) {
 			t.Fatalf("oversized state error=%v", err)
 		}
 		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {

--- a/core/pkg/policy/reconcile/persistent_store_test.go
+++ b/core/pkg/policy/reconcile/persistent_store_test.go
@@ -1,0 +1,161 @@
+package reconcile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPersistentSnapshotStoreRejectsReplayAcrossRestart(t *testing.T) {
+	scope := PolicyScope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+	path := filepath.Join(t.TempDir(), "policy-replay-watermarks.json")
+	store, err := NewPersistentSnapshotStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle := []byte("policy-v2")
+	head := PolicyHead{Scope: scope, PolicyEpoch: 2, PolicyHash: HashBytes(bundle)}
+	headMaterial, err := PolicyHeadSignatureMaterial(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	epochTwo := replayTestSnapshot(scope, 2, "policy-v2", "head-v2")
+	epochTwo.PolicyHeadHash = HashBytes(headMaterial)
+	if err := store.Swap(scope, epochTwo); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("watermark mode=%v", info.Mode().Perm())
+	}
+
+	restarted, err := NewPersistentSnapshotStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, ok := restarted.Get(scope)
+	if !ok || persisted.PolicyEpoch != 2 || persisted.PolicyHash != epochTwo.PolicyHash ||
+		persisted.PolicyHeadHash != epochTwo.PolicyHeadHash || persisted.Validation.Status != StatusInvalid {
+		t.Fatalf("persisted watermark=%+v", persisted)
+	}
+	if err := restarted.Swap(scope, replayTestSnapshot(scope, 1, "policy-v1", "head-v1")); !errors.Is(err, ErrPolicyEpochRollback) {
+		t.Fatalf("rollback error=%v", err)
+	}
+	if err := restarted.Swap(scope, replayTestSnapshot(scope, 2, "policy-v2-mutated", "head-v2")); !errors.Is(err, ErrPolicyEpochEquivocation) {
+		t.Fatalf("policy equivocation error=%v", err)
+	}
+	if err := restarted.Swap(scope, replayTestSnapshot(scope, 2, "policy-v2", "head-v2-mutated")); !errors.Is(err, ErrPolicyEpochEquivocation) {
+		t.Fatalf("head equivocation error=%v", err)
+	}
+	reconciler, err := NewReconciler(ReconcilerConfig{
+		Source:   &mutableSource{head: head, bundle: bundle},
+		Store:    restarted,
+		Compiler: testCompiler,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, err := reconciler.Reconcile(t.Context(), scope)
+	if err != nil || !status.Updated {
+		t.Fatalf("revalidate persisted epoch: status=%+v err=%v", status, err)
+	}
+	active, ok := restarted.Get(scope)
+	if !ok || active.Validation.Status != StatusActive {
+		t.Fatalf("revalidated snapshot=%+v", active)
+	}
+	epochThree := replayTestSnapshot(scope, 3, "policy-v3", "head-v3")
+	if err := restarted.Swap(scope, epochThree); err != nil {
+		t.Fatalf("advance watermark: %v", err)
+	}
+	restartedAgain, err := NewPersistentSnapshotStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	latest, ok := restartedAgain.Get(scope)
+	if !ok || latest.PolicyEpoch != 3 || latest.PolicyHash != epochThree.PolicyHash || latest.PolicyHeadHash != epochThree.PolicyHeadHash {
+		t.Fatalf("latest persisted watermark=%+v", latest)
+	}
+}
+
+func TestPersistentSnapshotStoreFailsClosedOnInvalidOrUnwritableState(t *testing.T) {
+	t.Run("corrupt", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "policy-replay-watermarks.json")
+		if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewPersistentSnapshotStore(path); !errors.Is(err, ErrPolicyReplayStateInvalid) {
+			t.Fatalf("corrupt state error=%v", err)
+		}
+	})
+
+	t.Run("public mode", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "policy-replay-watermarks.json")
+		store, err := NewPersistentSnapshotStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		scope := PolicyScope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+		if err := store.Swap(scope, replayTestSnapshot(scope, 1, "policy-v1", "head-v1")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chmod(path, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := NewPersistentSnapshotStore(path); !errors.Is(err, ErrPolicyReplayStateInvalid) {
+			t.Fatalf("public state error=%v", err)
+		}
+	})
+
+	t.Run("persistence failure", func(t *testing.T) {
+		root := t.TempDir()
+		blockedParent := filepath.Join(root, "blocked")
+		path := filepath.Join(blockedParent, "policy-replay-watermarks.json")
+		store, err := NewPersistentSnapshotStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(blockedParent, []byte("not a directory"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		scope := PolicyScope{TenantID: "tenant-a", WorkspaceID: "workspace-a"}
+		if err := store.Swap(scope, replayTestSnapshot(scope, 1, "policy-v1", "head-v1")); err == nil {
+			t.Fatal("snapshot installed without durable watermark")
+		}
+		if _, ok := store.Get(scope); ok {
+			t.Fatal("persistence failure updated the in-memory snapshot")
+		}
+	})
+
+	t.Run("oversized state", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "policy-replay-watermarks.json")
+		watermark := policyReplayWatermark{
+			TenantID:       strings.Repeat("t", maxPolicyReplayWatermarkBytes),
+			WorkspaceID:    "workspace-a",
+			PolicyEpoch:    1,
+			PolicyHash:     HashBytes([]byte("policy-v1")),
+			PolicyHeadHash: HashBytes([]byte("head-v1")),
+		}
+		if err := writePolicyReplayWatermarks(path, map[string]policyReplayWatermark{watermark.scope().Key(): watermark}); !errors.Is(err, ErrPolicyReplayStateInvalid) {
+			t.Fatalf("oversized state error=%v", err)
+		}
+		if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("oversized state was written: %v", err)
+		}
+	})
+}
+
+func replayTestSnapshot(scope PolicyScope, epoch uint64, policy, head string) *EffectivePolicySnapshot {
+	return &EffectivePolicySnapshot{
+		TenantID:       scope.TenantID,
+		WorkspaceID:    scope.WorkspaceID,
+		PolicyEpoch:    epoch,
+		PolicyHash:     HashBytes([]byte(policy)),
+		PolicyHeadHash: HashBytes([]byte(head)),
+		Validation:     ValidationStatus{Status: StatusActive},
+	}
+}

--- a/core/scripts/ci/generate_policy_controlplane_fixture.go
+++ b/core/scripts/ci/generate_policy_controlplane_fixture.go
@@ -1,3 +1,6 @@
+// quantum_posture: this smoke fixture uses ephemeral classical Ed25519 only
+// for the current Kernel policy-head compatibility contract; it makes no
+// post-quantum assurance claim.
 package main
 
 import (

--- a/core/scripts/ci/generate_policy_controlplane_fixture.go
+++ b/core/scripts/ci/generate_policy_controlplane_fixture.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	policyreconcile "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/policy/reconcile"
+)
+
+const (
+	runtimePolicyRef     = "/etc/helm-ai-kernel/serve-policy.toml"
+	runtimeReferencePack = "reference_packs/eu_ai_act_high_risk.v2.json"
+)
+
+func main() {
+	outDir := flag.String("out", "", "directory for generated fixture files")
+	tenantID := flag.String("tenant", "", "policy tenant")
+	workspaceID := flag.String("workspace", "", "policy workspace")
+	referencePack := flag.String("reference-pack", "", "host path to the bundled reference pack")
+	flag.Parse()
+
+	if err := generate(*outDir, *tenantID, *workspaceID, *referencePack); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func generate(outDir, tenantID, workspaceID, referencePack string) error {
+	if outDir == "" || tenantID == "" || workspaceID == "" || referencePack == "" {
+		return fmt.Errorf("out, tenant, workspace, and reference-pack are required")
+	}
+	referencePackBytes, err := os.ReadFile(filepath.Clean(referencePack))
+	if err != nil {
+		return fmt.Errorf("read reference pack: %w", err)
+	}
+	bundle := []byte(fmt.Sprintf(`name = "kind-smoke"
+profile = "high_risk"
+reference_pack = %q
+
+[server]
+bind = "0.0.0.0"
+port = 8080
+
+[receipts]
+store = "sqlite"
+path = "/var/lib/helm-ai-kernel/helm.db"
+`, runtimeReferencePack))
+	head := policyreconcile.PolicyHead{
+		Scope:       policyreconcile.PolicyScope{TenantID: tenantID, WorkspaceID: workspaceID}.Normalize(),
+		PolicyEpoch: 1,
+		PolicyHash:  policyreconcile.HashBytes(bundle),
+		BundleRef:   runtimePolicyRef,
+		SourceRefs: []string{fmt.Sprintf(
+			"reference_pack:%s@%s",
+			filepath.Join(filepath.Dir(runtimePolicyRef), runtimeReferencePack),
+			policyreconcile.HashBytes(referencePackBytes),
+		)},
+	}
+	material, err := policyreconcile.PolicyHeadSignatureMaterial(head)
+	if err != nil {
+		return fmt.Errorf("build policy signature material: %w", err)
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate fixture signing key: %w", err)
+	}
+	signature := ed25519.Sign(privateKey, material)
+	if !ed25519.Verify(publicKey, material, signature) {
+		return fmt.Errorf("fixture signature self-check failed")
+	}
+	head.Signature = hex.EncodeToString(signature)
+	headJSON, err := json.MarshalIndent(head, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode policy head: %w", err)
+	}
+
+	if err := os.MkdirAll(outDir, 0o700); err != nil {
+		return fmt.Errorf("create fixture directory: %w", err)
+	}
+	files := map[string][]byte{
+		"bundle.toml":    bundle,
+		"head.json":      append(headJSON, '\n'),
+		"public-key.hex": []byte(hex.EncodeToString(publicKey) + "\n"),
+	}
+	for name, data := range files {
+		if err := os.WriteFile(filepath.Join(outDir, name), data, 0o600); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/core/scripts/ci/generate_policy_controlplane_fixture_test.go
+++ b/core/scripts/ci/generate_policy_controlplane_fixture_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	policyreconcile "github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/policy/reconcile"
+)
+
+func TestGenerateSignsResolvablePolicyFixture(t *testing.T) {
+	root := filepath.Clean(filepath.Join("..", "..", ".."))
+	referencePackPath := filepath.Join(root, "reference_packs", "eu_ai_act_high_risk.v2.json")
+	outDir := t.TempDir()
+	if err := generate(outDir, "tenant-smoke", "default", referencePackPath); err != nil {
+		t.Fatal(err)
+	}
+
+	bundle, err := os.ReadFile(filepath.Join(outDir, "bundle.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var head policyreconcile.PolicyHead
+	headJSON, err := os.ReadFile(filepath.Join(outDir, "head.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(headJSON, &head); err != nil {
+		t.Fatal(err)
+	}
+	if head.BundleRef != runtimePolicyRef {
+		t.Fatalf("bundle_ref = %q, want %q", head.BundleRef, runtimePolicyRef)
+	}
+	if head.PolicyHash != policyreconcile.HashBytes(bundle) {
+		t.Fatal("policy_hash does not bind the generated bundle")
+	}
+
+	publicKeyHex, err := os.ReadFile(filepath.Join(outDir, "public-key.hex"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey, err := hex.DecodeString(strings.TrimSpace(string(publicKeyHex)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature, err := hex.DecodeString(head.Signature)
+	if err != nil {
+		t.Fatal(err)
+	}
+	material, err := policyreconcile.PolicyHeadSignatureMaterial(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ed25519.Verify(ed25519.PublicKey(publicKey), material, signature) {
+		t.Fatal("generated policy head signature is invalid")
+	}
+
+	var bundleConfig struct {
+		ReferencePack string `toml:"reference_pack"`
+	}
+	if _, err := toml.Decode(string(bundle), &bundleConfig); err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := policyreconcile.ResolveReferencePackPath(head.BundleRef, bundleConfig.ReferencePack)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRuntimePack := filepath.Join(filepath.Dir(runtimePolicyRef), runtimeReferencePack)
+	if resolved != wantRuntimePack {
+		t.Fatalf("resolved reference pack = %q, want %q", resolved, wantRuntimePack)
+	}
+	referencePack, err := os.ReadFile(referencePackPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantSourceRef := "reference_pack:" + wantRuntimePack + "@" + policyreconcile.HashBytes(referencePack)
+	if len(head.SourceRefs) != 1 || head.SourceRefs[0] != wantSourceRef {
+		t.Fatalf("source_refs = %v, want [%q]", head.SourceRefs, wantSourceRef)
+	}
+}

--- a/core/scripts/ci/generate_policy_controlplane_fixture_test.go
+++ b/core/scripts/ci/generate_policy_controlplane_fixture_test.go
@@ -1,3 +1,5 @@
+// quantum_posture: this test exercises the fixture's classical Ed25519
+// compatibility path only; it makes no post-quantum assurance claim.
 package main
 
 import (

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -142,7 +142,8 @@ flowchart TD
   `helm.signing.existingSecret`.
 - Keep `persistence.enabled=true` and `replicaCount=1`. Production writes a
   private, atomic policy replay watermark under `helm.dataDir` before activating
-  a snapshot; multi-writer deployment requires a distributed transactional
+  a snapshot and uses a `Recreate` rollout so old and new writers cannot overlap;
+  zero-downtime or multi-writer deployment requires a distributed transactional
   watermark store first.
 - Enable `networkPolicy` and supply explicit ingress/egress allowlists. This is
   a rendered contract only until the target cluster proves a CNI that enforces

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -84,6 +84,7 @@ flowchart TD
 | `launchpadApps.hermes.model` | `openai/gpt-4o-mini` | Model passed to the default Hermes Job command. |
 | `launchpadApps.hermes.query` | `ping` | Single query passed to the default Hermes Job command. |
 | `launchpadApps.hermes.commandOverride` | `[]` | Full command array replacement for operator-specific Hermes runtime evidence. |
+| `replicaCount` | `1` | Kernel pod count. Production is single-writer until policy replay watermarks move to a distributed transactional store. |
 | `helm.*` | retained | Legacy values root retained for one compatibility window. |
 | `helm.bindAddr` | `0.0.0.0` | Required inside Kubernetes pods. |
 | `helm.production` | `false` | Refuses generated signing/auth material when set to `true`. |
@@ -125,7 +126,7 @@ flowchart TD
 | `helm.policy.runtimeActions` | `[]` | Explicit mounted-file rules compiled into the chart-managed reference pack; empty remains fail-closed. Prefer signed control-plane/CRD policy in production. |
 | `helm.policy.reloadHints.httpWakeEndpoint` | `/internal/policy/reconcile` | Wake-only internal endpoint for sidecars/operators. |
 | `helm.policy.reloadHints.configReloaderSidecar.enabled` | `false` | Optional mounted-file wake hint; disabled by default. |
-| `persistence.enabled` | `true` | Creates or uses a PVC for `/data`. |
+| `persistence.enabled` | `true` | Creates or uses a PVC for `/data`; required in production so policy replay watermarks survive restarts. |
 | `ingress.enabled` | `false` | Enables Kubernetes ingress. |
 | `helm.metrics.enabled` | `false` | Enables `/metrics` on `service.metricsPort`. |
 | `helm.metrics.serviceMonitor.enabled` | `false` | Emits a Prometheus Operator `ServiceMonitor`. |
@@ -139,6 +140,10 @@ flowchart TD
 
 - Set `helm.production=true` and provide `helm.signing.key` or
   `helm.signing.existingSecret`.
+- Keep `persistence.enabled=true` and `replicaCount=1`. Production writes a
+  private, atomic policy replay watermark under `helm.dataDir` before activating
+  a snapshot; multi-writer deployment requires a distributed transactional
+  watermark store first.
 - Enable `networkPolicy` and supply explicit ingress/egress allowlists. This is
   a rendered contract only until the target cluster proves a CNI that enforces
   `networking.k8s.io/v1` NetworkPolicy and records prohibited-egress denial.

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -113,7 +113,7 @@ flowchart TD
 | `helm.limits.concurrency.max` | `0` | Process in-flight request cap; `0` disables. |
 | `helm.limits.loadShed.enabled` | `false` | Enable low-priority load shedding. |
 | `helm.guardian.semanticThreatEscalationBP` | `0` | Semantic ESCALATE threshold in basis points; `0` is advisory-only, while a positive value fails closed when assessment is unavailable or truncated. |
-| `helm.policy.source.kind` | `mountedFile` | `controlplane`, `crd`, or `mountedFile`; Kubernetes delivery is not policy truth. |
+| `helm.policy.source.kind` | `mountedFile` | `controlplane`, `crd`, or non-production `mountedFile`; Kubernetes delivery is not policy truth. |
 | `helm.policy.source.controlplane.auth.mode` | `serviceAccountJWT` | `serviceAccountJWT` uses a rotating projected token; `bearerToken` requires explicit static Secret material. |
 | `helm.policy.source.controlplane.auth.serviceAccountJWT.audience` | `helm-control-plane` | Audience required from the policy authority's Kubernetes TokenReview verifier. |
 | `helm.policy.source.controlplane.auth.serviceAccountJWT.expirationSeconds` | `600` | Projected token TTL, constrained to 600–3600 seconds. |
@@ -164,7 +164,9 @@ flowchart TD
   rotation. Prefer `helm.emergencyStop.existingSecret` plus
   `commandReplayKeyringSecretKey` for deployment configuration; the chart
   rejects a direct value and secret key together.
-- Prefer `helm.policy.source.kind=controlplane` for production deployments.
+- Production rejects `helm.policy.source.kind=mountedFile` because filesystem
+  timestamps are not source-owned monotonic publication epochs. Use
+  `helm.policy.source.kind=controlplane` for the shipped runtime.
   The chart configures where policy truth is published; the runtime still
   polls, verifies hash/signature/provenance, compiles, and atomically swaps
   immutable snapshots. Production control-plane renders require
@@ -173,7 +175,7 @@ flowchart TD
 - Use `helm.policy.source.kind=crd` for Kubernetes-native self-hosted control
   in runtime builds that include a CRD `PolicySource`. The OSS chart renders
   the optional `HelmPolicyBundle` CRD and RBAC only in CRD mode.
-- `mountedFile` mode is retained for OSS/local/bootstrap/demo use. ConfigMap
+- `mountedFile` mode is retained only for OSS/local/bootstrap/demo use. ConfigMap
   or Secret bytes are delivery backends only and the sidecar, when enabled,
   only calls `/internal/policy/reconcile`. Signed mounted-file policies can
   provide a companion `serve-policy.toml.sig`; it must sign the versioned

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -88,6 +88,10 @@ metadata:
   labels:
     {{- include "helm-ai-kernel.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.helm.production }}
+  strategy:
+    type: Recreate
+  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -9,6 +9,9 @@
 {{- if and .Values.helm.production (ne (int .Values.replicaCount) 1) -}}
 {{- fail "helm.production=true requires replicaCount=1 until policy replay state has a distributed store" -}}
 {{- end -}}
+{{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "mountedFile") -}}
+{{- fail "helm.production=true rejects helm.policy.source.kind=mountedFile because filesystem timestamps are not source-owned monotonic publication epochs; use controlplane" -}}
+{{- end -}}
 {{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "controlplane") (not .Values.helm.policy.source.controlplane.url) -}}
 {{- fail "helm.production=true with helm.policy.source.kind=controlplane requires helm.policy.source.controlplane.url" -}}
 {{- end -}}
@@ -141,6 +144,7 @@ spec:
               umask 077
               data_dir="$HELM_AUTHORITY_DATA_DIR"
               root_key="$data_dir/root.key"
+              watermark="$data_dir/policy-replay-watermarks.json"
               source_key="/var/run/helm-signing-key/root.key"
 
               if [ ! -r "$source_key" ]; then
@@ -150,6 +154,19 @@ spec:
 
               if [ ! -d "$data_dir" ] || [ ! -w "$data_dir" ] || [ ! -x "$data_dir" ]; then
                 echo "authority data volume is not writable by the restricted runtime identity" >&2
+                exit 1
+              fi
+
+              if [ -L "$watermark" ]; then
+                echo "refusing symlinked policy replay watermark" >&2
+                exit 1
+              fi
+              if [ -e "$watermark" ] && [ ! -f "$watermark" ]; then
+                echo "policy replay watermark is not a regular file" >&2
+                exit 1
+              fi
+              if [ -f "$watermark" ] && ! chmod 0600 "$watermark"; then
+                echo "could not restore private policy replay watermark mode after fsGroup processing" >&2
                 exit 1
               fi
 

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -3,6 +3,12 @@
 {{- if not (or (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.kind "crd") (eq .Values.helm.policy.source.kind "mountedFile")) -}}
 {{- fail "helm.policy.source.kind must be one of controlplane, crd, mountedFile" -}}
 {{- end -}}
+{{- if and .Values.helm.production (not .Values.persistence.enabled) -}}
+{{- fail "helm.production=true requires persistence.enabled=true for durable policy replay protection" -}}
+{{- end -}}
+{{- if and .Values.helm.production (ne (int .Values.replicaCount) 1) -}}
+{{- fail "helm.production=true requires replicaCount=1 until policy replay state has a distributed store" -}}
+{{- end -}}
 {{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "controlplane") (not .Values.helm.policy.source.controlplane.url) -}}
 {{- fail "helm.production=true with helm.policy.source.kind=controlplane requires helm.policy.source.controlplane.url" -}}
 {{- end -}}

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -665,7 +665,7 @@
                   "type": "string",
                   "enum": ["controlplane", "crd", "mountedFile"],
                   "default": "mountedFile",
-                  "description": "Policy source backend. controlplane is recommended for production; crd suits Kubernetes-native self-hosting; mountedFile is for OSS/local/bootstrap/demo use."
+                  "description": "Policy source backend. controlplane is required by the shipped production runtime; crd suits Kubernetes-native self-hosting with a compatible runtime; mountedFile is rejected in production and remains for OSS/local/bootstrap/demo use."
                 },
                 "pollInterval": {
                   "type": "string",

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -230,7 +230,7 @@ helm:
     # Kubernetes delivery is a policy-source backend, not runtime truth.
     # Runtime reconciliation verifies and compiles an EffectivePolicySnapshot.
     source:
-      kind: "mountedFile" # controlplane | crd | mountedFile
+      kind: "mountedFile" # controlplane | crd | mountedFile (non-production only)
       pollInterval: "10s"
       initialReconcileTimeout: "30s"
       controlplane:

--- a/docs/launchpad/K8S_SMOKE.md
+++ b/docs/launchpad/K8S_SMOKE.md
@@ -22,6 +22,12 @@ and `launchpadApps.hermes` enabled, see the openclaw Pod reach Ready and
 the hermes Job reach Complete, run `helm test` to confirm kernel health,
 and uninstall with no residual resources.
 
+This is deliberately a non-production policy-bootstrap smoke: it uses the
+chart-managed mounted policy while testing launchpad co-deployment and network
+behavior. It is not evidence for the managed policy-authority boundary. The
+Kernel's production `controlplane` transport, signed native policy fixture, and
+restart path are exercised separately by `scripts/ci/kind_smoke.sh`.
+
 ## Topology
 
 This is a **co-deployment** path. openclaw and hermes are pinned chart-

--- a/scripts/ci/check_helm_smoke_hardening.py
+++ b/scripts/ci/check_helm_smoke_hardening.py
@@ -32,9 +32,23 @@ def require_digest_default(path: Path, text: str) -> None:
         fail(f"{path}: missing runtime digest-pin guard")
 
 
+def require_policy_fixture_digest_default(path: Path, text: str) -> None:
+    match = re.search(
+        r'POLICY_FIXTURE_IMAGE="\$\{HELM_SMOKE_POLICY_FIXTURE_IMAGE:-([^}]+)\}"',
+        text,
+    )
+    if not match:
+        fail(f"{path}: missing POLICY_FIXTURE_IMAGE default")
+    if not SHA256_REF.search(match.group(1)):
+        fail(f"{path}: POLICY_FIXTURE_IMAGE default must be digest pinned")
+    if "require_pinned_policy_fixture_image" not in text:
+        fail(f"{path}: missing policy fixture runtime digest-pin guard")
+
+
 def check_kind_smoke(path: Path) -> None:
     text = path.read_text(encoding="utf-8")
     require_digest_default(path, text)
+    require_policy_fixture_digest_default(path, text)
     forbidden = [
         "--network host",
         '${HOME}/.kube:/root/.kube',
@@ -54,6 +68,11 @@ def check_kind_smoke(path: Path) -> None:
         "ctr --namespace k8s.io images inspect",
         "ctr --namespace k8s.io images tag --force",
         "--set image.digest=",
+        "go run ./scripts/ci/generate_policy_controlplane_fixture.go",
+        "--set helm.production=true",
+        "--set helm.policy.source.kind=controlplane",
+        "--set helm.policy.signature.required=true",
+        "policy-controlplane-fixture",
     ]
     for token in required:
         if token not in text:

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -592,6 +592,32 @@ assert_contains "$rendered" "app.kubernetes.io/name: svc-helm-control-plane"
 assert_contains "$rendered" "cidr: 10.116.0.8/32"
 assert_contains "$rendered" "port: 5432"
 
+ephemeral_production_log="$RENDER_DIR/production-ephemeral-policy-state.log"
+if production_helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.production=true \
+    --set helm.signing.key="$SIGNING_KEY" \
+    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set persistence.enabled=false >"$RENDER_DIR/production-ephemeral-policy-state.yaml" 2>"$ephemeral_production_log"; then
+    echo "::error::production render without durable policy state unexpectedly succeeded"
+    exit 1
+fi
+assert_contains "$ephemeral_production_log" "persistence.enabled=true"
+
+multi_replica_production_log="$RENDER_DIR/production-multi-replica-policy-state.log"
+if production_helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.production=true \
+    --set helm.signing.key="$SIGNING_KEY" \
+    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set replicaCount=2 >"$RENDER_DIR/production-multi-replica-policy-state.yaml" 2>"$multi_replica_production_log"; then
+    echo "::error::production multi-writer policy state unexpectedly rendered"
+    exit 1
+fi
+assert_contains "$multi_replica_production_log" "replicaCount=1"
+
 controlplane_fail_log="$RENDER_DIR/controlplane-missing-url.log"
 if production_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -557,6 +557,8 @@ production_helm_runner template "$RELEASE" "$CHART" \
     --set image.pullPolicy=IfNotPresent >"$rendered"
 
 assert_contains "$rendered" "kind: Deployment"
+assert_contains "$rendered" "strategy:"
+assert_contains "$rendered" "type: Recreate"
 assert_contains "$rendered" "image: \"ghcr.io/mindburn-labs/helm-ai-kernel@${PRODUCTION_IMAGE_DIGEST}\""
 assert_contains "$rendered" "serve"
 assert_contains "$rendered" "--policy"

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -85,6 +85,14 @@ production_helm_runner() {
         --set image.digest="$PRODUCTION_IMAGE_DIGEST"
 }
 
+production_controlplane_helm_runner() {
+    production_helm_runner "$@" \
+        --set helm.policy.source.kind=controlplane \
+        --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+        --set helm.policy.signature.required=true \
+        --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY"
+}
+
 default_rendered="$RENDER_DIR/rendered-default.yaml"
 helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
@@ -153,6 +161,9 @@ assert_not_contains "$default_rendered" "mountPath: /data/root.key"
 # installs (CI) passed. An unreadable existing key must still fail closed.
 assert_contains "$default_rendered" 'chmod 0600 "$root_key" 2>/dev/null || true'
 assert_contains "$default_rendered" "durable authority root key exists but is not readable"
+assert_contains "$default_rendered" 'watermark="$data_dir/policy-replay-watermarks.json"'
+assert_contains "$default_rendered" 'chmod 0600 "$watermark"'
+assert_contains "$default_rendered" "could not restore private policy replay watermark mode after fsGroup processing"
 authority_init_script="$RENDER_DIR/rendered-authority-init-script.txt"
 awk '/prepare-authority-state/{capture=1} capture{print} capture && /volumeMounts:/{exit}' "$default_rendered" >"$authority_init_script"
 if [ "$(/usr/bin/grep -c 'chmod 0600 "$root_key"' "$authority_init_script" 2>/dev/null || grep -c 'chmod 0600 "$root_key"' "$authority_init_script")" != "1" ]; then
@@ -386,7 +397,7 @@ fi
 assert_contains "$hermes_mode_fail_log" "launchpadApps.hermes.mode"
 
 fail_log="$RENDER_DIR/production-missing-key.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true >"$RENDER_DIR/production-missing-key.yaml" 2>"$fail_log"; then
     echo "::error::production render without signing key unexpectedly succeeded"
@@ -403,7 +414,11 @@ if helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.adminAPIKey="$ADMIN_KEY" \
     --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
     --set helm.auth.tenantID="$TENANT_ID" \
-    --set helm.auth.principalID="$AGENT_ID" >"$RENDER_DIR/production-missing-image-digest.yaml" 2>"$image_digest_fail_log"; then
+    --set helm.auth.principalID="$AGENT_ID" \
+    --set helm.policy.source.kind=controlplane \
+    --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.signature.required=true \
+    --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" >"$RENDER_DIR/production-missing-image-digest.yaml" 2>"$image_digest_fail_log"; then
     echo "::error::production render without an immutable Kernel image digest unexpectedly succeeded"
     exit 1
 fi
@@ -427,6 +442,10 @@ if helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
     --set helm.auth.tenantID="$TENANT_ID" \
     --set helm.auth.principalID="$AGENT_ID" \
+    --set helm.policy.source.kind=controlplane \
+    --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.signature.required=true \
+    --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" \
     --set image.digest="$PRODUCTION_IMAGE_DIGEST" >"$RENDER_DIR/production-network-policy-disabled.yaml" 2>"$network_policy_disabled_log"; then
     echo "::error::production render without a kernel NetworkPolicy unexpectedly succeeded"
     exit 1
@@ -434,7 +453,7 @@ fi
 assert_contains "$network_policy_disabled_log" "networkPolicy.enabled=true"
 
 network_policy_wildcard_log="$RENDER_DIR/production-network-policy-wildcard.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -447,7 +466,7 @@ fi
 assert_contains "$network_policy_wildcard_log" "exact /32 or /128 host CIDRs"
 
 tenant_fail_log="$RENDER_DIR/production-missing-runtime-tenant.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -460,7 +479,7 @@ fi
 assert_contains "$tenant_fail_log" "helm.auth.tenantID"
 
 principal_fail_log="$RENDER_DIR/production-missing-runtime-principal.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -473,7 +492,7 @@ fi
 assert_contains "$principal_fail_log" "helm.auth.principalID"
 
 postgres_inline_fail_log="$RENDER_DIR/postgres-inline-production.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -488,7 +507,7 @@ fi
 assert_contains "$postgres_inline_fail_log" "requires helm.storage.postgres.existingSecret"
 
 postgres_tls_fail_log="$RENDER_DIR/postgres-weak-tls-production.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -503,7 +522,7 @@ fi
 assert_contains "$postgres_tls_fail_log" "requires helm.storage.postgres.sslMode"
 
 postgres_subchart_fail_log="$RENDER_DIR/postgres-subchart-production.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -518,7 +537,7 @@ fi
 assert_contains "$postgres_subchart_fail_log" "does not support the bundled postgresql subchart"
 
 postgres_rendered="$RENDER_DIR/rendered-postgres-secret.yaml"
-production_helm_runner template "$RELEASE" "$CHART" \
+production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -534,7 +553,7 @@ assert_not_contains "$postgres_rendered" "postgres://"
 assert_not_contains "$postgres_rendered" "POSTGRES_PASSWORD"
 assert_not_contains "$postgres_rendered" "sslmode=disable"
 
-production_helm_runner lint "$CHART" \
+production_controlplane_helm_runner lint "$CHART" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
     --set helm.auth.adminAPIKey="$ADMIN_KEY" \
@@ -545,7 +564,7 @@ production_helm_runner lint "$CHART" \
     --set image.pullPolicy=IfNotPresent >/dev/null
 
 rendered="$RENDER_DIR/rendered.yaml"
-production_helm_runner template "$RELEASE" "$CHART" \
+production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -567,7 +586,9 @@ assert_contains "$rendered" "--data-dir"
 assert_contains "$rendered" "/data"
 assert_contains "$rendered" "HELM_PRODUCTION"
 assert_contains "$rendered" "HELM_POLICY_SOURCE_KIND"
-assert_contains "$rendered" "mountedFile"
+assert_contains "$rendered" "controlplane"
+assert_contains "$rendered" "https://helm-controlplane.example.internal"
+assert_contains "$rendered" "HELM_POLICY_TRUST_PUBLIC_KEY"
 assert_contains "$rendered" "HELM_POLICY_POLL_INTERVAL"
 assert_contains "$rendered" "HELM_POLICY_SIGNATURE_REQUIRED"
 assert_contains "$rendered" "/internal/policy/reconcile"
@@ -595,7 +616,7 @@ assert_contains "$rendered" "cidr: 10.116.0.8/32"
 assert_contains "$rendered" "port: 5432"
 
 ephemeral_production_log="$RENDER_DIR/production-ephemeral-policy-state.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -608,7 +629,7 @@ fi
 assert_contains "$ephemeral_production_log" "persistence.enabled=true"
 
 multi_replica_production_log="$RENDER_DIR/production-multi-replica-policy-state.log"
-if production_helm_runner template "$RELEASE" "$CHART" \
+if production_controlplane_helm_runner template "$RELEASE" "$CHART" \
     --namespace "$NAMESPACE" \
     --set helm.production=true \
     --set helm.signing.key="$SIGNING_KEY" \
@@ -619,6 +640,19 @@ if production_helm_runner template "$RELEASE" "$CHART" \
     exit 1
 fi
 assert_contains "$multi_replica_production_log" "replicaCount=1"
+
+mounted_file_production_log="$RENDER_DIR/production-mounted-file-policy.log"
+if production_helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.production=true \
+    --set helm.signing.key="$SIGNING_KEY" \
+    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set helm.policy.source.kind=mountedFile >"$RENDER_DIR/production-mounted-file-policy.yaml" 2>"$mounted_file_production_log"; then
+    echo "::error::production mounted-file policy source unexpectedly rendered"
+    exit 1
+fi
+assert_contains "$mounted_file_production_log" "source-owned monotonic publication epochs"
 
 controlplane_fail_log="$RENDER_DIR/controlplane-missing-url.log"
 if production_helm_runner template "$RELEASE" "$CHART" \

--- a/scripts/ci/kind_smoke.sh
+++ b/scripts/ci/kind_smoke.sh
@@ -14,10 +14,15 @@ ADMIN_KEY="${HELM_SMOKE_ADMIN_KEY:-helm-admin-smoke}"
 TENANT_ID="${HELM_SMOKE_TENANT_ID:-tenant-smoke}"
 AGENT_ID="${HELM_SMOKE_AGENT_ID:-agent.smoke}"
 KUBE_HELM_IMAGE="${KUBE_HELM_IMAGE:-docker.io/alpine/helm@sha256:105741fa6621ed9a3ea944066de78bb27d4b9bb93a56ce8e7cb4d621e1e4bbf2}"
+POLICY_FIXTURE_IMAGE="${HELM_SMOKE_POLICY_FIXTURE_IMAGE:-docker.io/library/busybox@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662}"
+POLICY_FIXTURE_CONFIGMAP="helm-policy-controlplane-fixture"
+POLICY_AUTH_SECRET="helm-policy-reader"
+POLICY_FIXTURE_PORT=18081
 CREATED_CLUSTER=0
 PF_PID=""
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/helm-ai-kernel-kind-smoke.XXXXXX")"
 HELM_KUBECONFIG="$TMP_DIR/kubeconfig.helm"
+POLICY_FIXTURE_DIR="$TMP_DIR/policy-controlplane"
 
 require() {
     command -v "$1" >/dev/null 2>&1 || {
@@ -31,6 +36,7 @@ require kind
 require kubectl
 require curl
 require python3
+require go
 
 require_pinned_helm_image() {
     if [[ ! "$KUBE_HELM_IMAGE" =~ @sha256:[0-9a-f]{64}$ ]]; then
@@ -38,6 +44,15 @@ require_pinned_helm_image() {
         exit 1
     fi
 }
+
+require_pinned_policy_fixture_image() {
+    if [[ ! "$POLICY_FIXTURE_IMAGE" =~ @sha256:[0-9a-f]{64}$ ]]; then
+        echo "::error::POLICY_FIXTURE_IMAGE must be pinned by immutable sha256 digest, got: ${POLICY_FIXTURE_IMAGE}"
+        exit 1
+    fi
+}
+
+require_pinned_policy_fixture_image
 
 prepare_helm_kubeconfig() {
     if [ -s "$HELM_KUBECONFIG" ]; then
@@ -150,6 +165,27 @@ kubectl label namespace "$NAMESPACE" \
     pod-security.kubernetes.io/enforce-version=latest \
     --overwrite >/dev/null
 
+(
+    cd "$ROOT/core"
+    go run ./scripts/ci/generate_policy_controlplane_fixture.go \
+        --out "$POLICY_FIXTURE_DIR" \
+        --tenant "$TENANT_ID" \
+        --workspace default \
+        --reference-pack "$ROOT/reference_packs/eu_ai_act_high_risk.v2.json"
+)
+POLICY_PUBLIC_KEY="$(tr -d '\r\n' <"$POLICY_FIXTURE_DIR/public-key.hex")"
+if [[ ! "$POLICY_PUBLIC_KEY" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "::error::generated policy fixture public key is invalid"
+    exit 1
+fi
+kubectl -n "$NAMESPACE" create configmap "$POLICY_FIXTURE_CONFIGMAP" \
+    --from-file=head="$POLICY_FIXTURE_DIR/head.json" \
+    --from-file=bundle="$POLICY_FIXTURE_DIR/bundle.toml" \
+    --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+kubectl -n "$NAMESPACE" create secret generic "$POLICY_AUTH_SECRET" \
+    --from-literal=HELM_POLICY_BEARER_TOKEN=kind-smoke-policy-reader \
+    --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+
 helm_runner upgrade --install "$RELEASE" deploy/helm-chart \
     --namespace "$NAMESPACE" \
     --values scripts/ci/helm_production_network_policy_values.yaml \
@@ -159,11 +195,62 @@ helm_runner upgrade --install "$RELEASE" deploy/helm-chart \
     --set helm.auth.serviceAPIKey="${HELM_SMOKE_SERVICE_KEY:-helm-service-smoke}" \
     --set helm.auth.tenantID="$TENANT_ID" \
     --set helm.auth.principalID="$AGENT_ID" \
+    --set helm.policy.source.kind=controlplane \
+    --set-string helm.policy.source.controlplane.url="http://127.0.0.1:${POLICY_FIXTURE_PORT}" \
+    --set helm.policy.source.controlplane.auth.mode=bearerToken \
+    --set helm.policy.source.controlplane.auth.existingSecret="$POLICY_AUTH_SECRET" \
+    --set helm.policy.signature.required=true \
+    --set-string helm.policy.signature.publicKey="$POLICY_PUBLIC_KEY" \
     --set image.repository="$IMAGE_REPOSITORY" \
     --set image.digest="$IMAGE_DIGEST" \
     --set image.pullPolicy=IfNotPresent \
-    --set persistence.enabled=true \
-    --wait --timeout 180s
+    --set persistence.enabled=true
+
+cat >"$TMP_DIR/policy-controlplane-patch.yaml" <<EOF
+spec:
+  template:
+    spec:
+      containers:
+        - name: policy-controlplane-fixture
+          image: ${POLICY_FIXTURE_IMAGE}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/httpd", "-f", "-p", "${POLICY_FIXTURE_PORT}", "-h", "/www"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+          readinessProbe:
+            httpGet:
+              path: /api/v1/policy/head
+              port: ${POLICY_FIXTURE_PORT}
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+          volumeMounts:
+            - name: policy-controlplane-fixture
+              mountPath: /www
+              readOnly: true
+      volumes:
+        - name: policy-controlplane-fixture
+          configMap:
+            name: ${POLICY_FIXTURE_CONFIGMAP}
+            items:
+              - key: head
+                path: api/v1/policy/head
+              - key: bundle
+                path: api/v1/policy/bundle
+EOF
+kubectl -n "$NAMESPACE" patch "deployment/${FULLNAME}" \
+    --type=strategic \
+    --patch-file "$TMP_DIR/policy-controlplane-patch.yaml" >/dev/null
 
 kubectl -n "$NAMESPACE" rollout status "deployment/${FULLNAME}" --timeout=180s
 kubectl -n "$NAMESPACE" port-forward "svc/${FULLNAME}" "${API_PORT}:8080" >"$TMP_DIR/port-forward.log" 2>&1 &

--- a/scripts/ci/launchpad_k8s_smoke.sh
+++ b/scripts/ci/launchpad_k8s_smoke.sh
@@ -66,7 +66,7 @@ Environment overrides:
   LAUNCHPAD_SMOKE_GHCR_SECRET_NAME Secret name for private GHCR pulls (default ghcr-read)
   LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_IMAGES set to 1 for debug-only host pull + minikube image load verification
   LAUNCHPAD_SMOKE_PRE_LOAD_LAUNCHPAD_PLATFORM platform for debug-only launchpad image preload (default linux/amd64)
-  KUBE_HELM_CMD                  Kubernetes Helm binary to use when `helm` is occupied by HELM verifier
+  KUBE_HELM_CMD                  Kubernetes Helm binary to use when helm is occupied by HELM verifier
   GHCR_USERNAME                  GitHub/GHCR username for positive/negative launchpad app image pulls
   GHCR_TOKEN                     GitHub token with read:packages for private GHCR launchpad app image pulls
   OPENROUTER_API_KEY            real key for the positive scenario; ignored on negative
@@ -361,7 +361,9 @@ helm_args=(
     "$RELEASE" "${ROOT}/deploy/helm-chart"
     --namespace "$NAMESPACE"
     --values "${ROOT}/scripts/ci/helm_production_network_policy_values.yaml"
-    --set "helm.production=true"
+    # This smoke owns launchpad co-deployment, not the managed policy authority.
+    # The production controlplane path is exercised by kind_smoke.sh.
+    --set "helm.production=false"
     --set "helm.signing.key=${SIGNING_KEY}"
     --set "helm.auth.adminAPIKey=${ADMIN_KEY}"
     --set "helm.auth.serviceAPIKey=${SERVICE_KEY}"


### PR DESCRIPTION
## Why

Production policy rollback/equivocation protection was process-local. A Kernel restart discarded the accepted epoch and signed-head commitment, allowing an older source head to be reconsidered as fresh state.

## What

- persist only tenant/workspace scope, policy epoch, policy hash, and signed policy-head hash
- require a private regular state file and reject corrupt, oversized, duplicate, or trailing data at startup
- fsync and atomically rename the watermark before activating the in-memory snapshot
- restore watermarks as invalid/cold snapshots so the signed source and bundle must be revalidated before authorization
- make production Helm rendering fail without persistence or with more than one Kernel writer
- exercise the production `controlplane` transport with an ephemeral Ed25519-signed Kernel-native policy fixture and prove PVC-backed restart recovery
- keep the launchpad co-deployment smoke explicitly scoped to non-production mounted-policy bootstrap

## Validation

Exact head: `203b94428c63decdfe06be72830bb90e8aa333d9`

Local:
- `go test ./scripts/ci`
- `python3 scripts/ci/check_helm_smoke_hardening.py`
- `bash scripts/ci/helm_chart_smoke.sh`
- uniquely tagged exact-source image `ghcr.io/mindburn-labs/helm-ai-kernel:helm191-2430a1981`: production signed-control-plane Kind smoke, decision/receipt/evidence/replay checks, rollout restart, and signing-key persistence passed
- `make quality-pr`

GitHub Actions:
- CI run `33280058038`: quality, hygiene, Kernel, race, SDKs, contract drift, deployment smoke, Kind smoke, and release smoke passed
- Launchpad run `33280058077`: chart baseline, real OpenRouter positive path, and fake-key negative path passed
- CodeQL run `33280058092` and analysis run `33280056068`: all configured languages passed
- all review threads resolved; merge state clean

## Boundary

This is source readiness, not release or production-deployment evidence. The file backend prevents source rollback across ordinary restarts; it does not defend against a privileged host/PVC operator. A distributed transactional monotonic store is required before production can run multiple Kernel writers.

The smoke intentionally uses the Kernel-native TOML policy format. The real Control Plane currently publishes `helm-policy-bundle-json`; its semantic compilation into the Kernel authorization runtime is not established by this PR and remains a separate production blocker.