### PR TITLE
HELM-658: add fail-closed external CLI adapters

### DIFF
--- a/policies/launchpad/apps/external-workstation.toml
+++ b/policies/launchpad/apps/external-workstation.toml
@@ -1,0 +1,14 @@
+[app]
+id = "external-workstation"
+availability = "external_proprietary_adapter"
+redistribution = "helm_does_not_redistribute_byo_tool"
+permission_bypass_forbidden = true
+recursive_launch_forbidden = true
+network_default = "deny"
+mcp_unknown_server_policy = "quarantine"
+mcp_unknown_tool_policy = "ESCALATE"
+require_schema_pin = true
+receipt_required = true
+evidencepack_required = true
+workstation_policy_profile = "workstation.observe_draft.v1"
+workstation_adapter_mode = "selected_effect_enforceable"

--- a/registry/launchpad/apps/gemini.external.yaml
+++ b/registry/launchpad/apps/gemini.external.yaml
@@ -1,0 +1,79 @@
+id: gemini.external
+name: Gemini CLI External Adapter
+version: external-byo
+license:
+  status: upstream_oss_byo
+  spdx: Apache-2.0
+  url: https://github.com/google-gemini/gemini-cli/blob/main/LICENSE
+redistribution: helm_does_not_redistribute_byo_tool
+availability: external_proprietary_adapter
+support_level: external_byo_adapter
+install:
+  strategy: byo_tool
+runtime:
+  command: ["gemini"]
+model_gateway_env: []
+required_secrets: ["vendor_account"]
+filesystem_policy:
+  mode: scoped_workspace
+  mounts: ["workspace:rw", "app_state:rw"]
+  policy_ref: policies/launchpad/apps/external-workstation.toml
+network_policy:
+  default: deny
+  allowlist: []
+mcp_policy:
+  unknown_server_policy: quarantine
+  unknown_tool_policy: ESCALATE
+  require_schema_pin: true
+healthchecks:
+  - type: command
+    command: "gemini --version"
+risk_class: T1
+budget_ceiling:
+  usd_max: 0
+  api_calls_max: 0
+  time_ms_max: 0
+framework_contract:
+  f2_contract_preflight: true
+  claim_level: external_byo_adapter
+  live_command_kind: workstation_adapter
+  runtime_install_policy: forbidden
+  baked_dependencies: ["byo_gemini_cli"]
+  forbidden_runtime_install_patterns: ["npm install", "pnpm install", "yarn install", "pip install", "uv pip install", "playwright install", "apt-get", "apk add", "curl | sh", "curl -fsSL"]
+  writable_paths:
+    - path: /var/lib/gemini/app_state
+      purpose: workstation_state_manifest
+      required: true
+  provider_host_groups: []
+  egress_proxy:
+    required: false
+  mcp_manifest_refs: []
+  healthcheck: "gemini --version"
+  evidence_profile: workstation.contract.v1
+  evidence_refs:
+    - contract_preflight.json
+    - launch_plan.json
+    - workstation_artifact_manifest.json
+    - agent_run_receipt.json
+    - offline_verify.txt
+evidence_requirements:
+  - contract_preflight
+  - cpi_output
+  - kernel_verdict
+  - sandbox_grant
+  - launch_receipt
+  - teardown_receipt
+  - evidence_pack
+  - offline_verify
+  - workstation_artifact_manifest
+  - agent_run_receipt
+conformance:
+  license_verified: false
+  artifact_verified: false
+  policy_pack_present: true
+  sandbox_verified: false
+  healthcheck_passing: false
+  e2e_passing: false
+  teardown_verified: false
+  receipt_verified: false
+  evidence_pack_verified: false

--- a/registry/launchpad/apps/grok.external.yaml
+++ b/registry/launchpad/apps/grok.external.yaml
@@ -1,0 +1,79 @@
+id: grok.external
+name: Grok CLI External Adapter
+version: external-byo
+license:
+  status: proprietary_byo
+redistribution: prohibited
+availability: external_proprietary_adapter
+support_level: external_byo_adapter
+install:
+  strategy: byo_tool
+runtime:
+  command: ["grok"]
+model_gateway_env: []
+required_secrets: ["vendor_account"]
+filesystem_policy:
+  mode: scoped_workspace
+  mounts: ["workspace:rw", "app_state:rw"]
+  policy_ref: policies/launchpad/apps/external-workstation.toml
+network_policy:
+  default: deny
+  allowlist: []
+mcp_policy:
+  unknown_server_policy: quarantine
+  unknown_tool_policy: ESCALATE
+  require_schema_pin: true
+healthchecks:
+  - type: command
+    command: "grok version"
+risk_class: T1
+budget_ceiling:
+  usd_max: 0
+  api_calls_max: 0
+  time_ms_max: 0
+framework_contract:
+  f2_contract_preflight: true
+  claim_level: external_byo_adapter
+  live_command_kind: workstation_adapter
+  runtime_install_policy: forbidden
+  baked_dependencies: ["byo_grok_cli"]
+  forbidden_runtime_install_patterns: ["npm install", "pnpm install", "yarn install", "pip install", "uv pip install", "playwright install", "apt-get", "apk add", "curl | sh", "curl -fsSL"]
+  writable_paths:
+    - path: /var/lib/grok/app_state
+      purpose: workstation_state_manifest
+      required: true
+  provider_host_groups: []
+  egress_proxy:
+    required: false
+  mcp_manifest_refs: []
+  healthcheck: "grok version"
+  evidence_profile: workstation.contract.v1
+  evidence_refs:
+    - contract_preflight.json
+    - launch_plan.json
+    - workstation_artifact_manifest.json
+    - agent_run_receipt.json
+    - offline_verify.txt
+evidence_requirements:
+  - contract_preflight
+  - cpi_output
+  - kernel_verdict
+  - sandbox_grant
+  - launch_receipt
+  - teardown_receipt
+  - evidence_pack
+  - offline_verify
+  - workstation_artifact_manifest
+  - agent_run_receipt
+conformance:
+  license_verified: false
+  artifact_verified: false
+  policy_pack_present: true
+  sandbox_verified: false
+  healthcheck_passing: false
+  e2e_passing: false
+  teardown_verified: false
+  receipt_verified: false
+  evidence_pack_verified: false
+metadata:
+  upstream_cli_docs: https://docs.x.ai/build/cli/reference

--- a/registry/launchpad/apps/kimi.external.yaml
+++ b/registry/launchpad/apps/kimi.external.yaml
@@ -1,0 +1,79 @@
+id: kimi.external
+name: Kimi Code CLI External Adapter
+version: external-byo
+license:
+  status: upstream_oss_byo
+  spdx: MIT
+  url: https://github.com/MoonshotAI/kimi-code/blob/main/LICENSE
+redistribution: helm_does_not_redistribute_byo_tool
+availability: external_proprietary_adapter
+support_level: external_byo_adapter
+install:
+  strategy: byo_tool
+runtime:
+  command: ["kimi"]
+model_gateway_env: []
+required_secrets: ["vendor_account"]
+filesystem_policy:
+  mode: scoped_workspace
+  mounts: ["workspace:rw", "app_state:rw"]
+  policy_ref: policies/launchpad/apps/external-workstation.toml
+network_policy:
+  default: deny
+  allowlist: []
+mcp_policy:
+  unknown_server_policy: quarantine
+  unknown_tool_policy: ESCALATE
+  require_schema_pin: true
+healthchecks:
+  - type: command
+    command: "kimi --version"
+risk_class: T1
+budget_ceiling:
+  usd_max: 0
+  api_calls_max: 0
+  time_ms_max: 0
+framework_contract:
+  f2_contract_preflight: true
+  claim_level: external_byo_adapter
+  live_command_kind: workstation_adapter
+  runtime_install_policy: forbidden
+  baked_dependencies: ["byo_kimi_cli"]
+  forbidden_runtime_install_patterns: ["npm install", "pnpm install", "yarn install", "pip install", "uv pip install", "playwright install", "apt-get", "apk add", "curl | sh", "curl -fsSL"]
+  writable_paths:
+    - path: /var/lib/kimi/app_state
+      purpose: workstation_state_manifest
+      required: true
+  provider_host_groups: []
+  egress_proxy:
+    required: false
+  mcp_manifest_refs: []
+  healthcheck: "kimi --version"
+  evidence_profile: workstation.contract.v1
+  evidence_refs:
+    - contract_preflight.json
+    - launch_plan.json
+    - workstation_artifact_manifest.json
+    - agent_run_receipt.json
+    - offline_verify.txt
+evidence_requirements:
+  - contract_preflight
+  - cpi_output
+  - kernel_verdict
+  - sandbox_grant
+  - launch_receipt
+  - teardown_receipt
+  - evidence_pack
+  - offline_verify
+  - workstation_artifact_manifest
+  - agent_run_receipt
+conformance:
+  license_verified: false
+  artifact_verified: false
+  policy_pack_present: true
+  sandbox_verified: false
+  healthcheck_passing: false
+  e2e_passing: false
+  teardown_verified: false
+  receipt_verified: false
+  evidence_pack_verified: false

--- a/registry/launchpad/apps/pi.external.yaml
+++ b/registry/launchpad/apps/pi.external.yaml
@@ -1,0 +1,79 @@
+id: pi.external
+name: Pi External Adapter
+version: external-byo
+license:
+  status: upstream_oss_byo
+  spdx: MIT
+  url: https://github.com/earendil-works/pi/blob/main/LICENSE
+redistribution: helm_does_not_redistribute_byo_tool
+availability: external_proprietary_adapter
+support_level: external_byo_adapter
+install:
+  strategy: byo_tool
+runtime:
+  command: ["pi"]
+model_gateway_env: []
+required_secrets: ["vendor_account"]
+filesystem_policy:
+  mode: scoped_workspace
+  mounts: ["workspace:rw", "app_state:rw"]
+  policy_ref: policies/launchpad/apps/external-workstation.toml
+network_policy:
+  default: deny
+  allowlist: []
+mcp_policy:
+  unknown_server_policy: quarantine
+  unknown_tool_policy: ESCALATE
+  require_schema_pin: true
+healthchecks:
+  - type: command
+    command: "pi --version"
+risk_class: T1
+budget_ceiling:
+  usd_max: 0
+  api_calls_max: 0
+  time_ms_max: 0
+framework_contract:
+  f2_contract_preflight: true
+  claim_level: external_byo_adapter
+  live_command_kind: workstation_adapter
+  runtime_install_policy: forbidden
+  baked_dependencies: ["byo_pi_cli"]
+  forbidden_runtime_install_patterns: ["npm install", "pnpm install", "yarn install", "pip install", "uv pip install", "playwright install", "apt-get", "apk add", "curl | sh", "curl -fsSL"]
+  writable_paths:
+    - path: /var/lib/pi/app_state
+      purpose: workstation_state_manifest
+      required: true
+  provider_host_groups: []
+  egress_proxy:
+    required: false
+  mcp_manifest_refs: []
+  healthcheck: "pi --version"
+  evidence_profile: workstation.contract.v1
+  evidence_refs:
+    - contract_preflight.json
+    - launch_plan.json
+    - workstation_artifact_manifest.json
+    - agent_run_receipt.json
+    - offline_verify.txt
+evidence_requirements:
+  - contract_preflight
+  - cpi_output
+  - kernel_verdict
+  - sandbox_grant
+  - launch_receipt
+  - teardown_receipt
+  - evidence_pack
+  - offline_verify
+  - workstation_artifact_manifest
+  - agent_run_receipt
+conformance:
+  license_verified: false
+  artifact_verified: false
+  policy_pack_present: true
+  sandbox_verified: false
+  healthcheck_passing: false
+  e2e_passing: false
+  teardown_verified: false
+  receipt_verified: false
+  evidence_pack_verified: false

--- a/tests/launchpad/adapter_catalog_test.go
+++ b/tests/launchpad/adapter_catalog_test.go
@@ -1,0 +1,98 @@
+package launchpad_test
+
+import (
+	"testing"
+
+	"github.com/Mindburn-Labs/helm-ai-kernel/core/pkg/launchpad/registry"
+)
+
+func TestExternalCLIAdaptersRemainFailClosed(t *testing.T) {
+	root := repoRoot(t)
+	catalog, err := registry.LoadCatalog(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type expectation struct {
+		command         string
+		healthcheck     string
+		licenseStatus   string
+		licenseSPDX     string
+		licenseURL      string
+		redistribution  string
+		upstreamCLIDocs string
+	}
+	expected := map[string]expectation{
+		"gemini.external": {
+			command:        "gemini",
+			healthcheck:    "gemini --version",
+			licenseStatus:  "upstream_oss_byo",
+			licenseSPDX:    "Apache-2.0",
+			licenseURL:     "https://github.com/google-gemini/gemini-cli/blob/main/LICENSE",
+			redistribution: "helm_does_not_redistribute_byo_tool",
+		},
+		"grok.external": {
+			command:         "grok",
+			healthcheck:     "grok version",
+			licenseStatus:   "proprietary_byo",
+			redistribution:  "prohibited",
+			upstreamCLIDocs: "https://docs.x.ai/build/cli/reference",
+		},
+		"kimi.external": {
+			command:        "kimi",
+			healthcheck:    "kimi --version",
+			licenseStatus:  "upstream_oss_byo",
+			licenseSPDX:    "MIT",
+			licenseURL:     "https://github.com/MoonshotAI/kimi-code/blob/main/LICENSE",
+			redistribution: "helm_does_not_redistribute_byo_tool",
+		},
+		"pi.external": {
+			command:        "pi",
+			healthcheck:    "pi --version",
+			licenseStatus:  "upstream_oss_byo",
+			licenseSPDX:    "MIT",
+			licenseURL:     "https://github.com/earendil-works/pi/blob/main/LICENSE",
+			redistribution: "helm_does_not_redistribute_byo_tool",
+		},
+	}
+
+	for id, want := range expected {
+		app, ok := catalog.App(id)
+		if !ok {
+			t.Fatalf("%s missing from Launchpad catalog", id)
+		}
+		if app.Availability != registry.AvailabilityExternalProprietaryAdapter {
+			t.Fatalf("%s availability = %q, want %q", id, app.Availability, registry.AvailabilityExternalProprietaryAdapter)
+		}
+		if app.SupportLevel != registry.SupportLevelExternalBYOAdapter {
+			t.Fatalf("%s support level = %q, want %q", id, app.SupportLevel, registry.SupportLevelExternalBYOAdapter)
+		}
+		if app.Install.Strategy != "byo_tool" {
+			t.Fatalf("%s install strategy = %q, want byo_tool", id, app.Install.Strategy)
+		}
+		if len(app.Runtime.Command) != 1 || app.Runtime.Command[0] != want.command {
+			t.Fatalf("%s runtime command = %#v, want [%q]", id, app.Runtime.Command, want.command)
+		}
+		if len(app.Healthchecks) != 1 || app.Healthchecks[0].Type != "command" || app.Healthchecks[0].Command != want.healthcheck {
+			t.Fatalf("%s healthcheck = %#v, want command %q", id, app.Healthchecks, want.healthcheck)
+		}
+		if app.FrameworkContract.Healthcheck != want.healthcheck {
+			t.Fatalf("%s framework healthcheck = %q, want %q", id, app.FrameworkContract.Healthcheck, want.healthcheck)
+		}
+		if app.BudgetCeiling.USDMax != 0 || app.BudgetCeiling.APICallsMax != 0 || app.BudgetCeiling.TimeMSMax != 0 {
+			t.Fatalf("%s budget ceiling = %#v, want all zero", id, app.BudgetCeiling)
+		}
+		if app.Conformance.LicenseVerified || app.Conformance.ArtifactVerified || app.Conformance.SandboxVerified || app.Conformance.HealthcheckPassing || app.Conformance.E2EPassing || app.Conformance.TeardownVerified || app.Conformance.ReceiptVerified || app.Conformance.EvidencePackVerified || app.Conformance.FullyVerified() {
+			t.Fatalf("%s has verified conformance: %#v", id, app.Conformance)
+		}
+		if app.License.Status != want.licenseStatus || app.License.SPDX != want.licenseSPDX || app.License.URL != want.licenseURL {
+			t.Fatalf("%s license = %#v, want status=%q spdx=%q url=%q", id, app.License, want.licenseStatus, want.licenseSPDX, want.licenseURL)
+		}
+		if app.Redistribution != want.redistribution {
+			t.Fatalf("%s redistribution = %q, want %q", id, app.Redistribution, want.redistribution)
+		}
+		if want.upstreamCLIDocs != "" && app.Metadata["upstream_cli_docs"] != want.upstreamCLIDocs {
+			t.Fatalf("%s upstream CLI docs = %q, want %q", id, app.Metadata["upstream_cli_docs"], want.upstreamCLIDocs)
+		}
+	}
+}


### PR DESCRIPTION
## Outcome

Adds source-owned Launchpad catalog entries for Gemini CLI, Grok CLI, Kimi Code CLI, and Pi at the Kernel boundary, plus one shared deny-by-default workstation policy.

This PR is intentionally claim-limited: catalog presence is not install, provider, sandbox, deployment, or live-runtime proof. All new adapters remain BYO, zero-budget, no-runtime-install, and unverified for live conformance.

## Safety invariants

- scoped workspace and app-state mounts
- deny-by-default network policy
- unknown MCP servers quarantined and schema pins required
- zero USD/API-call/time budget ceilings
- runtime installation forbidden
- all live conformance flags false

## Validation

- `GOWORK=off go test ./pkg/launchpad/registry` (from `core`)
- `GOWORK=off go test ./...` (from `tests/launchpad`)
- `make test`
- `make lint` with Bash 5 on PATH
- `git diff --check origin/main...HEAD`

## Ownership correction

The prototype first existed in the Enterprise mirror, where `make quality` correctly rejected it as extra protected-boundary content. This PR moves the slice to the Kernel source of truth; Enterprise sync will follow only after upstream merge.
