### PR TITLE
HELM-191: pin Control Plane policy TLS trust

### DIFF
--- a/core/cmd/helm-ai-kernel/main.go
+++ b/core/cmd/helm-ai-kernel/main.go
@@ -1093,6 +1093,17 @@ func policySourceFromEnv(policyPath string, scope policyreconcile.PolicyScope) (
 			return nil, "controlplane", err
 		}
 		source := policyreconcile.NewControlPlaneSource(baseURL, scope)
+		caFile := strings.TrimSpace(os.Getenv("HELM_POLICY_CONTROLPLANE_CA_FILE"))
+		if envBool("HELM_PRODUCTION") && caFile == "" && !policyreconcile.IsLoopbackControlPlaneURL(baseURL) {
+			return nil, "controlplane", fmt.Errorf("HELM_POLICY_CONTROLPLANE_CA_FILE is required in production so managed policy TLS uses an exclusive trust root")
+		}
+		if caFile != "" {
+			client, err := policyreconcile.NewControlPlaneHTTPClient(baseURL, caFile)
+			if err != nil {
+				return nil, "controlplane", err
+			}
+			source.HTTPClient = client
+		}
 		source.BearerToken = bearerToken
 		source.BearerTokenFile = bearerTokenFile
 		return source, "controlplane", nil

--- a/core/cmd/helm-ai-kernel/policy_source_test.go
+++ b/core/cmd/helm-ai-kernel/policy_source_test.go
@@ -65,6 +65,7 @@ func TestPolicySourceFromEnvControlPlaneUsesBearerToken(t *testing.T) {
 }
 
 func TestPolicySourceFromEnvControlPlaneAllowsLoopbackHTTP(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "true")
 	t.Setenv("HELM_POLICY_SOURCE_KIND", "controlplane")
 	t.Setenv("HELM_POLICY_CONTROLPLANE_URL", "http://127.0.0.1:18080")
 	t.Setenv("HELM_POLICY_CONTROLPLANE_AUTH_MODE", "bearerToken")
@@ -136,6 +137,18 @@ func TestPolicySourceFromEnvControlPlaneRejectsPlainHTTP(t *testing.T) {
 	_, _, err := policySourceFromEnv("/tmp/policy.toml", policyreconcile.DefaultScope)
 	if err == nil || !strings.Contains(err.Error(), "must use https") {
 		t.Fatalf("expected non-HTTPS controlplane URL error, got %v", err)
+	}
+}
+
+func TestPolicySourceFromEnvProductionControlPlaneRequiresPrivateCA(t *testing.T) {
+	t.Setenv("HELM_PRODUCTION", "true")
+	t.Setenv("HELM_POLICY_SOURCE_KIND", "controlplane")
+	t.Setenv("HELM_POLICY_CONTROLPLANE_URL", "https://controlplane.example")
+	t.Setenv("HELM_POLICY_CONTROLPLANE_AUTH_MODE", "bearerToken")
+	t.Setenv("HELM_POLICY_BEARER_TOKEN", "token-1")
+	_, _, err := policySourceFromEnv("/tmp/policy.toml", policyreconcile.DefaultScope)
+	if err == nil || !strings.Contains(err.Error(), "HELM_POLICY_CONTROLPLANE_CA_FILE") {
+		t.Fatalf("expected production private CA requirement, got %v", err)
 	}
 }
 

--- a/core/pkg/policy/reconcile/reconcile.go
+++ b/core/pkg/policy/reconcile/reconcile.go
@@ -940,7 +940,13 @@ func NewControlPlaneHTTPClient(baseURL, caFile string) (*http.Client, error) {
 			return verifyControlPlaneConnection(caFile, serverName, state)
 		},
 	}
-	return &http.Client{Transport: transport, Timeout: controlPlaneRequestTimeout}, nil
+	return &http.Client{
+		Transport: transport,
+		Timeout:   controlPlaneRequestTimeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}, nil
 }
 
 func loadControlPlaneRoots(caFile string) (*x509.CertPool, error) {

--- a/core/pkg/policy/reconcile/reconcile.go
+++ b/core/pkg/policy/reconcile/reconcile.go
@@ -933,12 +933,23 @@ func NewControlPlaneHTTPClient(baseURL, caFile string) (*http.Client, error) {
 	transport.ForceAttemptHTTP2 = true
 	transport.DisableKeepAlives = true
 	transport.TLSClientConfig = &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		ServerName:         serverName,
-		InsecureSkipVerify: true, // Verification is exclusive to the rotating CA below.
-		VerifyConnection: func(state tls.ConnectionState) error {
-			return verifyControlPlaneConnection(caFile, serverName, state)
-		},
+		MinVersion: tls.VersionTLS13,
+		ServerName: serverName,
+	}
+	transport.DialTLSContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		roots, err := loadControlPlaneRoots(caFile)
+		if err != nil {
+			return nil, err
+		}
+		return (&tls.Dialer{
+			NetDialer: &net.Dialer{Timeout: controlPlaneRequestTimeout},
+			Config: &tls.Config{
+				MinVersion: tls.VersionTLS13,
+				ServerName: serverName,
+				RootCAs:    roots,
+				NextProtos: []string{"h2", "http/1.1"},
+			},
+		}).DialContext(ctx, network, address)
 	}
 	return &http.Client{
 		Transport: transport,
@@ -959,28 +970,6 @@ func loadControlPlaneRoots(caFile string) (*x509.CertPool, error) {
 		return nil, fmt.Errorf("controlplane policy CA contains no certificates")
 	}
 	return roots, nil
-}
-
-func verifyControlPlaneConnection(caFile, serverName string, state tls.ConnectionState) error {
-	if len(state.PeerCertificates) == 0 {
-		return fmt.Errorf("controlplane TLS peer certificate is missing")
-	}
-	roots, err := loadControlPlaneRoots(caFile)
-	if err != nil {
-		return err
-	}
-	intermediates := x509.NewCertPool()
-	for _, certificate := range state.PeerCertificates[1:] {
-		intermediates.AddCert(certificate)
-	}
-	_, err = state.PeerCertificates[0].Verify(x509.VerifyOptions{
-		DNSName: serverName, Roots: roots, Intermediates: intermediates,
-		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	})
-	if err != nil {
-		return fmt.Errorf("verify controlplane policy TLS: %w", err)
-	}
-	return nil
 }
 
 func ValidateControlPlaneURL(raw string) error {

--- a/core/pkg/policy/reconcile/reconcile.go
+++ b/core/pkg/policy/reconcile/reconcile.go
@@ -12,6 +12,8 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -47,6 +49,7 @@ const (
 
 	maxControlPlaneHeadBytes   int64 = 64 << 10
 	maxControlPlaneBundleBytes int64 = 1 << 20
+	controlPlaneRequestTimeout       = 30 * time.Second
 )
 
 const (
@@ -907,6 +910,73 @@ func NewControlPlaneSource(baseURL string, scope PolicyScope) *ControlPlaneSourc
 	return &ControlPlaneSource{BaseURL: strings.TrimRight(baseURL, "/"), HTTPClient: http.DefaultClient, Scope: scope.Normalize()}
 }
 
+// NewControlPlaneHTTPClient returns a private-CA client for managed policy
+// publication. The CA file is re-read for every new TLS connection so a
+// projected Kubernetes Secret can rotate without widening trust to system
+// roots or requiring a Kernel restart.
+func NewControlPlaneHTTPClient(baseURL, caFile string) (*http.Client, error) {
+	parsedURL, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || !strings.EqualFold(parsedURL.Scheme, "https") || parsedURL.Hostname() == "" {
+		return nil, fmt.Errorf("private-CA controlplane policy URL must be absolute HTTPS")
+	}
+	serverName := parsedURL.Hostname()
+	caFile = strings.TrimSpace(caFile)
+	if !filepath.IsAbs(caFile) {
+		return nil, fmt.Errorf("controlplane policy CA file must be an absolute path")
+	}
+	if _, err := loadControlPlaneRoots(caFile); err != nil {
+		return nil, err
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.ForceAttemptHTTP2 = true
+	transport.DisableKeepAlives = true
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion:         tls.VersionTLS13,
+		ServerName:         serverName,
+		InsecureSkipVerify: true, // Verification is exclusive to the rotating CA below.
+		VerifyConnection: func(state tls.ConnectionState) error {
+			return verifyControlPlaneConnection(caFile, serverName, state)
+		},
+	}
+	return &http.Client{Transport: transport, Timeout: controlPlaneRequestTimeout}, nil
+}
+
+func loadControlPlaneRoots(caFile string) (*x509.CertPool, error) {
+	pemBytes, err := os.ReadFile(filepath.Clean(caFile))
+	if err != nil {
+		return nil, fmt.Errorf("read controlplane policy CA: %w", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(pemBytes) {
+		return nil, fmt.Errorf("controlplane policy CA contains no certificates")
+	}
+	return roots, nil
+}
+
+func verifyControlPlaneConnection(caFile, serverName string, state tls.ConnectionState) error {
+	if len(state.PeerCertificates) == 0 {
+		return fmt.Errorf("controlplane TLS peer certificate is missing")
+	}
+	roots, err := loadControlPlaneRoots(caFile)
+	if err != nil {
+		return err
+	}
+	intermediates := x509.NewCertPool()
+	for _, certificate := range state.PeerCertificates[1:] {
+		intermediates.AddCert(certificate)
+	}
+	_, err = state.PeerCertificates[0].Verify(x509.VerifyOptions{
+		DNSName: serverName, Roots: roots, Intermediates: intermediates,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	if err != nil {
+		return fmt.Errorf("verify controlplane policy TLS: %w", err)
+	}
+	return nil
+}
+
 func ValidateControlPlaneURL(raw string) error {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil {
@@ -926,6 +996,11 @@ func ValidateControlPlaneURL(raw string) error {
 	default:
 		return fmt.Errorf("controlplane URL must use https")
 	}
+}
+
+func IsLoopbackControlPlaneURL(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	return err == nil && strings.EqualFold(parsed.Scheme, "http") && isLoopbackControlPlaneHost(parsed.Hostname())
 }
 
 func isLoopbackControlPlaneHost(host string) bool {

--- a/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
+++ b/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
@@ -229,6 +229,37 @@ func TestControlPlaneHTTPClientUsesExclusiveRotatingCA(t *testing.T) {
 	}
 }
 
+func TestControlPlaneHTTPClientRejectsRedirects(t *testing.T) {
+	leakedAuthorization := make(chan string, 1)
+	plaintextTarget := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, request *http.Request) {
+		leakedAuthorization <- request.Header.Get("Authorization")
+	}))
+	defer plaintextTarget.Close()
+
+	redirector := newControlPlaneTLSServer(t, 3, http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Redirect(response, request, plaintextTarget.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	caFile := filepath.Join(t.TempDir(), "controlplane-ca.pem")
+	writeControlPlaneTestCA(t, caFile, redirector)
+	client, err := NewControlPlaneHTTPClient(redirector.URL, caFile)
+	if err != nil {
+		t.Fatalf("new controlplane client: %v", err)
+	}
+	source := NewControlPlaneSource(redirector.URL, DefaultScope)
+	source.HTTPClient = client
+	source.BearerToken = "secret-policy-token"
+	if _, err := source.Head(context.Background(), DefaultScope); err == nil || !strings.Contains(err.Error(), "302") {
+		t.Fatalf("expected redirect rejection, got %v", err)
+	}
+	select {
+	case authorization := <-leakedAuthorization:
+		t.Fatalf("redirect reached plaintext target with authorization %q", authorization)
+	default:
+	}
+}
+
 func newControlPlaneTLSServer(t *testing.T, serial int64, handler http.Handler) *httptest.Server {
 	t.Helper()
 	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)

--- a/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
+++ b/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
@@ -207,7 +207,7 @@ func TestControlPlaneHTTPClientUsesExclusiveRotatingCA(t *testing.T) {
 		t.Fatalf("new controlplane client: %v", err)
 	}
 	transport := client.Transport.(*http.Transport)
-	if transport.Proxy != nil || !transport.DisableKeepAlives || transport.TLSClientConfig.MinVersion != tls.VersionTLS13 || !transport.TLSClientConfig.InsecureSkipVerify || transport.TLSClientConfig.VerifyConnection == nil {
+	if transport.Proxy != nil || !transport.DisableKeepAlives || transport.TLSClientConfig.MinVersion != tls.VersionTLS13 || transport.TLSClientConfig.InsecureSkipVerify || transport.DialTLSContext == nil {
 		t.Fatalf("unexpected private-CA transport: %+v", transport)
 	}
 

--- a/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
+++ b/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
@@ -1,3 +1,5 @@
+// quantum_posture: these tests exercise classical Ed25519 signatures and
+// X.509/TLS trust rotation only; they make no post-quantum assurance claim.
 package reconcile
 
 import (

--- a/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
+++ b/core/pkg/policy/reconcile/reconcile_core_coverage_test.go
@@ -2,8 +2,15 @@ package reconcile
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -178,6 +185,78 @@ func TestControlPlaneSourceErrorAndHeaderBranches(t *testing.T) {
 	source.BearerToken = "token-1"
 	if _, err := source.Head(context.Background(), scope); err == nil {
 		t.Fatal("expected controlplane decode error")
+	}
+}
+
+func TestControlPlaneHTTPClientUsesExclusiveRotatingCA(t *testing.T) {
+	serverOne := newControlPlaneTLSServer(t, 1, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"scope":{"tenant_id":"default","workspace_id":"default"},"policy_epoch":1,"policy_hash":"hash"}`))
+	}))
+	defer serverOne.Close()
+	serverTwo := newControlPlaneTLSServer(t, 2, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"scope":{"tenant_id":"default","workspace_id":"default"},"policy_epoch":2,"policy_hash":"hash"}`))
+	}))
+	defer serverTwo.Close()
+
+	caFile := filepath.Join(t.TempDir(), "controlplane-ca.pem")
+	writeControlPlaneTestCA(t, caFile, serverOne)
+	client, err := NewControlPlaneHTTPClient(serverOne.URL, caFile)
+	if err != nil {
+		t.Fatalf("new controlplane client: %v", err)
+	}
+	transport := client.Transport.(*http.Transport)
+	if transport.Proxy != nil || !transport.DisableKeepAlives || transport.TLSClientConfig.MinVersion != tls.VersionTLS13 || !transport.TLSClientConfig.InsecureSkipVerify || transport.TLSClientConfig.VerifyConnection == nil {
+		t.Fatalf("unexpected private-CA transport: %+v", transport)
+	}
+
+	source := NewControlPlaneSource(serverOne.URL, DefaultScope)
+	source.HTTPClient = client
+	source.BearerToken = "token"
+	if _, err := source.Head(context.Background(), DefaultScope); err != nil {
+		t.Fatalf("initial private CA rejected: %v", err)
+	}
+
+	writeControlPlaneTestCA(t, caFile, serverTwo)
+	source.BaseURL = serverTwo.URL
+	if _, err := source.Head(context.Background(), DefaultScope); err != nil {
+		t.Fatalf("rotated private CA rejected: %v", err)
+	}
+	source.BaseURL = serverOne.URL
+	if _, err := source.Head(context.Background(), DefaultScope); err == nil {
+		t.Fatal("retired private CA remained trusted")
+	}
+}
+
+func newControlPlaneTLSServer(t *testing.T, serial int64, handler http.Handler) *httptest.Server {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate controlplane test key: %v", err)
+	}
+	now := time.Now()
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		NotBefore:    now.Add(-time.Minute), NotAfter: now.Add(time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{net.ParseIP("127.0.0.1")},
+		IsCA:        true, BasicConstraintsValid: true,
+	}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	if err != nil {
+		t.Fatalf("create controlplane test certificate: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{certificate}, PrivateKey: privateKey}}}
+	server.StartTLS()
+	return server
+}
+
+func writeControlPlaneTestCA(t *testing.T, path string, server *httptest.Server) {
+	t.Helper()
+	certificate := server.TLS.Certificates[0].Certificate[0]
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate}), 0o600); err != nil {
+		t.Fatalf("write controlplane CA: %v", err)
 	}
 }
 

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -1,5 +1,6 @@
 {{/* quantum_posture: chart wiring supplies a raw Ed25519 command-key keyring;
       it does not claim hybrid or post-quantum command signing. */}}
+{{- $controlPlaneLoopback := regexMatch "^http://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?(/|$)" .Values.helm.policy.source.controlplane.url -}}
 {{- if not (or (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.kind "crd") (eq .Values.helm.policy.source.kind "mountedFile")) -}}
 {{- fail "helm.policy.source.kind must be one of controlplane, crd, mountedFile" -}}
 {{- end -}}
@@ -14,6 +15,15 @@
 {{- end -}}
 {{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "controlplane") (not .Values.helm.policy.source.controlplane.url) -}}
 {{- fail "helm.production=true with helm.policy.source.kind=controlplane requires helm.policy.source.controlplane.url" -}}
+{{- end -}}
+{{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "controlplane") (not $controlPlaneLoopback) (not (regexMatch "^https://" .Values.helm.policy.source.controlplane.url)) -}}
+{{- fail "helm.production=true requires an https helm.policy.source.controlplane.url except for an in-Pod loopback fixture" -}}
+{{- end -}}
+{{- if and .Values.helm.production (eq .Values.helm.policy.source.kind "controlplane") (not $controlPlaneLoopback) (not .Values.helm.policy.source.controlplane.tls.existingSecret) -}}
+{{- fail "helm.production=true with a controlplane policy source requires helm.policy.source.controlplane.tls.existingSecret for exclusive CA trust" -}}
+{{- end -}}
+{{- if and .Values.helm.policy.source.controlplane.tls.existingSecret (not .Values.helm.policy.source.controlplane.tls.existingSecretKey) -}}
+{{- fail "helm.policy.source.controlplane.tls.existingSecretKey is required when a TLS CA Secret is configured" -}}
 {{- end -}}
 {{- if and (eq .Values.helm.policy.source.kind "controlplane") (not (or (eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT") (eq .Values.helm.policy.source.controlplane.auth.mode "bearerToken"))) -}}
 {{- fail "controlplane auth mode must be serviceAccountJWT or bearerToken" -}}
@@ -336,6 +346,10 @@ spec:
             {{- if eq .Values.helm.policy.source.kind "controlplane" }}
             - name: HELM_POLICY_CONTROLPLANE_URL
               value: {{ .Values.helm.policy.source.controlplane.url | quote }}
+            {{- if .Values.helm.policy.source.controlplane.tls.existingSecret }}
+            - name: HELM_POLICY_CONTROLPLANE_CA_FILE
+              value: "/var/run/secrets/helm-policy-controlplane-tls/ca.pem"
+            {{- end }}
             - name: HELM_POLICY_CONTROLPLANE_AUTH_MODE
               value: {{ .Values.helm.policy.source.controlplane.auth.mode | quote }}
             {{- if eq .Values.helm.policy.source.controlplane.auth.mode "serviceAccountJWT" }}
@@ -485,6 +499,11 @@ spec:
               mountPath: /var/run/secrets/helm-policy
               readOnly: true
             {{- end }}
+            {{- if and (eq .Values.helm.policy.source.kind "controlplane") .Values.helm.policy.source.controlplane.tls.existingSecret }}
+            - name: policy-controlplane-tls
+              mountPath: /var/run/secrets/helm-policy-controlplane-tls
+              readOnly: true
+            {{- end }}
         {{- if and .Values.helm.policy.reloadHints.enabled .Values.helm.policy.reloadHints.configReloaderSidecar.enabled }}
         - name: config-reloader
           image: {{ .Values.helm.policy.reloadHints.configReloaderSidecar.image | quote }}
@@ -533,6 +552,15 @@ spec:
                   audience: {{ required "helm.policy.source.controlplane.auth.serviceAccountJWT.audience is required" .Values.helm.policy.source.controlplane.auth.serviceAccountJWT.audience | quote }}
                   expirationSeconds: {{ .Values.helm.policy.source.controlplane.auth.serviceAccountJWT.expirationSeconds }}
                   path: token
+        {{- end }}
+        {{- if and (eq .Values.helm.policy.source.kind "controlplane") .Values.helm.policy.source.controlplane.tls.existingSecret }}
+        - name: policy-controlplane-tls
+          secret:
+            secretName: {{ .Values.helm.policy.source.controlplane.tls.existingSecret }}
+            defaultMode: 256
+            items:
+              - key: {{ .Values.helm.policy.source.controlplane.tls.existingSecretKey }}
+                path: ca.pem
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -1,6 +1,7 @@
 {{/* quantum_posture: chart wiring supplies a raw Ed25519 command-key keyring;
       it does not claim hybrid or post-quantum command signing. */}}
-{{- $controlPlaneLoopback := regexMatch "^http://(localhost|127\\.0\\.0\\.1)(:[0-9]+)?(/|$)" .Values.helm.policy.source.controlplane.url -}}
+{{- $ipv4Octet := "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])" -}}
+{{- $controlPlaneLoopback := regexMatch (printf "^http://(localhost|127\\.%s\\.%s\\.%s|\\[::1\\])(:[0-9]+)?(/|$)" $ipv4Octet $ipv4Octet $ipv4Octet) .Values.helm.policy.source.controlplane.url -}}
 {{- if not (or (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.kind "crd") (eq .Values.helm.policy.source.kind "mountedFile")) -}}
 {{- fail "helm.policy.source.kind must be one of controlplane, crd, mountedFile" -}}
 {{- end -}}

--- a/deploy/helm-chart/templates/deployment.yaml
+++ b/deploy/helm-chart/templates/deployment.yaml
@@ -1,7 +1,7 @@
 {{/* quantum_posture: chart wiring supplies a raw Ed25519 command-key keyring;
       it does not claim hybrid or post-quantum command signing. */}}
 {{- $ipv4Octet := "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])" -}}
-{{- $controlPlaneLoopback := regexMatch (printf "^http://(localhost|127\\.%s\\.%s\\.%s|\\[::1\\])(:[0-9]+)?(/|$)" $ipv4Octet $ipv4Octet $ipv4Octet) .Values.helm.policy.source.controlplane.url -}}
+{{- $controlPlaneLoopback := regexMatch (printf "(?i)^http://(localhost|127\\.%s\\.%s\\.%s|\\[[0:]*1\\]|\\[[0:]*ffff:(127\\.%s\\.%s\\.%s|7f[0-9a-f]{2}:[0-9a-f]{1,4})\\])(:[0-9]+)?(/|$)" $ipv4Octet $ipv4Octet $ipv4Octet $ipv4Octet $ipv4Octet $ipv4Octet) .Values.helm.policy.source.controlplane.url -}}
 {{- if not (or (eq .Values.helm.policy.source.kind "controlplane") (eq .Values.helm.policy.source.kind "crd") (eq .Values.helm.policy.source.kind "mountedFile")) -}}
 {{- fail "helm.policy.source.kind must be one of controlplane, crd, mountedFile" -}}
 {{- end -}}

--- a/deploy/helm-chart/values.schema.json
+++ b/deploy/helm-chart/values.schema.json
@@ -686,6 +686,22 @@
                       "type": "string",
                       "description": "Control-plane URL serving the policy bundle (HTTPS only in production)."
                     },
+                    "tls": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Exclusive CA trust for managed policy transport. Required for non-loopback production endpoints.",
+                      "properties": {
+                        "existingSecret": {
+                          "type": "string",
+                          "description": "Existing Secret containing the private CA certificate trusted for the control plane."
+                        },
+                        "existingSecretKey": {
+                          "type": "string",
+                          "default": "ca.crt",
+                          "description": "Key inside existingSecret holding the PEM-encoded CA certificate."
+                        }
+                      }
+                    },
                     "auth": {
                       "type": "object",
                       "additionalProperties": false,

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -235,6 +235,10 @@ helm:
       initialReconcileTimeout: "30s"
       controlplane:
         url: ""
+        tls:
+          # Production requires an exclusive CA Secret instead of system roots.
+          existingSecret: ""
+          existingSecretKey: "ca.crt"
         auth:
           mode: "serviceAccountJWT" # serviceAccountJWT | bearerToken
           serviceAccountJWT:

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -702,7 +702,13 @@ fi
 assert_contains "$controlplane_ca_log" "helm.policy.source.controlplane.tls.existingSecret"
 
 controlplane_loopback_rendered="$RENDER_DIR/rendered-controlplane-loopback.yaml"
-for controlplane_loopback_url in "http://127.42.0.9:18080" "http://[::1]:18080"; do
+for controlplane_loopback_url in \
+    "http://127.42.0.9:18080" \
+    "HTTP://LOCALHOST:18080" \
+    "http://[::1]:18080" \
+    "http://[0:0:0:0:0:0:0:1]:18080" \
+    "http://[::ffff:127.0.0.1]:18080" \
+    "http://[0:0:0:0:0:ffff:7f00:1]:18080"; do
     production_helm_runner template "$RELEASE" "$CHART" \
         --namespace "$NAMESPACE" \
         --set helm.production=true \

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -702,18 +702,20 @@ fi
 assert_contains "$controlplane_ca_log" "helm.policy.source.controlplane.tls.existingSecret"
 
 controlplane_loopback_rendered="$RENDER_DIR/rendered-controlplane-loopback.yaml"
-production_helm_runner template "$RELEASE" "$CHART" \
-    --namespace "$NAMESPACE" \
-    --set helm.production=true \
-    --set helm.signing.key="$SIGNING_KEY" \
-    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
-    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
-    --set helm.policy.source.kind=controlplane \
-    --set-string helm.policy.source.controlplane.url=http://127.0.0.1:18080 \
-    --set helm.policy.signature.required=true \
-    --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" >"$controlplane_loopback_rendered"
-assert_contains "$controlplane_loopback_rendered" "http://127.0.0.1:18080"
-assert_not_contains "$controlplane_loopback_rendered" "HELM_POLICY_CONTROLPLANE_CA_FILE"
+for controlplane_loopback_url in "http://127.42.0.9:18080" "http://[::1]:18080"; do
+    production_helm_runner template "$RELEASE" "$CHART" \
+        --namespace "$NAMESPACE" \
+        --set helm.production=true \
+        --set helm.signing.key="$SIGNING_KEY" \
+        --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+        --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+        --set helm.policy.source.kind=controlplane \
+        --set-string "helm.policy.source.controlplane.url=$controlplane_loopback_url" \
+        --set helm.policy.signature.required=true \
+        --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" >"$controlplane_loopback_rendered"
+    assert_contains "$controlplane_loopback_rendered" "$controlplane_loopback_url"
+    assert_not_contains "$controlplane_loopback_rendered" "HELM_POLICY_CONTROLPLANE_CA_FILE"
+done
 
 controlplane_rendered="$RENDER_DIR/rendered-controlplane.yaml"
 production_helm_runner template "$RELEASE" "$CHART" \

--- a/scripts/ci/helm_chart_smoke.sh
+++ b/scripts/ci/helm_chart_smoke.sh
@@ -89,6 +89,7 @@ production_controlplane_helm_runner() {
     production_helm_runner "$@" \
         --set helm.policy.source.kind=controlplane \
         --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+        --set helm.policy.source.controlplane.tls.existingSecret=helm-policy-controlplane-ca \
         --set helm.policy.signature.required=true \
         --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY"
 }
@@ -417,6 +418,7 @@ if helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.principalID="$AGENT_ID" \
     --set helm.policy.source.kind=controlplane \
     --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.source.controlplane.tls.existingSecret=helm-policy-controlplane-ca \
     --set helm.policy.signature.required=true \
     --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" >"$RENDER_DIR/production-missing-image-digest.yaml" 2>"$image_digest_fail_log"; then
     echo "::error::production render without an immutable Kernel image digest unexpectedly succeeded"
@@ -444,6 +446,7 @@ if helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.principalID="$AGENT_ID" \
     --set helm.policy.source.kind=controlplane \
     --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.source.controlplane.tls.existingSecret=helm-policy-controlplane-ca \
     --set helm.policy.signature.required=true \
     --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" \
     --set image.digest="$PRODUCTION_IMAGE_DIGEST" >"$RENDER_DIR/production-network-policy-disabled.yaml" 2>"$network_policy_disabled_log"; then
@@ -675,11 +678,42 @@ if production_helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.adminAPIKey="$ADMIN_KEY" \
     --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
     --set helm.policy.source.kind=controlplane \
-    --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal >"$RENDER_DIR/controlplane-missing-signature.yaml" 2>"$controlplane_unsigned_log"; then
+    --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.source.controlplane.tls.existingSecret=helm-policy-controlplane-ca >"$RENDER_DIR/controlplane-missing-signature.yaml" 2>"$controlplane_unsigned_log"; then
     echo "::error::production controlplane render without required policy signatures unexpectedly succeeded"
     exit 1
 fi
 assert_contains "$controlplane_unsigned_log" "helm.policy.signature.required=true"
+
+controlplane_ca_log="$RENDER_DIR/controlplane-missing-ca.log"
+if production_helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.production=true \
+    --set helm.signing.key="$SIGNING_KEY" \
+    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set helm.policy.source.kind=controlplane \
+    --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.signature.required=true \
+    --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" >"$RENDER_DIR/controlplane-missing-ca.yaml" 2>"$controlplane_ca_log"; then
+    echo "::error::production controlplane render without an exclusive TLS CA unexpectedly succeeded"
+    exit 1
+fi
+assert_contains "$controlplane_ca_log" "helm.policy.source.controlplane.tls.existingSecret"
+
+controlplane_loopback_rendered="$RENDER_DIR/rendered-controlplane-loopback.yaml"
+production_helm_runner template "$RELEASE" "$CHART" \
+    --namespace "$NAMESPACE" \
+    --set helm.production=true \
+    --set helm.signing.key="$SIGNING_KEY" \
+    --set helm.auth.adminAPIKey="$ADMIN_KEY" \
+    --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
+    --set helm.policy.source.kind=controlplane \
+    --set-string helm.policy.source.controlplane.url=http://127.0.0.1:18080 \
+    --set helm.policy.signature.required=true \
+    --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" >"$controlplane_loopback_rendered"
+assert_contains "$controlplane_loopback_rendered" "http://127.0.0.1:18080"
+assert_not_contains "$controlplane_loopback_rendered" "HELM_POLICY_CONTROLPLANE_CA_FILE"
 
 controlplane_rendered="$RENDER_DIR/rendered-controlplane.yaml"
 production_helm_runner template "$RELEASE" "$CHART" \
@@ -690,6 +724,7 @@ production_helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
     --set helm.policy.source.kind=controlplane \
     --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.source.controlplane.tls.existingSecret=helm-policy-controlplane-ca \
     --set helm.policy.signature.required=true \
     --set helm.policy.signature.publicKey="$TRUST_PUBLIC_KEY" \
     --set image.repository=ghcr.io/mindburn-labs/helm-ai-kernel \
@@ -700,6 +735,10 @@ assert_contains "$controlplane_rendered" "HELM_POLICY_SOURCE_KIND"
 assert_contains "$controlplane_rendered" "controlplane"
 assert_contains "$controlplane_rendered" "HELM_POLICY_CONTROLPLANE_URL"
 assert_contains "$controlplane_rendered" "https://helm-controlplane.example.internal"
+assert_contains "$controlplane_rendered" "HELM_POLICY_CONTROLPLANE_CA_FILE"
+assert_contains "$controlplane_rendered" "/var/run/secrets/helm-policy-controlplane-tls/ca.pem"
+assert_contains "$controlplane_rendered" "name: policy-controlplane-tls"
+assert_contains "$controlplane_rendered" "secretName: helm-policy-controlplane-ca"
 assert_contains "$controlplane_rendered" "HELM_POLICY_CONTROLPLANE_AUTH_MODE"
 assert_contains "$controlplane_rendered" "serviceAccountJWT"
 assert_contains "$controlplane_rendered" "HELM_POLICY_SERVICE_ACCOUNT_TOKEN_FILE"
@@ -724,6 +763,7 @@ production_helm_runner template "$RELEASE" "$CHART" \
     --set helm.auth.serviceAPIKey="$SERVICE_KEY" \
     --set helm.policy.source.kind=controlplane \
     --set helm.policy.source.controlplane.url=https://helm-controlplane.example.internal \
+    --set helm.policy.source.controlplane.tls.existingSecret=helm-policy-controlplane-ca \
     --set helm.policy.source.controlplane.auth.mode=bearerToken \
     --set helm.policy.source.controlplane.auth.existingSecret=policy-reader \
     --set helm.policy.signature.required=true \


### PR DESCRIPTION
Closes the Kernel side of the managed-policy transport gap.

- requires an exclusive private CA for every non-loopback production Control Plane policy source
- enforces TLS 1.3, hostname/SAN verification, no environment proxy, and live CA reload
- wires the CA from an existing Kubernetes Secret through the Helm chart
- preserves only the existing in-Pod localhost fixture exception
- adds negative chart gates plus trust-rotation coverage

Validation:
- make test
- docs coverage and truth, go vet, gofmt
- go_mod_tidy_check.sh under Bash 5
- focused race test for CA rotation
- scripts/ci/helm_chart_smoke.sh
- isolated go build output under /tmp

Not production evidence: cluster kind/e2e and production readback remain gated.