### PR TITLE
Add authenticated read-only projection replay lookup

### DIFF
--- a/core/pkg/skillpacks/lifecycle.go
+++ b/core/pkg/skillpacks/lifecycle.go
@@ -632,18 +632,11 @@ func (l *ProjectionLifecycle) LookupReplay(
 		return ProjectionLifecycleResult{}, err
 	}
 	relativePath := filepath.ToSlash(projection.Path)
-	journal, pending, err := l.readProjectionRecoveryJournal(effect, relativePath)
+	pending, err := l.hasPendingProjectionRecoveryJournal(effect, relativePath)
 	if err != nil {
 		return ProjectionLifecycleResult{}, err
 	}
-	if journal != nil {
-		replay, ok := findProjectionReplay(pending.Replays, effect.IdempotencyKey)
-		if !ok {
-			return ProjectionLifecycleResult{}, fmt.Errorf("%w: recovery replay is missing", ErrProjectionDrift)
-		}
-		if err := validateProjectionReplayLookupBinding(effect, relativePath, consumedPermitRef, rollbackPermit, replay); err != nil {
-			return ProjectionLifecycleResult{}, err
-		}
+	if pending {
 		return ProjectionLifecycleResult{}, ErrProjectionRecoveryPending
 	}
 
@@ -2098,22 +2091,121 @@ func (l *ProjectionLifecycle) readProjectionRecoveryJournal(
 	effect contracts.SkillProjectionEffect,
 	relativePath string,
 ) (*projectionRecoveryJournal, *projectionLifecycleState, error) {
-	data, err := readManagedFileAt(l.managed, l.journalRel(effect), maxProjectionRecoveryJournalBytes)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil, nil, nil
+	journal, err := l.readProjectionRecoveryJournalRecord(effect)
+	if err != nil || journal == nil {
+		return nil, nil, err
 	}
-	if err != nil {
-		return nil, nil, fmt.Errorf("%w: read recovery journal: %w", ErrProjectionDrift, err)
-	}
-	var journal projectionRecoveryJournal
-	if err := decodeStrictProjectionJSON(data, &journal); err != nil {
-		return nil, nil, fmt.Errorf("%w: decode recovery journal: %v", ErrProjectionDrift, err)
-	}
-	next, err := l.validateProjectionRecoveryJournal(journal, effect, relativePath)
+	next, err := l.validateProjectionRecoveryJournal(*journal, effect, relativePath)
 	if err != nil {
 		return nil, nil, err
 	}
-	return &journal, &next, nil
+	return journal, &next, nil
+}
+
+func (l *ProjectionLifecycle) readProjectionRecoveryJournalRecord(
+	effect contracts.SkillProjectionEffect,
+) (*projectionRecoveryJournal, error) {
+	data, err := readManagedFileAt(l.managed, l.journalRel(effect), maxProjectionRecoveryJournalBytes)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: read recovery journal: %w", ErrProjectionDrift, err)
+	}
+	var journal projectionRecoveryJournal
+	if err := decodeStrictProjectionJSON(data, &journal); err != nil {
+		return nil, fmt.Errorf("%w: decode recovery journal: %v", ErrProjectionDrift, err)
+	}
+	return &journal, nil
+}
+
+func (l *ProjectionLifecycle) hasPendingProjectionRecoveryJournal(
+	lookup contracts.SkillProjectionEffect,
+	relativePath string,
+) (bool, error) {
+	journal, err := l.readProjectionRecoveryJournalRecord(lookup)
+	if err != nil || journal == nil {
+		return false, err
+	}
+	if err := l.verifyProjectionRecoveryJournal(*journal); err != nil {
+		return false, err
+	}
+	if journal.SchemaVersion != projectionRecoveryJournalSchemaV1 ||
+		journal.TenantID != lookup.TenantID || journal.WorkspaceID != lookup.WorkspaceID ||
+		journal.SkillID != lookup.SkillID || journal.AgentTarget != lookup.AgentTarget ||
+		journal.RelativePath != relativePath || len(journal.NextStateBytes) == 0 ||
+		len(journal.NextStateBytes) > maxProjectionLifecycleStateBytes ||
+		!validProjectionSHA256(journal.NextStateHash) || HashBytes(journal.NextStateBytes) != journal.NextStateHash {
+		return false, fmt.Errorf("%w: recovery journal projection binding is invalid", ErrProjectionDrift)
+	}
+
+	var next projectionLifecycleState
+	if err := decodeStrictProjectionJSON(journal.NextStateBytes, &next); err != nil {
+		return false, fmt.Errorf("%w: decode recovery state: %v", ErrProjectionDrift, err)
+	}
+	if err := l.verifyProjectionLifecycleState(next); err != nil {
+		return false, fmt.Errorf("%w: recovery state integrity: %v", ErrProjectionDrift, err)
+	}
+	if err := validateProjectionStateIdentity(next, lookup, relativePath); err != nil {
+		return false, err
+	}
+	replay, ok := findProjectionReplay(next.Replays, journal.IdempotencyKey)
+	if !ok || replay.RequestHash != journal.CanonicalRequestHash ||
+		replay.Result.ResultHash != journal.ResultHash || !validProjectionSHA256(replay.Result.ConsumedPermitRef) {
+		return false, fmt.Errorf("%w: recovery journal replay binding is invalid", ErrProjectionDrift)
+	}
+	if (journal.Action == contracts.SkillProjectionActionRollback && !validProjectionSHA256(replay.Result.RollbackPermitRef)) ||
+		(journal.Action != contracts.SkillProjectionActionRollback && replay.Result.RollbackPermitRef != "") {
+		return false, fmt.Errorf("%w: recovery journal replay binding is invalid", ErrProjectionDrift)
+	}
+
+	var record projectionGeneration
+	found := false
+	for i := range next.Generations {
+		candidate := next.Generations[i]
+		if candidate.SkillVersion == journal.SkillVersion &&
+			candidate.ArtifactHash == replay.Result.TrustArtifactHash &&
+			candidate.ContentHash == replay.Result.TrustContentHash &&
+			candidate.ManifestHash == replay.Result.TrustManifestHash &&
+			candidate.PolicyHash == replay.Result.TrustPolicyHash &&
+			candidate.SchemaHash == replay.Result.TrustSchemaHash &&
+			projectionCertificationRefsHash(candidate.CertificationRefs) == replay.Result.TrustCertificationHash &&
+			candidate.SandboxProfile == replay.Result.TrustSandboxProfile {
+			record = candidate
+			found = true
+			break
+		}
+	}
+	if !found {
+		return false, fmt.Errorf("%w: recovery journal generation binding is invalid", ErrProjectionDrift)
+	}
+
+	pendingEffect := contracts.SkillProjectionEffect{
+		SchemaVersion:        contracts.SkillProjectionEffectSchemaV1,
+		ContractVersion:      contracts.SkillProjectionEffectContractV1,
+		Action:               journal.Action,
+		TenantID:             journal.TenantID,
+		WorkspaceID:          journal.WorkspaceID,
+		SkillID:              journal.SkillID,
+		SkillVersion:         journal.SkillVersion,
+		AgentTarget:          journal.AgentTarget,
+		ArtifactHash:         record.ArtifactHash,
+		ContentHash:          record.ContentHash,
+		ManifestHash:         record.ManifestHash,
+		PolicyHash:           record.PolicyHash,
+		SchemaHash:           record.SchemaHash,
+		CertificationRefs:    append([]string(nil), record.CertificationRefs...),
+		ConsumedPermitRef:    replay.Result.ConsumedPermitRef,
+		IdempotencyKey:       journal.IdempotencyKey,
+		AttemptID:            journal.AttemptID,
+		Generation:           replay.Result.NewGeneration,
+		SandboxProfile:       record.SandboxProfile,
+		CanonicalRequestHash: journal.CanonicalRequestHash,
+	}
+	if _, err := l.validateProjectionRecoveryJournal(*journal, pendingEffect, relativePath); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (l *ProjectionLifecycle) recoverProjectionJournal(

--- a/core/pkg/skillpacks/lifecycle.go
+++ b/core/pkg/skillpacks/lifecycle.go
@@ -70,6 +70,7 @@ const (
 var (
 	ErrProjectionDrift            = errors.New("skillpacks: managed projection drift")
 	ErrUnmanagedProjection        = errors.New("skillpacks: unmanaged projection exists")
+	ErrProjectionReplayNotFound   = errors.New("skillpacks: projection replay not found")
 	ErrProjectionReplayConflict   = errors.New("skillpacks: projection replay conflict")
 	ErrProjectionPathUnsafe       = errors.New("skillpacks: unsafe managed path")
 	ErrProjectionLockContended    = errors.New("skillpacks: projection root lock contended")
@@ -588,6 +589,121 @@ func (l *ProjectionLifecycle) Apply(
 	default:
 		return ProjectionLifecycleResult{}, fmt.Errorf("skillpacks: unsupported projection action")
 	}
+}
+
+// LookupReplay returns one authenticated durable result without dispatching,
+// recovering, or otherwise mutating a projection. An authenticated recovery
+// journal remains owned by Apply, which revalidates live authority and trust
+// before completing or aborting the pending mutation.
+func (l *ProjectionLifecycle) LookupReplay(
+	effect contracts.SkillProjectionEffect,
+	consumedPermitRef string,
+	rollbackPermit *contracts.SkillProjectionRollbackPermit,
+) (result ProjectionLifecycleResult, returnErr error) {
+	if l == nil {
+		return ProjectionLifecycleResult{}, fmt.Errorf("skillpacks: projection lifecycle is nil")
+	}
+	if rollbackPermit != nil {
+		permitCopy := *rollbackPermit
+		rollbackPermit = &permitCopy
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closing.Load() || l.managed == nil {
+		return ProjectionLifecycleResult{}, fmt.Errorf("skillpacks: projection lifecycle is closed")
+	}
+	if err := l.validateProjectionAuthorityBinding(effect, consumedPermitRef, rollbackPermit); err != nil {
+		return ProjectionLifecycleResult{}, err
+	}
+	releaseRootLock, err := l.acquireRootLock()
+	if err != nil {
+		return ProjectionLifecycleResult{}, err
+	}
+	defer func() {
+		if err := releaseRootLock(); err != nil {
+			result = ProjectionLifecycleResult{}
+			returnErr = errors.Join(returnErr, fmt.Errorf("skillpacks: release projection root lock: %w", err))
+		}
+	}()
+
+	projection, err := projectionRelativePath(effect.SkillID, effect.AgentTarget)
+	if err != nil {
+		return ProjectionLifecycleResult{}, err
+	}
+	relativePath := filepath.ToSlash(projection.Path)
+	journal, pending, err := l.readProjectionRecoveryJournal(effect, relativePath)
+	if err != nil {
+		return ProjectionLifecycleResult{}, err
+	}
+	if journal != nil {
+		replay, ok := findProjectionReplay(pending.Replays, effect.IdempotencyKey)
+		if !ok {
+			return ProjectionLifecycleResult{}, fmt.Errorf("%w: recovery replay is missing", ErrProjectionDrift)
+		}
+		if err := validateProjectionReplayLookupBinding(effect, relativePath, consumedPermitRef, rollbackPermit, replay); err != nil {
+			return ProjectionLifecycleResult{}, err
+		}
+		return ProjectionLifecycleResult{}, ErrProjectionRecoveryPending
+	}
+
+	state, err := l.readState(effect, relativePath)
+	if err != nil {
+		return ProjectionLifecycleResult{}, err
+	}
+	if state == nil {
+		if err := l.verifyProjectionAbsent(effect, relativePath); err != nil {
+			return ProjectionLifecycleResult{}, err
+		}
+		return ProjectionLifecycleResult{}, ErrProjectionReplayNotFound
+	}
+	replay, ok := findProjectionReplay(state.Replays, effect.IdempotencyKey)
+	if !ok {
+		if attempt, found := findProjectionAttempt(state.Attempts, effect.AttemptID); found &&
+			(attempt.IdempotencyKey != effect.IdempotencyKey || attempt.RequestHash != effect.CanonicalRequestHash) {
+			return ProjectionLifecycleResult{}, ErrProjectionReplayConflict
+		}
+		if err := l.verifyManagedState(*state); err != nil {
+			return ProjectionLifecycleResult{}, err
+		}
+		return ProjectionLifecycleResult{}, ErrProjectionReplayNotFound
+	}
+	if err := validateProjectionReplayLookupBinding(effect, relativePath, consumedPermitRef, rollbackPermit, replay); err != nil {
+		return ProjectionLifecycleResult{}, err
+	}
+	if err := l.verifyManagedState(*state); err != nil {
+		return ProjectionLifecycleResult{}, err
+	}
+	return replay.Result, nil
+}
+
+func validateProjectionReplayLookupBinding(
+	effect contracts.SkillProjectionEffect,
+	relativePath, consumedPermitRef string,
+	rollbackPermit *contracts.SkillProjectionRollbackPermit,
+	replay projectionReplay,
+) error {
+	if replay.RequestHash != effect.CanonicalRequestHash {
+		return ErrProjectionReplayConflict
+	}
+	if err := verifyProjectionLifecycleResult(replay.Result); err != nil {
+		return fmt.Errorf("%w: stored replay result: %v", ErrProjectionDrift, err)
+	}
+	expectedRollbackPermitRef := ""
+	if rollbackPermit != nil {
+		expectedRollbackPermitRef = rollbackPermit.PermitRef
+	}
+	if replay.Result.Action != effect.Action || replay.Result.TenantID != effect.TenantID ||
+		replay.Result.WorkspaceID != effect.WorkspaceID || replay.Result.SkillID != effect.SkillID ||
+		replay.Result.SkillVersion != effect.SkillVersion || replay.Result.AgentTarget != effect.AgentTarget ||
+		replay.Result.CanonicalRequestHash != effect.CanonicalRequestHash ||
+		replay.Result.IdempotencyKey != effect.IdempotencyKey || replay.Result.AttemptID != effect.AttemptID ||
+		replay.Result.ConsumedPermitRef != consumedPermitRef ||
+		replay.Result.RollbackPermitRef != expectedRollbackPermitRef ||
+		replay.Result.NewGeneration != effect.Generation || replay.Result.RelativePath != relativePath {
+		return fmt.Errorf("%w: stored replay does not match lookup authority", ErrProjectionDrift)
+	}
+	return nil
 }
 
 func (l *ProjectionLifecycle) validateProjectionAuthority(

--- a/core/pkg/skillpacks/lifecycle_test.go
+++ b/core/pkg/skillpacks/lifecycle_test.go
@@ -212,6 +212,71 @@ func TestProjectionLifecycleLookupReplayReadOnlyOutcomes(t *testing.T) {
 		}
 	})
 
+	t.Run("newer pending journal shadows completed replay", func(t *testing.T) {
+		root := t.TempDir()
+		verifierCalls := 0
+		lifecycle, err := NewProjectionLifecycleWithVerifierKey(root, projectionTrustVerifierFunc(func(request ProjectionTrustRequest) (ProjectionTrustDecision, error) {
+			verifierCalls++
+			return allowProjectionTrust(request)
+		}), testProjectionTrustVerifierKey())
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = lifecycle.Close() })
+		lifecycle.clock = func() time.Time { return now }
+		completed := newProjectionFixture(t, "1.0.0", "completed lookup prompt", 1, now)
+		if _, err := lifecycle.Apply(completed.effect, &completed.artifact, completed.effect.ConsumedPermitRef, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		newer := newProjectionFixture(t, "2.0.0", "newer pending prompt", 2, now)
+		simulatedCrash := errors.New("stop newer operation after journal")
+		lifecycle.mutationHook = func(stage string) error {
+			if stage == projectionMutationAfterJournal {
+				return simulatedCrash
+			}
+			return nil
+		}
+		if _, err := lifecycle.Apply(newer.effect, &newer.artifact, newer.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionRecoveryPending) || !errors.Is(err, simulatedCrash) {
+			t.Fatalf("prepare newer pending journal: %v", err)
+		}
+		lifecycle.mutationHook = nil
+		lifecycle.clock = func() time.Time { return completed.effect.ExpiresAt.Add(time.Hour) }
+
+		before := snapshotProjectionTree(t, root)
+		if result, err := lifecycle.LookupReplay(completed.effect, completed.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionRecoveryPending) || result != (ProjectionLifecycleResult{}) {
+			t.Fatalf("older lookup with newer pending journal result=%+v err=%v", result, err)
+		}
+		if verifierCalls != 2 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("newer pending lookup mutated state or called verifier: calls=%d", verifierCalls)
+		}
+
+		journalPath := filepath.Join(root, lifecycle.journalRel(newer.effect))
+		journalBytes, err := os.ReadFile(journalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var journal projectionRecoveryJournal
+		if err := json.Unmarshal(journalBytes, &journal); err != nil {
+			t.Fatal(err)
+		}
+		journal.JournalSignature = tamperProjectionTrustSignature(journal.JournalSignature)
+		journalBytes, err = json.MarshalIndent(journal, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(journalPath, journalBytes, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		before = snapshotProjectionTree(t, root)
+		if result, err := lifecycle.LookupReplay(completed.effect, completed.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionDrift) || result != (ProjectionLifecycleResult{}) {
+			t.Fatalf("older lookup with tampered newer journal result=%+v err=%v", result, err)
+		}
+		if verifierCalls != 2 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("tampered newer journal lookup mutated state or called verifier: calls=%d", verifierCalls)
+		}
+	})
+
 	t.Run("pending journal stays pending and authentic", func(t *testing.T) {
 		root := t.TempDir()
 		oldKey := testProjectionTrustVerifierKey()

--- a/core/pkg/skillpacks/lifecycle_test.go
+++ b/core/pkg/skillpacks/lifecycle_test.go
@@ -77,6 +77,306 @@ func TestProjectionLifecycleInstallReadbackReplayAndPermitMismatch(t *testing.T)
 	}
 }
 
+func TestProjectionLifecycleLookupReplayReadOnlyOutcomes(t *testing.T) {
+	now := time.Date(2026, 8, 30, 12, 30, 0, 0, time.UTC)
+
+	t.Run("absent and closed", func(t *testing.T) {
+		root := t.TempDir()
+		verifierCalls := 0
+		lifecycle, err := NewProjectionLifecycleWithVerifierKey(root, projectionTrustVerifierFunc(func(request ProjectionTrustRequest) (ProjectionTrustDecision, error) {
+			verifierCalls++
+			return allowProjectionTrust(request)
+		}), testProjectionTrustVerifierKey())
+		if err != nil {
+			t.Fatal(err)
+		}
+		fixture := newProjectionFixture(t, "1.0.0", "lookup absent prompt", 1, now)
+
+		before := snapshotProjectionTree(t, root)
+		if result, err := lifecycle.LookupReplay(fixture.effect, fixture.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionReplayNotFound) || result != (ProjectionLifecycleResult{}) {
+			t.Fatalf("absent lookup result=%+v err=%v", result, err)
+		}
+		if verifierCalls != 0 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("absent lookup mutated state or called verifier: calls=%d", verifierCalls)
+		}
+
+		if err := lifecycle.Close(); err != nil {
+			t.Fatal(err)
+		}
+		before = snapshotProjectionTree(t, root)
+		if result, err := lifecycle.LookupReplay(fixture.effect, fixture.effect.ConsumedPermitRef, nil); err == nil || !strings.Contains(err.Error(), "lifecycle is closed") || result != (ProjectionLifecycleResult{}) {
+			t.Fatalf("closed lookup result=%+v err=%v", result, err)
+		}
+		if verifierCalls != 0 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("closed lookup mutated state or called verifier: calls=%d", verifierCalls)
+		}
+	})
+
+	t.Run("completed after expiry with historical key", func(t *testing.T) {
+		root := t.TempDir()
+		oldKey := testProjectionTrustVerifierKey()
+		applyVerifierCalls := 0
+		oldLifecycle, err := NewProjectionLifecycleWithVerifierKey(root, projectionTrustVerifierFunc(func(request ProjectionTrustRequest) (ProjectionTrustDecision, error) {
+			applyVerifierCalls++
+			return allowProjectionTrustWithKey(request, oldKey)
+		}), oldKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldLifecycle.clock = func() time.Time { return now }
+		fixture := newProjectionFixture(t, "1.0.0", "historical replay prompt", 1, now)
+		want, err := oldLifecycle.Apply(fixture.effect, &fixture.artifact, fixture.effect.ConsumedPermitRef, nil)
+		if err != nil {
+			t.Fatalf("prepare replay result=%+v err=%v verifier_calls=%d", want, err, applyVerifierCalls)
+		}
+		v2 := newProjectionFixture(t, "2.0.0", "historical replay prompt v2", 2, now)
+		if _, err := oldLifecycle.Apply(v2.effect, &v2.artifact, v2.effect.ConsumedPermitRef, nil); err != nil {
+			t.Fatal(err)
+		}
+		rollback := actionEffect(t, fixture.effect, contracts.SkillProjectionActionRollback, 3, "lookup-rollback", "attempt-lookup-rollback", testHash("7"))
+		permit := contracts.SkillProjectionRollbackPermit{
+			SchemaVersion:      contracts.SkillProjectionRollbackPermitSchemaV1,
+			ContractVersion:    contracts.SkillProjectionRollbackPermitContractV1,
+			PermitRef:          testHash("8"),
+			Action:             contracts.SkillProjectionActionRollback,
+			TenantID:           rollback.TenantID,
+			WorkspaceID:        rollback.WorkspaceID,
+			SkillID:            rollback.SkillID,
+			AgentTarget:        rollback.AgentTarget,
+			FromGeneration:     2,
+			TargetGeneration:   1,
+			TargetSkillVersion: rollback.SkillVersion,
+			TargetArtifactHash: rollback.ArtifactHash,
+			TargetPolicyHash:   rollback.PolicyHash,
+			IssuedAt:           now.Add(-time.Minute),
+			ExpiresAt:          now.Add(time.Minute),
+			Nonce:              strings.Repeat("8", 64),
+		}
+		permit = signRollbackPermitForTest(t, permit, oldKey)
+		rollback.RollbackPermitHash = permit.PermitHash
+		rollback.CanonicalRequestHash = ""
+		rollback, err = rollback.Seal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		rollbackWant, err := oldLifecycle.Apply(rollback, nil, rollback.ConsumedPermitRef, &permit)
+		if err != nil || applyVerifierCalls != 3 {
+			t.Fatalf("prepare rollback replay result=%+v err=%v verifier_calls=%d", rollbackWant, err, applyVerifierCalls)
+		}
+		if err := oldLifecycle.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		currentKey := rotatedProjectionTrustVerifierKey()
+		lookupVerifierCalls := 0
+		lifecycle, err := NewProjectionLifecycleWithVerifierKeyring(root, projectionTrustVerifierFunc(func(request ProjectionTrustRequest) (ProjectionTrustDecision, error) {
+			lookupVerifierCalls++
+			return allowProjectionTrustWithKey(request, currentKey)
+		}), ProjectionTrustVerifierKeyring{Current: currentKey, Historical: []ProjectionTrustVerifierKey{oldKey}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = lifecycle.Close() })
+		lifecycle.clock = func() time.Time { return fixture.effect.ExpiresAt.Add(time.Hour) }
+
+		before := snapshotProjectionTree(t, root)
+		got, err := lifecycle.LookupReplay(fixture.effect, fixture.effect.ConsumedPermitRef, nil)
+		if err != nil || !reflect.DeepEqual(got, want) {
+			t.Fatalf("completed lookup result=%+v err=%v want=%+v", got, err, want)
+		}
+		if lookupVerifierCalls != 0 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("completed lookup mutated state or called verifier: calls=%d", lookupVerifierCalls)
+		}
+		before = snapshotProjectionTree(t, root)
+		got, err = lifecycle.LookupReplay(rollback, rollback.ConsumedPermitRef, &permit)
+		if err != nil || !reflect.DeepEqual(got, rollbackWant) {
+			t.Fatalf("expired rollback lookup result=%+v err=%v want=%+v", got, err, rollbackWant)
+		}
+		if lookupVerifierCalls != 0 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("rollback lookup mutated state or called verifier: calls=%d", lookupVerifierCalls)
+		}
+
+		conflict := fixture.effect
+		conflict.AttemptID = "conflicting-attempt"
+		conflict.CanonicalRequestHash = ""
+		conflict, err = conflict.Seal()
+		if err != nil {
+			t.Fatal(err)
+		}
+		before = snapshotProjectionTree(t, root)
+		if result, err := lifecycle.LookupReplay(conflict, conflict.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionReplayConflict) || result != (ProjectionLifecycleResult{}) {
+			t.Fatalf("conflicting lookup result=%+v err=%v", result, err)
+		}
+		if lookupVerifierCalls != 0 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("conflicting lookup mutated state or called verifier: calls=%d", lookupVerifierCalls)
+		}
+	})
+
+	t.Run("pending journal stays pending and authentic", func(t *testing.T) {
+		root := t.TempDir()
+		oldKey := testProjectionTrustVerifierKey()
+		oldLifecycle, err := NewProjectionLifecycleWithVerifierKey(root, projectionTrustVerifierFunc(func(request ProjectionTrustRequest) (ProjectionTrustDecision, error) {
+			return allowProjectionTrustWithKey(request, oldKey)
+		}), oldKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		oldLifecycle.clock = func() time.Time { return now }
+		fixture := newProjectionFixture(t, "1.0.0", "pending lookup prompt", 1, now)
+		simulatedCrash := errors.New("stop after journal")
+		oldLifecycle.mutationHook = func(stage string) error {
+			if stage == projectionMutationAfterJournal {
+				return simulatedCrash
+			}
+			return nil
+		}
+		if _, err := oldLifecycle.Apply(fixture.effect, &fixture.artifact, fixture.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionRecoveryPending) || !errors.Is(err, simulatedCrash) {
+			t.Fatalf("prepare pending journal: %v", err)
+		}
+		oldLifecycle.mutationHook = nil
+		if err := oldLifecycle.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		currentKey := rotatedProjectionTrustVerifierKey()
+		lookupVerifierCalls := 0
+		lifecycle, err := NewProjectionLifecycleWithVerifierKeyring(root, projectionTrustVerifierFunc(func(request ProjectionTrustRequest) (ProjectionTrustDecision, error) {
+			lookupVerifierCalls++
+			return allowProjectionTrustWithKey(request, currentKey)
+		}), ProjectionTrustVerifierKeyring{Current: currentKey, Historical: []ProjectionTrustVerifierKey{oldKey}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = lifecycle.Close() })
+		lifecycle.clock = func() time.Time { return fixture.effect.ExpiresAt.Add(time.Hour) }
+
+		before := snapshotProjectionTree(t, root)
+		if result, err := lifecycle.LookupReplay(fixture.effect, fixture.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionRecoveryPending) || result != (ProjectionLifecycleResult{}) {
+			t.Fatalf("pending lookup result=%+v err=%v", result, err)
+		}
+		if lookupVerifierCalls != 0 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("pending lookup mutated state or called verifier: calls=%d", lookupVerifierCalls)
+		}
+
+		journalPath := filepath.Join(root, lifecycle.journalRel(fixture.effect))
+		journalBytes, err := os.ReadFile(journalPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var journal projectionRecoveryJournal
+		if err := json.Unmarshal(journalBytes, &journal); err != nil {
+			t.Fatal(err)
+		}
+		journal.JournalSignature = tamperProjectionTrustSignature(journal.JournalSignature)
+		journalBytes, err = json.MarshalIndent(journal, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(journalPath, journalBytes, 0o600); err != nil {
+			t.Fatalf("tamper journal: %v", err)
+		}
+		before = snapshotProjectionTree(t, root)
+		if result, err := lifecycle.LookupReplay(fixture.effect, fixture.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionDrift) || result != (ProjectionLifecycleResult{}) {
+			t.Fatalf("tampered journal lookup result=%+v err=%v", result, err)
+		}
+		if lookupVerifierCalls != 0 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+			t.Fatalf("tampered journal lookup mutated state or called verifier: calls=%d", lookupVerifierCalls)
+		}
+	})
+}
+
+func TestProjectionLifecycleLookupReplayRejectsStoredAuthorityMismatch(t *testing.T) {
+	now := time.Date(2026, 8, 30, 12, 45, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		mutate func(*projectionLifecycleState) error
+	}{
+		{
+			name: "result hash",
+			mutate: func(state *projectionLifecycleState) error {
+				state.Replays[0].Result.ResultHash = testHash("0")
+				return nil
+			},
+		},
+		{
+			name: "consumed permit ref",
+			mutate: func(state *projectionLifecycleState) error {
+				result := state.Replays[0].Result
+				result.ConsumedPermitRef = testHash("0")
+				sealed, err := sealProjectionLifecycleResult(result)
+				state.Replays[0].Result = sealed
+				return err
+			},
+		},
+		{
+			name: "rollback permit ref",
+			mutate: func(state *projectionLifecycleState) error {
+				result := state.Replays[0].Result
+				result.RollbackPermitRef = testHash("1")
+				sealed, err := sealProjectionLifecycleResult(result)
+				state.Replays[0].Result = sealed
+				return err
+			},
+		},
+		{
+			name: "attempt id",
+			mutate: func(state *projectionLifecycleState) error {
+				result := state.Replays[0].Result
+				result.AttemptID = "different-attempt"
+				sealed, err := sealProjectionLifecycleResult(result)
+				state.Replays[0].Result = sealed
+				state.Attempts[0].AttemptID = result.AttemptID
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			verifierCalls := 0
+			lifecycle, err := NewProjectionLifecycleWithVerifierKey(root, projectionTrustVerifierFunc(func(request ProjectionTrustRequest) (ProjectionTrustDecision, error) {
+				verifierCalls++
+				return allowProjectionTrust(request)
+			}), testProjectionTrustVerifierKey())
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = lifecycle.Close() })
+			lifecycle.clock = func() time.Time { return now }
+			fixture := newProjectionFixture(t, "1.0.0", "stored authority mismatch prompt", 1, now)
+			if _, err := lifecycle.Apply(fixture.effect, &fixture.artifact, fixture.effect.ConsumedPermitRef, nil); err != nil {
+				t.Fatal(err)
+			}
+			projection, err := projectionRelativePath(fixture.effect.SkillID, fixture.effect.AgentTarget)
+			if err != nil {
+				t.Fatal(err)
+			}
+			state, err := lifecycle.readState(fixture.effect, filepath.ToSlash(projection.Path))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := tt.mutate(state); err != nil {
+				t.Fatal(err)
+			}
+			_, stateBytes, err := lifecycle.marshalProjectionLifecycleState(*state)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(root, lifecycle.stateRel(fixture.effect)), stateBytes, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			before := snapshotProjectionTree(t, root)
+			if result, err := lifecycle.LookupReplay(fixture.effect, fixture.effect.ConsumedPermitRef, nil); !errors.Is(err, ErrProjectionDrift) || result != (ProjectionLifecycleResult{}) {
+				t.Fatalf("mismatched stored authority result=%+v err=%v", result, err)
+			}
+			if verifierCalls != 1 || !reflect.DeepEqual(before, snapshotProjectionTree(t, root)) {
+				t.Fatalf("mismatched lookup mutated state or called verifier: calls=%d", verifierCalls)
+			}
+		})
+	}
+}
+
 func TestProjectionLifecycleUpgradeRollbackAndRevoke(t *testing.T) {
 	now := time.Date(2026, 8, 30, 13, 0, 0, 0, time.UTC)
 	root := t.TempDir()
@@ -3292,4 +3592,37 @@ func tamperProjectionTrustSignature(signature string) string {
 		replacement = "1"
 	}
 	return signature[:len(signature)-1] + replacement
+}
+
+type projectionTreeSnapshotEntry struct {
+	Mode     os.FileMode
+	ModTime  int64
+	Contents string
+}
+
+func snapshotProjectionTree(t *testing.T, root string) map[string]projectionTreeSnapshotEntry {
+	t.Helper()
+	snapshot := make(map[string]projectionTreeSnapshotEntry)
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		entry := projectionTreeSnapshotEntry{Mode: info.Mode(), ModTime: info.ModTime().UnixNano()}
+		if info.Mode().IsRegular() {
+			contents, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			entry.Contents = string(contents)
+		}
+		snapshot[relative] = entry
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
 }


### PR DESCRIPTION
## Outcome

Adds a Kernel-owned `LookupReplay` path for skill projection effects so downstream runtimes can retrieve an already-completed result without redispatching, recovering, or mutating the projection.

## Security contract

- structurally authenticates the effect and consumed-permit binding
- authenticates rollback permits, including historical signing keys for exact old replays
- validates lifecycle and recovery-journal seals, replay result hashes, trust receipts, managed content, and exact authority fields
- returns typed `ErrProjectionReplayNotFound` when no durable replay exists
- returns existing `ErrProjectionRecoveryPending` for an authenticated pending journal
- never invokes the live trust verifier, performs liveness checks, dispatches, recovers, or writes projection state

## Validation

- focused replay tests
- full `core/pkg/skillpacks` tests
- race tests
- `go vet ./core/pkg/skillpacks`
- `make verify-boundary`
- independent exact-source review plus a second focused/race run

Tracks HELM-658.
