### PR TITLE
Harden AI OS Kernel image release authority and evidence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,7 @@ platform-config-*.json
 platform-labels-*.json
 sbom-*.spdx.json
 slsa-provenance*.json
+grype-*.json
 release-evidence*.json
 signature-verification.json
 tmp/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# The Dockerfile has an explicit source set; every other checkout file is noise.
+*
+!Dockerfile
+!core/
+!core/**
+!release.high_risk.v3.toml
+!reference_packs/
+!reference_packs/**
+
+# Keep generated release evidence and repository metadata excluded explicitly.
+.git
+.git/**
+buildx-inspect.txt
+ci-runs.json
+promotion-ci-runs.json
+image-index.json
+final-image-index.json
+platform-config-*.json
+platform-labels-*.json
+sbom-*.spdx.json
+slsa-provenance*.json
+release-evidence*.json
+signature-verification.json
+tmp/

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -864,6 +864,10 @@ jobs:
             fi
           done
 
+          if [[ "${SOURCE_SHA}" != "${WORKFLOW_SHA}" ]]; then
+            echo "::error::source_sha no longer matches the workflow commit before promotion"
+            exit 1
+          fi
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.extraheader \
           GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_TOKEN}" \

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -58,41 +58,105 @@ jobs:
             echo "::error::publication reruns are prohibited; dispatch a new run so release-production requires a fresh owner approval"
             exit 1
           fi
+          if [[ -z "${OWNER_READBACK_TOKEN:-}" ]]; then
+            echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for authoritative owner readback"
+            exit 1
+          fi
           if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then
             echo "::error::release-production is not explicitly armed"
             exit 1
           fi
+          if ! jq -e '. == ["mindburnlabs","peycheff-com"]' <<<"${RELEASE_ACTORS_JSON:-}" >/dev/null; then
+            echo "::error::HELM_AI_OS_IMAGE_RELEASE_ACTORS must equal [\"mindburnlabs\",\"peycheff-com\"]"
+            exit 1
+          fi
+          release_environment_payload="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}")"
+          deployment_branch_policies="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies")"
+          live_release_authority="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}/variables/HELM_RELEASE_AUTHORITY_ARMED" \
+            --jq '.value')"
+          live_release_actors="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/actions/variables/HELM_AI_OS_IMAGE_RELEASE_ACTORS" \
+            --jq '.value')"
+          if ! jq -e --arg environment "${RELEASE_ENVIRONMENT}" '
+            .name == $environment and
+            .can_admins_bypass == false and
+            .deployment_branch_policy == {
+              protected_branches: false,
+              custom_branch_policies: true
+            } and
+            (.protection_rules | type == "array" and length == 2) and
+            (([.protection_rules[].type] | sort) == ["branch_policy", "required_reviewers"]) and
+            ([.protection_rules[] | select(.type == "required_reviewers")] | length == 1) and
+            (first(.protection_rules[] | select(.type == "required_reviewers")) |
+              .prevent_self_review == true and
+              (.reviewers | type == "array" and length == 1) and
+              .reviewers[0].type == "User" and
+              (.reviewers[0].id | type == "number" and (try (floor == . and . > 0) catch false)))
+          ' <<<"${release_environment_payload}" >/dev/null; then
+            echo "::error::release-production environment protection readback is not exact"
+            exit 1
+          fi
           if ! jq -e '
-            type == "array" and
-            length > 0 and
-            all(.[]; type == "string" and test("^[A-Za-z0-9-]{1,39}$")) and
-            (unique | length) == length
-          ' <<<"${RELEASE_ACTORS_JSON:-}" >/dev/null; then
-            echo "::error::HELM_AI_OS_IMAGE_RELEASE_ACTORS must be a non-empty JSON array of unique GitHub logins"
+            .total_count == 1 and
+            (.branch_policies | type == "array" and length == 1) and
+            .branch_policies[0].name == "main" and
+            .branch_policies[0].type == "branch"
+          ' <<<"${deployment_branch_policies}" >/dev/null; then
+            echo "::error::release-production deployment branch policy must contain only main"
+            exit 1
+          fi
+          if [[ "${live_release_authority}" != "release-production" ]]; then
+            echo "::error::release-production is not armed in the authoritative environment variable readback"
+            exit 1
+          fi
+          if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then
+            echo "::error::release-production changed from the job-start authority snapshot"
+            exit 1
+          fi
+          if ! jq -e '. == ["mindburnlabs","peycheff-com"]' <<<"${live_release_actors}" >/dev/null; then
+            echo "::error::the authoritative HELM_AI_OS_IMAGE_RELEASE_ACTORS value is not exact"
+            exit 1
+          fi
+          if ! jq -e --argjson configured "${RELEASE_ACTORS_JSON}" '. == $configured' <<<"${live_release_actors}" >/dev/null; then
+            echo "::error::the release actor allowlist changed from the job-start snapshot"
             exit 1
           fi
           for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do
             if ! jq -e --arg actor "${candidate}" 'index($actor) != null' \
-              <<<"${RELEASE_ACTORS_JSON}" >/dev/null; then
+              <<<"${live_release_actors}" >/dev/null; then
               echo "::error::GitHub actor ${candidate} is not authorized for AI OS image publication"
               exit 1
             fi
           done
-          if [[ -z "${OWNER_READBACK_TOKEN:-}" ]]; then
-            echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for authoritative organization-role readback"
+          run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq '.run_started_at')"
+          if [[ -z "${run_started_at}" ]]; then
+            echo "::error::the current workflow run has no authoritative start timestamp"
             exit 1
           fi
-          approval_history="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"
-          if ! jq -e '
+          approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"
+          if ! jq -e \
+            --arg run_started_at "${run_started_at}" \
+            --arg release_environment "${RELEASE_ENVIRONMENT}" \
+            --arg request_actor "${REQUEST_ACTOR}" \
+            --arg triggering_actor "${TRIGGERING_ACTOR}" '
             [
               .[] |
               select(
                 .state == "approved" and
-                (.user.login == "mindburnlabs" or .user.login == "peycheff-com")
+                (.created_at > $run_started_at) and
+                (.environments | type == "array" and any(.[]; .name == $release_environment)) and
+                (.user.login == "mindburnlabs" or .user.login == "peycheff-com") and
+                .user.login != $request_actor and
+                .user.login != $triggering_actor
               )
             ] | length > 0
           ' <<<"${approval_history}" >/dev/null; then
-            echo "::error::release-production requires a single-run approval from an authorized human owner"
+            echo "::error::release-production requires a fresh approval from a distinct authorized human owner"
             exit 1
           fi
           for owner in mindburnlabs peycheff-com; do
@@ -121,11 +185,17 @@ jobs:
         with:
           ref: ${{ env.SOURCE_SHA }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Verify source is the current main tip
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_TOKEN}" \
+            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           main_tip="$(git rev-parse refs/remotes/origin/main)"
           if [[ "${SOURCE_SHA}" != "${main_tip}" ]]; then
             echo "::error::source_sha must equal the current origin/main tip (${main_tip})"
@@ -498,31 +568,56 @@ jobs:
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          promotion_main_tip="$(git rev-parse refs/remotes/origin/main)"
-          if [[ "${SOURCE_SHA}" != "${promotion_main_tip}" ]]; then
-            echo "::error::origin/main moved before promotion (${promotion_main_tip})"
-            exit 1
-          fi
-          gh api --paginate \
-            "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${SOURCE_SHA}&branch=main&per_page=100" \
-            > promotion-ci-runs.json
-          ./scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}" < promotion-ci-runs.json
-
-          if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then
-            echo "::error::release-production is no longer explicitly armed"
-            exit 1
-          fi
           if [[ -z "${OWNER_READBACK_TOKEN:-}" ]]; then
             echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for final owner readback"
             exit 1
           fi
+          if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then
+            echo "::error::release-production is no longer explicitly armed"
+            exit 1
+          fi
+          if ! jq -e '. == ["mindburnlabs","peycheff-com"]' <<<"${RELEASE_ACTORS_JSON:-}" >/dev/null; then
+            echo "::error::HELM_AI_OS_IMAGE_RELEASE_ACTORS changed from its exact job-start value"
+            exit 1
+          fi
+          live_release_environment_payload="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}")"
+          live_deployment_branch_policies="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies")"
           live_release_authority="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
             "/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}/variables/HELM_RELEASE_AUTHORITY_ARMED" \
             --jq '.value')"
           live_release_actors="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
             "/repos/${GITHUB_REPOSITORY}/actions/variables/HELM_AI_OS_IMAGE_RELEASE_ACTORS" \
             --jq '.value')"
+          if ! jq -e --arg environment "${RELEASE_ENVIRONMENT}" '
+            .name == $environment and
+            .can_admins_bypass == false and
+            .deployment_branch_policy == {
+              protected_branches: false,
+              custom_branch_policies: true
+            } and
+            (.protection_rules | type == "array" and length == 2) and
+            (([.protection_rules[].type] | sort) == ["branch_policy", "required_reviewers"]) and
+            ([.protection_rules[] | select(.type == "required_reviewers")] | length == 1) and
+            (first(.protection_rules[] | select(.type == "required_reviewers")) |
+              .prevent_self_review == true and
+              (.reviewers | type == "array" and length == 1) and
+              .reviewers[0].type == "User" and
+              (.reviewers[0].id | type == "number" and (try (floor == . and . > 0) catch false)))
+          ' <<<"${live_release_environment_payload}" >/dev/null; then
+            echo "::error::release-production environment protection changed during the build"
+            exit 1
+          fi
+          if ! jq -e '
+            .total_count == 1 and
+            (.branch_policies | type == "array" and length == 1) and
+            .branch_policies[0].name == "main" and
+            .branch_policies[0].type == "branch"
+          ' <<<"${live_deployment_branch_policies}" >/dev/null; then
+            echo "::error::release-production deployment branch policy changed during the build"
+            exit 1
+          fi
           if [[ "${live_release_authority}" != "release-production" ]]; then
             echo "::error::release-production was disarmed during the build"
             exit 1
@@ -532,12 +627,13 @@ jobs:
             exit 1
           fi
           if ! jq -e '
-            type == "array" and
-            length > 0 and
-            all(.[]; type == "string" and test("^[A-Za-z0-9-]{1,39}$")) and
-            (unique | length) == length
+            . == ["mindburnlabs","peycheff-com"]
           ' <<<"${live_release_actors}" >/dev/null; then
-            echo "::error::the live HELM_AI_OS_IMAGE_RELEASE_ACTORS value is invalid"
+            echo "::error::the live HELM_AI_OS_IMAGE_RELEASE_ACTORS value is not exact"
+            exit 1
+          fi
+          if ! jq -e --argjson configured "${RELEASE_ACTORS_JSON}" '. == $configured' <<<"${live_release_actors}" >/dev/null; then
+            echo "::error::the release actor allowlist changed from the job-start snapshot"
             exit 1
           fi
           for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do
@@ -547,17 +643,32 @@ jobs:
               exit 1
             fi
           done
-          approval_history="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"
-          if ! jq -e '
+          run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --jq '.run_started_at')"
+          if [[ -z "${run_started_at}" ]]; then
+            echo "::error::the current workflow run has no authoritative start timestamp"
+            exit 1
+          fi
+          approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"
+          if ! jq -e \
+            --arg run_started_at "${run_started_at}" \
+            --arg release_environment "${RELEASE_ENVIRONMENT}" \
+            --arg request_actor "${REQUEST_ACTOR}" \
+            --arg triggering_actor "${TRIGGERING_ACTOR}" '
             [
               .[] |
               select(
                 .state == "approved" and
-                (.user.login == "mindburnlabs" or .user.login == "peycheff-com")
+                (.created_at > $run_started_at) and
+                (.environments | type == "array" and any(.[]; .name == $release_environment)) and
+                (.user.login == "mindburnlabs" or .user.login == "peycheff-com") and
+                .user.login != $request_actor and
+                .user.login != $triggering_actor
               )
             ] | length > 0
           ' <<<"${approval_history}" >/dev/null; then
-            echo "::error::release-production no longer has this run's authorized human-owner approval"
+            echo "::error::release-production no longer has this run's fresh distinct human-owner approval"
             exit 1
           fi
           for owner in mindburnlabs peycheff-com; do
@@ -568,6 +679,20 @@ jobs:
               exit 1
             fi
           done
+
+          GIT_CONFIG_COUNT=1 \
+          GIT_CONFIG_KEY_0=http.extraheader \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_TOKEN}" \
+            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          promotion_main_tip="$(git rev-parse refs/remotes/origin/main)"
+          if [[ "${SOURCE_SHA}" != "${promotion_main_tip}" ]]; then
+            echo "::error::origin/main moved before promotion (${promotion_main_tip})"
+            exit 1
+          fi
+          gh api --paginate \
+            "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${SOURCE_SHA}&branch=main&per_page=100" \
+            > promotion-ci-runs.json
+          ./scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}" < promotion-ci-runs.json
 
           expected_digest="${{ steps.build.outputs.digest }}"
           staging_ref="${IMAGE_NAME}@${expected_digest}"

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -94,7 +94,8 @@ jobs:
               .prevent_self_review == true and
               (.reviewers | type == "array" and length == 1) and
               .reviewers[0].type == "User" and
-              (.reviewers[0].id | type == "number" and (try (floor == . and . > 0) catch false)))
+              (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com"))
           ' <<<"${release_environment_payload}" >/dev/null; then
             echo "::error::release-production environment protection readback is not exact"
             exit 1
@@ -604,7 +605,8 @@ jobs:
               .prevent_self_review == true and
               (.reviewers | type == "array" and length == 1) and
               .reviewers[0].type == "User" and
-              (.reviewers[0].id | type == "number" and (try (floor == . and . > 0) catch false)))
+              (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com"))
           ' <<<"${live_release_environment_payload}" >/dev/null; then
             echo "::error::release-production environment protection changed during the build"
             exit 1

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -91,10 +91,17 @@ jobs:
             (([.protection_rules[].type] | sort) == ["branch_policy", "required_reviewers"]) and
             ([.protection_rules[] | select(.type == "required_reviewers")] | length == 1) and
             (first(.protection_rules[] | select(.type == "required_reviewers")) |
+              (keys | sort) == ["id", "node_id", "prevent_self_review", "reviewers", "type"] and
+              (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.node_id | type == "string" and length > 0) and
               .prevent_self_review == true and
               (.reviewers | type == "array" and length == 1) and
-              .reviewers[0].type == "User" and
+              (.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User") and
+              (.reviewers[0].reviewer | type == "object") and
               (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.reviewers[0].reviewer.node_id | type == "string" and length > 0) and
+              .reviewers[0].reviewer.type == "User" and
+              .reviewers[0].reviewer.site_admin == false and
               (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
             (first(.protection_rules[] | select(.type == "branch_policy")) |
               (keys | sort) == ["id", "node_id", "type"] and
@@ -368,24 +375,54 @@ jobs:
           output-file: sbom-linux-arm64.spdx.json
           upload-artifact: false
 
-      - name: Install Grype vulnerability scanner
-        uses: anchore/scan-action/download-grype@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
-
-      - name: Expose pinned Grype binary
+      - name: Install checksum-pinned Grype vulnerability scanner
+        env:
+          GRYPE_VERSION: v0.116.1
+          GRYPE_SHA256: 0122df7b655981abe547ad3d2190d65551dac6a2bfc80b4dc2a989b5d0587458
         run: |
           set -euo pipefail
-          grype_binary="$(find /opt/hostedtoolcache/grype -type f -name grype -perm -111 | sort | tail -n 1)"
-          if [[ -z "${grype_binary}" ]]; then
-            echo "::error::grype binary not found after pinned download"
-            exit 1
-          fi
-          dirname "${grype_binary}" >> "${GITHUB_PATH}"
-          "${grype_binary}" version
+          test "$(uname -m)" = "x86_64"
+          grype_archive="${RUNNER_TEMP}/grype_${GRYPE_VERSION#v}_linux_amd64.tar.gz"
+          grype_extract_dir="${RUNNER_TEMP}/grype-extract"
+          grype_bin_dir="${RUNNER_TEMP}/grype-bin"
+          mkdir -p "${grype_extract_dir}" "${grype_bin_dir}"
+          curl --fail --location --retry 3 --proto '=https' --tlsv1.2 \
+            "https://github.com/anchore/grype/releases/download/${GRYPE_VERSION}/grype_${GRYPE_VERSION#v}_linux_amd64.tar.gz" \
+            --output "${grype_archive}"
+          printf '%s  %s\n' "${GRYPE_SHA256}" "${grype_archive}" | sha256sum --check --strict
+          tar -xzf "${grype_archive}" -C "${grype_extract_dir}"
+          grype_binary="${grype_bin_dir}/grype"
+          install -m 0755 "${grype_extract_dir}/grype" "${grype_binary}"
+          echo "${grype_bin_dir}" >> "${GITHUB_PATH}"
+          "${grype_binary}" version | grep -Fq "Version:             ${GRYPE_VERSION#v}"
+
+      - name: Bootstrap and audit the Grype vulnerability database
+        id: grype-db
+        env:
+          GRYPE_DB_CACHE_DIR: ${{ runner.temp }}/grype-db
+          GRYPE_CHECK_FOR_APP_UPDATE: "false"
+          GRYPE_DB_AUTO_UPDATE: "false"
+        run: |
+          set -euo pipefail
+          mkdir -p "${GRYPE_DB_CACHE_DIR}"
+          grype db update
+          grype db status --output json > grype-db-status.json
+          jq -e '
+            type == "object" and
+            (keys | sort) == ["built", "from", "path", "schemaVersion", "valid"] and
+            (.schemaVersion | type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) and
+            (.from | type == "string" and startswith("https://grype.anchore.io/databases/")) and
+            (.built | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+            (.path | type == "string" and length > 0) and
+            .valid == true
+          ' grype-db-status.json >/dev/null
+          echo "status_digest=sha256:$(sha256sum grype-db-status.json | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
 
       - name: Scan exact linux-amd64 digest for CRITICAL/HIGH OS and library CVEs
         id: scan-amd64
         env:
           IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64_digest }}
+          GRYPE_DB_CACHE_DIR: ${{ runner.temp }}/grype-db
           GRYPE_CHECK_FOR_APP_UPDATE: "false"
           GRYPE_DB_AUTO_UPDATE: "false"
         run: |
@@ -409,6 +446,7 @@ jobs:
         id: scan-arm64
         env:
           IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64_digest }}
+          GRYPE_DB_CACHE_DIR: ${{ runner.temp }}/grype-db
           GRYPE_CHECK_FOR_APP_UPDATE: "false"
           GRYPE_DB_AUTO_UPDATE: "false"
         run: |
@@ -603,6 +641,7 @@ jobs:
             --arg arm64_digest "${{ steps.platforms.outputs.arm64_digest }}" \
             --arg amd64_scan_digest "${{ steps.scan-amd64.outputs.report_digest }}" \
             --arg arm64_scan_digest "${{ steps.scan-arm64.outputs.report_digest }}" \
+            --arg db_status_digest "${{ steps.grype-db.outputs.status_digest }}" \
             --arg build_type "${SLSA_BUILD_TYPE}" '
               {
                 schema: $schema,
@@ -645,6 +684,7 @@ jobs:
                   scope: "os-and-library",
                   fail_on: "high",
                   status: "passed",
+                  database: {status: "grype-db-status.json", status_digest: $db_status_digest},
                   platforms: [
                     {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
                     {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
@@ -672,7 +712,8 @@ jobs:
             --arg amd64_digest "${{ steps.platforms.outputs.amd64_digest }}" \
             --arg arm64_digest "${{ steps.platforms.outputs.arm64_digest }}" \
             --arg amd64_scan_digest "${{ steps.scan-amd64.outputs.report_digest }}" \
-            --arg arm64_scan_digest "${{ steps.scan-arm64.outputs.report_digest }}" '
+            --arg arm64_scan_digest "${{ steps.scan-arm64.outputs.report_digest }}" \
+            --arg db_status_digest "${{ steps.grype-db.outputs.status_digest }}" '
               (keys | sort) == [
                 "actor", "component", "cosign", "cve_gate", "default_command",
                 "digest", "entrypoint", "final_tag", "healthcheck", "image",
@@ -700,6 +741,7 @@ jobs:
                 scope: "os-and-library",
                 fail_on: "high",
                 status: "passed",
+                database: {status: "grype-db-status.json", status_digest: $db_status_digest},
                 platforms: [
                   {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
                   {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
@@ -793,10 +835,17 @@ jobs:
             (([.protection_rules[].type] | sort) == ["branch_policy", "required_reviewers"]) and
             ([.protection_rules[] | select(.type == "required_reviewers")] | length == 1) and
             (first(.protection_rules[] | select(.type == "required_reviewers")) |
+              (keys | sort) == ["id", "node_id", "prevent_self_review", "reviewers", "type"] and
+              (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.node_id | type == "string" and length > 0) and
               .prevent_self_review == true and
               (.reviewers | type == "array" and length == 1) and
-              .reviewers[0].type == "User" and
+              (.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User") and
+              (.reviewers[0].reviewer | type == "object") and
               (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.reviewers[0].reviewer.node_id | type == "string" and length > 0) and
+              .reviewers[0].reviewer.type == "User" and
+              .reviewers[0].reviewer.site_admin == false and
               (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
             (first(.protection_rules[] | select(.type == "branch_policy")) |
               (keys | sort) == ["id", "node_id", "type"] and
@@ -974,6 +1023,7 @@ jobs:
             sbom-linux-amd64.attestation.json
             sbom-linux-arm64.spdx.json
             sbom-linux-arm64.attestation.json
+            grype-db-status.json
             grype-linux-amd64.json
             grype-linux-arm64.json
             slsa-provenance.json

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -359,9 +359,112 @@ jobs:
           output-file: sbom-linux-arm64.spdx.json
           upload-artifact: false
 
-      - name: Generate source-owned SLSA provenance predicate
+      - name: Install Grype vulnerability scanner
+        uses: anchore/scan-action/download-grype@1638637db639e0ade3258b51db49a9a137574c3e # v6.5.1
+
+      - name: Expose pinned Grype binary
         run: |
           set -euo pipefail
+          grype_binary="$(find /opt/hostedtoolcache/grype -type f -name grype -perm -111 | sort | tail -n 1)"
+          if [[ -z "${grype_binary}" ]]; then
+            echo "::error::grype binary not found after pinned download"
+            exit 1
+          fi
+          dirname "${grype_binary}" >> "${GITHUB_PATH}"
+          "${grype_binary}" version
+
+      - name: Scan exact linux-amd64 digest for CRITICAL/HIGH OS and library CVEs
+        id: scan-amd64
+        env:
+          IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64_digest }}
+          GRYPE_CHECK_FOR_APP_UPDATE: "false"
+          GRYPE_DB_AUTO_UPDATE: "false"
+        run: |
+          set -euo pipefail
+          grype "${IMAGE_REF}" \
+            --scope all-layers \
+            --fail-on high \
+            --output json \
+            --file grype-linux-amd64.json
+          jq -e '
+            type == "object" and
+            (.matches | type == "array") and
+            all(.matches[]?;
+              (.vulnerability.severity | ascii_downcase) != "critical" and
+              (.vulnerability.severity | ascii_downcase) != "high"
+            )
+          ' grype-linux-amd64.json >/dev/null
+          echo "report_digest=sha256:$(sha256sum grype-linux-amd64.json | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
+
+      - name: Scan exact linux-arm64 digest for CRITICAL/HIGH OS and library CVEs
+        id: scan-arm64
+        env:
+          IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64_digest }}
+          GRYPE_CHECK_FOR_APP_UPDATE: "false"
+          GRYPE_DB_AUTO_UPDATE: "false"
+        run: |
+          set -euo pipefail
+          grype "${IMAGE_REF}" \
+            --scope all-layers \
+            --fail-on high \
+            --output json \
+            --file grype-linux-arm64.json
+          jq -e '
+            type == "object" and
+            (.matches | type == "array") and
+            all(.matches[]?;
+              (.vulnerability.severity | ascii_downcase) != "critical" and
+              (.vulnerability.severity | ascii_downcase) != "high"
+            )
+          ' grype-linux-arm64.json >/dev/null
+          echo "report_digest=sha256:$(sha256sum grype-linux-arm64.json | cut -d' ' -f1)" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate source-owned SLSA provenance predicates
+        run: |
+          set -euo pipefail
+          write_slsa_predicate() {
+            output=$1
+            platform=$2
+            platform_digest=$3
+            jq -n \
+              --arg image "${IMAGE_NAME}" \
+              --arg source_sha "${SOURCE_SHA}" \
+              --arg workflow_sha "${WORKFLOW_SHA}" \
+              --arg repository "${GITHUB_REPOSITORY}" \
+              --arg build_type "${SLSA_BUILD_TYPE}" \
+              --arg run_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+              --arg workflow "${WORKFLOW_IDENTITY}" \
+              --arg platform "${platform}" \
+              --arg platform_digest "${platform_digest}" \
+              '
+                {
+                  buildDefinition: {
+                    buildType: $build_type,
+                    externalParameters: {
+                      source_sha: $source_sha
+                    },
+                    internalParameters: {
+                      image: $image,
+                      workflow: $workflow,
+                      workflow_sha: $workflow_sha,
+                      dockerfile: "Dockerfile",
+                      platform: $platform,
+                      platform_digest: $platform_digest
+                    },
+                    resolvedDependencies: [{
+                      uri: ("git+https://github.com/" + $repository + "@refs/heads/main"),
+                      digest: { gitCommit: $source_sha }
+                    }]
+                  },
+                  runDetails: {
+                    builder: { id: $workflow },
+                    metadata: { invocationId: $run_url }
+                  }
+                }
+              ' > "${output}"
+          }
+          write_slsa_predicate slsa-provenance-linux-amd64.json linux/amd64 "${{ steps.platforms.outputs.amd64_digest }}"
+          write_slsa_predicate slsa-provenance-linux-arm64.json linux/arm64 "${{ steps.platforms.outputs.arm64_digest }}"
           jq -n \
             --arg image "${IMAGE_NAME}" \
             --arg source_sha "${SOURCE_SHA}" \
@@ -409,6 +512,8 @@ jobs:
 
           cosign sign --yes "${image_ref}"
           cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance.json "${image_ref}"
+          cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance-linux-amd64.json "${amd64_ref}"
+          cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance-linux-arm64.json "${arm64_ref}"
           cosign attest --yes --type spdxjson --predicate sbom-linux-amd64.spdx.json "${amd64_ref}"
           cosign attest --yes --type spdxjson --predicate sbom-linux-arm64.spdx.json "${arm64_ref}"
 
@@ -421,6 +526,16 @@ jobs:
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-identity "${WORKFLOW_IDENTITY}" \
             "${image_ref}" > slsa-provenance.attestation.json
+          cosign verify-attestation \
+            --type slsaprovenance1 \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity "${WORKFLOW_IDENTITY}" \
+            "${amd64_ref}" > slsa-provenance-linux-amd64.attestation.json
+          cosign verify-attestation \
+            --type slsaprovenance1 \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity "${WORKFLOW_IDENTITY}" \
+            "${arm64_ref}" > slsa-provenance-linux-arm64.attestation.json
           cosign verify-attestation \
             --type spdxjson \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
@@ -448,15 +563,24 @@ jobs:
               ' "${attestation_file}" >/dev/null
           }
           verify_attestation slsa-provenance.attestation.json slsa-provenance.json "${{ steps.build.outputs.digest }}"
+          verify_attestation slsa-provenance-linux-amd64.attestation.json slsa-provenance-linux-amd64.json "${{ steps.platforms.outputs.amd64_digest }}"
+          verify_attestation slsa-provenance-linux-arm64.attestation.json slsa-provenance-linux-arm64.json "${{ steps.platforms.outputs.arm64_digest }}"
           verify_attestation sbom-linux-amd64.attestation.json sbom-linux-amd64.spdx.json "${{ steps.platforms.outputs.amd64_digest }}"
           verify_attestation sbom-linux-arm64.attestation.json sbom-linux-arm64.spdx.json "${{ steps.platforms.outputs.arm64_digest }}"
 
       - name: Generate verified release evidence
+        env:
+          RELEASE_ACTOR: ${{ github.actor }}
+          RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          RELEASE_ENVIRONMENT: release-production
         run: |
           set -euo pipefail
           jq -n \
             --arg schema "${RELEASE_EVIDENCE_TYPE}" \
             --arg component "helm-ai-kernel" \
+            --arg actor "${RELEASE_ACTOR}" \
+            --arg triggering_actor "${RELEASE_TRIGGERING_ACTOR}" \
+            --arg release_environment "${RELEASE_ENVIRONMENT}" \
             --arg source_repository "${GITHUB_REPOSITORY}" \
             --arg source_sha "${SOURCE_SHA}" \
             --arg workflow_sha "${WORKFLOW_SHA}" \
@@ -468,10 +592,15 @@ jobs:
             --arg final_tag "sha-${SOURCE_SHA}" \
             --arg amd64_digest "${{ steps.platforms.outputs.amd64_digest }}" \
             --arg arm64_digest "${{ steps.platforms.outputs.arm64_digest }}" \
+            --arg amd64_scan_digest "${{ steps.scan-amd64.outputs.report_digest }}" \
+            --arg arm64_scan_digest "${{ steps.scan-arm64.outputs.report_digest }}" \
             --arg build_type "${SLSA_BUILD_TYPE}" '
               {
                 schema: $schema,
                 component: $component,
+                actor: $actor,
+                triggering_actor: $triggering_actor,
+                release_environment: $release_environment,
                 source_repository: $source_repository,
                 source_ref: "refs/heads/main",
                 source_sha: $source_sha,
@@ -502,18 +631,52 @@ jobs:
                   exercised_platform: "linux/amd64",
                   smoke: "health-denial-receipt-stop-restart-exact-readback-passed"
                 },
-                slsa: ("slsa-provenance.json using " + $build_type),
+                cve_gate: {
+                  tool: "grype",
+                  scope: "os-and-library",
+                  fail_on: "high",
+                  status: "passed",
+                  platforms: [
+                    {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
+                    {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
+                  ]
+                },
+                slsa: {
+                  build_type: $build_type,
+                  index: {predicate: "slsa-provenance.json", attestation: "slsa-provenance.attestation.json"},
+                  platforms: [
+                    {platform: "linux/amd64", digest: $amd64_digest, predicate: "slsa-provenance-linux-amd64.json", attestation: "slsa-provenance-linux-amd64.attestation.json"},
+                    {platform: "linux/arm64", digest: $arm64_digest, predicate: "slsa-provenance-linux-arm64.json", attestation: "slsa-provenance-linux-arm64.attestation.json"}
+                  ]
+                },
                 cosign: "keyless-signature-and-platform-attestations-exactly-verified",
                 promotion_status: "staging-digest-verified"
               }
             ' > release-evidence.json
           jq -e \
             --arg schema "${RELEASE_EVIDENCE_TYPE}" \
+            --arg actor "${RELEASE_ACTOR}" \
+            --arg triggering_actor "${RELEASE_TRIGGERING_ACTOR}" \
+            --arg release_environment "${RELEASE_ENVIRONMENT}" \
             --arg source_sha "${SOURCE_SHA}" \
             --arg digest "${{ steps.build.outputs.digest }}" \
             --arg amd64_digest "${{ steps.platforms.outputs.amd64_digest }}" \
-            --arg arm64_digest "${{ steps.platforms.outputs.arm64_digest }}" '
+            --arg arm64_digest "${{ steps.platforms.outputs.arm64_digest }}" \
+            --arg amd64_scan_digest "${{ steps.scan-amd64.outputs.report_digest }}" \
+            --arg arm64_scan_digest "${{ steps.scan-arm64.outputs.report_digest }}" '
+              (keys | sort) == [
+                "actor", "component", "cosign", "cve_gate", "default_command",
+                "digest", "entrypoint", "final_tag", "healthcheck", "image",
+                "oci_labels", "persistence", "platforms", "promotion_status",
+                "release_environment", "runtime_verification", "schema", "slsa",
+                "source_ref", "source_repository", "source_sha", "staging_tag",
+                "triggering_actor", "workflow_file", "workflow_identity", "workflow_name",
+                "workflow_ref", "workflow_run", "workflow_sha"
+              ] and
               .schema == $schema and
+              .actor == $actor and
+              .triggering_actor == $triggering_actor and
+              .release_environment == $release_environment and
               .source_repository == "Mindburn-Labs/helm-ai-kernel" and
               .source_ref == "refs/heads/main" and
               .source_sha == $source_sha and
@@ -523,12 +686,31 @@ jobs:
                 exercised_platform: "linux/amd64",
                 smoke: "health-denial-receipt-stop-restart-exact-readback-passed"
               } and
+              .cve_gate == {
+                tool: "grype",
+                scope: "os-and-library",
+                fail_on: "high",
+                status: "passed",
+                platforms: [
+                  {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
+                  {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
+                ]
+              } and
+              .slsa == {
+                build_type: "https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/docs/supply-chain/kernel-image-build-v1.md",
+                index: {predicate: "slsa-provenance.json", attestation: "slsa-provenance.attestation.json"},
+                platforms: [
+                  {platform: "linux/amd64", digest: $amd64_digest, predicate: "slsa-provenance-linux-amd64.json", attestation: "slsa-provenance-linux-amd64.attestation.json"},
+                  {platform: "linux/arm64", digest: $arm64_digest, predicate: "slsa-provenance-linux-arm64.json", attestation: "slsa-provenance-linux-arm64.attestation.json"}
+                ]
+              } and
               .promotion_status == "staging-digest-verified" and
               .platforms == [
                 {platform: "linux/amd64", digest: $amd64_digest, sbom: "sbom-linux-amd64.spdx.json"},
                 {platform: "linux/arm64", digest: $arm64_digest, sbom: "sbom-linux-arm64.spdx.json"}
               ]
             ' release-evidence.json >/dev/null
+          cp release-evidence.json release-evidence.staging.json
 
       - name: Attest and exactly verify durable release evidence
         env:
@@ -718,6 +900,23 @@ jobs:
             .final_tag_digest = $final_digest
           ' release-evidence.json > release-evidence.final.json
           mv release-evidence.final.json release-evidence.json
+          jq -e \
+            --slurpfile staging release-evidence.staging.json \
+            --arg final_digest "${final_digest}" '
+            (keys | sort) == [
+              "actor", "component", "cosign", "cve_gate", "default_command",
+              "digest", "entrypoint", "final_tag", "final_tag_digest", "healthcheck",
+              "image", "oci_labels", "persistence", "platforms", "promotion_status",
+              "release_environment", "runtime_verification", "schema", "slsa",
+              "source_ref", "source_repository", "source_sha", "staging_tag",
+              "triggering_actor", "workflow_file", "workflow_identity", "workflow_name",
+              "workflow_ref", "workflow_run", "workflow_sha"
+            ] and
+            .final_tag_digest == $final_digest and
+            .promotion_status == "final-tag-digest-platforms-signature-and-evidence-verified" and
+            ((. | del(.promotion_status, .final_tag_digest)) ==
+              ($staging[0] | del(.promotion_status, .final_tag_digest)))
+          ' release-evidence.json >/dev/null
           cosign attest --yes \
             --type "${RELEASE_EVIDENCE_TYPE}" \
             --predicate release-evidence.json \
@@ -753,8 +952,14 @@ jobs:
             sbom-linux-amd64.attestation.json
             sbom-linux-arm64.spdx.json
             sbom-linux-arm64.attestation.json
+            grype-linux-amd64.json
+            grype-linux-arm64.json
             slsa-provenance.json
             slsa-provenance.attestation.json
+            slsa-provenance-linux-amd64.json
+            slsa-provenance-linux-amd64.attestation.json
+            slsa-provenance-linux-arm64.json
+            slsa-provenance-linux-arm64.attestation.json
             release-evidence.json
             release-evidence.attestation.json
             release-evidence.final-attestation.json

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -95,7 +95,12 @@ jobs:
               (.reviewers | type == "array" and length == 1) and
               .reviewers[0].type == "User" and
               (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
-              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com"))
+              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
+            (first(.protection_rules[] | select(.type == "branch_policy")) |
+              (keys | sort) == ["id", "node_id", "type"] and
+              (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.node_id | type == "string" and length > 0) and
+              .type == "branch_policy")
           ' <<<"${release_environment_payload}" >/dev/null; then
             echo "::error::release-production environment protection readback is not exact"
             exit 1
@@ -103,8 +108,12 @@ jobs:
           if ! jq -e '
             .total_count == 1 and
             (.branch_policies | type == "array" and length == 1) and
-            .branch_policies[0].name == "main" and
-            .branch_policies[0].type == "branch"
+            (.branch_policies[0] |
+              (keys | sort) == ["id", "name", "node_id", "type"] and
+              (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.node_id | type == "string" and length > 0) and
+              .name == "main" and
+              .type == "branch")
           ' <<<"${deployment_branch_policies}" >/dev/null; then
             echo "::error::release-production deployment branch policy must contain only main"
             exit 1
@@ -788,7 +797,12 @@ jobs:
               (.reviewers | type == "array" and length == 1) and
               .reviewers[0].type == "User" and
               (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
-              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com"))
+              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
+            (first(.protection_rules[] | select(.type == "branch_policy")) |
+              (keys | sort) == ["id", "node_id", "type"] and
+              (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.node_id | type == "string" and length > 0) and
+              .type == "branch_policy")
           ' <<<"${live_release_environment_payload}" >/dev/null; then
             echo "::error::release-production environment protection changed during the build"
             exit 1
@@ -796,8 +810,12 @@ jobs:
           if ! jq -e '
             .total_count == 1 and
             (.branch_policies | type == "array" and length == 1) and
-            .branch_policies[0].name == "main" and
-            .branch_policies[0].type == "branch"
+            (.branch_policies[0] |
+              (keys | sort) == ["id", "name", "node_id", "type"] and
+              (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+              (.node_id | type == "string" and length > 0) and
+              .name == "main" and
+              .type == "branch")
           ' <<<"${live_deployment_branch_policies}" >/dev/null; then
             echo "::error::release-production deployment branch policy changed during the build"
             exit 1

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${GITHUB_RUN_ATTEMPT}" != "1" ]]; then
-            echo "::error::publication reruns are prohibited; dispatch a new run so release-production requires a fresh owner approval"
+            echo "::error::publication reruns are prohibited; dispatch a new run for an exact-run owner approval"
             exit 1
           fi
           if [[ -z "${OWNER_READBACK_TOKEN:-}" ]]; then
@@ -94,14 +94,20 @@ jobs:
               (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
               (.node_id | type == "string" and length > 0) and
               .prevent_self_review == true and
-              (.reviewers | type == "array" and length == 1) and
-              (.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User") and
-              (.reviewers[0].reviewer | type == "object") and
-              (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
-              (.reviewers[0].reviewer.node_id | type == "string" and length > 0) and
-              .reviewers[0].reviewer.type == "User" and
-              .reviewers[0].reviewer.site_admin == false and
-              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
+              (.reviewers | type == "array" and length == 2) and
+              (all(.reviewers[];
+                (keys | sort) == ["reviewer", "type"] and
+                .type == "User" and
+                (.reviewer | type == "object") and
+                (.reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+                (.reviewer.node_id | type == "string" and length > 0) and
+                .reviewer.type == "User" and
+                .reviewer.site_admin == false and
+                (.reviewer.login == "mindburnlabs" or .reviewer.login == "peycheff-com")
+              )) and
+              (([.reviewers[].reviewer.login] | sort) == ["mindburnlabs", "peycheff-com"]) and
+              ([.reviewers[].reviewer.id] | unique | length == 2) and
+              ([.reviewers[].reviewer.node_id] | unique | length == 2)) and
             (first(.protection_rules[] | select(.type == "branch_policy")) |
               (keys | sort) == ["id", "node_id", "type"] and
               (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
@@ -147,16 +153,8 @@ jobs:
               exit 1
             fi
           done
-          run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
-            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --jq '.run_started_at')"
-          if [[ -z "${run_started_at}" ]]; then
-            echo "::error::the current workflow run has no authoritative start timestamp"
-            exit 1
-          fi
           approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"
           if ! jq -e \
-            --arg run_started_at "${run_started_at}" \
             --arg release_environment "${RELEASE_ENVIRONMENT}" \
             --arg request_actor "${REQUEST_ACTOR}" \
             --arg triggering_actor "${TRIGGERING_ACTOR}" '
@@ -164,7 +162,6 @@ jobs:
               .[] |
               select(
                 .state == "approved" and
-                (.created_at > $run_started_at) and
                 (.environments | type == "array" and any(.[]; .name == $release_environment)) and
                 (.user.login == "mindburnlabs" or .user.login == "peycheff-com") and
                 .user.login != $request_actor and
@@ -172,7 +169,7 @@ jobs:
               )
             ] | length > 0
           ' <<<"${approval_history}" >/dev/null; then
-            echo "::error::release-production requires a fresh approval from a distinct authorized human owner"
+            echo "::error::release-production requires an approved exact-run review from a distinct authorized human owner"
             exit 1
           fi
           for owner in mindburnlabs peycheff-com; do
@@ -221,13 +218,15 @@ jobs:
             echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for the current-main readback"
             exit 1
           fi
-          GIT_CONFIG_COUNT=1 \
-          GIT_CONFIG_KEY_0=http.extraheader \
-          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}" \
-            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          main_tip="$(git rev-parse refs/remotes/origin/main)"
-          if [[ "${SOURCE_SHA}" != "${main_tip}" ]]; then
-            echo "::error::source_sha must equal the current origin/main tip (${main_tip})"
+          current_main_ref="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+            --jq '.object.sha')"
+          if [[ ! "${current_main_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::current main ref readback is not an exact commit SHA"
+            exit 1
+          fi
+          if [[ "${SOURCE_SHA}" != "${current_main_ref}" ]]; then
+            echo "::error::source_sha must equal the current main ref (${current_main_ref})"
             exit 1
           fi
           test "$(git rev-parse HEAD)" = "${SOURCE_SHA}"
@@ -854,14 +853,20 @@ jobs:
               (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
               (.node_id | type == "string" and length > 0) and
               .prevent_self_review == true and
-              (.reviewers | type == "array" and length == 1) and
-              (.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User") and
-              (.reviewers[0].reviewer | type == "object") and
-              (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
-              (.reviewers[0].reviewer.node_id | type == "string" and length > 0) and
-              .reviewers[0].reviewer.type == "User" and
-              .reviewers[0].reviewer.site_admin == false and
-              (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
+              (.reviewers | type == "array" and length == 2) and
+              (all(.reviewers[];
+                (keys | sort) == ["reviewer", "type"] and
+                .type == "User" and
+                (.reviewer | type == "object") and
+                (.reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+                (.reviewer.node_id | type == "string" and length > 0) and
+                .reviewer.type == "User" and
+                .reviewer.site_admin == false and
+                (.reviewer.login == "mindburnlabs" or .reviewer.login == "peycheff-com")
+              )) and
+              (([.reviewers[].reviewer.login] | sort) == ["mindburnlabs", "peycheff-com"]) and
+              ([.reviewers[].reviewer.id] | unique | length == 2) and
+              ([.reviewers[].reviewer.node_id] | unique | length == 2)) and
             (first(.protection_rules[] | select(.type == "branch_policy")) |
               (keys | sort) == ["id", "node_id", "type"] and
               (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
@@ -922,16 +927,8 @@ jobs:
               exit 1
             fi
           done
-          run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
-            "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-            --jq '.run_started_at')"
-          if [[ -z "${run_started_at}" ]]; then
-            echo "::error::the current workflow run has no authoritative start timestamp"
-            exit 1
-          fi
           approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"
           if ! jq -e \
-            --arg run_started_at "${run_started_at}" \
             --arg release_environment "${RELEASE_ENVIRONMENT}" \
             --arg request_actor "${REQUEST_ACTOR}" \
             --arg triggering_actor "${TRIGGERING_ACTOR}" '
@@ -939,7 +936,6 @@ jobs:
               .[] |
               select(
                 .state == "approved" and
-                (.created_at > $run_started_at) and
                 (.environments | type == "array" and any(.[]; .name == $release_environment)) and
                 (.user.login == "mindburnlabs" or .user.login == "peycheff-com") and
                 .user.login != $request_actor and
@@ -947,7 +943,7 @@ jobs:
               )
             ] | length > 0
           ' <<<"${approval_history}" >/dev/null; then
-            echo "::error::release-production no longer has this run's fresh distinct human-owner approval"
+            echo "::error::release-production no longer has this exact-run distinct human-owner approval"
             exit 1
           fi
           for owner in mindburnlabs peycheff-com; do
@@ -963,15 +959,18 @@ jobs:
             echo "::error::source_sha no longer matches the workflow commit before promotion"
             exit 1
           fi
-          GIT_CONFIG_COUNT=1 \
-          GIT_CONFIG_KEY_0=http.extraheader \
-          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}" \
-            git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          promotion_main_tip="$(git rev-parse refs/remotes/origin/main)"
-          if [[ "${SOURCE_SHA}" != "${promotion_main_tip}" ]]; then
-            echo "::error::origin/main moved before promotion (${promotion_main_tip})"
+          promotion_main_ref="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api \
+            "/repos/${GITHUB_REPOSITORY}/git/ref/heads/main" \
+            --jq '.object.sha')"
+          if [[ ! "${promotion_main_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::current main ref readback is not an exact commit SHA"
             exit 1
           fi
+          if [[ "${SOURCE_SHA}" != "${promotion_main_ref}" ]]; then
+            echo "::error::main moved before promotion (${promotion_main_ref})"
+            exit 1
+          fi
+          test "$(git rev-parse HEAD)" = "${SOURCE_SHA}"
           GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api --paginate \
             "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${SOURCE_SHA}&branch=main&per_page=100" \
             > promotion-ci-runs.json

--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -45,7 +45,6 @@ jobs:
     steps:
       - name: Validate publication authority
         env:
-          GH_TOKEN: ${{ github.token }}
           OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}
           RELEASE_ACTORS_JSON: ${{ vars.HELM_AI_OS_IMAGE_RELEASE_ACTORS }}
           RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}
@@ -196,6 +195,15 @@ jobs:
             echo "::error::source_sha must equal the main commit recorded at dispatch (${WORKFLOW_SHA})"
             exit 1
           fi
+          initial_live_release_actors_sha256="$(printf '%s' "${live_release_actors}" | sha256sum | cut -d' ' -f1)"
+          if [[ ! "${initial_live_release_actors_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "::error::the initial live release actor JSON digest is invalid"
+            exit 1
+          fi
+          {
+            printf 'INITIAL_LIVE_RELEASE_AUTHORITY=%s\n' "${live_release_authority}"
+            printf 'INITIAL_LIVE_RELEASE_ACTORS_SHA256=%s\n' "${initial_live_release_actors_sha256}"
+          } >> "${GITHUB_ENV}"
 
       - name: Checkout exact source
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -206,12 +214,16 @@ jobs:
 
       - name: Verify source is the current main tip
         env:
-          GH_TOKEN: ${{ github.token }}
+          OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}
         run: |
           set -euo pipefail
+          if [[ -z "${OWNER_READBACK_TOKEN:-}" ]]; then
+            echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for the current-main readback"
+            exit 1
+          fi
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.extraheader \
-          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_TOKEN}" \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}" \
             git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           main_tip="$(git rev-parse refs/remotes/origin/main)"
           if [[ "${SOURCE_SHA}" != "${main_tip}" ]]; then
@@ -222,10 +234,14 @@ jobs:
 
       - name: Require newest CI run to be completed and green
         env:
-          GH_TOKEN: ${{ github.token }}
+          OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}
         run: |
           set -euo pipefail
-          gh api --paginate \
+          if [[ -z "${OWNER_READBACK_TOKEN:-}" ]]; then
+            echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for the CI readback"
+            exit 1
+          fi
+          GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api --paginate \
             "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${SOURCE_SHA}&branch=main&per_page=100" \
             > ci-runs.json
           ./scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}" < ci-runs.json
@@ -410,7 +426,7 @@ jobs:
           jq -e '
             type == "object" and
             (keys | sort) == ["built", "from", "path", "schemaVersion", "valid"] and
-            (.schemaVersion | type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) and
+            (.schemaVersion | type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) and
             (.from | type == "string" and startswith("https://grype.anchore.io/databases/")) and
             (.built | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
             (.path | type == "string" and length > 0) and
@@ -793,7 +809,6 @@ jobs:
       - name: Reauthorize and promote the verified digest
         env:
           COSIGN_EXPERIMENTAL: "true"
-          GH_TOKEN: ${{ github.token }}
           OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}
           RELEASE_ACTORS_JSON: ${{ vars.HELM_AI_OS_IMAGE_RELEASE_ACTORS }}
           RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}
@@ -877,6 +892,14 @@ jobs:
             echo "::error::release-production changed from the job-start authority snapshot"
             exit 1
           fi
+          if [[ -z "${INITIAL_LIVE_RELEASE_AUTHORITY:-}" || -z "${INITIAL_LIVE_RELEASE_ACTORS_SHA256:-}" ]]; then
+            echo "::error::initial live release authority binding is missing"
+            exit 1
+          fi
+          if [[ "${live_release_authority}" != "${INITIAL_LIVE_RELEASE_AUTHORITY}" ]]; then
+            echo "::error::release-production changed from the initial live authority readback"
+            exit 1
+          fi
           if ! jq -e '
             . == ["mindburnlabs","peycheff-com"]
           ' <<<"${live_release_actors}" >/dev/null; then
@@ -885,6 +908,11 @@ jobs:
           fi
           if ! jq -e --argjson configured "${RELEASE_ACTORS_JSON}" '. == $configured' <<<"${live_release_actors}" >/dev/null; then
             echo "::error::the release actor allowlist changed from the job-start snapshot"
+            exit 1
+          fi
+          live_release_actors_sha256="$(printf '%s' "${live_release_actors}" | sha256sum | cut -d' ' -f1)"
+          if [[ ! "${live_release_actors_sha256}" =~ ^[0-9a-f]{64}$ || "${live_release_actors_sha256}" != "${INITIAL_LIVE_RELEASE_ACTORS_SHA256}" ]]; then
+            echo "::error::the live release actor JSON changed from the initial owner readback"
             exit 1
           fi
           for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do
@@ -937,14 +965,14 @@ jobs:
           fi
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.extraheader \
-          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_TOKEN}" \
+          GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}" \
             git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
           promotion_main_tip="$(git rev-parse refs/remotes/origin/main)"
           if [[ "${SOURCE_SHA}" != "${promotion_main_tip}" ]]; then
             echo "::error::origin/main moved before promotion (${promotion_main_tip})"
             exit 1
           fi
-          gh api --paginate \
+          GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api --paginate \
             "/repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs?head_sha=${SOURCE_SHA}&branch=main&per_page=100" \
             > promotion-ci-runs.json
           ./scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}" < promotion-ci-runs.json

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -23,16 +23,21 @@ the checkout's `.git` directory and generated Buildx, runtime, platform, SBOM,
 SLSA, Grype, and release-evidence files from the build context.
 
 After the platform manifests are inspected and before any Cosign signature is
-created, the workflow downloads Grype through the pinned
-`anchore/scan-action/download-grype@1638637db639e0ade3258b51db49a9a137574c3e`
-action. Automatic application and vulnerability-database updates are disabled;
-if the pinned binary or its database is unavailable, the job stops. Grype scans
-each exact `linux/amd64` and `linux/arm64` manifest digest with
+created, the workflow downloads the Grype `v0.116.1` Linux amd64 release
+archive from its immutable versioned URL and accepts it only after matching the
+source-owned SHA-256
+`0122df7b655981abe547ad3d2190d65551dac6a2bfc80b4dc2a989b5d0587458`. It
+explicitly bootstraps the vulnerability database once
+into the run's dedicated cache, records `grype db status --output json`, and
+requires a valid machine-readable status object. Both platform scans then use
+that same cache with application and database auto-updates disabled; if the
+binary, database bootstrap, or status readback is unavailable, the job stops.
+Grype scans each exact `linux/amd64` and `linux/arm64` manifest digest with
 `--scope all-layers --fail-on high --output json`. A scan is accepted only when
 its report is an object with an array `matches` field containing no `high` or
-`critical` severity. Each report is retained with a SHA-256 digest in the
-release evidence, so the CVE gate cannot silently change from one platform to
-the other or from one retry to the next.
+`critical` severity. Each report and the database-status file are retained with
+SHA-256 digests in the release evidence, so the CVE gate cannot silently change
+from one platform to the other or from one retry to the next.
 
 ## Parameters
 
@@ -93,12 +98,16 @@ The environment readback is authoritative, not a name-only check. The workflow
 requires `can_admins_bypass=false`,
 `deployment_branch_policy={protected_branches:false,custom_branch_policies:true}`,
 and exactly two protection rules: one `required_reviewers` rule with
-`prevent_self_review=true` and exactly one nested provider `User` reviewer whose
-numeric identity and login resolve to a current Mindburn-Labs owner, plus one
-`branch_policy` rule. That branch rule has exactly the provider keys
-`[id,node_id,type]`, with a positive integer `id` and nonempty `node_id`. The
+`prevent_self_review=true`, exact outer provider keys
+`[id,node_id,prevent_self_review,reviewers,type]`, and exactly one outer
+reviewer entry with keys `[reviewer,type]`. Its nested provider `User` trust
+projection requires a positive integral identity, nonempty `node_id`,
+`type=User`, `site_admin=false`, and a login that resolves to a current
+Mindburn-Labs owner; unrelated documented User metadata is tolerated. The
+second rule is one `branch_policy` rule with exactly the provider keys
+`[id,node_id,type]`, with a positive integral `id` and nonempty `node_id`. The
 deployment-branch-policies endpoint must report one record with exactly the
-provider keys `[id,name,node_id,type]`, a positive integer `id`, nonempty
+provider keys `[id,name,node_id,type]`, a positive integral `id`, nonempty
 `node_id`, and name/type exactly `main`/`branch`.
 
 The dispatch snapshot and the owner-token live readback both require the exact

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -95,8 +95,11 @@ requires `can_admins_bypass=false`,
 and exactly two protection rules: one `required_reviewers` rule with
 `prevent_self_review=true` and exactly one nested provider `User` reviewer whose
 numeric identity and login resolve to a current Mindburn-Labs owner, plus one
-`branch_policy` rule. The deployment-branch-policies endpoint must report one
-branch policy whose name/type are exactly `main`/`branch`.
+`branch_policy` rule. That branch rule has exactly the provider keys
+`[id,node_id,type]`, with a positive integer `id` and nonempty `node_id`. The
+deployment-branch-policies endpoint must report one record with exactly the
+provider keys `[id,name,node_id,type]`, a positive integer `id`, nonempty
+`node_id`, and name/type exactly `main`/`branch`.
 
 The dispatch snapshot and the owner-token live readback both require the exact
 actor JSON `["mindburnlabs","peycheff-com"]`. Every policy, variable, and

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -77,7 +77,8 @@ The environment readback is authoritative, not a name-only check. The workflow
 requires `can_admins_bypass=false`,
 `deployment_branch_policy={protected_branches:false,custom_branch_policies:true}`,
 and exactly two protection rules: one `required_reviewers` rule with
-`prevent_self_review=true` and exactly one numeric `User` reviewer, plus one
+`prevent_self_review=true` and exactly one nested provider `User` reviewer whose
+numeric identity and login resolve to a current Mindburn-Labs owner, plus one
 `branch_policy` rule. The deployment-branch-policies endpoint must report one
 branch policy whose name/type are exactly `main`/`branch`.
 

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -86,9 +86,10 @@ these external owner-managed settings pass:
    able to read the repository release-actor variable and Mindburn-Labs
    organization memberships. The workflow fails unless both `mindburnlabs` and
    `peycheff-com` read back as active admins.
-5. The current workflow run's environment review history contains an approval
-   from one of those two human owners. This binds approval to one run rather
-   than treating a repository variable or older approval as reusable authority.
+5. The exact current workflow run's environment review history contains an
+   approval from one of those two human owners. Reruns are rejected, so the
+   approval endpoint remains bound to this immutable run rather than treating
+   a repository variable or another run's approval as reusable authority.
 
 Those settings are an owner blocker outside this source-only change. Until
 they are confirmed in GitHub, the workflow is intentionally not dispatchable.
@@ -100,11 +101,12 @@ requires `can_admins_bypass=false`,
 `deployment_branch_policy={protected_branches:false,custom_branch_policies:true}`,
 and exactly two protection rules: one `required_reviewers` rule with
 `prevent_self_review=true`, exact outer provider keys
-`[id,node_id,prevent_self_review,reviewers,type]`, and exactly one outer
-reviewer entry with keys `[reviewer,type]`. Its nested provider `User` trust
-projection requires a positive integral identity, nonempty `node_id`,
-`type=User`, `site_admin=false`, and a login that resolves to a current
-Mindburn-Labs owner; unrelated documented User metadata is tolerated. The
+`[id,node_id,prevent_self_review,reviewers,type]`, and exactly two outer
+reviewer entries with keys `[reviewer,type]`. Their nested provider `User`
+trust projections require positive integral identities, nonempty `node_id`
+values, `type=User`, `site_admin=false`, and the exact login set
+`[mindburnlabs,peycheff-com]`; reviewer IDs and node IDs must also be
+distinct, while unrelated documented User metadata is tolerated. The
 second rule is one `branch_policy` rule with exactly the provider keys
 `[id,node_id,type]`, with a positive integral `id` and nonempty `node_id`. The
 deployment-branch-policies endpoint must report one record with exactly the
@@ -112,19 +114,20 @@ provider keys `[id,name,node_id,type]`, a positive integral `id`, nonempty
 `node_id`, and name/type exactly `main`/`branch`.
 
 The dispatch snapshot and the owner-token live readback both require the exact
-actor JSON `["mindburnlabs","peycheff-com"]`. Every policy, variable, and
-membership read uses `GH_TOKEN="${OWNER_READBACK_TOKEN}"` explicitly. The
-run approval must be `approved`, target `release-production`, have a
-`created_at` after the current run's authoritative `run_started_at` readback,
-and be from one of those owners while differing from both the request and
-triggering actors. The
+actor JSON `["mindburnlabs","peycheff-com"]`. Every policy, variable,
+membership, and current-main ref read uses `GH_TOKEN="${OWNER_READBACK_TOKEN}"`
+explicitly. The exact-run approvals response must contain an `approved` review
+targeting `release-production` from one of those owners while differing from
+both the request and triggering actors. Approval timestamps are not inferred
+from unsupported top-level fields; any nested environment metadata timestamp
+is informational only. The
 full environment, branch-policy, actor, owner, approval, source-tip, and newest
 CI readbacks are repeated immediately before the immutable `sha-<SOURCE_SHA>`
 promotion. The initial live authority and SHA-256 of its exact actor JSON are
 persisted through `GITHUB_ENV` and both are compared again at that final
-checkpoint. Current-main fetches and CI-run queries at both checkpoints are
-bound explicitly to the owner readback token; the job token is reserved for
-publication operations. Reruns are rejected.
+checkpoint. Current-main REST ref readbacks and CI-run queries at both
+checkpoints are bound explicitly to the owner readback token; the job token is
+reserved for publication operations. Reruns are rejected.
 
 This workflow exclusively owns the governed immutable `sha-<SOURCE_SHA>` tag
 namespace. The legacy `release.yml` QA publisher uses the disjoint

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -29,8 +29,9 @@ source-owned SHA-256
 `0122df7b655981abe547ad3d2190d65551dac6a2bfc80b4dc2a989b5d0587458`. It
 explicitly bootstraps the vulnerability database once
 into the run's dedicated cache, records `grype db status --output json`, and
-requires a valid machine-readable status object. Both platform scans then use
-that same cache with application and database auto-updates disabled; if the
+requires the exact provider-shaped machine-readable status object, including a
+dotted numeric `schemaVersion` without a leading `v`. Both platform scans
+then use that same cache with application and database auto-updates disabled; if the
 binary, database bootstrap, or status readback is unavailable, the job stops.
 Grype scans each exact `linux/amd64` and `linux/arm64` manifest digest with
 `--scope all-layers --fail-on high --output json`. A scan is accepted only when
@@ -119,7 +120,11 @@ and be from one of those owners while differing from both the request and
 triggering actors. The
 full environment, branch-policy, actor, owner, approval, source-tip, and newest
 CI readbacks are repeated immediately before the immutable `sha-<SOURCE_SHA>`
-promotion. Reruns are rejected.
+promotion. The initial live authority and SHA-256 of its exact actor JSON are
+persisted through `GITHUB_ENV` and both are compared again at that final
+checkpoint. Current-main fetches and CI-run queries at both checkpoints are
+bound explicitly to the owner readback token; the job token is reserved for
+publication operations. Reruns are rejected.
 
 This workflow exclusively owns the governed immutable `sha-<SOURCE_SHA>` tag
 namespace. The legacy `release.yml` QA publisher uses the disjoint

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -17,6 +17,10 @@ same-source dispatch therefore cannot silently change either builder. The
 pinned builder image already supplies the CA bundle; the Dockerfile performs no
 live `apk add`, and Go module content remains bound by `core/go.sum`, so a
 same-source retry does not resolve mutable Alpine packages.
+The root `.dockerignore` starts with a deny-all rule and re-includes only the
+Dockerfile's `core/`, policy, and reference-pack inputs. It explicitly excludes
+the checkout's `.git` directory and generated Buildx, runtime, platform, SBOM,
+SLSA, and release-evidence files from the build context.
 
 ## Parameters
 
@@ -68,6 +72,25 @@ Those settings are an owner blocker outside this source-only change. Until
 they are confirmed in GitHub, the workflow is intentionally not dispatchable.
 The owner-readback token is never used for mutation. GHCR and keyless Cosign
 operations still use only the job-scoped GitHub token and OIDC identity.
+
+The environment readback is authoritative, not a name-only check. The workflow
+requires `can_admins_bypass=false`,
+`deployment_branch_policy={protected_branches:false,custom_branch_policies:true}`,
+and exactly two protection rules: one `required_reviewers` rule with
+`prevent_self_review=true` and exactly one numeric `User` reviewer, plus one
+`branch_policy` rule. The deployment-branch-policies endpoint must report one
+branch policy whose name/type are exactly `main`/`branch`.
+
+The dispatch snapshot and the owner-token live readback both require the exact
+actor JSON `["mindburnlabs","peycheff-com"]`. Every policy, variable, and
+membership read uses `GH_TOKEN="${OWNER_READBACK_TOKEN}"` explicitly. The
+run approval must be `approved`, target `release-production`, have a
+`created_at` after the current run's authoritative `run_started_at` readback,
+and be from one of those owners while differing from both the request and
+triggering actors. The
+full environment, branch-policy, actor, owner, approval, source-tip, and newest
+CI readbacks are repeated immediately before the immutable `sha-<SOURCE_SHA>`
+promotion. Reruns are rejected.
 
 This workflow exclusively owns the governed immutable `sha-<SOURCE_SHA>` tag
 namespace. The legacy `release.yml` QA publisher uses the disjoint

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -20,7 +20,19 @@ same-source retry does not resolve mutable Alpine packages.
 The root `.dockerignore` starts with a deny-all rule and re-includes only the
 Dockerfile's `core/`, policy, and reference-pack inputs. It explicitly excludes
 the checkout's `.git` directory and generated Buildx, runtime, platform, SBOM,
-SLSA, and release-evidence files from the build context.
+SLSA, Grype, and release-evidence files from the build context.
+
+After the platform manifests are inspected and before any Cosign signature is
+created, the workflow downloads Grype through the pinned
+`anchore/scan-action/download-grype@1638637db639e0ade3258b51db49a9a137574c3e`
+action. Automatic application and vulnerability-database updates are disabled;
+if the pinned binary or its database is unavailable, the job stops. Grype scans
+each exact `linux/amd64` and `linux/arm64` manifest digest with
+`--scope all-layers --fail-on high --output json`. A scan is accepted only when
+its report is an object with an array `matches` field containing no `high` or
+`critical` severity. Each report is retained with a SHA-256 digest in the
+release evidence, so the CVE gate cannot silently change from one platform to
+the other or from one retry to the next.
 
 ## Parameters
 
@@ -41,11 +53,15 @@ single resolved dependency is:
 }
 ```
 
-The Cosign in-toto statement, rather than the predicate object, owns the
-`subject` field. The workflow decodes the verified statement and requires its
-only subject SHA-256 digest to equal the built multi-platform index digest. It
-also requires the decoded predicate to equal the generated predicate byte
-structure before promotion.
+The workflow emits one source-owned SLSA v1 predicate for the multi-platform
+index and one for each exact platform manifest. Each platform predicate records
+its `linux/amd64` or `linux/arm64` value and the corresponding manifest digest
+in `internalParameters`. Cosign attests all three predicates before signing is
+accepted. The Cosign in-toto statement, rather than the predicate object, owns
+the `subject` field. The workflow decodes every verified statement and requires
+its only subject SHA-256 digest to equal the corresponding index or platform
+digest. It also requires each decoded predicate to equal its generated
+predicate byte structure before promotion.
 
 ## Invocation and authority
 

--- a/docs/supply-chain/kernel-image-release-evidence-v1.md
+++ b/docs/supply-chain/kernel-image-release-evidence-v1.md
@@ -33,10 +33,13 @@ pass. The predicate's `runtime_verification` field records those completed
 checks; it is not inferred from the Dockerfile.
 
 The `cve_gate` object is also closed and records `tool=grype`,
-`scope=os-and-library`, `fail_on=high`, `status=passed`, and one report name,
-platform digest, and report SHA-256 digest for each exact platform. Both
-platform digests must have passed the scan before signing, and the reports are
-uploaded with the durable evidence convenience copy.
+`scope=os-and-library`, `fail_on=high`, `status=passed`, the machine-readable
+`grype-db-status.json` name and its SHA-256 digest, and one report name,
+platform digest, and report SHA-256 digest for each exact platform. The status
+file is emitted once after the explicit database bootstrap and before either
+scan; both scans use that same run-local cache with auto-update disabled. Both
+platform digests must have passed the scan before signing, and the status file
+and reports are uploaded with the durable evidence convenience copy.
 
 The `slsa` object records the source-owned build type, the index predicate and
 attestation names, and one predicate/attestation name pair plus exact platform

--- a/docs/supply-chain/kernel-image-release-evidence-v1.md
+++ b/docs/supply-chain/kernel-image-release-evidence-v1.md
@@ -34,7 +34,8 @@ checks; it is not inferred from the Dockerfile.
 
 The `cve_gate` object is also closed and records `tool=grype`,
 `scope=os-and-library`, `fail_on=high`, `status=passed`, the machine-readable
-`grype-db-status.json` name and its SHA-256 digest, and one report name,
+`grype-db-status.json` name and its SHA-256 digest (whose provider
+`schemaVersion` is a dotted numeric version without a leading `v`), and one report name,
 platform digest, and report SHA-256 digest for each exact platform. The status
 file is emitted once after the explicit database bootstrap and before either
 scan; both scans use that same run-local cache with auto-update disabled. Both

--- a/docs/supply-chain/kernel-image-release-evidence-v1.md
+++ b/docs/supply-chain/kernel-image-release-evidence-v1.md
@@ -16,8 +16,12 @@ Required evidence fields identify the Kernel component, exact source
 repository/ref/SHA, explicit producer workflow name/file/ref/SHA/identity/run,
 image repository, staging and final tags, index digest, both platform digests
 and SPDX files, exact OCI source/revision labels, entrypoint/default command,
-health and persistence contracts, SLSA build type, Cosign verification state,
-and promotion status.
+health and persistence contracts, the request and triggering GitHub actors, the
+`release-production` environment, the SLSA build type, Cosign verification
+state, and promotion status. The top-level object is closed: the interim form
+has exactly the declared fields and `promotion_status=staging-digest-verified`;
+the finalized form adds only `final_tag_digest` and uses the finalized promotion
+status.
 
 Before any release-evidence predicate is generated, the workflow reads both
 platform manifests' final OCI configs and requires the governed entrypoint,
@@ -27,6 +31,21 @@ health checks, a fail-closed governed denial, stop, restart against the same
 bind mount, root-key continuity, and exact denial-receipt read-back must all
 pass. The predicate's `runtime_verification` field records those completed
 checks; it is not inferred from the Dockerfile.
+
+The `cve_gate` object is also closed and records `tool=grype`,
+`scope=os-and-library`, `fail_on=high`, `status=passed`, and one report name,
+platform digest, and report SHA-256 digest for each exact platform. Both
+platform digests must have passed the scan before signing, and the reports are
+uploaded with the durable evidence convenience copy.
+
+The `slsa` object records the source-owned build type, the index predicate and
+attestation names, and one predicate/attestation name pair plus exact platform
+digest for each `linux/amd64` and `linux/arm64` manifest. The workflow verifies
+each attestation by requiring both byte-for-byte predicate equality and a
+single subject whose digest is the expected platform digest. This exact
+predicate check is repeated for the finalized release-evidence attestation
+after immutable-tag promotion; a matching subject with a different predicate
+does not authorize publication.
 
 The workflow first attaches an interim predicate with
 `promotion_status=staging-digest-verified`. After the immutable tag is created

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -309,6 +309,10 @@ if [ "$(grep -Fc 'git fetch --no-tags origin +refs/heads/main:refs/remotes/origi
   echo 'current main and newest completed CI must be checked initially and immediately before promotion' >&2
   exit 1
 fi
+if [ "$(grep -Fc 'if [[ "${SOURCE_SHA}" != "${WORKFLOW_SHA}" ]]; then' "$workflow")" -ne 2 ]; then
+  echo 'source_sha must remain bound to the workflow commit at both authority checkpoints' >&2
+  exit 1
+fi
 run_start_read_pattern='run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api'
 authority_environment_count="$(awk '
   /^      - name: Validate publication authority$/ { in_step = 1; next }

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -162,11 +162,15 @@ require '[.protection_rules[].type] | sort' "$workflow"
 require '== ["branch_policy", "required_reviewers"]' "$workflow"
 require 'required_reviewers' "$workflow"
 require 'branch_policy' "$workflow"
+require '(keys | sort) == ["id", "node_id", "prevent_self_review", "reviewers", "type"]' "$workflow"
+require '(.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User")' "$workflow"
 require '(first(.protection_rules[] | select(.type == "branch_policy")) |' "$workflow"
 require '(keys | sort) == ["id", "node_id", "type"]' "$workflow"
 require '.prevent_self_review == true' "$workflow"
-require '.reviewers[0].type == "User"' "$workflow"
 require '.reviewers[0].reviewer.id' "$workflow"
+require '.reviewers[0].reviewer.node_id | type == "string" and length > 0' "$workflow"
+require '.reviewers[0].reviewer.type == "User"' "$workflow"
+require '.reviewers[0].reviewer.site_admin == false' "$workflow"
 require '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow"
 require 'type == "number"' "$workflow"
 require '.total_count == 1' "$workflow"
@@ -226,7 +230,22 @@ require "git+https://github.com/" "$workflow"
 require '@refs/heads/main' "$workflow"
 require 'output-file: sbom-linux-amd64.spdx.json' "$workflow"
 require 'output-file: sbom-linux-arm64.spdx.json' "$workflow"
-require 'anchore/scan-action/download-grype@1638637db639e0ade3258b51db49a9a137574c3e' "$workflow"
+require 'GRYPE_VERSION: v0.116.1' "$workflow"
+require 'GRYPE_SHA256: 0122df7b655981abe547ad3d2190d65551dac6a2bfc80b4dc2a989b5d0587458' "$workflow"
+require 'https://github.com/anchore/grype/releases/download/${GRYPE_VERSION}/grype_${GRYPE_VERSION#v}_linux_amd64.tar.gz' "$workflow"
+require 'printf '\''%s  %s\n'\'' "${GRYPE_SHA256}" "${grype_archive}" | sha256sum --check --strict' "$workflow"
+require 'tar -xzf "${grype_archive}" -C "${grype_extract_dir}"' "$workflow"
+require 'install -m 0755 "${grype_extract_dir}/grype" "${grype_binary}"' "$workflow"
+require 'grype db update' "$workflow"
+require 'grype db status --output json > grype-db-status.json' "$workflow"
+require 'GRYPE_DB_CACHE_DIR: ${{ runner.temp }}/grype-db' "$workflow"
+require '(keys | sort) == ["built", "from", "path", "schemaVersion", "valid"]' "$workflow"
+require '(.schemaVersion | type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' "$workflow"
+require '(.from | type == "string" and startswith("https://grype.anchore.io/databases/"))' "$workflow"
+require '(.built | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))' "$workflow"
+require '(.path | type == "string" and length > 0)' "$workflow"
+require '.valid == true' "$workflow"
+require 'status_digest=sha256:$(sha256sum grype-db-status.json' "$workflow"
 require 'GRYPE_CHECK_FOR_APP_UPDATE: "false"' "$workflow"
 require 'GRYPE_DB_AUTO_UPDATE: "false"' "$workflow"
 require 'IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64_digest }}' "$workflow"
@@ -265,6 +284,7 @@ require 'cve_gate: {' "$workflow"
 require 'scope: "os-and-library"' "$workflow"
 require 'fail_on: "high"' "$workflow"
 require 'status: "passed"' "$workflow"
+require 'database: {status: "grype-db-status.json", status_digest: $db_status_digest}' "$workflow"
 require 'report: "grype-linux-amd64.json"' "$workflow"
 require 'report: "grype-linux-arm64.json"' "$workflow"
 require 'slsa: {' "$workflow"
@@ -288,6 +308,7 @@ require 'final-tag-digest-platforms-signature-and-evidence-verified' "$workflow"
 require '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-sha-${{ inputs.source_sha }}' "$legacy_workflow"
 
 for upload_entry in \
+  '            grype-db-status.json' \
   '            grype-linux-amd64.json' \
   '            grype-linux-arm64.json' \
   '            slsa-provenance-linux-amd64.json' \
@@ -351,21 +372,25 @@ if [ "$(grep -Fc '.can_admins_bypass == false' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '[.protection_rules[].type] | sort' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '== ["branch_policy", "required_reviewers"]' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.protection_rules | type == "array" and length == 2)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(keys | sort) == ["id", "node_id", "prevent_self_review", "reviewers", "type"]' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User")' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(first(.protection_rules[] | select(.type == "branch_policy")) |' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(keys | sort) == ["id", "node_id", "type"]' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.prevent_self_review == true' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.reviewers | type == "array" and length == 1)' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.reviewers[0].type == "User"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.reviewers[0].reviewer.id' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewers[0].reviewer.node_id | type == "string" and length > 0)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewers[0].reviewer.type == "User"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewers[0].reviewer.site_admin == false' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.total_count == 1' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.branch_policies[0] |' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(keys | sort) == ["id", "name", "node_id", "type"]' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.name == "main"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.type == "branch"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '(.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 4 ] ||
-  [ "$(grep -Fc '(.node_id | type == "string" and length > 0)' "$workflow")" -ne 4 ] ||
+  [ "$(grep -Fc '(.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 6 ] ||
+  [ "$(grep -Fc '(.node_id | type == "string" and length > 0)' "$workflow")" -ne 6 ] ||
   [ "$(grep -Fc '.created_at > $run_started_at' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.environments | type == "array"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'any(.[]; .name == $release_environment)' "$workflow")" -ne 2 ] ||
@@ -384,13 +409,16 @@ if [ "$(grep -Fc -- '--type spdxjson' "$workflow")" -ne 4 ]; then
 fi
 if [ "$(grep -Fc -- '--scope all-layers' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc -- '--fail-on high' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc -- '--output json' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc -- '--output json' "$workflow")" -ne 3 ] ||
   [ "$(grep -Fc 'IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64_digest }}' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc 'IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64_digest }}' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc -- '--file grype-linux-amd64.json' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc -- '--file grype-linux-arm64.json' "$workflow")" -ne 1 ] ||
-  [ "$(grep -Fc 'GRYPE_DB_AUTO_UPDATE: "false"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc 'GRYPE_CHECK_FOR_APP_UPDATE: "false"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'GRYPE_DB_CACHE_DIR: ${{ runner.temp }}/grype-db' "$workflow")" -ne 3 ] ||
+  [ "$(grep -Fc 'GRYPE_DB_AUTO_UPDATE: "false"' "$workflow")" -ne 3 ] ||
+  [ "$(grep -Fc 'GRYPE_CHECK_FOR_APP_UPDATE: "false"' "$workflow")" -ne 3 ] ||
+  [ "$(grep -Fc 'grype db update' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'grype db status --output json > grype-db-status.json' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc 'type == "object" and' "$workflow")" -lt 2 ] ||
   [ "$(grep -Fc 'report_digest=sha256:$(sha256sum grype-linux-amd64.json' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc 'report_digest=sha256:$(sha256sum grype-linux-arm64.json' "$workflow")" -ne 1 ]; then
@@ -406,12 +434,13 @@ if [ "$(grep -Fc 'cosign attest --yes --type slsaprovenance1 --predicate slsa-pr
   echo 'each exact platform SLSA predicate must be attested and exactly verified' >&2
   exit 1
 fi
-if [ "$(grep -Fc '(keys | sort) == [' "$workflow")" -ne 6 ] ||
+if [ "$(grep -Fc '(keys | sort) == [' "$workflow")" -ne 11 ] ||
   [ "$(grep -Fc '"actor", "component", "cosign", "cve_gate", "default_command",' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.actor == $actor' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc '.triggering_actor == $triggering_actor' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc '.release_environment == $release_environment' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc '.cve_gate == {' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'database: {status: "grype-db-status.json", status_digest: $db_status_digest}' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.slsa == {' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc '.final_tag_digest == $final_digest' "$workflow")" -ne 1 ]; then
   echo 'release evidence must use the closed authority, CVE, and SLSA shape' >&2
@@ -431,6 +460,10 @@ if [ "$(grep -Ec '^[[:space:]]+tags:' "$workflow")" -ne 1 ]; then
 fi
 if grep -Fq 'https://actions.github.io/buildtypes/workflow/v1' "$workflow"; then
   echo 'custom provenance must not claim the GitHub-hosted build type' >&2
+  exit 1
+fi
+if grep -Fq 'anchore/scan-action/download-grype@' "$workflow"; then
+  echo 'Grype must be installed from the checksum-verified immutable release artifact' >&2
   exit 1
 fi
 if grep -Fq 'git merge-base --is-ancestor' "$workflow"; then
@@ -464,6 +497,8 @@ staging_line="$(first_line 'tags: ${{ env.IMAGE_NAME }}:${{ env.STAGING_TAG }}')
 config_line="$(first_line "--format '{{json .Image.Config}}'")"
 runtime_line="$(first_line '- name: Exercise digest-pinned native runtime and restart persistence')"
 sbom_line="$(first_line 'output-file: sbom-linux-amd64.spdx.json')"
+grype_install_line="$(first_line '- name: Install checksum-pinned Grype vulnerability scanner')"
+grype_db_line="$(first_line '- name: Bootstrap and audit the Grype vulnerability database')"
 scan_amd64_line="$(first_line '- name: Scan exact linux-amd64 digest for CRITICAL/HIGH OS and library CVEs')"
 scan_arm64_line="$(first_line '- name: Scan exact linux-arm64 digest for CRITICAL/HIGH OS and library CVEs')"
 slsa_predicates_line="$(first_line '- name: Generate source-owned SLSA provenance predicates')"
@@ -497,6 +532,9 @@ if ! [ "$authority_line" -lt "$checkout_line" ] ||
   ! [ "$staging_line" -lt "$config_line" ] ||
   ! [ "$config_line" -lt "$runtime_line" ] ||
   ! [ "$runtime_line" -lt "$sbom_line" ] ||
+  ! [ "$sbom_line" -lt "$grype_install_line" ] ||
+  ! [ "$grype_install_line" -lt "$grype_db_line" ] ||
+  ! [ "$grype_db_line" -lt "$scan_amd64_line" ] ||
   ! [ "$sbom_line" -lt "$scan_amd64_line" ] ||
   ! [ "$scan_amd64_line" -lt "$scan_arm64_line" ] ||
   ! [ "$scan_arm64_line" -lt "$slsa_predicates_line" ] ||

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -162,14 +162,18 @@ require '[.protection_rules[].type] | sort' "$workflow"
 require '== ["branch_policy", "required_reviewers"]' "$workflow"
 require 'required_reviewers' "$workflow"
 require 'branch_policy' "$workflow"
+require '(first(.protection_rules[] | select(.type == "branch_policy")) |' "$workflow"
+require '(keys | sort) == ["id", "node_id", "type"]' "$workflow"
 require '.prevent_self_review == true' "$workflow"
 require '.reviewers[0].type == "User"' "$workflow"
 require '.reviewers[0].reviewer.id' "$workflow"
 require '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow"
 require 'type == "number"' "$workflow"
 require '.total_count == 1' "$workflow"
-require '.branch_policies[0].name == "main"' "$workflow"
-require '.branch_policies[0].type == "branch"' "$workflow"
+require '(.branch_policies[0] |' "$workflow"
+require '(keys | sort) == ["id", "name", "node_id", "type"]' "$workflow"
+require '.name == "main"' "$workflow"
+require '.type == "branch"' "$workflow"
 require '/environments/${RELEASE_ENVIRONMENT}/variables/HELM_RELEASE_AUTHORITY_ARMED' "$workflow"
 require '/actions/variables/HELM_AI_OS_IMAGE_RELEASE_ACTORS' "$workflow"
 require 'if [[ "${live_release_authority}" != "release-production" ]]; then' "$workflow"
@@ -347,15 +351,21 @@ if [ "$(grep -Fc '.can_admins_bypass == false' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '[.protection_rules[].type] | sort' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '== ["branch_policy", "required_reviewers"]' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.protection_rules | type == "array" and length == 2)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(first(.protection_rules[] | select(.type == "branch_policy")) |' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(keys | sort) == ["id", "node_id", "type"]' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.prevent_self_review == true' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.reviewers | type == "array" and length == 1)' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.reviewers[0].type == "User"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.reviewers[0].reviewer.id' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc 'type == "number"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.total_count == 1' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.branch_policies[0].name == "main"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.branch_policies[0].type == "branch"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.branch_policies[0] |' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(keys | sort) == ["id", "name", "node_id", "type"]' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.name == "main"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.type == "branch"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 4 ] ||
+  [ "$(grep -Fc '(.node_id | type == "string" and length > 0)' "$workflow")" -ne 4 ] ||
   [ "$(grep -Fc '.created_at > $run_started_at' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.environments | type == "array"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'any(.[]; .name == $release_environment)' "$workflow")" -ne 2 ] ||
@@ -396,7 +406,8 @@ if [ "$(grep -Fc 'cosign attest --yes --type slsaprovenance1 --predicate slsa-pr
   echo 'each exact platform SLSA predicate must be attested and exactly verified' >&2
   exit 1
 fi
-if [ "$(grep -Fc '(keys | sort) == [' "$workflow")" -ne 2 ] ||
+if [ "$(grep -Fc '(keys | sort) == [' "$workflow")" -ne 6 ] ||
+  [ "$(grep -Fc '"actor", "component", "cosign", "cve_gate", "default_command",' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.actor == $actor' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc '.triggering_actor == $triggering_actor' "$workflow")" -ne 1 ] ||
   [ "$(grep -Fc '.release_environment == $release_environment' "$workflow")" -ne 1 ] ||

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -53,6 +53,7 @@ logical_run_instructions() {
 workflow=${1:-.github/workflows/release-ai-os-image.yml}
 legacy_workflow=${2:-.github/workflows/release.yml}
 dockerfile=${3:-Dockerfile}
+dockerignore=${4:-.dockerignore}
 build_doc=docs/supply-chain/kernel-image-build-v1.md
 evidence_doc=docs/supply-chain/kernel-image-release-evidence-v1.md
 build_uri=https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/docs/supply-chain/kernel-image-build-v1.md
@@ -62,6 +63,41 @@ require 'golang:1.25.13-alpine@sha256:' "$dockerfile"
 require 'gcr.io/distroless/static-debian12:nonroot@sha256:' "$dockerfile"
 require "$build_uri" "$build_doc"
 require "$evidence_uri" "$evidence_doc"
+
+if [ ! -f "$dockerignore" ]; then
+  echo "Docker build context contract is missing: $dockerignore" >&2
+  exit 1
+fi
+require_line() {
+  grep -Fxq -- "$1" "$2" || {
+    echo "missing exact Docker context contract: $1 in $2" >&2
+    exit 1
+  }
+}
+for dockerignore_entry in \
+  '*' \
+  '!Dockerfile' \
+  '!core/' \
+  '!core/**' \
+  '!release.high_risk.v3.toml' \
+  '!reference_packs/' \
+  '!reference_packs/**' \
+  '.git' \
+  '.git/**' \
+  'buildx-inspect.txt' \
+  'ci-runs.json' \
+  'promotion-ci-runs.json' \
+  'image-index.json' \
+  'final-image-index.json' \
+  'platform-config-*.json' \
+  'platform-labels-*.json' \
+  'sbom-*.spdx.json' \
+  'slsa-provenance*.json' \
+  'release-evidence*.json' \
+  'signature-verification.json' \
+  'tmp/'; do
+  require_line "$dockerignore_entry" "$dockerignore"
+done
 
 if grep -Ei '^[[:space:]]*FROM[[:space:]]' "$dockerfile" | grep -Ev '@sha256:[0-9a-f]{64}([[:space:]]|$)' >/dev/null; then
   echo 'every Docker base must be pinned to a full SHA-256 digest' >&2
@@ -112,15 +148,41 @@ require 'name: release-production' "$workflow"
 require 'RELEASE_ACTORS_JSON: ${{ vars.HELM_AI_OS_IMAGE_RELEASE_ACTORS }}' "$workflow"
 require 'RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}' "$workflow"
 require 'OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}' "$workflow"
+require 'run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
+require '.run_started_at' "$workflow"
+require 'persist-credentials: false' "$workflow"
+require 'release_environment_payload="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
+require 'live_release_environment_payload="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
+require '/deployment-branch-policies")' "$workflow"
+require '.can_admins_bypass == false' "$workflow"
+require 'protected_branches: false' "$workflow"
+require 'custom_branch_policies: true' "$workflow"
+require '[.protection_rules[].type] | sort' "$workflow"
+require '== ["branch_policy", "required_reviewers"]' "$workflow"
+require 'required_reviewers' "$workflow"
+require 'branch_policy' "$workflow"
+require '.prevent_self_review == true' "$workflow"
+require '.reviewers[0].type == "User"' "$workflow"
+require 'type == "number"' "$workflow"
+require '.total_count == 1' "$workflow"
+require '.branch_policies[0].name == "main"' "$workflow"
+require '.branch_policies[0].type == "branch"' "$workflow"
 require '/environments/${RELEASE_ENVIRONMENT}/variables/HELM_RELEASE_AUTHORITY_ARMED' "$workflow"
 require '/actions/variables/HELM_AI_OS_IMAGE_RELEASE_ACTORS' "$workflow"
 require 'if [[ "${live_release_authority}" != "release-production" ]]; then' "$workflow"
 require 'if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then' "$workflow"
+require '. == ["mindburnlabs","peycheff-com"]' "$workflow"
+require '--argjson configured "${RELEASE_ACTORS_JSON}"' "$workflow"
 require 'REQUEST_ACTOR: ${{ github.actor }}' "$workflow"
 require 'TRIGGERING_ACTOR: ${{ github.triggering_actor }}' "$workflow"
 require 'if [[ "${GITHUB_RUN_ATTEMPT}" != "1" ]]; then' "$workflow"
 require 'jq -e --arg actor "${candidate}"' "$workflow"
 require '/actions/runs/${GITHUB_RUN_ID}/approvals' "$workflow"
+require '.created_at > $run_started_at' "$workflow"
+require '.environments | type == "array"' "$workflow"
+require 'any(.[]; .name == $release_environment)' "$workflow"
+require '.user.login != $request_actor' "$workflow"
+require '.user.login != $triggering_actor' "$workflow"
 require '/orgs/Mindburn-Labs/memberships/${owner}' "$workflow"
 require 'for owner in mindburnlabs peycheff-com; do' "$workflow"
 require 'if [[ "${SOURCE_SHA}" != "${WORKFLOW_SHA}" ]]; then' "$workflow"
@@ -187,13 +249,40 @@ if [ "$(grep -Fc 'git fetch --no-tags origin +refs/heads/main:refs/remotes/origi
   echo 'current main and newest completed CI must be checked initially and immediately before promotion' >&2
   exit 1
 fi
+run_start_read_pattern='run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api'
 if [ "$(grep -Fc 'if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'RELEASE_ENVIRONMENT: release-production' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'jq -e --arg actor "${candidate}"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc 'approval_history="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc 'for owner in mindburnlabs peycheff-com; do' "$workflow")" -ne 2 ]; then
+  [ "$(grep -Fc 'approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'for owner in mindburnlabs peycheff-com; do' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '. == ["mindburnlabs","peycheff-com"]' "$workflow")" -ne 4 ] ||
+  [ "$(grep -Fc 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow")" -ne 14 ] ||
+  [ "$(grep -Fc "$run_start_read_pattern" "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}")' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies")' "$workflow")" -ne 2 ]; then
   echo 'owner authority, actor allowlist, and run approval must be read back initially and immediately before promotion' >&2
+  exit 1
+fi
+if [ "$(grep -Fc '.can_admins_bypass == false' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'protected_branches: false' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'custom_branch_policies: true' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '[.protection_rules[].type] | sort' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '== ["branch_policy", "required_reviewers"]' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.protection_rules | type == "array" and length == 2)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.prevent_self_review == true' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewers | type == "array" and length == 1)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewers[0].type == "User"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'type == "number"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.total_count == 1' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.branch_policies[0].name == "main"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.branch_policies[0].type == "branch"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.created_at > $run_started_at' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.environments | type == "array"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'any(.[]; .name == $release_environment)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.user.login != $request_actor' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.user.login != $triggering_actor' "$workflow")" -ne 2 ]; then
+  echo 'environment protection and fresh distinct approval predicates must be exact in both checkpoints' >&2
   exit 1
 fi
 if [ "$(grep -Fc 'upload-artifact: false' "$workflow")" -ne 2 ]; then
@@ -255,14 +344,18 @@ signature_line="$(first_line 'cosign sign --yes "${image_ref}"')"
 evidence_line="$(first_line '> release-evidence.json')"
 evidence_attest_line="$(first_line '--predicate release-evidence.json')"
 promotion_ci_line="$(last_line './scripts/release/require_latest_main_ci_success.sh')"
-promotion_live_authority_read_line="$(first_line 'live_release_authority="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api')"
-promotion_live_actors_read_line="$(first_line 'live_release_actors="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api')"
-promotion_authority_line="$(first_line 'if [[ "${live_release_authority}" != "release-production" ]]; then')"
-promotion_authority_binding_line="$(first_line 'if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then')"
-promotion_live_actor_validation_line="$(first_line '<<<"${live_release_actors}" >/dev/null; then')"
+promotion_live_environment_read_line="$(last_line 'live_release_environment_payload="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api')"
+promotion_live_branch_read_line="$(last_line 'live_deployment_branch_policies="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api')"
+promotion_live_authority_read_line="$(last_line 'live_release_authority="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api')"
+promotion_live_actors_read_line="$(last_line 'live_release_actors="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api')"
+promotion_environment_validation_line="$(last_line '<<<"${live_release_environment_payload}" >/dev/null; then')"
+promotion_branch_validation_line="$(last_line '<<<"${live_deployment_branch_policies}" >/dev/null; then')"
+promotion_authority_line="$(last_line 'if [[ "${live_release_authority}" != "release-production" ]]; then')"
+promotion_authority_binding_line="$(last_line 'if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then')"
+promotion_live_actor_validation_line="$(last_line '. == ["mindburnlabs","peycheff-com"]')"
 promotion_actor_loop_line="$(last_line 'for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do')"
 promotion_actor_check_line="$(last_line 'jq -e --arg actor "${candidate}"')"
-promotion_approval_read_line="$(last_line 'approval_history="$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"')"
+promotion_approval_read_line="$(last_line 'approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"')"
 promotion_approval_check_line="$(last_line '<<<"${approval_history}" >/dev/null; then')"
 promotion_owner_loop_line="$(last_line 'for owner in mindburnlabs peycheff-com; do')"
 promotion_owner_read_line="$(last_line '/orgs/Mindburn-Labs/memberships/${owner}')"
@@ -279,10 +372,13 @@ if ! [ "$authority_line" -lt "$checkout_line" ] ||
   ! [ "$sbom_line" -lt "$signature_line" ] ||
   ! [ "$signature_line" -lt "$evidence_line" ] ||
   ! [ "$evidence_line" -lt "$evidence_attest_line" ] ||
-  ! [ "$evidence_attest_line" -lt "$promotion_ci_line" ] ||
-  ! [ "$promotion_ci_line" -lt "$promotion_live_authority_read_line" ] ||
+  ! [ "$evidence_attest_line" -lt "$promotion_live_environment_read_line" ] ||
+  ! [ "$promotion_live_environment_read_line" -lt "$promotion_live_branch_read_line" ] ||
+  ! [ "$promotion_live_branch_read_line" -lt "$promotion_live_authority_read_line" ] ||
   ! [ "$promotion_live_authority_read_line" -lt "$promotion_live_actors_read_line" ] ||
-  ! [ "$promotion_live_actors_read_line" -lt "$promotion_authority_line" ] ||
+  ! [ "$promotion_live_actors_read_line" -lt "$promotion_environment_validation_line" ] ||
+  ! [ "$promotion_environment_validation_line" -lt "$promotion_branch_validation_line" ] ||
+  ! [ "$promotion_branch_validation_line" -lt "$promotion_authority_line" ] ||
   ! [ "$promotion_authority_line" -lt "$promotion_authority_binding_line" ] ||
   ! [ "$promotion_authority_binding_line" -lt "$promotion_live_actor_validation_line" ] ||
   ! [ "$promotion_live_actor_validation_line" -lt "$promotion_actor_loop_line" ] ||
@@ -291,7 +387,8 @@ if ! [ "$authority_line" -lt "$checkout_line" ] ||
   ! [ "$promotion_approval_read_line" -lt "$promotion_approval_check_line" ] ||
   ! [ "$promotion_approval_check_line" -lt "$promotion_owner_loop_line" ] ||
   ! [ "$promotion_owner_loop_line" -lt "$promotion_owner_read_line" ] ||
-  ! [ "$promotion_owner_read_line" -lt "$promotion_line" ] ||
+  ! [ "$promotion_owner_read_line" -lt "$promotion_ci_line" ] ||
+  ! [ "$promotion_ci_line" -lt "$promotion_line" ] ||
   ! [ "$promotion_line" -lt "$final_platform_line" ] ||
   ! [ "$final_platform_line" -lt "$finalize_evidence_line" ] ||
   ! [ "$finalize_evidence_line" -lt "$final_attest_line" ]; then

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -149,6 +149,13 @@ require 'name: release-production' "$workflow"
 require 'RELEASE_ACTORS_JSON: ${{ vars.HELM_AI_OS_IMAGE_RELEASE_ACTORS }}' "$workflow"
 require 'RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}' "$workflow"
 require 'OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}' "$workflow"
+require 'INITIAL_LIVE_RELEASE_AUTHORITY=%s' "$workflow"
+require 'INITIAL_LIVE_RELEASE_ACTORS_SHA256=%s' "$workflow"
+require '} >> "${GITHUB_ENV}"' "$workflow"
+require 'if [[ "${live_release_authority}" != "${INITIAL_LIVE_RELEASE_AUTHORITY}" ]]; then' "$workflow"
+require 'if [[ ! "${live_release_actors_sha256}" =~ ^[0-9a-f]{64}$ || "${live_release_actors_sha256}" != "${INITIAL_LIVE_RELEASE_ACTORS_SHA256}" ]]; then' "$workflow"
+require 'GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}"' "$workflow"
+require 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api --paginate' "$workflow"
 require 'run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
 require '.run_started_at' "$workflow"
 require 'persist-credentials: false' "$workflow"
@@ -240,7 +247,7 @@ require 'grype db update' "$workflow"
 require 'grype db status --output json > grype-db-status.json' "$workflow"
 require 'GRYPE_DB_CACHE_DIR: ${{ runner.temp }}/grype-db' "$workflow"
 require '(keys | sort) == ["built", "from", "path", "schemaVersion", "valid"]' "$workflow"
-require '(.schemaVersion | type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' "$workflow"
+require '(.schemaVersion | type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' "$workflow"
 require '(.from | type == "string" and startswith("https://grype.anchore.io/databases/"))' "$workflow"
 require '(.built | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))' "$workflow"
 require '(.path | type == "string" and length > 0)' "$workflow"
@@ -330,7 +337,10 @@ if [ "$trigger_count" -ne 1 ]; then
 fi
 
 if [ "$(grep -Fc 'git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc './scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}"' "$workflow")" -ne 2 ]; then
+  [ "$(grep -Fc './scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api --paginate' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}' "$workflow")" -ne 4 ]; then
   echo 'current main and newest completed CI must be checked initially and immediately before promotion' >&2
   exit 1
 fi
@@ -359,11 +369,19 @@ if [ "$(grep -Fc 'if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]
   [ "$(grep -Fc 'approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'for owner in mindburnlabs peycheff-com; do' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '. == ["mindburnlabs","peycheff-com"]' "$workflow")" -ne 4 ] ||
-  [ "$(grep -Fc 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow")" -ne 14 ] ||
+  [ "$(grep -Fc 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow")" -ne 16 ] ||
   [ "$(grep -Fc "$run_start_read_pattern" "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}")' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies")' "$workflow")" -ne 2 ]; then
   echo 'owner authority, actor allowlist, and run approval must be read back initially and immediately before promotion' >&2
+  exit 1
+fi
+if [ "$(grep -Fc 'INITIAL_LIVE_RELEASE_AUTHORITY=%s' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'INITIAL_LIVE_RELEASE_ACTORS_SHA256=%s' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '} >> "${GITHUB_ENV}"' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'if [[ "${live_release_authority}" != "${INITIAL_LIVE_RELEASE_AUTHORITY}" ]]; then' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'if [[ ! "${live_release_actors_sha256}" =~ ^[0-9a-f]{64}$ || "${live_release_actors_sha256}" != "${INITIAL_LIVE_RELEASE_ACTORS_SHA256}" ]]; then' "$workflow")" -ne 1 ]; then
+  echo 'initial live authority and actor JSON digest must be persisted and compared before promotion' >&2
   exit 1
 fi
 if [ "$(grep -Fc '.can_admins_bypass == false' "$workflow")" -ne 2 ] ||
@@ -464,6 +482,10 @@ if grep -Fq 'https://actions.github.io/buildtypes/workflow/v1' "$workflow"; then
 fi
 if grep -Fq 'anchore/scan-action/download-grype@' "$workflow"; then
   echo 'Grype must be installed from the checksum-verified immutable release artifact' >&2
+  exit 1
+fi
+if grep -Fq 'GH_TOKEN: ${{ github.token }}' "$workflow"; then
+  echo 'source, CI, and authority readbacks must not use the job token' >&2
   exit 1
 fi
 if grep -Fq 'git merge-base --is-ancestor' "$workflow"; then

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -154,10 +154,7 @@ require 'INITIAL_LIVE_RELEASE_ACTORS_SHA256=%s' "$workflow"
 require '} >> "${GITHUB_ENV}"' "$workflow"
 require 'if [[ "${live_release_authority}" != "${INITIAL_LIVE_RELEASE_AUTHORITY}" ]]; then' "$workflow"
 require 'if [[ ! "${live_release_actors_sha256}" =~ ^[0-9a-f]{64}$ || "${live_release_actors_sha256}" != "${INITIAL_LIVE_RELEASE_ACTORS_SHA256}" ]]; then' "$workflow"
-require 'GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}"' "$workflow"
 require 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api --paginate' "$workflow"
-require 'run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
-require '.run_started_at' "$workflow"
 require 'persist-credentials: false' "$workflow"
 require 'release_environment_payload="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
 require 'live_release_environment_payload="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
@@ -170,15 +167,20 @@ require '== ["branch_policy", "required_reviewers"]' "$workflow"
 require 'required_reviewers' "$workflow"
 require 'branch_policy' "$workflow"
 require '(keys | sort) == ["id", "node_id", "prevent_self_review", "reviewers", "type"]' "$workflow"
-require '(.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User")' "$workflow"
+require '(.reviewers | type == "array" and length == 2)' "$workflow"
+require '(all(.reviewers[];' "$workflow"
+require '(keys | sort) == ["reviewer", "type"]' "$workflow"
 require '(first(.protection_rules[] | select(.type == "branch_policy")) |' "$workflow"
 require '(keys | sort) == ["id", "node_id", "type"]' "$workflow"
 require '.prevent_self_review == true' "$workflow"
-require '.reviewers[0].reviewer.id' "$workflow"
-require '.reviewers[0].reviewer.node_id | type == "string" and length > 0' "$workflow"
-require '.reviewers[0].reviewer.type == "User"' "$workflow"
-require '.reviewers[0].reviewer.site_admin == false' "$workflow"
-require '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow"
+require '.reviewer.id | type == "number"' "$workflow"
+require '.reviewer.node_id | type == "string" and length > 0' "$workflow"
+require '.reviewer.type == "User"' "$workflow"
+require '.reviewer.site_admin == false' "$workflow"
+require '.reviewer.login == "mindburnlabs"' "$workflow"
+require '(([.reviewers[].reviewer.login] | sort) == ["mindburnlabs", "peycheff-com"])' "$workflow"
+require '([.reviewers[].reviewer.id] | unique | length == 2)' "$workflow"
+require '([.reviewers[].reviewer.node_id] | unique | length == 2)' "$workflow"
 require 'type == "number"' "$workflow"
 require '.total_count == 1' "$workflow"
 require '(.branch_policies[0] |' "$workflow"
@@ -196,7 +198,6 @@ require 'TRIGGERING_ACTOR: ${{ github.triggering_actor }}' "$workflow"
 require 'if [[ "${GITHUB_RUN_ATTEMPT}" != "1" ]]; then' "$workflow"
 require 'jq -e --arg actor "${candidate}"' "$workflow"
 require '/actions/runs/${GITHUB_RUN_ID}/approvals' "$workflow"
-require '.created_at > $run_started_at' "$workflow"
 require '.environments | type == "array"' "$workflow"
 require 'any(.[]; .name == $release_environment)' "$workflow"
 require '.user.login != $request_actor' "$workflow"
@@ -204,8 +205,13 @@ require '.user.login != $triggering_actor' "$workflow"
 require '/orgs/Mindburn-Labs/memberships/${owner}' "$workflow"
 require 'for owner in mindburnlabs peycheff-com; do' "$workflow"
 require 'if [[ "${SOURCE_SHA}" != "${WORKFLOW_SHA}" ]]; then' "$workflow"
-require 'if [[ "${SOURCE_SHA}" != "${main_tip}" ]]; then' "$workflow"
-require 'if [[ "${SOURCE_SHA}" != "${promotion_main_tip}" ]]; then' "$workflow"
+require 'current_main_ref="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
+require 'promotion_main_ref="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow"
+require '"/repos/${GITHUB_REPOSITORY}/git/ref/heads/main"' "$workflow"
+require '--jq '\''.object.sha'\''' "$workflow"
+require 'if [[ "${SOURCE_SHA}" != "${current_main_ref}" ]]; then' "$workflow"
+require 'if [[ "${SOURCE_SHA}" != "${promotion_main_ref}" ]]; then' "$workflow"
+require 'test "$(git rev-parse HEAD)" = "${SOURCE_SHA}"' "$workflow"
 require 'head_sha=${SOURCE_SHA}&branch=main&per_page=100' "$workflow"
 require './scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}"' "$workflow"
 require 'source_date_epoch="$(git show -s --format=%ct "${SOURCE_SHA}")"' "$workflow"
@@ -336,11 +342,20 @@ if [ "$trigger_count" -ne 1 ]; then
   exit 1
 fi
 
-if [ "$(grep -Fc 'git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main' "$workflow")" -ne 2 ] ||
+current_main_ref_pattern='current_main_ref="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api'
+promotion_main_ref_pattern='promotion_main_ref="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api'
+head_equality_pattern='test "$(git rev-parse HEAD)" = "${SOURCE_SHA}"'
+if [ "$(grep -Fc "$current_main_ref_pattern" "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc "$promotion_main_ref_pattern" "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '"/repos/${GITHUB_REPOSITORY}/git/ref/heads/main"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc -- "--jq '.object.sha'" "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc "$head_equality_pattern" "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc './scripts/release/require_latest_main_ci_success.sh "${GITHUB_REPOSITORY}" "${SOURCE_SHA}"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc 'GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${OWNER_READBACK_TOKEN}"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api --paginate' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc 'OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}' "$workflow")" -ne 4 ]; then
+  [ "$(grep -Fc 'OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}' "$workflow")" -ne 4 ] ||
+  grep -Fq 'git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main' "$workflow" ||
+  grep -Fq 'http.extraheader' "$workflow" ||
+  grep -Fq 'AUTHORIZATION: bearer' "$workflow"; then
   echo 'current main and newest completed CI must be checked initially and immediately before promotion' >&2
   exit 1
 fi
@@ -348,7 +363,6 @@ if [ "$(grep -Fc 'if [[ "${SOURCE_SHA}" != "${WORKFLOW_SHA}" ]]; then' "$workflo
   echo 'source_sha must remain bound to the workflow commit at both authority checkpoints' >&2
   exit 1
 fi
-run_start_read_pattern='run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api'
 authority_environment_count="$(awk '
   /^      - name: Validate publication authority$/ { in_step = 1; next }
   in_step && /^      - name:/ { in_step = 0 }
@@ -370,7 +384,6 @@ if [ "$(grep -Fc 'if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]
   [ "$(grep -Fc 'for owner in mindburnlabs peycheff-com; do' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '. == ["mindburnlabs","peycheff-com"]' "$workflow")" -ne 4 ] ||
   [ "$(grep -Fc 'GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api' "$workflow")" -ne 16 ] ||
-  [ "$(grep -Fc "$run_start_read_pattern" "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}")' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '/repos/${GITHUB_REPOSITORY}/environments/${RELEASE_ENVIRONMENT}/deployment-branch-policies")' "$workflow")" -ne 2 ]; then
   echo 'owner authority, actor allowlist, and run approval must be read back initially and immediately before promotion' >&2
@@ -391,17 +404,19 @@ if [ "$(grep -Fc '.can_admins_bypass == false' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '== ["branch_policy", "required_reviewers"]' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.protection_rules | type == "array" and length == 2)' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(keys | sort) == ["id", "node_id", "prevent_self_review", "reviewers", "type"]' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '(.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User")' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewers | type == "array" and length == 2)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(all(.reviewers[];' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(([.reviewers[].reviewer.login] | sort) == ["mindburnlabs", "peycheff-com"])' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '([.reviewers[].reviewer.id] | unique | length == 2)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '([.reviewers[].reviewer.node_id] | unique | length == 2)' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(first(.protection_rules[] | select(.type == "branch_policy")) |' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(keys | sort) == ["id", "node_id", "type"]' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.prevent_self_review == true' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '(.reviewers | type == "array" and length == 1)' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.reviewers[0].reviewer.id' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '(.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '(.reviewers[0].reviewer.node_id | type == "string" and length > 0)' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.reviewers[0].reviewer.type == "User"' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.reviewers[0].reviewer.site_admin == false' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewer.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewer.node_id | type == "string" and length > 0)' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewer.type == "User"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewer.site_admin == false' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '(.reviewer.login == "mindburnlabs" or .reviewer.login == "peycheff-com")' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.total_count == 1' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.branch_policies[0] |' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(keys | sort) == ["id", "name", "node_id", "type"]' "$workflow")" -ne 2 ] ||
@@ -409,12 +424,11 @@ if [ "$(grep -Fc '.can_admins_bypass == false' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.type == "branch"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.id | type == "number" and (try (floor == . and . > 0) catch false))' "$workflow")" -ne 6 ] ||
   [ "$(grep -Fc '(.node_id | type == "string" and length > 0)' "$workflow")" -ne 6 ] ||
-  [ "$(grep -Fc '.created_at > $run_started_at' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.environments | type == "array"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'any(.[]; .name == $release_environment)' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.user.login != $request_actor' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.user.login != $triggering_actor' "$workflow")" -ne 2 ]; then
-  echo 'environment protection and fresh distinct approval predicates must be exact in both checkpoints' >&2
+  echo 'environment protection and exact-run distinct approval predicates must be exact in both checkpoints' >&2
   exit 1
 fi
 if [ "$(grep -Fc 'upload-artifact: false' "$workflow")" -ne 2 ]; then
@@ -472,6 +486,10 @@ if grep -Fq 'status=completed&per_page=100' "$workflow"; then
   echo 'CI readback must include queued and in-progress newest attempts' >&2
   exit 1
 fi
+if grep -Fq 'run_started_at' "$workflow" || grep -Fq '.created_at' "$workflow"; then
+  echo 'exact-run approvals must not infer freshness from unsupported timestamp fields' >&2
+  exit 1
+fi
 if [ "$(grep -Ec '^[[:space:]]+tags:' "$workflow")" -ne 1 ]; then
   echo 'the build may publish exactly one staging tag before promotion' >&2
   exit 1
@@ -515,6 +533,7 @@ last_line() {
 
 authority_line="$(first_line '- name: Validate publication authority')"
 checkout_line="$(first_line 'uses: actions/checkout@')"
+source_main_ref_line="$(first_line "$current_main_ref_pattern")"
 staging_line="$(first_line 'tags: ${{ env.IMAGE_NAME }}:${{ env.STAGING_TAG }}')"
 config_line="$(first_line "--format '{{json .Image.Config}}'")"
 runtime_line="$(first_line '- name: Exercise digest-pinned native runtime and restart persistence')"
@@ -543,6 +562,7 @@ promotion_approval_read_line="$(last_line 'approval_history="$(GH_TOKEN="${OWNER
 promotion_approval_check_line="$(last_line '<<<"${approval_history}" >/dev/null; then')"
 promotion_owner_loop_line="$(last_line 'for owner in mindburnlabs peycheff-com; do')"
 promotion_owner_read_line="$(last_line '/orgs/Mindburn-Labs/memberships/${owner}')"
+promotion_main_ref_line="$(last_line "$promotion_main_ref_pattern")"
 promotion_line="$(first_line 'final_digest="$(./scripts/release/promote_immutable_image_tag.sh')"
 final_platform_line="$(first_line 'final-image-index.json')"
 finalize_evidence_line="$(first_line '.promotion_status = "final-tag-digest-platforms-signature-and-evidence-verified"')"
@@ -550,7 +570,8 @@ final_evidence_shape_line="$(last_line '.final_tag_digest == $final_digest')"
 final_attest_line="$(last_line '--predicate release-evidence.json')"
 
 if ! [ "$authority_line" -lt "$checkout_line" ] ||
-  ! [ "$checkout_line" -lt "$staging_line" ] ||
+  ! [ "$checkout_line" -lt "$source_main_ref_line" ] ||
+  ! [ "$source_main_ref_line" -lt "$staging_line" ] ||
   ! [ "$staging_line" -lt "$config_line" ] ||
   ! [ "$config_line" -lt "$runtime_line" ] ||
   ! [ "$runtime_line" -lt "$sbom_line" ] ||
@@ -578,6 +599,8 @@ if ! [ "$authority_line" -lt "$checkout_line" ] ||
   ! [ "$promotion_approval_read_line" -lt "$promotion_approval_check_line" ] ||
   ! [ "$promotion_approval_check_line" -lt "$promotion_owner_loop_line" ] ||
   ! [ "$promotion_owner_loop_line" -lt "$promotion_owner_read_line" ] ||
+  ! [ "$promotion_owner_read_line" -lt "$promotion_main_ref_line" ] ||
+  ! [ "$promotion_main_ref_line" -lt "$promotion_ci_line" ] ||
   ! [ "$promotion_owner_read_line" -lt "$promotion_ci_line" ] ||
   ! [ "$promotion_ci_line" -lt "$promotion_line" ] ||
   ! [ "$promotion_line" -lt "$final_platform_line" ] ||

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -93,6 +93,7 @@ for dockerignore_entry in \
   'platform-labels-*.json' \
   'sbom-*.spdx.json' \
   'slsa-provenance*.json' \
+  'grype-*.json' \
   'release-evidence*.json' \
   'signature-verification.json' \
   'tmp/'; do
@@ -221,12 +222,59 @@ require "git+https://github.com/" "$workflow"
 require '@refs/heads/main' "$workflow"
 require 'output-file: sbom-linux-amd64.spdx.json' "$workflow"
 require 'output-file: sbom-linux-arm64.spdx.json' "$workflow"
+require 'anchore/scan-action/download-grype@1638637db639e0ade3258b51db49a9a137574c3e' "$workflow"
+require 'GRYPE_CHECK_FOR_APP_UPDATE: "false"' "$workflow"
+require 'GRYPE_DB_AUTO_UPDATE: "false"' "$workflow"
+require 'IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64_digest }}' "$workflow"
+require 'IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64_digest }}' "$workflow"
+require '--scope all-layers' "$workflow"
+require '--fail-on high' "$workflow"
+require '--output json' "$workflow"
+require '--file grype-linux-amd64.json' "$workflow"
+require '--file grype-linux-arm64.json' "$workflow"
+require '.matches | type == "array"' "$workflow"
+require 'report_digest=sha256:$(sha256sum grype-linux-amd64.json' "$workflow"
+require 'report_digest=sha256:$(sha256sum grype-linux-arm64.json' "$workflow"
+require 'slsa-provenance-linux-amd64.json' "$workflow"
+require 'slsa-provenance-linux-arm64.json' "$workflow"
+require 'platform_digest: $platform_digest' "$workflow"
+require 'write_slsa_predicate slsa-provenance-linux-amd64.json linux/amd64 "${{ steps.platforms.outputs.amd64_digest }}"' "$workflow"
+require 'write_slsa_predicate slsa-provenance-linux-arm64.json linux/arm64 "${{ steps.platforms.outputs.arm64_digest }}"' "$workflow"
+require 'cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance-linux-amd64.json "${amd64_ref}"' "$workflow"
+require 'cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance-linux-arm64.json "${arm64_ref}"' "$workflow"
+require 'slsa-provenance-linux-amd64.attestation.json' "$workflow"
+require 'slsa-provenance-linux-arm64.attestation.json' "$workflow"
+require 'Scan exact linux-amd64 digest for CRITICAL/HIGH OS and library CVEs' "$workflow"
+require 'Scan exact linux-arm64 digest for CRITICAL/HIGH OS and library CVEs' "$workflow"
 require 'cosign sign --yes "${image_ref}"' "$workflow"
 require 'cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance.json "${image_ref}"' "$workflow"
 require 'cosign attest --yes --type spdxjson --predicate sbom-linux-amd64.spdx.json "${amd64_ref}"' "$workflow"
 require 'cosign attest --yes --type spdxjson --predicate sbom-linux-arm64.spdx.json "${arm64_ref}"' "$workflow"
 require '.predicate == $expected[0] and' "$workflow"
 require '.subject[0].digest.sha256 == $expected_digest' "$workflow"
+require 'verify_attestation slsa-provenance-linux-amd64.attestation.json slsa-provenance-linux-amd64.json' "$workflow"
+require 'verify_attestation slsa-provenance-linux-arm64.attestation.json slsa-provenance-linux-arm64.json' "$workflow"
+require 'actor: $actor' "$workflow"
+require 'triggering_actor: $triggering_actor' "$workflow"
+require 'release_environment: $release_environment' "$workflow"
+require 'cve_gate: {' "$workflow"
+require 'scope: "os-and-library"' "$workflow"
+require 'fail_on: "high"' "$workflow"
+require 'status: "passed"' "$workflow"
+require 'report: "grype-linux-amd64.json"' "$workflow"
+require 'report: "grype-linux-arm64.json"' "$workflow"
+require 'slsa: {' "$workflow"
+require 'index: {predicate: "slsa-provenance.json", attestation: "slsa-provenance.attestation.json"}' "$workflow"
+require 'predicate: "slsa-provenance-linux-amd64.json"' "$workflow"
+require 'attestation: "slsa-provenance-linux-amd64.attestation.json"' "$workflow"
+require 'predicate: "slsa-provenance-linux-arm64.json"' "$workflow"
+require 'attestation: "slsa-provenance-linux-arm64.attestation.json"' "$workflow"
+require '(keys | sort)' "$workflow"
+require '.final_tag_digest == $final_digest' "$workflow"
+require 'cp release-evidence.json release-evidence.staging.json' "$workflow"
+require '--slurpfile staging release-evidence.staging.json' "$workflow"
+require '((. | del(.promotion_status, .final_tag_digest)) ==' "$workflow"
+require '.predicate == $expected[0] and' "$workflow"
 require '--predicate release-evidence.json' "$workflow"
 require '--type "${RELEASE_EVIDENCE_TYPE}"' "$workflow"
 require 'smoke: "health-denial-receipt-stop-restart-exact-readback-passed"' "$workflow"
@@ -234,6 +282,16 @@ require 'final_digest="$(./scripts/release/promote_immutable_image_tag.sh "${sta
 require 'docker buildx imagetools inspect --raw "${final_tag}" > final-image-index.json' "$workflow"
 require 'final-tag-digest-platforms-signature-and-evidence-verified' "$workflow"
 require '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev-sha-${{ inputs.source_sha }}' "$legacy_workflow"
+
+for upload_entry in \
+  '            grype-linux-amd64.json' \
+  '            grype-linux-arm64.json' \
+  '            slsa-provenance-linux-amd64.json' \
+  '            slsa-provenance-linux-amd64.attestation.json' \
+  '            slsa-provenance-linux-arm64.json' \
+  '            slsa-provenance-linux-arm64.attestation.json'; do
+  require_line "$upload_entry" "$workflow"
+done
 
 trigger_count="$(awk '
   /^on:$/ { in_on = 1; next }
@@ -252,8 +310,21 @@ if [ "$(grep -Fc 'git fetch --no-tags origin +refs/heads/main:refs/remotes/origi
   exit 1
 fi
 run_start_read_pattern='run_started_at="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api'
+authority_environment_count="$(awk '
+  /^      - name: Validate publication authority$/ { in_step = 1; next }
+  in_step && /^      - name:/ { in_step = 0 }
+  in_step && /^          RELEASE_ENVIRONMENT: release-production$/ { count++ }
+  END { print count + 0 }
+' "$workflow")"
+promotion_environment_count="$(awk '
+  /^      - name: Reauthorize and promote the verified digest$/ { in_step = 1; next }
+  in_step && /^      - name:/ { in_step = 0 }
+  in_step && /^          RELEASE_ENVIRONMENT: release-production$/ { count++ }
+  END { print count + 0 }
+' "$workflow")"
 if [ "$(grep -Fc 'if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then' "$workflow")" -ne 2 ] ||
-  [ "$(grep -Fc 'RELEASE_ENVIRONMENT: release-production' "$workflow")" -ne 2 ] ||
+  [ "$authority_environment_count" -ne 1 ] ||
+  [ "$promotion_environment_count" -ne 1 ] ||
   [ "$(grep -Fc 'for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'jq -e --arg actor "${candidate}"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"' "$workflow")" -ne 2 ] ||
@@ -295,6 +366,40 @@ if [ "$(grep -Fc 'upload-artifact: false' "$workflow")" -ne 2 ]; then
 fi
 if [ "$(grep -Fc -- '--type spdxjson' "$workflow")" -ne 4 ]; then
   echo 'both platform SPDX predicates must be attested and verified' >&2
+  exit 1
+fi
+if [ "$(grep -Fc -- '--scope all-layers' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc -- '--fail-on high' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc -- '--output json' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64_digest }}' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'IMAGE_REF: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64_digest }}' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc -- '--file grype-linux-amd64.json' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc -- '--file grype-linux-arm64.json' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'GRYPE_DB_AUTO_UPDATE: "false"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'GRYPE_CHECK_FOR_APP_UPDATE: "false"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc 'type == "object" and' "$workflow")" -lt 2 ] ||
+  [ "$(grep -Fc 'report_digest=sha256:$(sha256sum grype-linux-amd64.json' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'report_digest=sha256:$(sha256sum grype-linux-arm64.json' "$workflow")" -ne 1 ]; then
+  echo 'each exact platform digest must pass the pinned fail-closed CRITICAL/HIGH OS and library scan' >&2
+  exit 1
+fi
+if [ "$(grep -Fc 'cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance-linux-amd64.json "${amd64_ref}"' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance-linux-arm64.json "${arm64_ref}"' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '"${amd64_ref}" > slsa-provenance-linux-amd64.attestation.json' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '"${arm64_ref}" > slsa-provenance-linux-arm64.attestation.json' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'verify_attestation slsa-provenance-linux-amd64.attestation.json slsa-provenance-linux-amd64.json' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc 'verify_attestation slsa-provenance-linux-arm64.attestation.json slsa-provenance-linux-arm64.json' "$workflow")" -ne 1 ]; then
+  echo 'each exact platform SLSA predicate must be attested and exactly verified' >&2
+  exit 1
+fi
+if [ "$(grep -Fc '(keys | sort) == [' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.actor == $actor' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '.triggering_actor == $triggering_actor' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '.release_environment == $release_environment' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '.cve_gate == {' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '.slsa == {' "$workflow")" -ne 1 ] ||
+  [ "$(grep -Fc '.final_tag_digest == $final_digest' "$workflow")" -ne 1 ]; then
+  echo 'release evidence must use the closed authority, CVE, and SLSA shape' >&2
   exit 1
 fi
 if [ "$(grep -Fc -- '--predicate release-evidence.json' "$workflow")" -ne 2 ]; then
@@ -344,6 +449,9 @@ staging_line="$(first_line 'tags: ${{ env.IMAGE_NAME }}:${{ env.STAGING_TAG }}')
 config_line="$(first_line "--format '{{json .Image.Config}}'")"
 runtime_line="$(first_line '- name: Exercise digest-pinned native runtime and restart persistence')"
 sbom_line="$(first_line 'output-file: sbom-linux-amd64.spdx.json')"
+scan_amd64_line="$(first_line '- name: Scan exact linux-amd64 digest for CRITICAL/HIGH OS and library CVEs')"
+scan_arm64_line="$(first_line '- name: Scan exact linux-arm64 digest for CRITICAL/HIGH OS and library CVEs')"
+slsa_predicates_line="$(first_line '- name: Generate source-owned SLSA provenance predicates')"
 signature_line="$(first_line 'cosign sign --yes "${image_ref}"')"
 evidence_line="$(first_line '> release-evidence.json')"
 evidence_attest_line="$(first_line '--predicate release-evidence.json')"
@@ -366,6 +474,7 @@ promotion_owner_read_line="$(last_line '/orgs/Mindburn-Labs/memberships/${owner}
 promotion_line="$(first_line 'final_digest="$(./scripts/release/promote_immutable_image_tag.sh')"
 final_platform_line="$(first_line 'final-image-index.json')"
 finalize_evidence_line="$(first_line '.promotion_status = "final-tag-digest-platforms-signature-and-evidence-verified"')"
+final_evidence_shape_line="$(last_line '.final_tag_digest == $final_digest')"
 final_attest_line="$(last_line '--predicate release-evidence.json')"
 
 if ! [ "$authority_line" -lt "$checkout_line" ] ||
@@ -373,7 +482,10 @@ if ! [ "$authority_line" -lt "$checkout_line" ] ||
   ! [ "$staging_line" -lt "$config_line" ] ||
   ! [ "$config_line" -lt "$runtime_line" ] ||
   ! [ "$runtime_line" -lt "$sbom_line" ] ||
-  ! [ "$sbom_line" -lt "$signature_line" ] ||
+  ! [ "$sbom_line" -lt "$scan_amd64_line" ] ||
+  ! [ "$scan_amd64_line" -lt "$scan_arm64_line" ] ||
+  ! [ "$scan_arm64_line" -lt "$slsa_predicates_line" ] ||
+  ! [ "$slsa_predicates_line" -lt "$signature_line" ] ||
   ! [ "$signature_line" -lt "$evidence_line" ] ||
   ! [ "$evidence_line" -lt "$evidence_attest_line" ] ||
   ! [ "$evidence_attest_line" -lt "$promotion_live_environment_read_line" ] ||
@@ -395,6 +507,8 @@ if ! [ "$authority_line" -lt "$checkout_line" ] ||
   ! [ "$promotion_ci_line" -lt "$promotion_line" ] ||
   ! [ "$promotion_line" -lt "$final_platform_line" ] ||
   ! [ "$final_platform_line" -lt "$finalize_evidence_line" ] ||
+  ! [ "$finalize_evidence_line" -lt "$final_evidence_shape_line" ] ||
+  ! [ "$final_evidence_shape_line" -lt "$final_attest_line" ] ||
   ! [ "$finalize_evidence_line" -lt "$final_attest_line" ]; then
   echo 'release authority, staging evidence, and immutable promotion ordering is invalid' >&2
   exit 1

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -163,6 +163,8 @@ require 'required_reviewers' "$workflow"
 require 'branch_policy' "$workflow"
 require '.prevent_self_review == true' "$workflow"
 require '.reviewers[0].type == "User"' "$workflow"
+require '.reviewers[0].reviewer.id' "$workflow"
+require '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow"
 require 'type == "number"' "$workflow"
 require '.total_count == 1' "$workflow"
 require '.branch_policies[0].name == "main"' "$workflow"
@@ -273,6 +275,8 @@ if [ "$(grep -Fc '.can_admins_bypass == false' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.prevent_self_review == true' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '(.reviewers | type == "array" and length == 1)' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.reviewers[0].type == "User"' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewers[0].reviewer.id' "$workflow")" -ne 2 ] ||
+  [ "$(grep -Fc '.reviewers[0].reviewer.login == "mindburnlabs"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'type == "number"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.total_count == 1' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc '.branch_policies[0].name == "main"' "$workflow")" -ne 2 ] ||

--- a/scripts/release/promote_immutable_image_tag.sh
+++ b/scripts/release/promote_immutable_image_tag.sh
@@ -46,6 +46,10 @@ else
     cat "$inspect_error" >&2
     echo "registry transport failure while inspecting immutable tag: $final_tag" >&2
     exit 1
+  elif grep -Eiq '(429|rate[-_ ]?limit|too many requests)' "$inspect_error"; then
+    cat "$inspect_error" >&2
+    echo "registry rate-limit response is ambiguous; unable to prove whether immutable tag exists: $final_tag" >&2
+    exit 1
   elif grep -Eiq '(manifest unknown|manifest_unknown|404[[:space:]]+not[[:space:]]+found|:[[:space:]]+not[[:space:]]+found([[:space:]]|$))' "$inspect_error"; then
     echo 'immutable tag is absent; creating it once' >&2
   else

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -31,11 +31,13 @@ case "$*" in
       conflict) printf '%s\n' "$MOCK_OTHER_DIGEST" ;;
       missing) echo 'manifest unknown' >&2; exit 1 ;;
       missing_not_found) echo 'ghcr.io/mindburn-labs/helm-ai-kernel:sha-500deadbeef: not found' >&2; exit 1 ;;
+      missing_ghcr) echo 'ERROR: ghcr.io/mindburn-labs/helm-ai-kernel:sha-500deadbeef: not found' >&2; exit 1 ;;
       missing_404) echo '404 Not Found' >&2; exit 1 ;;
       auth) echo 'unauthorized: authentication required' >&2; exit 1 ;;
       transport) echo 'TLS handshake timeout' >&2; exit 1 ;;
       server) echo '500 Internal Server Error: manifest unknown' >&2; exit 1 ;;
       ambiguous) echo 'unexpected registry response' >&2; exit 1 ;;
+      rate_limit) echo 'ERROR: 429 Too Many Requests (rate limit exceeded)' >&2; exit 1 ;;
       *) echo 'unknown mock mode' >&2; exit 2 ;;
     esac
     ;;
@@ -79,7 +81,7 @@ if grep -Fq 'buildx imagetools create' "$mock_log"; then
   exit 1
 fi
 
-for mode in missing missing_not_found missing_404; do
+for mode in missing missing_not_found missing_ghcr missing_404; do
   run_promotion "$mode" >/dev/null
   if [ "$(grep -Fc 'buildx imagetools create' "$mock_log")" -ne 1 ]; then
     echo "$mode immutable tag was not created exactly once" >&2
@@ -87,12 +89,18 @@ for mode in missing missing_not_found missing_404; do
   fi
 done
 
-for mode in auth transport server ambiguous; do
+for mode in auth transport server ambiguous rate_limit; do
   if run_promotion "$mode" >/dev/null 2>"$mock_error"; then
     echo "$mode registry failure was incorrectly treated as a missing tag" >&2
     exit 1
   fi
-  grep -Fq "${mode%iguous}" "$mock_error" || {
+  case "$mode" in
+    auth) grep -Fq 'authorization failure' "$mock_error" ;;
+    transport) grep -Fq 'transport failure' "$mock_error" ;;
+    server) grep -Fq 'server failure' "$mock_error" ;;
+    ambiguous) grep -Fq 'ambiguous registry failure' "$mock_error" ;;
+    rate_limit) grep -Fq 'rate-limit response is ambiguous' "$mock_error" ;;
+  esac || {
     echo "$mode registry failure was not classified explicitly" >&2
     exit 1
   }
@@ -150,6 +158,128 @@ fi
 workflow=.github/workflows/release-ai-os-image.yml
 checker=./scripts/release/check_ai_os_image_contract.sh
 
+# These fixtures mirror the GitHub REST provider shape, including both
+# environment protection rules and the deployment-branch policy response.
+provider_environment='{"name":"release-production","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","id":123456,"login":"mindburnlabs"}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
+provider_branch_policies='{"total_count":1,"branch_policies":[{"id":201,"node_id":"BP_main","name":"main","type":"branch"}]}'
+provider_approval='[{"environments":[{"name":"release-production","id":301}],"state":"approved","user":{"login":"peycheff-com"},"created_at":"2026-09-01T10:00:01Z"}]'
+run_started_at=2026-09-01T10:00:00Z
+
+assert_provider_authority() {
+  environment_json=$1
+  branch_policy_json=$2
+  printf '%s\n' "$environment_json" | jq -e --arg environment release-production '
+    .name == $environment and
+    .can_admins_bypass == false and
+    .deployment_branch_policy == {
+      protected_branches: false,
+      custom_branch_policies: true
+    } and
+    (.protection_rules | type == "array" and length == 2) and
+    (([.protection_rules[].type] | sort) == ["branch_policy", "required_reviewers"]) and
+    ([.protection_rules[] | select(.type == "required_reviewers")] | length == 1) and
+    (first(.protection_rules[] | select(.type == "required_reviewers")) |
+      .prevent_self_review == true and
+      (.reviewers | type == "array" and length == 1) and
+      .reviewers[0].type == "User" and
+      (.reviewers[0].id | type == "number" and (try (floor == . and . > 0) catch false)))
+  ' >/dev/null 2>&1 || return 1
+  printf '%s\n' "$branch_policy_json" | jq -e '
+    .total_count == 1 and
+    (.branch_policies | type == "array" and length == 1) and
+    .branch_policies[0].name == "main" and
+    .branch_policies[0].type == "branch"
+  ' >/dev/null 2>&1
+}
+
+assert_provider_actors() {
+  printf '%s\n' "$1" | jq -e '. == ["mindburnlabs","peycheff-com"]' >/dev/null
+}
+
+assert_provider_approval() {
+  approval_json=$1
+  approval_run_started_at=$2
+  approval_request_actor=$3
+  approval_triggering_actor=$4
+  printf '%s\n' "$approval_json" | jq -e \
+    --arg run_started_at "$approval_run_started_at" \
+    --arg release_environment release-production \
+    --arg request_actor "$approval_request_actor" \
+    --arg triggering_actor "$approval_triggering_actor" '
+    [
+      .[] |
+      select(
+        .state == "approved" and
+        (.created_at > $run_started_at) and
+        (.environments | type == "array" and any(.[]; .name == $release_environment)) and
+        (.user.login == "mindburnlabs" or .user.login == "peycheff-com") and
+        .user.login != $request_actor and
+        .user.login != $triggering_actor
+      )
+    ] | length > 0
+  ' >/dev/null 2>&1
+}
+
+if ! assert_provider_authority "$provider_environment" "$provider_branch_policies" ||
+  ! assert_provider_actors '["mindburnlabs","peycheff-com"]' ||
+  ! assert_provider_approval "$provider_approval" "$run_started_at" mindburnlabs mindburnlabs; then
+  echo 'provider-shaped release authority fixtures were not accepted' >&2
+  exit 1
+fi
+
+reject_provider_authority() {
+  mutation=$1
+  environment_json=$2
+  branch_policy_json=${3:-$provider_branch_policies}
+  if assert_provider_authority "$environment_json" "$branch_policy_json"; then
+    echo "provider authority mutation was accepted: $mutation" >&2
+    exit 1
+  fi
+}
+
+reject_provider_authority 'missing required reviewer rule' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules = [.protection_rules[0]]')"
+reject_provider_authority 'extra unknown rule' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules += [{"type":"unknown"}]')"
+reject_provider_authority 'unknown rule type' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].type = "unknown"')"
+reject_provider_authority 'Team reviewer' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].type = "Team"')"
+reject_provider_authority 'multiple reviewers' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers += [{"type":"User","id":654321}]')"
+reject_provider_authority 'administrator bypass' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.can_admins_bypass = true')"
+reject_provider_authority 'self review enabled' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].prevent_self_review = false')"
+reject_provider_authority 'protected branch policy' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.deployment_branch_policy.protected_branches = true')"
+reject_provider_authority 'custom branch policy disabled' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.deployment_branch_policy.custom_branch_policies = false')"
+reject_provider_authority 'extra deployment branch' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.total_count = 2 | .branch_policies += [{"id":202,"name":"release","type":"branch"}]')"
+reject_provider_authority 'wrong deployment branch name' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].name = "release"')"
+reject_provider_authority 'wrong deployment branch type' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].type = "tag"')"
+
+for actor_fixture in '["mindburnlabs"]' '["peycheff-com","mindburnlabs"]' '["mindburnlabs","peycheff-com","other"]'; do
+  if assert_provider_actors "$actor_fixture"; then
+    echo "non-exact release actor fixture was accepted: $actor_fixture" >&2
+    exit 1
+  fi
+done
+
+if assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].created_at = "2026-08-31T23:59:59Z"')" "$run_started_at" mindburnlabs mindburnlabs ||
+  assert_provider_approval "$provider_approval" "$run_started_at" peycheff-com mindburnlabs ||
+  assert_provider_approval "$provider_approval" "$run_started_at" mindburnlabs peycheff-com ||
+  assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].environments[0].name = "other"')" "$run_started_at" mindburnlabs mindburnlabs; then
+  echo 'stale, self, or wrong-environment approval fixture was accepted' >&2
+  exit 1
+fi
+
 mutate_and_reject() {
   fixture=$1
   if "$checker" "$fixture" >/dev/null 2>&1; then
@@ -157,6 +287,83 @@ mutate_and_reject() {
     exit 1
   fi
 }
+
+sed 's/persist-credentials: false/persist-credentials: true/' \
+  "$workflow" > "$test_dir/persisted-checkout-credentials.yml"
+mutate_and_reject "$test_dir/persisted-checkout-credentials.yml"
+
+sed 's/\["mindburnlabs","peycheff-com"\]/["mindburnlabs"]/' \
+  "$workflow" > "$test_dir/non-exact-actor-allowlist.yml"
+mutate_and_reject "$test_dir/non-exact-actor-allowlist.yml"
+
+sed 's/\["branch_policy", "required_reviewers"\]/["branch_policy", "unknown"]/' \
+  "$workflow" > "$test_dir/unknown-protection-rule.yml"
+mutate_and_reject "$test_dir/unknown-protection-rule.yml"
+
+sed 's/(\.protection_rules | type == "array" and length == 2)/(\.protection_rules | type == "array" and length == 3)/g' \
+  "$workflow" > "$test_dir/extra-protection-rule.yml"
+mutate_and_reject "$test_dir/extra-protection-rule.yml"
+
+sed 's/\.reviewers\[0\]\.type == "User"/.reviewers[0].type == "Team"/g' \
+  "$workflow" > "$test_dir/team-reviewer.yml"
+mutate_and_reject "$test_dir/team-reviewer.yml"
+
+sed 's/(\.reviewers | type == "array" and length == 1)/(\.reviewers | type == "array" and length == 2)/g' \
+  "$workflow" > "$test_dir/multiple-reviewers.yml"
+mutate_and_reject "$test_dir/multiple-reviewers.yml"
+
+sed 's/\.can_admins_bypass == false/.can_admins_bypass == true/g' \
+  "$workflow" > "$test_dir/admin-bypass.yml"
+mutate_and_reject "$test_dir/admin-bypass.yml"
+
+sed 's/protected_branches: false/protected_branches: true/g' \
+  "$workflow" > "$test_dir/protected-branches.yml"
+mutate_and_reject "$test_dir/protected-branches.yml"
+
+sed 's/custom_branch_policies: true/custom_branch_policies: false/g' \
+  "$workflow" > "$test_dir/custom-branches-disabled.yml"
+mutate_and_reject "$test_dir/custom-branches-disabled.yml"
+
+sed 's/\.prevent_self_review == true/.prevent_self_review == false/g' \
+  "$workflow" > "$test_dir/self-review.yml"
+mutate_and_reject "$test_dir/self-review.yml"
+
+sed 's/\.created_at > \$run_started_at/.created_at >= \$run_started_at/g' \
+  "$workflow" > "$test_dir/stale-approval-timestamp.yml"
+mutate_and_reject "$test_dir/stale-approval-timestamp.yml"
+
+sed 's/\.user.login != \$request_actor/.user.login == \$request_actor/g; s/\.user.login != \$triggering_actor/.user.login == \$triggering_actor/g' \
+  "$workflow" > "$test_dir/self-approval.yml"
+mutate_and_reject "$test_dir/self-approval.yml"
+
+sed 's/any(\.\[\]; \.name == \$release_environment)/any(.[ ]; .name == \$release_environment)/g' \
+  "$workflow" > "$test_dir/wrong-approval-environment.yml"
+mutate_and_reject "$test_dir/wrong-approval-environment.yml"
+
+sed 's/--jq '\''\.run_started_at'\''/--jq '\''\.missing'\''/g' \
+  "$workflow" > "$test_dir/missing-run-start-time.yml"
+mutate_and_reject "$test_dir/missing-run-start-time.yml"
+
+sed 's/GH_TOKEN="\${OWNER_READBACK_TOKEN}" gh api/gh api/g' \
+  "$workflow" > "$test_dir/unbound-owner-readback.yml"
+mutate_and_reject "$test_dir/unbound-owner-readback.yml"
+
+reject_dockerignore_mutation() {
+  entry=$1
+  fixture="$test_dir/missing-context.dockerignore"
+  awk -v entry="$entry" '$0 != entry' .dockerignore > "$fixture"
+  if "$checker" "$workflow" .github/workflows/release.yml Dockerfile "$fixture" >/dev/null 2>&1; then
+    echo "Docker context mutation was not rejected: $entry" >&2
+    exit 1
+  fi
+}
+
+while IFS= read -r dockerignore_entry; do
+  case "$dockerignore_entry" in
+    ''|'#'*) continue ;;
+  esac
+  reject_dockerignore_mutation "$dockerignore_entry"
+done < .dockerignore
 
 sed -e 's/^USER /  user /' -e 's/^ENTRYPOINT /  entrypoint /' -e 's/^CMD /  cmd /' \
   Dockerfile > "$test_dir/lowercase-governed.Dockerfile"
@@ -297,7 +504,7 @@ awk '
 mutate_and_reject "$test_dir/missing-final-actor-readback.yml"
 
 awk '
-  /approval_history="\$\(gh api .*\/approvals/ {
+  /approval_history="\$\(GH_TOKEN="\$\{OWNER_READBACK_TOKEN\}" gh api .*\/approvals/ {
     seen++
     if (seen == 2) {
       print "          approval_history=\"[]\" # mutation: skip final approval readback"
@@ -330,7 +537,7 @@ awk '
 mutate_and_reject "$test_dir/missing-final-release-environment.yml"
 
 awk '
-  /approval_history="\$\(gh api .*\/approvals/ {
+  /approval_history="\$\(GH_TOKEN="\$\{OWNER_READBACK_TOKEN\}" gh api .*\/approvals/ {
     seen++
     if (seen == 2) {
       held = $0

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
+# quantum_posture: this mutation suite checks classical SHA-256 and Cosign
+# release-evidence contracts; it adds no post-quantum cryptographic control.
 # Mutation fixtures intentionally match literal GitHub and shell expressions.
 # shellcheck disable=SC2016
 set -eu

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -160,7 +160,7 @@ checker=./scripts/release/check_ai_os_image_contract.sh
 
 # These fixtures mirror the GitHub REST provider shape, including both
 # environment protection rules and the deployment-branch policy response.
-provider_environment='{"name":"release-production","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","id":123456,"login":"mindburnlabs"}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
+provider_environment='{"name":"release-production","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"mindburnlabs","id":123456,"node_id":"U_owner","type":"User"}}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
 provider_branch_policies='{"total_count":1,"branch_policies":[{"id":201,"node_id":"BP_main","name":"main","type":"branch"}]}'
 provider_approval='[{"environments":[{"name":"release-production","id":301}],"state":"approved","user":{"login":"peycheff-com"},"created_at":"2026-09-01T10:00:01Z"}]'
 run_started_at=2026-09-01T10:00:00Z
@@ -182,7 +182,8 @@ assert_provider_authority() {
       .prevent_self_review == true and
       (.reviewers | type == "array" and length == 1) and
       .reviewers[0].type == "User" and
-      (.reviewers[0].id | type == "number" and (try (floor == . and . > 0) catch false)))
+      (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+      (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com"))
   ' >/dev/null 2>&1 || return 1
   printf '%s\n' "$branch_policy_json" | jq -e '
     .total_count == 1 and
@@ -246,7 +247,9 @@ reject_provider_authority 'unknown rule type' \
 reject_provider_authority 'Team reviewer' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].type = "Team"')"
 reject_provider_authority 'multiple reviewers' \
-  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers += [{"type":"User","id":654321}]')"
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers += [{"type":"User","reviewer":{"login":"peycheff-com","id":654321}}]')"
+reject_provider_authority 'reviewer outside owner set' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.login = "other"')"
 reject_provider_authority 'administrator bypass' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.can_admins_bypass = true')"
 reject_provider_authority 'self review enabled' \

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -221,10 +221,184 @@ assert_provider_approval() {
   ' >/dev/null 2>&1
 }
 
+evidence_amd64_digest=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+evidence_arm64_digest=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+evidence_amd64_scan_digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
+evidence_arm64_scan_digest=sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+evidence_build_type=https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/docs/supply-chain/kernel-image-build-v1.md
+
+assert_release_evidence_shape() {
+  evidence_json=$1
+  evidence_status=$2
+  evidence_final_digest=$3
+  printf '%s\n' "$evidence_json" | jq -e \
+    --arg expected_status "$evidence_status" \
+    --arg expected_final_digest "$evidence_final_digest" \
+    --arg index_digest "$expected_digest" \
+    --arg amd64_digest "$evidence_amd64_digest" \
+    --arg arm64_digest "$evidence_arm64_digest" \
+    --arg amd64_scan_digest "$evidence_amd64_scan_digest" \
+    --arg arm64_scan_digest "$evidence_arm64_scan_digest" \
+    --arg build_type "$evidence_build_type" '
+      (if $expected_status == "staging-digest-verified"
+       then (keys | sort) == [
+         "actor", "component", "cosign", "cve_gate", "default_command",
+         "digest", "entrypoint", "final_tag", "healthcheck", "image",
+         "oci_labels", "persistence", "platforms", "promotion_status",
+         "release_environment", "runtime_verification", "schema", "slsa",
+         "source_ref", "source_repository", "source_sha", "staging_tag",
+         "triggering_actor", "workflow_file", "workflow_identity", "workflow_name",
+         "workflow_ref", "workflow_run", "workflow_sha"
+       ]
+       else (keys | sort) == [
+         "actor", "component", "cosign", "cve_gate", "default_command",
+         "digest", "entrypoint", "final_tag", "final_tag_digest", "healthcheck",
+         "image", "oci_labels", "persistence", "platforms", "promotion_status",
+         "release_environment", "runtime_verification", "schema", "slsa",
+         "source_ref", "source_repository", "source_sha", "staging_tag",
+         "triggering_actor", "workflow_file", "workflow_identity", "workflow_name",
+         "workflow_ref", "workflow_run", "workflow_sha"
+       ]
+       end) and
+      .schema == "https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/docs/supply-chain/kernel-image-release-evidence-v1.md" and
+      .component == "helm-ai-kernel" and
+      .actor == "mindburnlabs" and
+      .triggering_actor == "peycheff-com" and
+      .release_environment == "release-production" and
+      .source_repository == "Mindburn-Labs/helm-ai-kernel" and
+      .source_ref == "refs/heads/main" and
+      (.source_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+      .workflow_name == "AI OS Kernel image" and
+      .workflow_file == ".github/workflows/release-ai-os-image.yml" and
+      .workflow_ref == "refs/heads/main" and
+      (.workflow_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+      .image == "ghcr.io/mindburn-labs/helm-ai-kernel" and
+      .digest == $index_digest and
+      .platforms == [
+        {platform: "linux/amd64", digest: $amd64_digest, sbom: "sbom-linux-amd64.spdx.json"},
+        {platform: "linux/arm64", digest: $arm64_digest, sbom: "sbom-linux-arm64.spdx.json"}
+      ] and
+      .cve_gate == {
+        tool: "grype",
+        scope: "os-and-library",
+        fail_on: "high",
+        status: "passed",
+        platforms: [
+          {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
+          {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
+        ]
+      } and
+      .slsa == {
+        build_type: $build_type,
+        index: {predicate: "slsa-provenance.json", attestation: "slsa-provenance.attestation.json"},
+        platforms: [
+          {platform: "linux/amd64", digest: $amd64_digest, predicate: "slsa-provenance-linux-amd64.json", attestation: "slsa-provenance-linux-amd64.attestation.json"},
+          {platform: "linux/arm64", digest: $arm64_digest, predicate: "slsa-provenance-linux-arm64.json", attestation: "slsa-provenance-linux-arm64.attestation.json"}
+        ]
+      } and
+      .promotion_status == $expected_status and
+      (if $expected_status == "staging-digest-verified"
+       then (has("final_tag_digest") | not)
+       else .final_tag_digest == $expected_final_digest
+       end)
+    ' >/dev/null 2>&1
+}
+
 if ! assert_provider_authority "$provider_environment" "$provider_branch_policies" ||
   ! assert_provider_actors '["mindburnlabs","peycheff-com"]' ||
   ! assert_provider_approval "$provider_approval" "$run_started_at" mindburnlabs mindburnlabs; then
   echo 'provider-shaped release authority fixtures were not accepted' >&2
+  exit 1
+fi
+
+evidence_fixture="$(jq -cn \
+  --arg schema 'https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/docs/supply-chain/kernel-image-release-evidence-v1.md' \
+  --arg build_type "$evidence_build_type" \
+  --arg source_sha "$source_sha" \
+  --arg index_digest "$expected_digest" \
+  --arg amd64_digest "$evidence_amd64_digest" \
+  --arg arm64_digest "$evidence_arm64_digest" \
+  --arg amd64_scan_digest "$evidence_amd64_scan_digest" \
+  --arg arm64_scan_digest "$evidence_arm64_scan_digest" '
+  {
+    schema: $schema,
+    component: "helm-ai-kernel",
+    actor: "mindburnlabs",
+    triggering_actor: "peycheff-com",
+    release_environment: "release-production",
+    source_repository: "Mindburn-Labs/helm-ai-kernel",
+    source_ref: "refs/heads/main",
+    source_sha: $source_sha,
+    workflow_name: "AI OS Kernel image",
+    workflow_file: ".github/workflows/release-ai-os-image.yml",
+    workflow_ref: "refs/heads/main",
+    workflow_sha: $source_sha,
+    workflow_identity: "https://github.com/Mindburn-Labs/helm-ai-kernel/.github/workflows/release-ai-os-image.yml@refs/heads/main",
+    workflow_run: "https://github.com/Mindburn-Labs/helm-ai-kernel/actions/runs/123",
+    image: "ghcr.io/mindburn-labs/helm-ai-kernel",
+    staging_tag: "staging-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-123-1",
+    final_tag: "sha-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    digest: $index_digest,
+    platforms: [
+      {platform: "linux/amd64", digest: $amd64_digest, sbom: "sbom-linux-amd64.spdx.json"},
+      {platform: "linux/arm64", digest: $arm64_digest, sbom: "sbom-linux-arm64.spdx.json"}
+    ],
+    oci_labels: {
+      "org.opencontainers.image.source": "https://github.com/Mindburn-Labs/helm-ai-kernel",
+      "org.opencontainers.image.revision": $source_sha
+    },
+    entrypoint: "/usr/local/bin/helm-ai-kernel",
+    default_command: "serve --policy /etc/helm-ai-kernel/release.high_risk.v3.toml --addr 0.0.0.0 --port 8080 --data-dir /var/lib/helm-ai-kernel",
+    healthcheck: "GET /healthz on port 8080",
+    persistence: "/var/lib/helm-ai-kernel",
+    runtime_verification: {
+      oci_config: "linux/amd64-and-linux/arm64-config-exactly-verified",
+      exercised_platform: "linux/amd64",
+      smoke: "health-denial-receipt-stop-restart-exact-readback-passed"
+    },
+    cve_gate: {
+      tool: "grype",
+      scope: "os-and-library",
+      fail_on: "high",
+      status: "passed",
+      platforms: [
+        {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
+        {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
+      ]
+    },
+    slsa: {
+      build_type: $build_type,
+      index: {predicate: "slsa-provenance.json", attestation: "slsa-provenance.attestation.json"},
+      platforms: [
+        {platform: "linux/amd64", digest: $amd64_digest, predicate: "slsa-provenance-linux-amd64.json", attestation: "slsa-provenance-linux-amd64.attestation.json"},
+        {platform: "linux/arm64", digest: $arm64_digest, predicate: "slsa-provenance-linux-arm64.json", attestation: "slsa-provenance-linux-arm64.attestation.json"}
+      ]
+    },
+    cosign: "keyless-signature-and-platform-attestations-exactly-verified",
+    promotion_status: "staging-digest-verified"
+  }
+')"
+if ! assert_release_evidence_shape "$evidence_fixture" staging-digest-verified ''; then
+  echo 'provider-shaped release evidence fixture was not accepted' >&2
+  exit 1
+fi
+final_evidence_fixture="$(printf '%s\n' "$evidence_fixture" | jq -c --arg final_digest "$expected_digest" '
+  .promotion_status = "final-tag-digest-platforms-signature-and-evidence-verified" |
+  .final_tag_digest = $final_digest
+')"
+if ! assert_release_evidence_shape "$final_evidence_fixture" final-tag-digest-platforms-signature-and-evidence-verified "$expected_digest"; then
+  echo 'final provider-shaped release evidence fixture was not accepted' >&2
+  exit 1
+fi
+if assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.actor = "other"')" staging-digest-verified '' ||
+  assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.cve_gate.fail_on = "medium"')" staging-digest-verified '' ||
+  assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.slsa.platforms[0].predicate = "slsa-provenance.json"')" staging-digest-verified '' ||
+  assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.extra = true')" staging-digest-verified ''; then
+  echo 'release evidence mutation was accepted' >&2
+  exit 1
+fi
+if assert_release_evidence_shape "$(printf '%s\n' "$final_evidence_fixture" | jq -c 'del(.final_tag_digest)')" final-tag-digest-platforms-signature-and-evidence-verified "$expected_digest"; then
+  echo 'final release evidence without final_tag_digest was accepted' >&2
   exit 1
 fi
 
@@ -290,6 +464,74 @@ mutate_and_reject() {
     exit 1
   fi
 }
+
+sed 's/--scope all-layers/--scope squashed/g' \
+  "$workflow" > "$test_dir/incomplete-layer-scan.yml"
+mutate_and_reject "$test_dir/incomplete-layer-scan.yml"
+
+sed 's/--fail-on high/--fail-on medium/g' \
+  "$workflow" > "$test_dir/weakened-cve-threshold.yml"
+mutate_and_reject "$test_dir/weakened-cve-threshold.yml"
+
+sed 's/GRYPE_DB_AUTO_UPDATE: "false"/GRYPE_DB_AUTO_UPDATE: "true"/g' \
+  "$workflow" > "$test_dir/mutable-grype-db.yml"
+mutate_and_reject "$test_dir/mutable-grype-db.yml"
+
+sed 's/GRYPE_CHECK_FOR_APP_UPDATE: "false"/GRYPE_CHECK_FOR_APP_UPDATE: "true"/g' \
+  "$workflow" > "$test_dir/mutable-grype-update-check.yml"
+mutate_and_reject "$test_dir/mutable-grype-update-check.yml"
+
+sed 's#IMAGE_REF: \${{ env.IMAGE_NAME }}@\${{ steps.platforms.outputs.amd64_digest }}#IMAGE_REF: \${{ env.IMAGE_NAME }}:\${{ env.STAGING_TAG }}#' \
+  "$workflow" > "$test_dir/unbound-amd64-cve-digest.yml"
+mutate_and_reject "$test_dir/unbound-amd64-cve-digest.yml"
+
+sed 's#IMAGE_REF: \${{ env.IMAGE_NAME }}@\${{ steps.platforms.outputs.arm64_digest }}#IMAGE_REF: \${{ env.IMAGE_NAME }}:\${{ env.STAGING_TAG }}#' \
+  "$workflow" > "$test_dir/unbound-arm64-cve-digest.yml"
+mutate_and_reject "$test_dir/unbound-arm64-cve-digest.yml"
+
+sed 's#write_slsa_predicate slsa-provenance-linux-amd64.json linux/amd64 "\${{ steps.platforms.outputs.amd64_digest }}"#write_slsa_predicate slsa-provenance-linux-amd64.json linux/amd64 "\${{ steps.build.outputs.digest }}"#' \
+  "$workflow" > "$test_dir/unbound-amd64-slsa-digest.yml"
+mutate_and_reject "$test_dir/unbound-amd64-slsa-digest.yml"
+
+sed 's#write_slsa_predicate slsa-provenance-linux-arm64.json linux/arm64 "\${{ steps.platforms.outputs.arm64_digest }}"#write_slsa_predicate slsa-provenance-linux-arm64.json linux/arm64 "\${{ steps.build.outputs.digest }}"#' \
+  "$workflow" > "$test_dir/unbound-arm64-slsa-digest.yml"
+mutate_and_reject "$test_dir/unbound-arm64-slsa-digest.yml"
+
+sed 's/\.actor == \$actor/.actor == "other"/' \
+  "$workflow" > "$test_dir/unbound-evidence-actor.yml"
+mutate_and_reject "$test_dir/unbound-evidence-actor.yml"
+
+sed 's/\.cve_gate == {/true and/' \
+  "$workflow" > "$test_dir/unbound-evidence-cve-gate.yml"
+mutate_and_reject "$test_dir/unbound-evidence-cve-gate.yml"
+
+sed 's/\.slsa == {/true and/' \
+  "$workflow" > "$test_dir/unbound-evidence-slsa.yml"
+mutate_and_reject "$test_dir/unbound-evidence-slsa.yml"
+
+sed 's/\.final_tag_digest == \$final_digest/.final_tag_digest != \$final_digest/' \
+  "$workflow" > "$test_dir/unbound-final-evidence-digest.yml"
+mutate_and_reject "$test_dir/unbound-final-evidence-digest.yml"
+
+sed '/cp release-evidence\.json release-evidence\.staging\.json/d' \
+  "$workflow" > "$test_dir/unbound-final-evidence-fields.yml"
+mutate_and_reject "$test_dir/unbound-final-evidence-fields.yml"
+
+sed 's/(keys | sort) == \[/(keys | sort) != [/g' \
+  "$workflow" > "$test_dir/open-evidence-shape.yml"
+mutate_and_reject "$test_dir/open-evidence-shape.yml"
+
+sed '/^            grype-linux-amd64\.json$/d' \
+  "$workflow" > "$test_dir/missing-amd64-grype-upload.yml"
+mutate_and_reject "$test_dir/missing-amd64-grype-upload.yml"
+
+sed '/^            slsa-provenance-linux-arm64\.attestation\.json$/d' \
+  "$workflow" > "$test_dir/missing-arm64-slsa-upload.yml"
+mutate_and_reject "$test_dir/missing-arm64-slsa-upload.yml"
+
+sed '/cosign attest --yes --type slsaprovenance1 --predicate slsa-provenance-linux-amd64\.json/d' \
+  "$workflow" > "$test_dir/missing-amd64-slsa-attestation.yml"
+mutate_and_reject "$test_dir/missing-amd64-slsa-attestation.yml"
 
 sed 's/persist-credentials: false/persist-credentials: true/' \
   "$workflow" > "$test_dir/persisted-checkout-credentials.yml"
@@ -531,10 +773,9 @@ awk '
 mutate_and_reject "$test_dir/missing-final-owner-readback.yml"
 
 awk '
-  /RELEASE_ENVIRONMENT: release-production/ {
-    seen++
-    if (seen == 2) next
-  }
+  /^      - name: Reauthorize and promote the verified digest$/ { in_final = 1 }
+  in_final && /^          RELEASE_ENVIRONMENT: release-production$/ { next }
+  in_final && /^      - name:/ && $0 !~ /Reauthorize and promote the verified digest/ { in_final = 0 }
   { print }
 ' "$workflow" > "$test_dir/missing-final-release-environment.yml"
 mutate_and_reject "$test_dir/missing-final-release-environment.yml"

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -209,13 +209,13 @@ assert_provider_authority() {
   ' >/dev/null 2>&1
 }
 
-provider_grype_db_status='{"schemaVersion":"v6.1.9","from":"https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.9_2026-08-31T00:36:25Z_1788158251.tar.zst?checksum=sha256%3A70e70f6232f41281063bd2a0a20600758ae12d6e60ba571b16070f950e2f99d3","built":"2026-08-31T06:37:31Z","path":"/runner/_temp/grype-db/6/vulnerability.db","valid":true}'
+provider_grype_db_status='{"schemaVersion":"6.1.9","from":"https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.9_2026-08-31T00:36:25Z_1788158251.tar.zst?checksum=sha256%3A70e70f6232f41281063bd2a0a20600758ae12d6e60ba571b16070f950e2f99d3","built":"2026-08-31T06:37:31Z","path":"/runner/_temp/grype-db/6/vulnerability.db","valid":true}'
 
 assert_provider_grype_db_status() {
   printf '%s\n' "$1" | jq -e '
     type == "object" and
     (keys | sort) == ["built", "from", "path", "schemaVersion", "valid"] and
-    (.schemaVersion | type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) and
+    (.schemaVersion | type == "string" and test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) and
     (.from | type == "string" and startswith("https://grype.anchore.io/databases/")) and
     (.built | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
     (.path | type == "string" and length > 0) and
@@ -349,7 +349,7 @@ fi
 for db_status_mutation in \
   "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.extra = true')" \
   "$(printf '%s\n' "$provider_grype_db_status" | jq -c 'del(.schemaVersion)')" \
-  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.schemaVersion = "6.1.9"')" \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.schemaVersion = "v6.1.9"')" \
   "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.from = "https://example.test/db"')" \
   "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.built = "not-a-timestamp"')" \
   "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.path = ""')" \
@@ -477,6 +477,8 @@ reject_provider_authority 'required reviewer outer rule zero id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].id = 0')"
 reject_provider_authority 'required reviewer outer rule string id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].id = "101"')"
+reject_provider_authority 'required reviewer outer rule fractional id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].id = 101.5')"
 reject_provider_authority 'required reviewer outer rule empty node id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].node_id = ""')"
 reject_provider_authority 'required reviewer outer rule missing prevent-self-review' \
@@ -505,6 +507,8 @@ reject_provider_authority 'reviewer User zero id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.id = 0')"
 reject_provider_authority 'reviewer User string id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.id = "123456"')"
+reject_provider_authority 'reviewer User fractional id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.id = 123456.5')"
 reject_provider_authority 'reviewer User missing id' \
   "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].reviewer.id)')"
 reject_provider_authority 'reviewer User empty node id' \
@@ -545,6 +549,8 @@ reject_provider_authority 'environment branch rule zero id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].id = 0')"
 reject_provider_authority 'environment branch rule string id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].id = "102"')"
+reject_provider_authority 'environment branch rule fractional id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].id = 102.5')"
 reject_provider_authority 'environment branch rule empty node id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].node_id = ""')"
 reject_provider_authority 'environment branch rule missing node id' \
@@ -563,6 +569,9 @@ reject_provider_authority 'deployment branch zero id' \
 reject_provider_authority 'deployment branch string id' \
   "$provider_environment" \
   "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].id = "201"')"
+reject_provider_authority 'deployment branch fractional id' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].id = 201.5')"
 reject_provider_authority 'deployment branch empty node id' \
   "$provider_environment" \
   "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].node_id = ""')"
@@ -893,6 +902,26 @@ mutate_and_reject "$test_dir/unbound-triggering-actor.yml"
 sed '/OWNER_READBACK_TOKEN: \${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}/d' \
   "$workflow" > "$test_dir/missing-owner-readback-token.yml"
 mutate_and_reject "$test_dir/missing-owner-readback-token.yml"
+
+sed '/INITIAL_LIVE_RELEASE_AUTHORITY=%s/d; /INITIAL_LIVE_RELEASE_ACTORS_SHA256=%s/d' \
+  "$workflow" > "$test_dir/missing-initial-live-authority-persistence.yml"
+mutate_and_reject "$test_dir/missing-initial-live-authority-persistence.yml"
+
+sed '/INITIAL_LIVE_RELEASE_AUTHORITY}/d' \
+  "$workflow" > "$test_dir/missing-final-live-authority-comparison.yml"
+mutate_and_reject "$test_dir/missing-final-live-authority-comparison.yml"
+
+sed '/INITIAL_LIVE_RELEASE_ACTORS_SHA256}/d' \
+  "$workflow" > "$test_dir/missing-final-live-actor-digest-comparison.yml"
+mutate_and_reject "$test_dir/missing-final-live-actor-digest-comparison.yml"
+
+sed 's/GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer \${OWNER_READBACK_TOKEN}"/GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer \${GH_TOKEN}"/g' \
+  "$workflow" > "$test_dir/unbound-current-main-readback.yml"
+mutate_and_reject "$test_dir/unbound-current-main-readback.yml"
+
+sed 's/GH_TOKEN="\${OWNER_READBACK_TOKEN}" gh api --paginate/gh api --paginate/g' \
+  "$workflow" > "$test_dir/unbound-ci-readback.yml"
+mutate_and_reject "$test_dir/unbound-ci-readback.yml"
 
 sed 's#actions/runs/${GITHUB_RUN_ID}/approvals#actions/runs/${GITHUB_RUN_ID}#' \
   "$workflow" > "$test_dir/missing-run-approval-readback.yml"

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -164,8 +164,20 @@ checker=./scripts/release/check_ai_os_image_contract.sh
 # environment protection rules and the deployment-branch policy response.
 provider_environment='{"name":"release-production","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"mindburnlabs","id":123456,"node_id":"U_owner","type":"User","site_admin":false,"avatar_url":"https://avatars.githubusercontent.com/u/123456?v=4","events_url":"https://api.github.com/users/mindburnlabs/events{/privacy}","followers_url":"https://api.github.com/users/mindburnlabs/followers","following_url":"https://api.github.com/users/mindburnlabs/following{/other_user}","gists_url":"https://api.github.com/users/mindburnlabs/gists{/gist_id}","gravatar_id":"","html_url":"https://github.com/mindburnlabs","organizations_url":"https://api.github.com/users/mindburnlabs/orgs","received_events_url":"https://api.github.com/users/mindburnlabs/received_events","repos_url":"https://api.github.com/users/mindburnlabs/repos","starred_url":"https://api.github.com/users/mindburnlabs/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mindburnlabs/subscriptions","url":"https://api.github.com/users/mindburnlabs","user_view_type":"public"}}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
 provider_branch_policies='{"total_count":1,"branch_policies":[{"id":201,"node_id":"BP_main","name":"main","type":"branch"}]}'
-provider_approval='[{"environments":[{"name":"release-production","id":301}],"state":"approved","user":{"login":"peycheff-com"},"created_at":"2026-09-01T10:00:01Z"}]'
-run_started_at=2026-09-01T10:00:00Z
+provider_environment="$(printf '%s\n' "$provider_environment" | jq -c '
+  .protection_rules[0].reviewers += [
+    (.protection_rules[0].reviewers[0] |
+      .reviewer |= with_entries(
+        .value |= if type == "string"
+          then sub("mindburnlabs"; "peycheff-com") | sub("123456"; "654321")
+          else .
+          end
+      ) |
+      .reviewer.id = 654321 |
+      .reviewer.node_id = "U_owner_2")
+  ]
+')"
+provider_approval='[{"environments":[{"name":"release-production","id":301,"created_at":"2026-09-01T10:00:01Z"}],"state":"approved","comment":"approved exact run","user":{"login":"peycheff-com"}}]'
 
 assert_provider_authority() {
   environment_json=$1
@@ -185,14 +197,20 @@ assert_provider_authority() {
       (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
       (.node_id | type == "string" and length > 0) and
       .prevent_self_review == true and
-      (.reviewers | type == "array" and length == 1) and
-      (.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User") and
-      (.reviewers[0].reviewer | type == "object") and
-      (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
-      (.reviewers[0].reviewer.node_id | type == "string" and length > 0) and
-      .reviewers[0].reviewer.type == "User" and
-      .reviewers[0].reviewer.site_admin == false and
-      (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
+      (.reviewers | type == "array" and length == 2) and
+      (all(.reviewers[];
+        (keys | sort) == ["reviewer", "type"] and
+        .type == "User" and
+        (.reviewer | type == "object") and
+        (.reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+        (.reviewer.node_id | type == "string" and length > 0) and
+        .reviewer.type == "User" and
+        .reviewer.site_admin == false and
+        (.reviewer.login == "mindburnlabs" or .reviewer.login == "peycheff-com")
+      )) and
+      (([.reviewers[].reviewer.login] | sort) == ["mindburnlabs", "peycheff-com"]) and
+      ([.reviewers[].reviewer.id] | unique | length == 2) and
+      ([.reviewers[].reviewer.node_id] | unique | length == 2)) and
     (first(.protection_rules[] | select(.type == "branch_policy")) |
       (keys | sort) == ["id", "node_id", "type"] and
       (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
@@ -231,11 +249,9 @@ assert_provider_actors() {
 
 assert_provider_approval() {
   approval_json=$1
-  approval_run_started_at=$2
-  approval_request_actor=$3
-  approval_triggering_actor=$4
+  approval_request_actor=$2
+  approval_triggering_actor=$3
   printf '%s\n' "$approval_json" | jq -e \
-    --arg run_started_at "$approval_run_started_at" \
     --arg release_environment release-production \
     --arg request_actor "$approval_request_actor" \
     --arg triggering_actor "$approval_triggering_actor" '
@@ -243,7 +259,6 @@ assert_provider_approval() {
       .[] |
       select(
         .state == "approved" and
-        (.created_at > $run_started_at) and
         (.environments | type == "array" and any(.[]; .name == $release_environment)) and
         (.user.login == "mindburnlabs" or .user.login == "peycheff-com") and
         .user.login != $request_actor and
@@ -342,7 +357,7 @@ assert_release_evidence_shape() {
 
 if ! assert_provider_authority "$provider_environment" "$provider_branch_policies" ||
   ! assert_provider_actors '["mindburnlabs","peycheff-com"]' ||
-  ! assert_provider_approval "$provider_approval" "$run_started_at" mindburnlabs mindburnlabs ||
+  ! assert_provider_approval "$provider_approval" mindburnlabs mindburnlabs ||
   ! assert_provider_grype_db_status "$provider_grype_db_status"; then
   echo 'provider-shaped release authority fixtures were not accepted' >&2
   exit 1
@@ -502,9 +517,17 @@ reject_provider_authority 'reviewer entry missing reviewer' \
 reject_provider_authority 'reviewer entry missing type' \
   "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].type)')"
 reject_provider_authority 'multiple reviewers' \
-  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers += [{"type":"User","reviewer":{"login":"peycheff-com","id":654321}}]')"
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers += [.protection_rules[0].reviewers[0]]')"
+reject_provider_authority 'missing second owner reviewer' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers = [.protection_rules[0].reviewers[0]]')"
 reject_provider_authority 'reviewer outside owner set' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.login = "other"')"
+reject_provider_authority 'duplicate reviewer login' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[1].reviewer.login = "mindburnlabs"')"
+reject_provider_authority 'duplicate reviewer id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[1].reviewer.id = 123456')"
+reject_provider_authority 'duplicate reviewer node id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[1].reviewer.node_id = "U_owner"')"
 reject_provider_authority 'reviewer User zero id' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.id = 0')"
 reject_provider_authority 'reviewer User string id' \
@@ -594,11 +617,14 @@ for actor_fixture in '["mindburnlabs"]' '["peycheff-com","mindburnlabs"]' '["min
   fi
 done
 
-if assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].created_at = "2026-08-31T23:59:59Z"')" "$run_started_at" mindburnlabs mindburnlabs ||
-  assert_provider_approval "$provider_approval" "$run_started_at" peycheff-com mindburnlabs ||
-  assert_provider_approval "$provider_approval" "$run_started_at" mindburnlabs peycheff-com ||
-  assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].environments[0].name = "other"')" "$run_started_at" mindburnlabs mindburnlabs; then
-  echo 'stale, self, or wrong-environment approval fixture was accepted' >&2
+if ! assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].environments[0].created_at = "1970-01-01T00:00:00Z"')" mindburnlabs mindburnlabs; then
+  echo 'nested environment metadata timestamp was incorrectly required as approval time' >&2
+  exit 1
+fi
+if assert_provider_approval "$provider_approval" peycheff-com mindburnlabs ||
+  assert_provider_approval "$provider_approval" mindburnlabs peycheff-com ||
+  assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].environments[0].name = "other"')" mindburnlabs mindburnlabs; then
+  echo 'self or wrong-environment exact-run approval fixture was accepted' >&2
   exit 1
 fi
 
@@ -634,7 +660,7 @@ sed 's/\["reviewer", "type"\]/["reviewer"]/g' \
   "$workflow" > "$test_dir/missing-reviewer-entry-type.yml"
 mutate_and_reject "$test_dir/missing-reviewer-entry-type.yml"
 
-sed 's/\.reviewers\[0\]\.reviewer\.site_admin == false/.reviewers[0].reviewer.site_admin == true/g' \
+sed 's/\.reviewer\.site_admin == false/.reviewer.site_admin == true/g' \
   "$workflow" > "$test_dir/allowlisted-site-admin-reviewer.yml"
 mutate_and_reject "$test_dir/allowlisted-site-admin-reviewer.yml"
 
@@ -754,9 +780,13 @@ sed 's/\.type == "User"/.type == "Team"/g' \
   "$workflow" > "$test_dir/team-reviewer.yml"
 mutate_and_reject "$test_dir/team-reviewer.yml"
 
-sed 's/(\.reviewers | type == "array" and length == 1)/(\.reviewers | type == "array" and length == 2)/g' \
+sed 's/(\.reviewers | type == "array" and length == 2)/(\.reviewers | type == "array" and length == 3)/g' \
   "$workflow" > "$test_dir/multiple-reviewers.yml"
 mutate_and_reject "$test_dir/multiple-reviewers.yml"
+
+sed 's/(\.reviewers | type == "array" and length == 2)/(\.reviewers | type == "array" and length == 1)/g' \
+  "$workflow" > "$test_dir/missing-second-reviewer.yml"
+mutate_and_reject "$test_dir/missing-second-reviewer.yml"
 
 sed 's/\.can_admins_bypass == false/.can_admins_bypass == true/g' \
   "$workflow" > "$test_dir/admin-bypass.yml"
@@ -774,7 +804,7 @@ sed 's/\.prevent_self_review == true/.prevent_self_review == false/g' \
   "$workflow" > "$test_dir/self-review.yml"
 mutate_and_reject "$test_dir/self-review.yml"
 
-sed 's/\.created_at > \$run_started_at/.created_at >= \$run_started_at/g' \
+awk '{ print } /\.state == "approved" and/ { print "                (.created_at > $run_started_at) and" }' \
   "$workflow" > "$test_dir/stale-approval-timestamp.yml"
 mutate_and_reject "$test_dir/stale-approval-timestamp.yml"
 
@@ -785,10 +815,6 @@ mutate_and_reject "$test_dir/self-approval.yml"
 sed 's/any(\.\[\]; \.name == \$release_environment)/any(.[ ]; .name == \$release_environment)/g' \
   "$workflow" > "$test_dir/wrong-approval-environment.yml"
 mutate_and_reject "$test_dir/wrong-approval-environment.yml"
-
-sed 's/--jq '\''\.run_started_at'\''/--jq '\''\.missing'\''/g' \
-  "$workflow" > "$test_dir/missing-run-start-time.yml"
-mutate_and_reject "$test_dir/missing-run-start-time.yml"
 
 sed 's/GH_TOKEN="\${OWNER_READBACK_TOKEN}" gh api/gh api/g' \
   "$workflow" > "$test_dir/unbound-owner-readback.yml"
@@ -917,7 +943,7 @@ sed '/INITIAL_LIVE_RELEASE_ACTORS_SHA256}/d' \
   "$workflow" > "$test_dir/missing-final-live-actor-digest-comparison.yml"
 mutate_and_reject "$test_dir/missing-final-live-actor-digest-comparison.yml"
 
-sed 's/GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer \${OWNER_READBACK_TOKEN}"/GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer \${GH_TOKEN}"/g' \
+sed 's/GH_TOKEN="\${OWNER_READBACK_TOKEN}" gh api/GH_TOKEN="\${GH_TOKEN}" gh api/g' \
   "$workflow" > "$test_dir/unbound-current-main-readback.yml"
 mutate_and_reject "$test_dir/unbound-current-main-readback.yml"
 
@@ -925,9 +951,17 @@ sed 's/GH_TOKEN="\${OWNER_READBACK_TOKEN}" gh api --paginate/gh api --paginate/g
   "$workflow" > "$test_dir/unbound-ci-readback.yml"
 mutate_and_reject "$test_dir/unbound-ci-readback.yml"
 
+sed '/test "$(git rev-parse HEAD)" = "${SOURCE_SHA}"/d' \
+  "$workflow" > "$test_dir/missing-current-main-head-equality.yml"
+mutate_and_reject "$test_dir/missing-current-main-head-equality.yml"
+
 sed 's#actions/runs/${GITHUB_RUN_ID}/approvals#actions/runs/${GITHUB_RUN_ID}#' \
   "$workflow" > "$test_dir/missing-run-approval-readback.yml"
 mutate_and_reject "$test_dir/missing-run-approval-readback.yml"
+
+sed 's#actions/runs/${GITHUB_RUN_ID}/approvals#actions/runs/${GITHUB_RUN_NUMBER}/approvals#g' \
+  "$workflow" > "$test_dir/wrong-run-approval-readback.yml"
+mutate_and_reject "$test_dir/wrong-run-approval-readback.yml"
 
 sed 's/if \[\[ "${GITHUB_RUN_ATTEMPT}" != "1" \]\]; then/if false; then/' \
   "$workflow" > "$test_dir/replayed-owner-approval.yml"
@@ -1026,9 +1060,17 @@ sed 's/if \[\[ "\${SOURCE_SHA}" != "\${WORKFLOW_SHA}" \]\]; then/if false; then/
   "$workflow" > "$test_dir/detached-dispatch-source.yml"
 mutate_and_reject "$test_dir/detached-dispatch-source.yml"
 
-sed 's/if \[\[ "\${SOURCE_SHA}" != "\${main_tip}" \]\]; then/if false; then/' \
+sed 's/if \[\[ "\${SOURCE_SHA}" != "\${current_main_ref}" \]\]; then/if false; then/' \
   "$workflow" > "$test_dir/stale-current-main.yml"
 mutate_and_reject "$test_dir/stale-current-main.yml"
+
+sed 's/if \[\[ "\${SOURCE_SHA}" != "\${promotion_main_ref}" \]\]; then/if false; then/' \
+  "$workflow" > "$test_dir/stale-promotion-main-ref.yml"
+mutate_and_reject "$test_dir/stale-promotion-main-ref.yml"
+
+sed 's#/repos/\${GITHUB_REPOSITORY}/git/ref/heads/main#/repos/\${GITHUB_REPOSITORY}/git/ref/heads/\${GITHUB_REF_NAME}#g' \
+  "$workflow" > "$test_dir/loose-current-main-ref.yml"
+mutate_and_reject "$test_dir/loose-current-main-ref.yml"
 
 awk '
   index($0, "./scripts/release/require_latest_main_ci_success.sh") {

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -183,13 +183,22 @@ assert_provider_authority() {
       (.reviewers | type == "array" and length == 1) and
       .reviewers[0].type == "User" and
       (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
-      (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com"))
+      (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
+    (first(.protection_rules[] | select(.type == "branch_policy")) |
+      (keys | sort) == ["id", "node_id", "type"] and
+      (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+      (.node_id | type == "string" and length > 0) and
+      .type == "branch_policy")
   ' >/dev/null 2>&1 || return 1
   printf '%s\n' "$branch_policy_json" | jq -e '
     .total_count == 1 and
     (.branch_policies | type == "array" and length == 1) and
-    .branch_policies[0].name == "main" and
-    .branch_policies[0].type == "branch"
+    (.branch_policies[0] |
+      (keys | sort) == ["id", "name", "node_id", "type"] and
+      (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+      (.node_id | type == "string" and length > 0) and
+      .name == "main" and
+      .type == "branch")
   ' >/dev/null 2>&1
 }
 
@@ -442,6 +451,45 @@ reject_provider_authority 'wrong deployment branch type' \
   "$provider_environment" \
   "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].type = "tag"')"
 
+reject_provider_authority 'environment branch rule extra field' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].extra = true')"
+reject_provider_authority 'environment branch rule missing id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[1].id)')"
+reject_provider_authority 'environment branch rule zero id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].id = 0')"
+reject_provider_authority 'environment branch rule string id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].id = "102"')"
+reject_provider_authority 'environment branch rule empty node id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].node_id = ""')"
+reject_provider_authority 'environment branch rule missing node id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[1].node_id)')"
+reject_provider_authority 'environment branch rule missing type' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[1].type)')"
+reject_provider_authority 'deployment branch extra field' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].extra = true')"
+reject_provider_authority 'deployment branch missing id' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c 'del(.branch_policies[0].id)')"
+reject_provider_authority 'deployment branch zero id' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].id = 0')"
+reject_provider_authority 'deployment branch string id' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].id = "201"')"
+reject_provider_authority 'deployment branch empty node id' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c '.branch_policies[0].node_id = ""')"
+reject_provider_authority 'deployment branch missing node id' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c 'del(.branch_policies[0].node_id)')"
+reject_provider_authority 'deployment branch missing name' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c 'del(.branch_policies[0].name)')"
+reject_provider_authority 'deployment branch missing type' \
+  "$provider_environment" \
+  "$(printf '%s\n' "$provider_branch_policies" | jq -c 'del(.branch_policies[0].type)')"
+
 for actor_fixture in '["mindburnlabs"]' '["peycheff-com","mindburnlabs"]' '["mindburnlabs","peycheff-com","other"]'; do
   if assert_provider_actors "$actor_fixture"; then
     echo "non-exact release actor fixture was accepted: $actor_fixture" >&2
@@ -464,6 +512,30 @@ mutate_and_reject() {
     exit 1
   fi
 }
+
+sed 's/\["id", "node_id", "type"\]/["id", "node_id", "type", "extra"]/g' \
+  "$workflow" > "$test_dir/loose-environment-branch-rule.yml"
+mutate_and_reject "$test_dir/loose-environment-branch-rule.yml"
+
+sed 's/\["id", "name", "node_id", "type"\]/["id", "name", "type"]/g' \
+  "$workflow" > "$test_dir/missing-deployment-branch-node-id.yml"
+mutate_and_reject "$test_dir/missing-deployment-branch-node-id.yml"
+
+sed 's/\.id | type == "number" and (try (floor == \. and \. > 0) catch false)/.id | type == "number" and (try (floor == \. and \. >= 0) catch false)/g' \
+  "$workflow" > "$test_dir/non-positive-branch-rule-id.yml"
+mutate_and_reject "$test_dir/non-positive-branch-rule-id.yml"
+
+sed 's/\.node_id | type == "string" and length > 0/.node_id | type == "string" and length >= 0/g' \
+  "$workflow" > "$test_dir/empty-branch-rule-node-id.yml"
+mutate_and_reject "$test_dir/empty-branch-rule-node-id.yml"
+
+sed 's/\.name == "main"/.name == "release"/g' \
+  "$workflow" > "$test_dir/loose-deployment-branch-name.yml"
+mutate_and_reject "$test_dir/loose-deployment-branch-name.yml"
+
+sed 's/\.type == "branch"/.type == "tag"/g' \
+  "$workflow" > "$test_dir/loose-deployment-branch-type.yml"
+mutate_and_reject "$test_dir/loose-deployment-branch-type.yml"
 
 sed 's/--scope all-layers/--scope squashed/g' \
   "$workflow" > "$test_dir/incomplete-layer-scan.yml"

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -160,7 +160,7 @@ checker=./scripts/release/check_ai_os_image_contract.sh
 
 # These fixtures mirror the GitHub REST provider shape, including both
 # environment protection rules and the deployment-branch policy response.
-provider_environment='{"name":"release-production","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"mindburnlabs","id":123456,"node_id":"U_owner","type":"User"}}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
+provider_environment='{"name":"release-production","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"mindburnlabs","id":123456,"node_id":"U_owner","type":"User","site_admin":false,"avatar_url":"https://avatars.githubusercontent.com/u/123456?v=4","events_url":"https://api.github.com/users/mindburnlabs/events{/privacy}","followers_url":"https://api.github.com/users/mindburnlabs/followers","following_url":"https://api.github.com/users/mindburnlabs/following{/other_user}","gists_url":"https://api.github.com/users/mindburnlabs/gists{/gist_id}","gravatar_id":"","html_url":"https://github.com/mindburnlabs","organizations_url":"https://api.github.com/users/mindburnlabs/orgs","received_events_url":"https://api.github.com/users/mindburnlabs/received_events","repos_url":"https://api.github.com/users/mindburnlabs/repos","starred_url":"https://api.github.com/users/mindburnlabs/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mindburnlabs/subscriptions","url":"https://api.github.com/users/mindburnlabs","user_view_type":"public"}}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
 provider_branch_policies='{"total_count":1,"branch_policies":[{"id":201,"node_id":"BP_main","name":"main","type":"branch"}]}'
 provider_approval='[{"environments":[{"name":"release-production","id":301}],"state":"approved","user":{"login":"peycheff-com"},"created_at":"2026-09-01T10:00:01Z"}]'
 run_started_at=2026-09-01T10:00:00Z
@@ -179,10 +179,17 @@ assert_provider_authority() {
     (([.protection_rules[].type] | sort) == ["branch_policy", "required_reviewers"]) and
     ([.protection_rules[] | select(.type == "required_reviewers")] | length == 1) and
     (first(.protection_rules[] | select(.type == "required_reviewers")) |
+      (keys | sort) == ["id", "node_id", "prevent_self_review", "reviewers", "type"] and
+      (.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+      (.node_id | type == "string" and length > 0) and
       .prevent_self_review == true and
       (.reviewers | type == "array" and length == 1) and
-      .reviewers[0].type == "User" and
+      (.reviewers[0] | (keys | sort) == ["reviewer", "type"] and .type == "User") and
+      (.reviewers[0].reviewer | type == "object") and
       (.reviewers[0].reviewer.id | type == "number" and (try (floor == . and . > 0) catch false)) and
+      (.reviewers[0].reviewer.node_id | type == "string" and length > 0) and
+      .reviewers[0].reviewer.type == "User" and
+      .reviewers[0].reviewer.site_admin == false and
       (.reviewers[0].reviewer.login == "mindburnlabs" or .reviewers[0].reviewer.login == "peycheff-com")) and
     (first(.protection_rules[] | select(.type == "branch_policy")) |
       (keys | sort) == ["id", "node_id", "type"] and
@@ -199,6 +206,20 @@ assert_provider_authority() {
       (.node_id | type == "string" and length > 0) and
       .name == "main" and
       .type == "branch")
+  ' >/dev/null 2>&1
+}
+
+provider_grype_db_status='{"schemaVersion":"v6.1.9","from":"https://grype.anchore.io/databases/v6/vulnerability-db_v6.1.9_2026-08-31T00:36:25Z_1788158251.tar.zst?checksum=sha256%3A70e70f6232f41281063bd2a0a20600758ae12d6e60ba571b16070f950e2f99d3","built":"2026-08-31T06:37:31Z","path":"/runner/_temp/grype-db/6/vulnerability.db","valid":true}'
+
+assert_provider_grype_db_status() {
+  printf '%s\n' "$1" | jq -e '
+    type == "object" and
+    (keys | sort) == ["built", "from", "path", "schemaVersion", "valid"] and
+    (.schemaVersion | type == "string" and test("^v[0-9]+\\.[0-9]+\\.[0-9]+$")) and
+    (.from | type == "string" and startswith("https://grype.anchore.io/databases/")) and
+    (.built | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+    (.path | type == "string" and length > 0) and
+    .valid == true
   ' >/dev/null 2>&1
 }
 
@@ -234,6 +255,7 @@ evidence_amd64_digest=sha256:ccccccccccccccccccccccccccccccccccccccccccccccccccc
 evidence_arm64_digest=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 evidence_amd64_scan_digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee
 evidence_arm64_scan_digest=sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+evidence_db_status_digest=sha256:1111111111111111111111111111111111111111111111111111111111111111
 evidence_build_type=https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/docs/supply-chain/kernel-image-build-v1.md
 
 assert_release_evidence_shape() {
@@ -248,6 +270,7 @@ assert_release_evidence_shape() {
     --arg arm64_digest "$evidence_arm64_digest" \
     --arg amd64_scan_digest "$evidence_amd64_scan_digest" \
     --arg arm64_scan_digest "$evidence_arm64_scan_digest" \
+    --arg db_status_digest "$evidence_db_status_digest" \
     --arg build_type "$evidence_build_type" '
       (if $expected_status == "staging-digest-verified"
        then (keys | sort) == [
@@ -292,11 +315,13 @@ assert_release_evidence_shape() {
         scope: "os-and-library",
         fail_on: "high",
         status: "passed",
+        database: {status: "grype-db-status.json", status_digest: $db_status_digest},
         platforms: [
           {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
           {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
         ]
       } and
+      (.cve_gate.database.status_digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
       .slsa == {
         build_type: $build_type,
         index: {predicate: "slsa-provenance.json", attestation: "slsa-provenance.attestation.json"},
@@ -315,10 +340,25 @@ assert_release_evidence_shape() {
 
 if ! assert_provider_authority "$provider_environment" "$provider_branch_policies" ||
   ! assert_provider_actors '["mindburnlabs","peycheff-com"]' ||
-  ! assert_provider_approval "$provider_approval" "$run_started_at" mindburnlabs mindburnlabs; then
+  ! assert_provider_approval "$provider_approval" "$run_started_at" mindburnlabs mindburnlabs ||
+  ! assert_provider_grype_db_status "$provider_grype_db_status"; then
   echo 'provider-shaped release authority fixtures were not accepted' >&2
   exit 1
 fi
+
+for db_status_mutation in \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.extra = true')" \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c 'del(.schemaVersion)')" \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.schemaVersion = "6.1.9"')" \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.from = "https://example.test/db"')" \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.built = "not-a-timestamp"')" \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.path = ""')" \
+  "$(printf '%s\n' "$provider_grype_db_status" | jq -c '.valid = false')"; do
+  if assert_provider_grype_db_status "$db_status_mutation"; then
+    echo "invalid Grype database status fixture was accepted: $db_status_mutation" >&2
+    exit 1
+  fi
+done
 
 evidence_fixture="$(jq -cn \
   --arg schema 'https://github.com/Mindburn-Labs/helm-ai-kernel/blob/main/docs/supply-chain/kernel-image-release-evidence-v1.md' \
@@ -328,7 +368,8 @@ evidence_fixture="$(jq -cn \
   --arg amd64_digest "$evidence_amd64_digest" \
   --arg arm64_digest "$evidence_arm64_digest" \
   --arg amd64_scan_digest "$evidence_amd64_scan_digest" \
-  --arg arm64_scan_digest "$evidence_arm64_scan_digest" '
+  --arg arm64_scan_digest "$evidence_arm64_scan_digest" \
+  --arg db_status_digest "$evidence_db_status_digest" '
   {
     schema: $schema,
     component: "helm-ai-kernel",
@@ -370,6 +411,7 @@ evidence_fixture="$(jq -cn \
       scope: "os-and-library",
       fail_on: "high",
       status: "passed",
+      database: {status: "grype-db-status.json", status_digest: $db_status_digest},
       platforms: [
         {platform: "linux/amd64", digest: $amd64_digest, report: "grype-linux-amd64.json", report_digest: $amd64_scan_digest},
         {platform: "linux/arm64", digest: $arm64_digest, report: "grype-linux-arm64.json", report_digest: $arm64_scan_digest}
@@ -401,6 +443,8 @@ if ! assert_release_evidence_shape "$final_evidence_fixture" final-tag-digest-pl
 fi
 if assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.actor = "other"')" staging-digest-verified '' ||
   assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.cve_gate.fail_on = "medium"')" staging-digest-verified '' ||
+  assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c 'del(.cve_gate.database)')" staging-digest-verified '' ||
+  assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.cve_gate.database.status_digest = "sha256:not-a-digest"')" staging-digest-verified '' ||
   assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.slsa.platforms[0].predicate = "slsa-provenance.json"')" staging-digest-verified '' ||
   assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.extra = true')" staging-digest-verified ''; then
   echo 'release evidence mutation was accepted' >&2
@@ -423,16 +467,58 @@ reject_provider_authority() {
 
 reject_provider_authority 'missing required reviewer rule' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules = [.protection_rules[0]]')"
+reject_provider_authority 'required reviewer outer rule extra field' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].extra = true')"
+reject_provider_authority 'required reviewer outer rule missing id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].id)')"
+reject_provider_authority 'required reviewer outer rule missing node id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].node_id)')"
+reject_provider_authority 'required reviewer outer rule zero id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].id = 0')"
+reject_provider_authority 'required reviewer outer rule string id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].id = "101"')"
+reject_provider_authority 'required reviewer outer rule empty node id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].node_id = ""')"
+reject_provider_authority 'required reviewer outer rule missing prevent-self-review' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].prevent_self_review)')"
+reject_provider_authority 'required reviewer outer rule missing reviewers' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers)')"
+reject_provider_authority 'required reviewer outer rule missing type' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].type)')"
 reject_provider_authority 'extra unknown rule' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules += [{"type":"unknown"}]')"
 reject_provider_authority 'unknown rule type' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[1].type = "unknown"')"
 reject_provider_authority 'Team reviewer' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].type = "Team"')"
+reject_provider_authority 'reviewer entry extra field' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].extra = true')"
+reject_provider_authority 'reviewer entry missing reviewer' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].reviewer)')"
+reject_provider_authority 'reviewer entry missing type' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].type)')"
 reject_provider_authority 'multiple reviewers' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers += [{"type":"User","reviewer":{"login":"peycheff-com","id":654321}}]')"
 reject_provider_authority 'reviewer outside owner set' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.login = "other"')"
+reject_provider_authority 'reviewer User zero id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.id = 0')"
+reject_provider_authority 'reviewer User string id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.id = "123456"')"
+reject_provider_authority 'reviewer User missing id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].reviewer.id)')"
+reject_provider_authority 'reviewer User empty node id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.node_id = ""')"
+reject_provider_authority 'reviewer User missing node id' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].reviewer.node_id)')"
+reject_provider_authority 'reviewer User wrong type' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.type = "Bot"')"
+reject_provider_authority 'reviewer User missing type' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].reviewer.type)')"
+reject_provider_authority 'reviewer User site admin' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules[0].reviewers[0].reviewer.site_admin = true')"
+reject_provider_authority 'reviewer User missing site admin' \
+  "$(printf '%s\n' "$provider_environment" | jq -c 'del(.protection_rules[0].reviewers[0].reviewer.site_admin)')"
 reject_provider_authority 'administrator bypass' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.can_admins_bypass = true')"
 reject_provider_authority 'self review enabled' \
@@ -529,6 +615,38 @@ sed 's/\.node_id | type == "string" and length > 0/.node_id | type == "string" a
   "$workflow" > "$test_dir/empty-branch-rule-node-id.yml"
 mutate_and_reject "$test_dir/empty-branch-rule-node-id.yml"
 
+sed 's/\["id", "node_id", "prevent_self_review", "reviewers", "type"\]/["id", "node_id", "prevent_self_review", "reviewers", "type", "extra"]/g' \
+  "$workflow" > "$test_dir/loose-required-reviewer-rule.yml"
+mutate_and_reject "$test_dir/loose-required-reviewer-rule.yml"
+
+sed 's/\["reviewer", "type"\]/["reviewer"]/g' \
+  "$workflow" > "$test_dir/missing-reviewer-entry-type.yml"
+mutate_and_reject "$test_dir/missing-reviewer-entry-type.yml"
+
+sed 's/\.reviewers\[0\]\.reviewer\.site_admin == false/.reviewers[0].reviewer.site_admin == true/g' \
+  "$workflow" > "$test_dir/allowlisted-site-admin-reviewer.yml"
+mutate_and_reject "$test_dir/allowlisted-site-admin-reviewer.yml"
+
+sed '/grype db update/d' \
+  "$workflow" > "$test_dir/missing-grype-db-bootstrap.yml"
+mutate_and_reject "$test_dir/missing-grype-db-bootstrap.yml"
+
+sed '/grype db status --output json > grype-db-status.json/d' \
+  "$workflow" > "$test_dir/missing-grype-db-status.yml"
+mutate_and_reject "$test_dir/missing-grype-db-status.yml"
+
+sed 's/(keys | sort) == \["built", "from", "path", "schemaVersion", "valid"\]/(keys | sort) != ["built", "from", "path", "schemaVersion", "valid"]/g' \
+  "$workflow" > "$test_dir/open-grype-db-status.yml"
+mutate_and_reject "$test_dir/open-grype-db-status.yml"
+
+sed 's/\.valid == true/.valid == false/g' \
+  "$workflow" > "$test_dir/invalid-grype-db-status.yml"
+mutate_and_reject "$test_dir/invalid-grype-db-status.yml"
+
+sed 's/status_digest=sha256:$(sha256sum grype-db-status.json/status_digest=sha256:$(sha256sum missing-grype-db-status.json/g' \
+  "$workflow" > "$test_dir/unbound-grype-db-status-digest.yml"
+mutate_and_reject "$test_dir/unbound-grype-db-status-digest.yml"
+
 sed 's/\.name == "main"/.name == "release"/g' \
   "$workflow" > "$test_dir/loose-deployment-branch-name.yml"
 mutate_and_reject "$test_dir/loose-deployment-branch-name.yml"
@@ -621,7 +739,7 @@ sed 's/(\.protection_rules | type == "array" and length == 2)/(\.protection_rule
   "$workflow" > "$test_dir/extra-protection-rule.yml"
 mutate_and_reject "$test_dir/extra-protection-rule.yml"
 
-sed 's/\.reviewers\[0\]\.type == "User"/.reviewers[0].type == "Team"/g' \
+sed 's/\.type == "User"/.type == "Team"/g' \
   "$workflow" > "$test_dir/team-reviewer.yml"
 mutate_and_reject "$test_dir/team-reviewer.yml"
 


### PR DESCRIPTION
## Summary
- bind initial and final release authority, actor, approval, owner, current-main, and CI readbacks to the owner token
- validate exact GitHub provider envelopes with canonical nested User trust projection and integral IDs
- add checksum-pinned Grype v0.116.1 database bootstrap and two-platform fail-closed CVE scans
- generate and exactly verify index plus per-platform SLSA predicates and durable evidence
- harden immutable promotion ambiguity handling and Docker build context

## Validation
- `actionlint -color .github/workflows/release-ai-os-image.yml`
- focused `shellcheck`
- `./scripts/release/check_ai_os_image_contract.sh`
- `./scripts/release/test_ai_os_image_release_contract.sh`
- all source-owned Go package tests via `make test-platform` (Go 1.25.13; fixture/vector/docs gates included)
- `make build`
- `make lint`
- `git diff --check origin/main...HEAD`

Local runtime selection pinned Go 1.25.13 and Python 3.12.11 directly because this isolated worktree has not been globally trusted by mise.

No workflow dispatch, image publication, environment or secret setting, deployment, package, or tag action is included.