### PR TITLE
fix(release): separate AI OS image and tag environments

### DIFF
--- a/.github/workflows/release-ai-os-image.yml
+++ b/.github/workflows/release-ai-os-image.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment:
-      name: release-production
+      name: helm-ai-os-image-release
     permissions:
       actions: read
       contents: read
@@ -48,7 +48,7 @@ jobs:
           OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}
           RELEASE_ACTORS_JSON: ${{ vars.HELM_AI_OS_IMAGE_RELEASE_ACTORS }}
           RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}
-          RELEASE_ENVIRONMENT: release-production
+          RELEASE_ENVIRONMENT: helm-ai-os-image-release
           REQUEST_ACTOR: ${{ github.actor }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
@@ -61,8 +61,8 @@ jobs:
             echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for authoritative owner readback"
             exit 1
           fi
-          if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then
-            echo "::error::release-production is not explicitly armed"
+          if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "helm-ai-os-image-release" ]]; then
+            echo "::error::helm-ai-os-image-release is not explicitly armed"
             exit 1
           fi
           if ! jq -e '. == ["mindburnlabs","peycheff-com"]' <<<"${RELEASE_ACTORS_JSON:-}" >/dev/null; then
@@ -114,7 +114,7 @@ jobs:
               (.node_id | type == "string" and length > 0) and
               .type == "branch_policy")
           ' <<<"${release_environment_payload}" >/dev/null; then
-            echo "::error::release-production environment protection readback is not exact"
+            echo "::error::helm-ai-os-image-release environment protection readback is not exact"
             exit 1
           fi
           if ! jq -e '
@@ -127,15 +127,15 @@ jobs:
               .name == "main" and
               .type == "branch")
           ' <<<"${deployment_branch_policies}" >/dev/null; then
-            echo "::error::release-production deployment branch policy must contain only main"
+            echo "::error::helm-ai-os-image-release deployment branch policy must contain only main"
             exit 1
           fi
-          if [[ "${live_release_authority}" != "release-production" ]]; then
-            echo "::error::release-production is not armed in the authoritative environment variable readback"
+          if [[ "${live_release_authority}" != "helm-ai-os-image-release" ]]; then
+            echo "::error::helm-ai-os-image-release is not armed in the authoritative environment variable readback"
             exit 1
           fi
           if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then
-            echo "::error::release-production changed from the job-start authority snapshot"
+            echo "::error::helm-ai-os-image-release changed from the job-start authority snapshot"
             exit 1
           fi
           if ! jq -e '. == ["mindburnlabs","peycheff-com"]' <<<"${live_release_actors}" >/dev/null; then
@@ -169,7 +169,7 @@ jobs:
               )
             ] | length > 0
           ' <<<"${approval_history}" >/dev/null; then
-            echo "::error::release-production requires an approved exact-run review from a distinct authorized human owner"
+            echo "::error::helm-ai-os-image-release requires an approved exact-run review from a distinct authorized human owner"
             exit 1
           fi
           for owner in mindburnlabs peycheff-com; do
@@ -634,7 +634,7 @@ jobs:
         env:
           RELEASE_ACTOR: ${{ github.actor }}
           RELEASE_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
-          RELEASE_ENVIRONMENT: release-production
+          RELEASE_ENVIRONMENT: helm-ai-os-image-release
         run: |
           set -euo pipefail
           jq -n \
@@ -811,7 +811,7 @@ jobs:
           OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}
           RELEASE_ACTORS_JSON: ${{ vars.HELM_AI_OS_IMAGE_RELEASE_ACTORS }}
           RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}
-          RELEASE_ENVIRONMENT: release-production
+          RELEASE_ENVIRONMENT: helm-ai-os-image-release
           REQUEST_ACTOR: ${{ github.actor }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
@@ -820,8 +820,8 @@ jobs:
             echo "::error::HELM_GITHUB_OWNER_READ_TOKEN is required for final owner readback"
             exit 1
           fi
-          if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then
-            echo "::error::release-production is no longer explicitly armed"
+          if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "helm-ai-os-image-release" ]]; then
+            echo "::error::helm-ai-os-image-release is no longer explicitly armed"
             exit 1
           fi
           if ! jq -e '. == ["mindburnlabs","peycheff-com"]' <<<"${RELEASE_ACTORS_JSON:-}" >/dev/null; then
@@ -873,7 +873,7 @@ jobs:
               (.node_id | type == "string" and length > 0) and
               .type == "branch_policy")
           ' <<<"${live_release_environment_payload}" >/dev/null; then
-            echo "::error::release-production environment protection changed during the build"
+            echo "::error::helm-ai-os-image-release environment protection changed during the build"
             exit 1
           fi
           if ! jq -e '
@@ -886,15 +886,15 @@ jobs:
               .name == "main" and
               .type == "branch")
           ' <<<"${live_deployment_branch_policies}" >/dev/null; then
-            echo "::error::release-production deployment branch policy changed during the build"
+            echo "::error::helm-ai-os-image-release deployment branch policy changed during the build"
             exit 1
           fi
-          if [[ "${live_release_authority}" != "release-production" ]]; then
-            echo "::error::release-production was disarmed during the build"
+          if [[ "${live_release_authority}" != "helm-ai-os-image-release" ]]; then
+            echo "::error::helm-ai-os-image-release was disarmed during the build"
             exit 1
           fi
           if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then
-            echo "::error::release-production changed from the job-start authority snapshot"
+            echo "::error::helm-ai-os-image-release changed from the job-start authority snapshot"
             exit 1
           fi
           if [[ -z "${INITIAL_LIVE_RELEASE_AUTHORITY:-}" || -z "${INITIAL_LIVE_RELEASE_ACTORS_SHA256:-}" ]]; then
@@ -902,7 +902,7 @@ jobs:
             exit 1
           fi
           if [[ "${live_release_authority}" != "${INITIAL_LIVE_RELEASE_AUTHORITY}" ]]; then
-            echo "::error::release-production changed from the initial live authority readback"
+            echo "::error::helm-ai-os-image-release changed from the initial live authority readback"
             exit 1
           fi
           if ! jq -e '
@@ -943,7 +943,7 @@ jobs:
               )
             ] | length > 0
           ' <<<"${approval_history}" >/dev/null; then
-            echo "::error::release-production no longer has this exact-run distinct human-owner approval"
+            echo "::error::helm-ai-os-image-release no longer has this exact-run distinct human-owner approval"
             exit 1
           fi
           for owner in mindburnlabs peycheff-com; do

--- a/docs/supply-chain/kernel-image-build-v1.md
+++ b/docs/supply-chain/kernel-image-build-v1.md
@@ -72,13 +72,13 @@ predicate byte structure before promotion.
 ## Invocation and authority
 
 The only trigger is `workflow_dispatch` from `refs/heads/main`. The publish job
-uses the `release-production` environment and performs no checkout until all of
-these external owner-managed settings pass:
+uses the `helm-ai-os-image-release` environment and performs no checkout until
+all of these external owner-managed settings pass:
 
 1. The environment is protected by required human reviewers, self-review is
    disabled, and administrator bypass is disabled.
 2. Its environment variable `HELM_RELEASE_AUTHORITY_ARMED` equals
-   `release-production`.
+   `helm-ai-os-image-release`.
 3. Repository variable `HELM_AI_OS_IMAGE_RELEASE_ACTORS` is a JSON array of
    exact allowed GitHub logins, for example `["mindburnlabs","peycheff-com"]`.
    Both `github.actor` and `github.triggering_actor` must be present.
@@ -90,6 +90,10 @@ these external owner-managed settings pass:
    approval from one of those two human owners. Reruns are rejected, so the
    approval endpoint remains bound to this immutable run rather than treating
    a repository variable or another run's approval as reusable authority.
+
+This image-only environment is separate from the `release-production`
+environment used by the `v*` tag-release workflow. Keep that tag policy intact;
+it cannot satisfy the image publisher's exact `main` branch policy.
 
 Those settings are an owner blocker outside this source-only change. Until
 they are confirmed in GitHub, the workflow is intentionally not dispatchable.
@@ -117,7 +121,7 @@ The dispatch snapshot and the owner-token live readback both require the exact
 actor JSON `["mindburnlabs","peycheff-com"]`. Every policy, variable,
 membership, and current-main ref read uses `GH_TOKEN="${OWNER_READBACK_TOKEN}"`
 explicitly. The exact-run approvals response must contain an `approved` review
-targeting `release-production` from one of those owners while differing from
+targeting `helm-ai-os-image-release` from one of those owners while differing from
 both the request and triggering actors. Approval timestamps are not inferred
 from unsupported top-level fields; any nested environment metadata timestamp
 is informational only. The

--- a/docs/supply-chain/kernel-image-release-evidence-v1.md
+++ b/docs/supply-chain/kernel-image-release-evidence-v1.md
@@ -17,7 +17,7 @@ repository/ref/SHA, explicit producer workflow name/file/ref/SHA/identity/run,
 image repository, staging and final tags, index digest, both platform digests
 and SPDX files, exact OCI source/revision labels, entrypoint/default command,
 health and persistence contracts, the request and triggering GitHub actors, the
-`release-production` environment, the SLSA build type, Cosign verification
+`helm-ai-os-image-release` environment, the SLSA build type, Cosign verification
 state, and promotion status. The top-level object is closed: the interim form
 has exactly the declared fields and `promotion_status=staging-digest-verified`;
 the finalized form adds only `final_tag_digest` and uses the finalized promotion

--- a/scripts/release/check_ai_os_image_contract.sh
+++ b/scripts/release/check_ai_os_image_contract.sh
@@ -145,7 +145,11 @@ require "SLSA_BUILD_TYPE: $build_uri" "$workflow"
 require "RELEASE_EVIDENCE_TYPE: $evidence_uri" "$workflow"
 require 'STAGING_TAG: staging-${{ inputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}' "$workflow"
 require 'WORKFLOW_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/release-ai-os-image.yml@refs/heads/main' "$workflow"
-require 'name: release-production' "$workflow"
+require 'name: helm-ai-os-image-release' "$workflow"
+if grep -Fq 'release-production' "$workflow"; then
+  echo 'AI OS image publication must not reuse the tag-release environment or its authority' >&2
+  exit 1
+fi
 require 'RELEASE_ACTORS_JSON: ${{ vars.HELM_AI_OS_IMAGE_RELEASE_ACTORS }}' "$workflow"
 require 'RELEASE_AUTHORITY_ARMED: ${{ vars.HELM_RELEASE_AUTHORITY_ARMED }}' "$workflow"
 require 'OWNER_READBACK_TOKEN: ${{ secrets.HELM_GITHUB_OWNER_READ_TOKEN }}' "$workflow"
@@ -189,7 +193,7 @@ require '.name == "main"' "$workflow"
 require '.type == "branch"' "$workflow"
 require '/environments/${RELEASE_ENVIRONMENT}/variables/HELM_RELEASE_AUTHORITY_ARMED' "$workflow"
 require '/actions/variables/HELM_AI_OS_IMAGE_RELEASE_ACTORS' "$workflow"
-require 'if [[ "${live_release_authority}" != "release-production" ]]; then' "$workflow"
+require 'if [[ "${live_release_authority}" != "helm-ai-os-image-release" ]]; then' "$workflow"
 require 'if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then' "$workflow"
 require '. == ["mindburnlabs","peycheff-com"]' "$workflow"
 require '--argjson configured "${RELEASE_ACTORS_JSON}"' "$workflow"
@@ -366,18 +370,25 @@ fi
 authority_environment_count="$(awk '
   /^      - name: Validate publication authority$/ { in_step = 1; next }
   in_step && /^      - name:/ { in_step = 0 }
-  in_step && /^          RELEASE_ENVIRONMENT: release-production$/ { count++ }
+  in_step && /^          RELEASE_ENVIRONMENT: helm-ai-os-image-release$/ { count++ }
+  END { print count + 0 }
+' "$workflow")"
+evidence_environment_count="$(awk '
+  /^      - name: Generate verified release evidence$/ { in_step = 1; next }
+  in_step && /^      - name:/ { in_step = 0 }
+  in_step && /^          RELEASE_ENVIRONMENT: helm-ai-os-image-release$/ { count++ }
   END { print count + 0 }
 ' "$workflow")"
 promotion_environment_count="$(awk '
   /^      - name: Reauthorize and promote the verified digest$/ { in_step = 1; next }
   in_step && /^      - name:/ { in_step = 0 }
-  in_step && /^          RELEASE_ENVIRONMENT: release-production$/ { count++ }
+  in_step && /^          RELEASE_ENVIRONMENT: helm-ai-os-image-release$/ { count++ }
   END { print count + 0 }
 ' "$workflow")"
-if [ "$(grep -Fc 'if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]]; then' "$workflow")" -ne 2 ] ||
+if [ "$(grep -Fc 'if [[ "${RELEASE_AUTHORITY_ARMED:-}" != "helm-ai-os-image-release" ]]; then' "$workflow")" -ne 2 ] ||
   [ "$authority_environment_count" -ne 1 ] ||
   [ "$promotion_environment_count" -ne 1 ] ||
+  [ "$evidence_environment_count" -ne 1 ] ||
   [ "$(grep -Fc 'for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'jq -e --arg actor "${candidate}"' "$workflow")" -ne 2 ] ||
   [ "$(grep -Fc 'approval_history="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/approvals")"' "$workflow")" -ne 2 ] ||
@@ -553,7 +564,7 @@ promotion_live_authority_read_line="$(last_line 'live_release_authority="$(GH_TO
 promotion_live_actors_read_line="$(last_line 'live_release_actors="$(GH_TOKEN="${OWNER_READBACK_TOKEN}" gh api')"
 promotion_environment_validation_line="$(last_line '<<<"${live_release_environment_payload}" >/dev/null; then')"
 promotion_branch_validation_line="$(last_line '<<<"${live_deployment_branch_policies}" >/dev/null; then')"
-promotion_authority_line="$(last_line 'if [[ "${live_release_authority}" != "release-production" ]]; then')"
+promotion_authority_line="$(last_line 'if [[ "${live_release_authority}" != "helm-ai-os-image-release" ]]; then')"
 promotion_authority_binding_line="$(last_line 'if [[ "${live_release_authority}" != "${RELEASE_AUTHORITY_ARMED}" ]]; then')"
 promotion_live_actor_validation_line="$(last_line '. == ["mindburnlabs","peycheff-com"]')"
 promotion_actor_loop_line="$(last_line 'for candidate in "${REQUEST_ACTOR}" "${TRIGGERING_ACTOR}"; do')"

--- a/scripts/release/test_ai_os_image_release_contract.sh
+++ b/scripts/release/test_ai_os_image_release_contract.sh
@@ -162,7 +162,7 @@ checker=./scripts/release/check_ai_os_image_contract.sh
 
 # These fixtures mirror the GitHub REST provider shape, including both
 # environment protection rules and the deployment-branch policy response.
-provider_environment='{"name":"release-production","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"mindburnlabs","id":123456,"node_id":"U_owner","type":"User","site_admin":false,"avatar_url":"https://avatars.githubusercontent.com/u/123456?v=4","events_url":"https://api.github.com/users/mindburnlabs/events{/privacy}","followers_url":"https://api.github.com/users/mindburnlabs/followers","following_url":"https://api.github.com/users/mindburnlabs/following{/other_user}","gists_url":"https://api.github.com/users/mindburnlabs/gists{/gist_id}","gravatar_id":"","html_url":"https://github.com/mindburnlabs","organizations_url":"https://api.github.com/users/mindburnlabs/orgs","received_events_url":"https://api.github.com/users/mindburnlabs/received_events","repos_url":"https://api.github.com/users/mindburnlabs/repos","starred_url":"https://api.github.com/users/mindburnlabs/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mindburnlabs/subscriptions","url":"https://api.github.com/users/mindburnlabs","user_view_type":"public"}}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
+provider_environment='{"name":"helm-ai-os-image-release","can_admins_bypass":false,"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true},"protection_rules":[{"id":101,"node_id":"PR_required","type":"required_reviewers","prevent_self_review":true,"reviewers":[{"type":"User","reviewer":{"login":"mindburnlabs","id":123456,"node_id":"U_owner","type":"User","site_admin":false,"avatar_url":"https://avatars.githubusercontent.com/u/123456?v=4","events_url":"https://api.github.com/users/mindburnlabs/events{/privacy}","followers_url":"https://api.github.com/users/mindburnlabs/followers","following_url":"https://api.github.com/users/mindburnlabs/following{/other_user}","gists_url":"https://api.github.com/users/mindburnlabs/gists{/gist_id}","gravatar_id":"","html_url":"https://github.com/mindburnlabs","organizations_url":"https://api.github.com/users/mindburnlabs/orgs","received_events_url":"https://api.github.com/users/mindburnlabs/received_events","repos_url":"https://api.github.com/users/mindburnlabs/repos","starred_url":"https://api.github.com/users/mindburnlabs/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/mindburnlabs/subscriptions","url":"https://api.github.com/users/mindburnlabs","user_view_type":"public"}}]},{"id":102,"node_id":"PR_branch","type":"branch_policy"}]}'
 provider_branch_policies='{"total_count":1,"branch_policies":[{"id":201,"node_id":"BP_main","name":"main","type":"branch"}]}'
 provider_environment="$(printf '%s\n' "$provider_environment" | jq -c '
   .protection_rules[0].reviewers += [
@@ -177,12 +177,12 @@ provider_environment="$(printf '%s\n' "$provider_environment" | jq -c '
       .reviewer.node_id = "U_owner_2")
   ]
 ')"
-provider_approval='[{"environments":[{"name":"release-production","id":301,"created_at":"2026-09-01T10:00:01Z"}],"state":"approved","comment":"approved exact run","user":{"login":"peycheff-com"}}]'
+provider_approval='[{"environments":[{"name":"helm-ai-os-image-release","id":301,"created_at":"2026-09-01T10:00:01Z"}],"state":"approved","comment":"approved exact run","user":{"login":"peycheff-com"}}]'
 
 assert_provider_authority() {
   environment_json=$1
   branch_policy_json=$2
-  printf '%s\n' "$environment_json" | jq -e --arg environment release-production '
+  printf '%s\n' "$environment_json" | jq -e --arg environment helm-ai-os-image-release '
     .name == $environment and
     .can_admins_bypass == false and
     .deployment_branch_policy == {
@@ -252,7 +252,7 @@ assert_provider_approval() {
   approval_request_actor=$2
   approval_triggering_actor=$3
   printf '%s\n' "$approval_json" | jq -e \
-    --arg release_environment release-production \
+    --arg release_environment helm-ai-os-image-release \
     --arg request_actor "$approval_request_actor" \
     --arg triggering_actor "$approval_triggering_actor" '
     [
@@ -313,7 +313,7 @@ assert_release_evidence_shape() {
       .component == "helm-ai-kernel" and
       .actor == "mindburnlabs" and
       .triggering_actor == "peycheff-com" and
-      .release_environment == "release-production" and
+      .release_environment == "helm-ai-os-image-release" and
       .source_repository == "Mindburn-Labs/helm-ai-kernel" and
       .source_ref == "refs/heads/main" and
       (.source_sha | type == "string" and test("^[0-9a-f]{40}$")) and
@@ -392,7 +392,7 @@ evidence_fixture="$(jq -cn \
     component: "helm-ai-kernel",
     actor: "mindburnlabs",
     triggering_actor: "peycheff-com",
-    release_environment: "release-production",
+    release_environment: "helm-ai-os-image-release",
     source_repository: "Mindburn-Labs/helm-ai-kernel",
     source_ref: "refs/heads/main",
     source_sha: $source_sha,
@@ -459,6 +459,7 @@ if ! assert_release_evidence_shape "$final_evidence_fixture" final-tag-digest-pl
   exit 1
 fi
 if assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.actor = "other"')" staging-digest-verified '' ||
+  assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.release_environment = "release-production"')" staging-digest-verified '' ||
   assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.cve_gate.fail_on = "medium"')" staging-digest-verified '' ||
   assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c 'del(.cve_gate.database)')" staging-digest-verified '' ||
   assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.cve_gate.database.status_digest = "sha256:not-a-digest"')" staging-digest-verified '' ||
@@ -469,6 +470,10 @@ if assert_release_evidence_shape "$(printf '%s\n' "$evidence_fixture" | jq -c '.
 fi
 if assert_release_evidence_shape "$(printf '%s\n' "$final_evidence_fixture" | jq -c 'del(.final_tag_digest)')" final-tag-digest-platforms-signature-and-evidence-verified "$expected_digest"; then
   echo 'final release evidence without final_tag_digest was accepted' >&2
+  exit 1
+fi
+if assert_release_evidence_shape "$(printf '%s\n' "$final_evidence_fixture" | jq -c '.release_environment = "release-production"')" final-tag-digest-platforms-signature-and-evidence-verified "$expected_digest"; then
+  echo 'tag-release environment incorrectly authorized final image evidence' >&2
   exit 1
 fi
 
@@ -482,6 +487,8 @@ reject_provider_authority() {
   fi
 }
 
+reject_provider_authority 'tag-release environment' \
+  "$(printf '%s\n' "$provider_environment" | jq -c '.name = "release-production"')"
 reject_provider_authority 'missing required reviewer rule' \
   "$(printf '%s\n' "$provider_environment" | jq -c '.protection_rules = [.protection_rules[0]]')"
 reject_provider_authority 'required reviewer outer rule extra field' \
@@ -623,6 +630,7 @@ if ! assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0
 fi
 if assert_provider_approval "$provider_approval" peycheff-com mindburnlabs ||
   assert_provider_approval "$provider_approval" mindburnlabs peycheff-com ||
+  assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].environments[0].name = "release-production"')" mindburnlabs mindburnlabs ||
   assert_provider_approval "$(printf '%s\n' "$provider_approval" | jq -c '.[0].environments[0].name = "other"')" mindburnlabs mindburnlabs; then
   echo 'self or wrong-environment exact-run approval fixture was accepted' >&2
   exit 1
@@ -968,7 +976,7 @@ sed 's/if \[\[ "${GITHUB_RUN_ATTEMPT}" != "1" \]\]; then/if false; then/' \
 mutate_and_reject "$test_dir/replayed-owner-approval.yml"
 
 awk '
-  /if \[\[ "\${RELEASE_AUTHORITY_ARMED:-}" != "release-production" \]\]; then/ {
+  /if \[\[ "\${RELEASE_AUTHORITY_ARMED:-}" != "helm-ai-os-image-release" \]\]; then/ {
     seen++
     if (seen == 2) {
       print "          if false; then # mutation: skip final authority recheck"
@@ -979,7 +987,7 @@ awk '
 ' "$workflow" > "$test_dir/stale-final-authority.yml"
 mutate_and_reject "$test_dir/stale-final-authority.yml"
 
-sed 's/if \[\[ "${live_release_authority}" != "release-production" \]\]; then/if false; then/' \
+sed 's/if \[\[ "${live_release_authority}" != "helm-ai-os-image-release" \]\]; then/if false; then/' \
   "$workflow" > "$test_dir/stale-live-authority-readback.yml"
 mutate_and_reject "$test_dir/stale-live-authority-readback.yml"
 
@@ -1029,7 +1037,7 @@ mutate_and_reject "$test_dir/missing-final-owner-readback.yml"
 
 awk '
   /^      - name: Reauthorize and promote the verified digest$/ { in_final = 1 }
-  in_final && /^          RELEASE_ENVIRONMENT: release-production$/ { next }
+  in_final && /^          RELEASE_ENVIRONMENT: helm-ai-os-image-release$/ { next }
   in_final && /^      - name:/ && $0 !~ /Reauthorize and promote the verified digest/ { in_final = 0 }
   { print }
 ' "$workflow" > "$test_dir/missing-final-release-environment.yml"
@@ -1053,8 +1061,35 @@ awk '
 ' "$workflow" > "$test_dir/reordered-final-authority.yml"
 mutate_and_reject "$test_dir/reordered-final-authority.yml"
 
-sed 's/name: release-production/name: unprotected-release/' "$workflow" > "$test_dir/wrong-environment.yml"
+sed 's/name: helm-ai-os-image-release/name: unprotected-release/' "$workflow" > "$test_dir/wrong-environment.yml"
 mutate_and_reject "$test_dir/wrong-environment.yml"
+
+sed 's/name: helm-ai-os-image-release/name: release-production/' \
+  "$workflow" > "$test_dir/tag-release-environment.yml"
+mutate_and_reject "$test_dir/tag-release-environment.yml"
+
+sed 's/!= "helm-ai-os-image-release"/!= "release-production"/g' \
+  "$workflow" > "$test_dir/tag-release-arming.yml"
+mutate_and_reject "$test_dir/tag-release-arming.yml"
+
+awk '
+  /^      - name: Generate verified release evidence$/ { in_evidence = 1 }
+  in_evidence && /^          RELEASE_ENVIRONMENT: helm-ai-os-image-release$/ {
+    print "          RELEASE_ENVIRONMENT: release-production"
+    next
+  }
+  in_evidence && /^      - name:/ && $0 !~ /Generate verified release evidence/ { in_evidence = 0 }
+  { print }
+' "$workflow" > "$test_dir/tag-release-evidence-environment.yml"
+mutate_and_reject "$test_dir/tag-release-evidence-environment.yml"
+
+awk '
+  /^      - name: Generate verified release evidence$/ { in_evidence = 1 }
+  in_evidence && /^          RELEASE_ENVIRONMENT: helm-ai-os-image-release$/ { next }
+  in_evidence && /^      - name:/ && $0 !~ /Generate verified release evidence/ { in_evidence = 0 }
+  { print }
+' "$workflow" > "$test_dir/missing-evidence-release-environment.yml"
+mutate_and_reject "$test_dir/missing-evidence-release-environment.yml"
 
 sed 's/if \[\[ "\${SOURCE_SHA}" != "\${WORKFLOW_SHA}" \]\]; then/if false; then/' \
   "$workflow" > "$test_dir/detached-dispatch-source.yml"


### PR DESCRIPTION
## Summary

HELM-684 / HELM-658: Give the AI OS image publisher its own helm-ai-os-image-release environment. The existing release-production environment remains unchanged for v* tag releases. Their branch policies are incompatible, so sharing an environment blocks image publication.

Keep both owner-readback checkpoints, current-main and CI binding, exact-run distinct-account approval, immutable promotion and provenance checks. Add negative fixtures rejecting the legacy environment in image arming, approvals and release evidence.

## Validation

- ./scripts/release/test_ai_os_image_release_contract.sh: passed
- python3 scripts/ci/release_workflow_contract_test.py: 11 passed
- make verify-presentation: passed
- git diff --check: passed
- Independent parent review of all five changed-file diffs: GO

Refreshed onto current main c4110054; its SDK-only update does not alter the tested release paths. No live environment, variable, secret, workflow dispatch or published artifact was changed. Creating the correctly protected image environment remains an external release step.