### PR TITLE
chore: ignore local tool output (.codegraph, __pycache__)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ version-status.json
 
 # Unlazy session ledger (not product source)
 /GATES.md
+
+# ─── Local tool output ───────────────────────────────────────────────────────
+.codegraph/


### PR DESCRIPTION
Adds `.codegraph/` to `.gitignore`. The codegraph MCP server writes its SQLite index into `.codegraph/` at the repo root, which showed up as untracked in `git status` today. The index is machine-local and regenerated by the file watcher; gitops-apps CI already fails if `.codegraph/` is ever committed, so ignoring it here matches estate policy.

Estate zero-state sweep 2026-09-07.