### PR TITLE
ci: importer-less package census gate and decision list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,13 @@ quality-release:
 quality-nightly:
 	$(QUALITY) run nightly
 
+.PHONY: dead-packages
+# dead-packages lists core/pkg packages with no non-test importer across every
+# Go module in the checkout. Registered as an advisory nightly gate; see
+# docs/architecture/dead-package-decisions.md for the open rows.
+dead-packages:
+	bash scripts/ci/dead-packages.sh
+
 quality-list:
 	$(QUALITY) list
 

--- a/docs/architecture/dead-package-decisions.md
+++ b/docs/architecture/dead-package-decisions.md
@@ -1,0 +1,201 @@
+# Dead package decisions (core/pkg)
+
+Status: proposed, 2026-09-07. No package is deleted by this document; every
+row is a proposal for the package owner. A row closes when the owner either
+adds the package to `scripts/ci/dead-packages-allowlist.txt` (KEEP), lands a
+PR that gives it a real importer (WIRE), or lands a deletion PR (DELETE).
+When zero rows remain open, flip `dead-packages` in
+`scripts/ci/quality-gates.json` from advisory to blocking.
+
+## How the list was produced
+
+`scripts/ci/dead-packages.sh` runs `GOWORK=off go list -e -json ./...` in
+every Go module of the checkout (`core`, `tools/*`, `tests/*`, `sdk/go`,
+`examples/*`, `core/pkg/compliance/zkprovider/gdpr17`) and reports every
+`core/pkg/...` package that no other package imports from non-test code.
+Test-only importers (`_test.go` in another package) are counted separately
+and do not rescue a package. Reachability from every `core/cmd/*` main is
+reported for context.
+
+Census on `main` at `04d48de2` (2026-09-07):
+
+| measure | count |
+|---|---|
+| `core/pkg` packages with non-test Go files | 289 |
+| importer-less | 134 |
+| of which have test-only importers | 14 |
+| unreachable from any `core/cmd/*` main | 145 |
+| imported by a downstream repo in the workspace | 2 |
+| proposed KEEP / WIRE / DELETE | 28 / 0 / 106 |
+
+The 2026-09-07 audit reported 122 importer-less packages; it treated a
+test-only importer as an importer. This census does not, which adds 12.
+
+Evidence columns were gathered with `git grep -P 'pkg/<name>(?![A-Za-z0-9_/-])'`
+over `docs/`, `protocols/`, `reference_packs/`, `sdk/`, `CLAIMS.md`,
+`README.md`, `HELM_INVARIANTS.md`, `deploy/`, `launchpad/` (doc evidence) and
+over `core/`, `tools/`, `tests/`, `scripts/`, `examples/` (code evidence, the
+package's own directory excluded), plus a search of every sibling repo in the
+workspace for Go imports of the package. `reference_packs/`, `sdk/` and
+`CLAIMS.md` name none of the 134 packages.
+
+## Decision rules
+
+- KEEP: named in a shipped doc, protocol, or policy template; imported by a
+  downstream repo; imported by the `tests/conformance` suite; listed in
+  `tools/boundary/protected-dirs.sh`; or a protected `crypto/` or `verifier/`
+  library package exercised by a cross-package test.
+- WIRE: a Linear issue (HELM-658, HELM-674, HELM-682) names the package as
+  work to wire into a `cmd/` with a test. None of the three names
+  `harness`, `worktree`, `patchdelivery`, or `runtimeadapters/*` by package,
+  so no row is WIRE. `docs/architecture/agent-process-ownership.md` (which
+  labels three of them "not yet wired") is a design doc, not a ticket.
+- DELETE: everything else, including packages whose only reference is a
+  "not to be confused with" comment or their own test files.
+
+A DELETE row under a protected path (`kernel/`, `contracts/`, `crypto/`,
+`evidencepack/`, `proofgraph/`, `receipts`, `verifier/`, `connectors/sandbox`,
+`conformance/`, `api/`, `packs/`) needs the `helm-kernel-reviewer` pass and a
+boundary-manifest regeneration in its deletion PR.
+
+## Table
+
+LOC counts non-test Go lines. "last commit" is the last commit touching the
+package directory.
+
+| package | LOC | last commit | tests? | test-only importers | proposed | evidence |
+|---|---|---|---|---|---|---|
+| `core/pkg/a2a/payments` | 837 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/actiongraph` | 318 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/aibom` | 313 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/api/trust` | 287 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/attention` | 463 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/authority` | 56 | 2026-05-12 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/buildguard` | 125 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/celcheck` | 147 | 2026-05-28 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/certification/admission` | 777 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/channels/lark` | 273 | 2026-06-02 | yes | 1 | KEEP | conformance suite: tests/conformance/channels |
+| `core/pkg/compliance` | 633 | 2026-08-24 | yes | 0 | KEEP | doc: docs/documentation-coverage.csv — row in docs/documentation-coverage.csv; parent of the compliance/* cluster |
+| `core/pkg/compliance/cftc` | 448 | 2026-06-20 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/controls` | 173 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/csr` | 1551 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/docs` | 419 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/dora` | 579 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/enforcement` | 386 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/euaiact` | 593 | 2026-08-10 | yes | 0 | KEEP | doc: docs/compliance/eu-ai-act-high-risk-pack.md |
+| `core/pkg/compliance/evidence` | 256 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/fca` | 138 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/gdpr` | 164 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/hipaa` | 247 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/mica` | 326 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/normalize` | 327 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/obligations` | 191 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/risk` | 570 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/sec` | 218 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/sox` | 149 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/templates` | 88 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/compliance/zkprovider/gdpr17` | 628 | 2026-08-24 | yes | 0 | KEEP | doc: docs/documentation-coverage.csv — own Go module; row in docs/documentation-coverage.csv |
+| `core/pkg/conformance/agentsafety` | 142 | 2026-06-04 | yes | 1 | KEEP | doc: docs/security/agent-safety-conformance-cases.md; test importer: core/pkg/conformance/scenarios |
+| `core/pkg/conformance/cases` | 402 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/conformance/negative` | 303 | 2026-07-28 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/conformance/sandbox` | 987 | 2026-06-02 | yes | 4 | KEEP | doc: docs/INTEGRATIONS/claude-managed-agents-self-hosted.md; doc: docs/security/owasp-agentic-top10-coverage.md; doc: protocols/conformance/managed-agents/claude-self-hosted/v1/conformance-pack.json; ref: core/pkg/conformance/agentsafety/registry.go; test importer: core/pkg/connectors/sandbox/claudemanaged; test importer: core/pkg/connectors/sandbox/daytona; test importer: core/pkg/connectors/sandbox/e2b; test importer: core/pkg/connectors/sandbox/opensandbox |
+| `core/pkg/conformance/scenarios` | 16 | 2026-06-04 | yes | 0 | KEEP | doc: docs/security/agent-safety-conformance-cases.md; doc: docs/security/owasp-agentic-top10-coverage.md; ref: core/pkg/conformance/agentsafety/registry.go |
+| `core/pkg/connectors/arc` | 1074 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/linear` | 1423 | 2026-08-13 | yes | 1 | DELETE | test importer: core/pkg/runtimeadapters/mcp — only importer is core/pkg/runtimeadapters/mcp/bridge_test.go (fixture); rewrite the fixture if deleted |
+| `core/pkg/connectors/oauth2` | 235 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/sandbox` | 219 | 2026-07-01 | yes | 0 | KEEP | ref: tools/boundary/protected-dirs.sh |
+| `core/pkg/connectors/sandbox/claudemanaged` | 1545 | 2026-07-01 | yes | 0 | KEEP | doc: docs/INTEGRATIONS/claude-managed-agents-self-hosted.md; doc: protocols/conformance/managed-agents/claude-self-hosted/v1/conformance-pack.json; doc: protocols/conformance/v1/compatibility-registry.json; ref: core/pkg/connectors/sandbox/README.md |
+| `core/pkg/connectors/sandbox/opensandbox` | 511 | 2026-07-01 | yes | 0 | KEEP | ref: core/pkg/connectors/sandbox/README.md — listed in core/pkg/connectors/sandbox/README.md; protected dir |
+| `core/pkg/connectors/siem/datadog_logs` | 212 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/siem/elastic_ecs` | 213 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/siem/loki` | 240 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/siem/splunk_hec` | 189 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/siem/sumo` | 167 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/slack` | 860 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/connectors/ton/acton` | 2259 | 2026-06-11 | yes | 0 | KEEP | ref: core/pkg/policy/templates/ton_acton.mapl — core/pkg/policy/templates/ton_acton.mapl ships a policy template for it |
+| `core/pkg/constitution` | 616 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/contracts/schemas` | 61 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/crypto/keystore` | 477 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/crypto/mtls` | 627 | 2026-06-11 | yes | 1 | KEEP | test importer: core/pkg/crypto |
+| `core/pkg/crypto/sdjwt` | 301 | 2026-04-23 | yes | 2 | KEEP | ref: core/pkg/evidencepack/inclusionproof.go; ref: core/pkg/evidencepack/merkle.go; test importer: core/pkg/crypto; test importer: core/pkg/evidencepack |
+| `core/pkg/crypto/shredding` | 193 | 2026-04-23 | yes | 1 | KEEP | test importer: core/pkg/crypto |
+| `core/pkg/crypto/tls` | 98 | 2026-04-23 | yes | 1 | KEEP | test importer: core/pkg/crypto |
+| `core/pkg/crypto/zk` | 257 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/database` | 142 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/delegation` | 308 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/delivery` | 286 | 2026-05-13 | yes | 0 | DELETE | doc: docs/architecture/agent-process-ownership.md; ref: core/pkg/patchdelivery/verifier.go — named only in 'not to be confused with' notes (agent-process-ownership.md, patchdelivery/verifier.go) |
+| `core/pkg/disclosure` | 42 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/edge` | 306 | 2026-05-01 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/edgegovernance` | 74 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/envelope` | 1527 | 2026-08-02 | yes | 0 | DELETE | doc: docs/architecture/agent-process-ownership.md; ref: core/pkg/worktree/worktree.go — named only in 'not to be confused with' notes (agent-process-ownership.md, worktree/worktree.go); 1527 LOC, last commit 2026-08-02 |
+| `core/pkg/escalation` | 242 | 2026-08-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/escalation/ceremony` | 237 | 2026-05-13 | yes | 0 | DELETE | ref: core/pkg/genesis/ceremony/ceremony.go — named only in a 'not to be confused with' comment in core/pkg/genesis/ceremony |
+| `core/pkg/evaluation` | 62 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/evidence/arc` | 64 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/evidence/externalhost/adapters` | 584 | 2026-06-20 | yes | 1 | KEEP | test importer: core/pkg/verifier/externalreceipt |
+| `core/pkg/evidencepack/retention` | 110 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/exportadmin` | 268 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/federation` | 533 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/forensics` | 65 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/forge` | 681 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/gateway` | 74 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/genesis/ceremony` | 318 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/harness` | 2518 | 2026-09-01 | yes | 0 | DELETE | doc: docs/architecture/agent-process-ownership.md — named only by docs/architecture/agent-process-ownership.md ("not yet wired"); HELM-658/674/682 do not name the package; last commit 2026-09-01 (#921, Prime Agent harness adapter; introduced by HELM-319 in #772) - owner to confirm before deletion |
+| `core/pkg/identity/iatp` | 537 | 2026-05-21 | yes | 1 | KEEP | conformance suite: tests/conformance/did |
+| `core/pkg/integrations/receipts` | 161 | 2026-08-02 | yes | 0 | KEEP | ref: tools/boundary/protected-dirs.sh |
+| `core/pkg/intervention` | 136 | 2026-04-25 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/kernel/celdp` | 231 | 2026-06-20 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/kernel/consistency` | 513 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/kernel/errorir` | 74 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/kernel/formal` | 59 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/kernel/pdp` | 87 | 2026-05-12 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/kernel/retry` | 156 | 2026-04-25 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/kernel/sovereignty` | 132 | 2026-06-03 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/launchpad/conformance` | 229 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/launchpad/install` | 120 | 2026-05-18 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/launchpad/redact` | 104 | 2026-05-31 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/ledger` | 446 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/networkproof` | 2198 | 2026-08-02 | yes | 0 | KEEP | svc-helm-control-plane imports it |
+| `core/pkg/orgdna` | 239 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/packs/antispoof` | 256 | 2026-05-13 | yes | 1 | KEEP | ref: core/pkg/packs/install/install.go; conformance suite: tests/conformance/antispoof |
+| `core/pkg/packs/install` | 744 | 2026-07-27 | yes | 0 | KEEP | svc-helm-control-plane imports it; ref: core/pkg/contracts/pack_manifest_v2.go |
+| `core/pkg/patchdelivery` | 988 | 2026-08-04 | yes | 0 | DELETE | doc: docs/architecture/agent-process-ownership.md — same doc; not named by HELM-658/674/682 |
+| `core/pkg/policy/lint` | 392 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/policy/suggest` | 202 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/policy/verify` | 224 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/policy/wasm` | 325 | 2026-04-23 | yes | 0 | KEEP | doc: HELM_INVARIANTS.md; doc: docs/PCAS_AUTHORIZATION_PROPAGATION_GAP_ANALYSIS.md; doc: protocols/policy-schema/v1/canonicalization.md |
+| `core/pkg/policyloader` | 153 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/proofgraph/aigp` | 624 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/proofgraph/attribution` | 218 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/proofgraph/cloudevents` | 208 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/proofgraph/consensus` | 554 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/proofgraph/crdt` | 595 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/proofgraph/graphql` | 136 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/rbac` | 309 | 2026-05-17 | yes | 0 | KEEP | doc: docs/security/agent-safety-conformance-cases.md |
+| `core/pkg/receipts` | 3 | 2026-05-21 | yes | 0 | KEEP | doc: docs/EXECUTION_SECURITY_MODEL.md; doc: docs/reference/execution-boundary.md; ref: tools/boundary/protected-dirs.sh — doc.go + policies fixtures + conformance test; named in docs/EXECUTION_SECURITY_MODEL.md, docs/reference/execution-boundary.md and tools/boundary/protected-dirs.sh |
+| `core/pkg/releasegovernance` | 69 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/replay` | 1225 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/rir` | 197 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/router` | 685 | 2026-06-20 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/runtime` | 172 | 2026-08-03 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/runtime/budget` | 86 | 2026-04-23 | yes | 1 | DELETE | test importer: core/pkg/runtime/sandbox — only importer is core/pkg/runtime/sandbox/wasi_adversarial_test.go; fold the budget type into runtime/sandbox or delete both |
+| `core/pkg/runtimeadapters/a2a` | 134 | 2026-05-13 | yes | 1 | KEEP | conformance suite: tests/conformance/a2a |
+| `core/pkg/runtimeadapters/generic_http` | 98 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — no doc, no importer; HELM-682 speaks of adapter/model selection at Control Plane level, not this package |
+| `core/pkg/runtimeadapters/grpc` | 133 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — as generic_http |
+| `core/pkg/runtimeadapters/websocket` | 136 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — as generic_http |
+| `core/pkg/saga` | 256 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/scheduler` | 1136 | 2026-04-23 | yes | 1 | KEEP | conformance suite: tests/conformance/scheduling |
+| `core/pkg/security/suites` | 153 | 2026-06-11 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/signals` | 592 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/skills` | 995 | 2026-06-11 | yes | 0 | KEEP | doc: docs/skills/SKILL_PACK_REPO_AUDIT.md |
+| `core/pkg/slo` | 367 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/store/objstore/fs` | 136 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/surface` | 61 | 2026-04-23 | no | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/tenants` | 215 | 2026-05-13 | yes | 0 | KEEP | doc: docs/security/agent-safety-conformance-cases.md |
+| `core/pkg/truth` | 557 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/util/resiliency` | 148 | 2026-06-02 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/verifier/agentprovenance` | 549 | 2026-07-27 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer — protected path: deletion PR needs helm-kernel-reviewer + boundary manifest regen |
+| `core/pkg/versioning` | 329 | 2026-04-23 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/witness` | 402 | 2026-04-24 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |
+| `core/pkg/worktree` | 253 | 2026-08-04 | yes | 0 | DELETE | doc: docs/architecture/agent-process-ownership.md; ref: core/pkg/harness/harness.go; ref: core/pkg/patchdelivery/verifier.go — same doc; not named by HELM-658/674/682; imported only by core/pkg/harness (itself importer-less) |
+| `core/pkg/zkgov/proofmarket` | 482 | 2026-05-13 | yes | 0 | DELETE | no doc, no protocol, no reference pack, no SDK, no importer |

--- a/docs/architecture/dead-package-decisions.md
+++ b/docs/architecture/dead-package-decisions.md
@@ -1,5 +1,8 @@
 # Dead package decisions (core/pkg)
 
+quantum_posture: inventory only; this document names crypto packages but
+exercises, changes, or asserts no cryptographic behaviour.
+
 Status: proposed, 2026-09-07. No package is deleted by this document; every
 row is a proposal for the package owner. A row closes when the owner either
 adds the package to `scripts/ci/dead-packages-allowlist.txt` (KEEP), lands a

--- a/scripts/ci/check_dead_packages.py
+++ b/scripts/ci/check_dead_packages.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Importer-less package census for core/pkg.
+
+Lists every ``core/pkg/...`` package that no other package in the repository
+imports from non-test code. The census spans every Go module in the checkout
+(``core``, ``tools/*``, ``tests/*``, ``sdk/go``, ``examples/*``), so a package
+that only the conformance suite or an SDK example imports still counts as
+imported. Test-only importers (``_test.go`` files in other packages) are
+reported separately and do not rescue a package.
+
+The gate exits non-zero when any importer-less package is not covered by the
+allowlist. The allowlist names packages that are deliberately public library
+surface; every line carries a one-line reason.
+
+Usage:
+
+    python3 scripts/ci/check_dead_packages.py [--allowlist FILE] [--format text|json|markdown]
+
+Run from the repository root. Every ``go`` invocation runs with ``GOWORK=off``
+so the census matches CI, not the workspace ``go.work``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+MODULE_PREFIX = "github.com/Mindburn-Labs/helm-ai-kernel/core/"
+TARGET_PREFIX = MODULE_PREFIX + "pkg/"
+CMD_PREFIX = MODULE_PREFIX + "cmd/"
+SKIP_DIRS = {"node_modules", "vendor", ".git", "target", "dist"}
+DEFAULT_ALLOWLIST = Path("scripts/ci/dead-packages-allowlist.txt")
+
+GO_LIST_FIELDS = (
+    "ImportPath,Name,Dir,GoFiles,TestGoFiles,XTestGoFiles,"
+    "Imports,TestImports,XTestImports,Error"
+)
+
+
+@dataclass
+class Package:
+    import_path: str
+    name: str
+    directory: str
+    go_files: list[str]
+    test_go_files: list[str]
+    imports: set[str]
+    test_imports: set[str]
+    module_dir: str
+    error: str | None = None
+
+
+@dataclass
+class Finding:
+    import_path: str
+    rel_path: str
+    test_only_importers: list[str] = field(default_factory=list)
+    reachable_from_cmd: bool = False
+    has_tests: bool = False
+    allowlisted: bool = False
+    allow_reason: str = ""
+
+
+def discover_modules(root: Path) -> list[Path]:
+    modules: list[Path] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+        if "go.mod" in filenames:
+            modules.append(Path(dirpath))
+    return sorted(modules)
+
+
+def go_list(module_dir: Path) -> list[Package]:
+    env = dict(os.environ)
+    env["GOWORK"] = "off"
+    env.setdefault("GOFLAGS", "-mod=mod")
+    proc = subprocess.run(
+        ["go", "list", "-e", f"-json={GO_LIST_FIELDS}", "./..."],
+        cwd=module_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0 and not proc.stdout.strip():
+        raise RuntimeError(f"go list failed in {module_dir}: {proc.stderr.strip()}")
+    packages: list[Package] = []
+    decoder = json.JSONDecoder()
+    text = proc.stdout
+    pos = 0
+    while pos < len(text):
+        while pos < len(text) and text[pos].isspace():
+            pos += 1
+        if pos >= len(text):
+            break
+        obj, pos = decoder.raw_decode(text, pos)
+        err = obj.get("Error")
+        packages.append(
+            Package(
+                import_path=obj["ImportPath"],
+                name=obj.get("Name", ""),
+                directory=obj.get("Dir", ""),
+                go_files=obj.get("GoFiles") or [],
+                test_go_files=(obj.get("TestGoFiles") or []) + (obj.get("XTestGoFiles") or []),
+                imports=set(obj.get("Imports") or []),
+                test_imports=set(obj.get("TestImports") or []) | set(obj.get("XTestImports") or []),
+                module_dir=str(module_dir),
+                error=err.get("Err") if isinstance(err, dict) else None,
+            )
+        )
+    return packages
+
+
+def load_allowlist(path: Path | None) -> dict[str, str]:
+    allow: dict[str, str] = {}
+    if path is None or not path.exists():
+        return allow
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "#" not in line:
+            raise ValueError(f"{path}:{lineno}: allowlist line needs '<package> # <reason>'")
+        pkg, reason = line.split("#", 1)
+        pkg = pkg.strip()
+        reason = reason.strip()
+        if not pkg or not reason:
+            raise ValueError(f"{path}:{lineno}: allowlist line needs '<package> # <reason>'")
+        if not pkg.startswith("core/pkg/"):
+            raise ValueError(f"{path}:{lineno}: allowlist entries are core/pkg/... paths, got {pkg!r}")
+        allow[pkg] = reason
+    return allow
+
+
+def census(root: Path, allowlist: dict[str, str]) -> tuple[list[Finding], dict[str, int]]:
+    by_path: dict[str, Package] = {}
+    for module_dir in discover_modules(root):
+        for pkg in go_list(module_dir):
+            by_path.setdefault(pkg.import_path, pkg)
+
+    importers: dict[str, set[str]] = {}
+    test_importers: dict[str, set[str]] = {}
+    for pkg in by_path.values():
+        for dep in pkg.imports:
+            if dep != pkg.import_path:
+                importers.setdefault(dep, set()).add(pkg.import_path)
+        for dep in pkg.test_imports:
+            if dep != pkg.import_path:
+                test_importers.setdefault(dep, set()).add(pkg.import_path)
+
+    reachable: set[str] = set()
+    stack = [p for p, pkg in by_path.items() if pkg.name == "main" and p.startswith(CMD_PREFIX)]
+    while stack:
+        current = stack.pop()
+        if current in reachable:
+            continue
+        reachable.add(current)
+        pkg = by_path.get(current)
+        if pkg is None:
+            continue
+        stack.extend(dep for dep in pkg.imports if dep in by_path and dep not in reachable)
+
+    targets = sorted(p for p in by_path if p.startswith(TARGET_PREFIX))
+    findings: list[Finding] = []
+    for path in targets:
+        pkg = by_path[path]
+        if not pkg.go_files:
+            continue  # test-only directory, nothing to import
+        if importers.get(path):
+            continue
+        rel = "core/" + path[len(MODULE_PREFIX):]
+        finding = Finding(
+            import_path=path,
+            rel_path=rel,
+            test_only_importers=sorted(
+                "core/" + i[len(MODULE_PREFIX):] if i.startswith(MODULE_PREFIX) else i
+                for i in test_importers.get(path, set())
+            ),
+            reachable_from_cmd=path in reachable,
+            has_tests=bool(pkg.test_go_files),
+        )
+        if rel in allowlist:
+            finding.allowlisted = True
+            finding.allow_reason = allowlist[rel]
+        findings.append(finding)
+
+    summary = {
+        "total_core_pkg_packages": sum(1 for p in targets if by_path[p].go_files),
+        "importer_less": len(findings),
+        "with_test_only_importers": sum(1 for f in findings if f.test_only_importers),
+        "unreachable_from_cmd": sum(1 for p in targets if by_path[p].go_files and p not in reachable),
+        "allowlisted": sum(1 for f in findings if f.allowlisted),
+        "unlisted": sum(1 for f in findings if not f.allowlisted),
+    }
+    stale = sorted(set(allowlist) - {f.rel_path for f in findings})
+    summary["stale_allowlist_entries"] = len(stale)
+    return findings, summary
+
+
+def render_text(findings: list[Finding], summary: dict[str, int], allowlist: dict[str, str]) -> str:
+    lines = []
+    for f in findings:
+        flags = []
+        if f.test_only_importers:
+            flags.append(f"test-only-importers={len(f.test_only_importers)}")
+        if f.has_tests:
+            flags.append("has-tests")
+        if f.allowlisted:
+            flags.append(f"allowlisted: {f.allow_reason}")
+        lines.append(f"{f.rel_path}\t{' '.join(flags)}".rstrip())
+    stale = sorted(set(allowlist) - {f.rel_path for f in findings})
+    for entry in stale:
+        lines.append(f"STALE allowlist entry (package now has importers or is gone): {entry}")
+    lines.append("")
+    lines.append(
+        "dead-packages: {total_core_pkg_packages} core/pkg packages, "
+        "{importer_less} importer-less ({with_test_only_importers} with test-only importers), "
+        "{unreachable_from_cmd} unreachable from any cmd/, "
+        "{allowlisted} allowlisted, {unlisted} unlisted".format(**summary)
+    )
+    return "\n".join(lines)
+
+
+def render_markdown(findings: list[Finding]) -> str:
+    lines = ["| package | test-only importers | tests? | reachable from cmd | allowlisted |", "|---|---|---|---|---|"]
+    for f in findings:
+        lines.append(
+            f"| `{f.rel_path}` | {len(f.test_only_importers)} | {'yes' if f.has_tests else 'no'} | "
+            f"{'yes' if f.reachable_from_cmd else 'no'} | {f.allow_reason or 'no'} |"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--root", default=".", help="repository root (default: cwd)")
+    parser.add_argument("--allowlist", default=str(DEFAULT_ALLOWLIST), help="allowlist file; '-' disables it")
+    parser.add_argument("--format", choices=("text", "json", "markdown"), default="text")
+    args = parser.parse_args(argv)
+
+    root = Path(args.root).resolve()
+    allow_path = None if args.allowlist == "-" else (root / args.allowlist)
+    try:
+        allowlist = load_allowlist(allow_path)
+        findings, summary = census(root, allowlist)
+    except (RuntimeError, ValueError) as exc:
+        print(f"dead-packages: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps({"summary": summary, "packages": [f.__dict__ for f in findings]}, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(render_markdown(findings))
+    else:
+        print(render_text(findings, summary, allowlist))
+
+    if summary["unlisted"] or summary["stale_allowlist_entries"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/dead-packages-allowlist.txt
+++ b/scripts/ci/dead-packages-allowlist.txt
@@ -1,0 +1,6 @@
+# Importer-less core/pkg packages that are deliberately public library surface.
+# One entry per line: <core/pkg/...> # <one-line reason>
+# Read by scripts/ci/dead-packages.sh. An entry whose package gains an importer
+# (or disappears) is reported as STALE and fails the gate, so prune on delete.
+# Ratified KEEP rows from docs/architecture/dead-package-decisions.md land here;
+# the gate flips from advisory to strict when that table has zero open rows.

--- a/scripts/ci/dead-packages.sh
+++ b/scripts/ci/dead-packages.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Importer-less package census for core/pkg. See check_dead_packages.py.
+#
+#   scripts/ci/dead-packages.sh                     # text summary, default allowlist
+#   scripts/ci/dead-packages.sh --allowlist FILE    # alternative allowlist ('-' disables)
+#   scripts/ci/dead-packages.sh --format json       # machine-readable
+#
+# Exits 1 when an importer-less package is not allowlisted (or an allowlist
+# entry is stale), 2 on tooling errors, 0 otherwise.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+export GOWORK=off
+exec python3 scripts/ci/check_dead_packages.py "$@"

--- a/scripts/ci/quality-gates.json
+++ b/scripts/ci/quality-gates.json
@@ -127,7 +127,8 @@
         "flake-core",
         "benchmark-report",
         "invariant-constitution",
-        "concept-change-marker"
+        "concept-change-marker",
+        "dead-packages"
       ]
     },
     "typecheck": {
@@ -815,6 +816,24 @@
       "paths": [
         "HELM_INVARIANTS.md",
         "tools/invcheck/**"
+      ]
+    },
+    {
+      "id": "dead-packages",
+      "title": "Importer-less package census",
+      "description": "Lists core/pkg packages no other package imports. Advisory until docs/architecture/dead-package-decisions.md has zero open rows, then drop this flag.",
+      "command": "make dead-packages",
+      "timeout_seconds": 300,
+      "advisory": true,
+      "paths": [
+        "core/**",
+        "tools/**",
+        "tests/**",
+        "sdk/go/**",
+        "examples/**",
+        "scripts/ci/check_dead_packages.py",
+        "scripts/ci/dead-packages.sh",
+        "scripts/ci/dead-packages-allowlist.txt"
       ]
     }
   ]


### PR DESCRIPTION
## What

`scripts/ci/dead-packages.sh` (wrapper over `scripts/ci/check_dead_packages.py`) runs `GOWORK=off go list -e -json ./...` in every Go module of the checkout (`core`, `tools/*`, `tests/*`, `sdk/go`, `examples/*`, the `gdpr17` module) and lists every `core/pkg/...` package that no other package imports from non-test code. Test-only importers are counted separately and do not rescue a package. Reachability from every `core/cmd/*` main is reported for context. `--allowlist FILE` (default `scripts/ci/dead-packages-allowlist.txt`, one `package # reason` per line) suppresses deliberate library surface; a stale entry fails the gate. Output is sorted by path; `--format json|markdown` available.

Registered in `scripts/ci/quality-gates.json` as `dead-packages` in the nightly profile, advisory, via `make dead-packages`. The gate description says when to drop the advisory flag: when `docs/architecture/dead-package-decisions.md` has zero open rows.

## Census on this head

```
dead-packages: 289 core/pkg packages, 134 importer-less (14 with test-only importers), 145 unreachable from any cmd/, 0 allowlisted, 134 unlisted
```

The 2026-09-07 audit counted 122; it treated a test-only importer as an importer, this census does not (+12).

## Decision list

`docs/architecture/dead-package-decisions.md`: all 134 packages with LOC, last commit date, test files, test-only importers, evidence (docs, protocols, policy templates, `tests/conformance`, `tools/boundary/protected-dirs.sh`, downstream repo imports), and a proposed decision. Proposed split: 28 KEEP / 0 WIRE / 106 DELETE. Two packages (`networkproof`, `packs/install`) are imported by `svc-helm-control-plane`. None of HELM-658/674/682 names `harness`, `worktree`, `patchdelivery`, or `runtimeadapters/*`, so those lean DELETE per the audit rule; `harness` carries an owner-confirm note because of #921 (2026-09-01).

**No package is deleted in this PR.** Deletions are separate PRs after the owner reads the list; DELETE rows under protected paths need `helm-kernel-reviewer` and a boundary-manifest regen.

## Gates run locally

- `GOWORK=off go build ./... && GOWORK=off go vet ./...` (core): pass
- `make lint` (docs-coverage, docs-truth, vet, gofmt, mod tidy): pass
- `python3 scripts/ci/quality.py self-test`: 53 gates, 11 profiles
- `make dead-packages`: exit 1 with the summary above (expected; advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
