### PR TITLE
ci(release): bind the pushed annotated tag object, not the tag SHA, to the workflow commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,16 +129,21 @@ jobs:
             echo "::error::Workflow commit is not a full commit SHA: ${WORKFLOW_COMMIT}"
             exit 1
           fi
-          if [ "${PUSH_COMMIT}" != "${WORKFLOW_COMMIT}" ]; then
-            echo "::error::Push commit ${PUSH_COMMIT} does not match workflow commit ${WORKFLOW_COMMIT}."
-            exit 1
-          fi
-
+          # For an annotated tag push, github.event.after is the SHA of the tag
+          # OBJECT, not of the commit it points to, while github.sha is the
+          # commit. Bind the pushed object to the live ref, then the ref's
+          # commit to the workflow commit. The old "after == sha" test could
+          # only pass for a lightweight tag, which the next check forbids
+          # (v0.8.5 run 34246001234 failed here on 2026-09-08).
           ref_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${GITHUB_REF_NAME}")"
           ref_type="$(jq -er '.object.type' <<<"${ref_json}")"
           live_tag_object="$(jq -er '.object.sha' <<<"${ref_json}")"
           if [ "${ref_type}" != "tag" ]; then
             echo "::error::Release ref ${GITHUB_REF_NAME} is ${ref_type}, not an annotated tag object."
+            exit 1
+          fi
+          if [ "${PUSH_COMMIT}" != "${live_tag_object}" ]; then
+            echo "::error::Pushed tag object ${PUSH_COMMIT} does not match the live ref object ${live_tag_object}; the tag moved after the push."
             exit 1
           fi
           tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${live_tag_object}")"
@@ -148,8 +153,8 @@ jobs:
             echo "::error::Annotated release tag points to ${target_type}, not a commit."
             exit 1
           fi
-          if [ "${target_commit}" != "${PUSH_COMMIT}" ]; then
-            echo "::error::Annotated release tag resolves to ${target_commit}, not pushed commit ${PUSH_COMMIT}."
+          if [ "${target_commit}" != "${WORKFLOW_COMMIT}" ]; then
+            echo "::error::Annotated release tag resolves to ${target_commit}, not workflow commit ${WORKFLOW_COMMIT}."
             exit 1
           fi
 

--- a/scripts/ci/release_workflow_contract_test.py
+++ b/scripts/ci/release_workflow_contract_test.py
@@ -184,12 +184,18 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
             'if [ "${RELEASE_AUTHORITY_ARMED:-}" != "release-production" ]; then',
             authority,
         )
-        # A push payload's `after` value is the commit at the tag ref, not the
-        # annotated tag object's SHA. The live tag object comes from the API.
+        # A push payload's `after` value is the annotated tag OBJECT's SHA
+        # (observed on v0.8.5 run 34246001234, 2026-09-08), while github.sha is
+        # the commit. The job binds the pushed object to the live ref, and the
+        # ref's target commit to the workflow commit.
         self.assertIn("PUSH_COMMIT: ${{ github.event.after }}", authority)
         self.assertIn("WORKFLOW_COMMIT: ${{ github.sha }}", authority)
-        self.assertIn(
+        self.assertNotIn(
             'if [ "${PUSH_COMMIT}" != "${WORKFLOW_COMMIT}" ]; then',
+            authority,
+        )
+        self.assertIn(
+            'if [ "${PUSH_COMMIT}" != "${live_tag_object}" ]; then',
             authority,
         )
         self.assertIn(
@@ -203,7 +209,7 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         )
         self.assertIn('if [ "${target_type}" != "commit" ]; then', authority)
         self.assertIn(
-            'if [ "${target_commit}" != "${PUSH_COMMIT}" ]; then',
+            'if [ "${target_commit}" != "${WORKFLOW_COMMIT}" ]; then',
             authority,
         )
 


### PR DESCRIPTION
github.event.after is the tag object for an annotated tag push, so the
release-authority job compared a tag object with a commit and could never
pass while also requiring an annotated tag (added in #850, after v0.8.4's
out-of-band release). v0.8.5 run 34246001234 failed there on 2026-09-08.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
