### PR TITLE
release: pin the v0.8.5 Console local sidecar to app-helm-console af284b6c

### DIFF
--- a/release/console-local-sidecar-pins.json
+++ b/release/console-local-sidecar-pins.json
@@ -39,10 +39,10 @@
       "source_repository": "Mindburn-Labs/app-helm-console",
       "workflow_ref": "refs/tags/helm-console-sidecar-v0.8.5",
       "source": {
-        "commit": "9c0e4d6685aec89240e7707c442578bd4cbd8f89",
-        "tree": "9976e98fdbab184f7a66fd3951a3150a4760e560",
-        "version": "0.2.1",
-        "package_lock_sha256": "0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1"
+        "commit": "af284b6c6063e1f26499a190578d7ff1ec42568d",
+        "tree": "ada0e869aa09d5a170afb26dac6f30bb45e92def",
+        "version": "0.2.2",
+        "package_lock_sha256": "92eeff17dc20ce6220d244e66801c811bdb33a620ed624ebbb6ae690bb733676"
       }
     }
   ]

--- a/scripts/release/console_local_sidecar_test.py
+++ b/scripts/release/console_local_sidecar_test.py
@@ -40,10 +40,10 @@ V084_RELEASE_SOURCE_PIN = {
     "package_lock_sha256": "0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1",
 }
 V085_RELEASE_SOURCE_PIN = {
-    "commit": "9c0e4d6685aec89240e7707c442578bd4cbd8f89",
-    "tree": "9976e98fdbab184f7a66fd3951a3150a4760e560",
-    "version": "0.2.1",
-    "package_lock_sha256": "0e0d41a1b3f04b088e4930b6d534ef9cf2e1d0fdd664f767da30f9fe762566e1",
+    "commit": "af284b6c6063e1f26499a190578d7ff1ec42568d",
+    "tree": "ada0e869aa09d5a170afb26dac6f30bb45e92def",
+    "version": "0.2.2",
+    "package_lock_sha256": "92eeff17dc20ce6220d244e66801c811bdb33a620ed624ebbb6ae690bb733676",
 }
 RELEASE_WORKFLOW_REF = "refs/tags/helm-console-sidecar-v0.8.1"
 TEST_WORKFLOW_REF = "refs/tags/test-console-source"


### PR DESCRIPTION
The previous pin 9c0e4d66 carried .env.example at the source root, which
scripts/package-local-sidecar.mjs refuses; Kernel v0.8.5 run 34260348534
failed its console-local-sidecar job on all four targets. app-helm-console
#187 renamed the file; the pin now follows Console main (version 0.2.2).
Gate: console_local_sidecar.py pin resolves the entry.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
