### PR TITLE
docs: state the actual MCP 2026-07-28, A2A card and OTel GenAI boundaries [HELM-709]

### DIFF
--- a/core/pkg/a2a/agent_card.go
+++ b/core/pkg/a2a/agent_card.go
@@ -3,8 +3,18 @@
 //
 // An AgentCard is the public identity document of an A2A agent. It contains
 // the agent's capabilities, supported protocol versions, authentication
-// requirements, and endpoint information. Cards are served at a well-known
-// URL (/.well-known/agent.json) and must be verifiable via signature.
+// requirements, and endpoint information. Cards are served at
+// /.well-known/agent-card.json (see wellknown.go) and must be verifiable via
+// signature.
+//
+// This is the HELM trust-protocol card. It borrows field names from the Linux
+// Foundation / Agentic AI Foundation A2A specification (skills, capabilities,
+// defaultInputModes, pushNotifications) but is not wire-compatible with the
+// a2a-protocol.org AgentCard: HELM keys the card by agent_id, carries
+// supported_versions/auth_methods/features and a content hash + signature,
+// and does not emit the A2A url/version/protocolVersion/securitySchemes
+// fields. Interoperating with an A2A v1.0 peer requires a separate,
+// conformance-tested translation; do not present this card as one.
 //
 // Invariants:
 //   - Agent ID must be non-empty.
@@ -27,8 +37,9 @@ import (
 
 // ── Agent Card ───────────────────────────────────────────────────
 
-// AgentCard is the public identity and capability document for an A2A agent.
-// Aligned with Linux Foundation A2A v1.0 GA schema.
+// AgentCard is the public identity and capability document for a HELM
+// agent-to-agent trust peer. See the package comment above for how it differs
+// from the a2a-protocol.org AgentCard.
 type AgentCard struct {
 	AgentID            string            `json:"agent_id"`
 	Name               string            `json:"name"`

--- a/core/pkg/observability/genai_attrs.go
+++ b/core/pkg/observability/genai_attrs.go
@@ -7,7 +7,16 @@
 // rely on these names.
 //
 // Reference: OpenTelemetry Semantic Conventions for Generative AI
-// https://github.com/open-telemetry/semantic-conventions/tree/main/docs/gen-ai
+// https://github.com/open-telemetry/semantic-conventions-genai/tree/main/docs/gen-ai
+// (moved out of the main semantic-conventions repository in its v1.42.0
+// release; status is still "Development", not Stable).
+//
+// Known drift from upstream as of 2026-09-12, kept deliberately until a major
+// version bump: upstream replaced gen_ai.system with gen_ai.provider.name and
+// its well-known value "azure.openai" with "azure.ai.openai"; upstream names
+// the tool operation "execute_tool" (span "execute_tool {gen_ai.tool.name}")
+// rather than "tool_call". The SIEM exporters and dashboards join on the keys
+// below, so the rename must ship as one coordinated change with them.
 package observability
 
 // ── OTel GenAI stable keys ───────────────────────────────────

--- a/docs/MCP_2026_07_28_AUTHORIZATION_MAPPING.md
+++ b/docs/MCP_2026_07_28_AUTHORIZATION_MAPPING.md
@@ -3,6 +3,11 @@ title: MCP 2026-07-28 RC Authorization Mapping
 last_reviewed: 2026-09-12
 ---
 
+<!-- quantum_posture: this page maps OAuth/JWT bearer validation performed by
+core/pkg/mcp/jwks.go (classical JWS via the configured JWKS) and references the
+ID-JAG exchange of the Enterprise-Managed Authorization extension, which happens
+outside HELM; it adds no cryptographic control of its own. -->
+
 # MCP 2026-07-28 Authorization Mapping
 
 ## Audience

--- a/docs/MCP_2026_07_28_AUTHORIZATION_MAPPING.md
+++ b/docs/MCP_2026_07_28_AUTHORIZATION_MAPPING.md
@@ -1,19 +1,23 @@
 ---
 title: MCP 2026-07-28 RC Authorization Mapping
-last_reviewed: 2026-06-10
+last_reviewed: 2026-09-12
 ---
 
-# MCP 2026-07-28 RC Authorization Mapping
+# MCP 2026-07-28 Authorization Mapping
 
 ## Audience
 
 Security reviewers and integrators mapping the HELM policy engine to the six
-authorization SEPs in the MCP 2026-07-28 release candidate (published
-2026-06-09).
+authorization SEPs of the MCP 2026-07-28 revision. The revision was published
+as a release candidate on 2026-06-09 and finalized on 2026-07-28; the SEP
+mapping below is unchanged between the two.
 
 ## Source Truth
 
-- Spec source: <https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/>
+- Spec source: <https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization>
+  (release candidate announcement:
+  <https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/>;
+  final release: <https://blog.modelcontextprotocol.io/posts/2026-07-28/>)
 - Conformance vectors: `core/pkg/mcp/testdata/mcp_2026_07_28_authz_vectors.json`
 - Vector driver: `core/pkg/mcp/mcp_2026_07_28_authz_vectors_test.go`
 - Enforcement points: `core/pkg/mcp/jwks.go`, `core/pkg/mcp/firewall.go`,
@@ -22,8 +26,8 @@ authorization SEPs in the MCP 2026-07-28 release candidate (published
 
 ## Mapping
 
-The RC hardens MCP authorization toward deployed OAuth 2.0 / OpenID Connect
-practice through six SEPs. HELM's position is the protected resource and
+The 2026-07-28 revision hardens MCP authorization toward deployed OAuth 2.0 /
+OpenID Connect practice through six SEPs. HELM's position is the protected resource and
 policy enforcement point (PEP): it validates inbound authorization, enforces
 scopes per tool call, and emits sealed structured decision records.
 
@@ -48,12 +52,34 @@ the AAT JSONL mode (`helm-ai-kernel export aat`). The vector driver asserts
 these fields on every tool-call vector. For trace correlation across
 gateways, OTel context propagates per SEP-414 (W3C Trace Context in `_meta`).
 
+## Final-revision items outside the six SEPs
+
+Verified against the final 2026-07-28 text on 2026-09-12. None of these
+change the enforcement points above; they bound what this page claims.
+
+- Dynamic Client Registration (RFC 7591) is deprecated in favour of Client ID
+  Metadata Documents (`draft-ietf-oauth-client-id-metadata-document`), which
+  clients SHOULD support. HELM is the protected resource and does not register
+  clients; the SEP-837 row above stays a client obligation. HELM does not host
+  an authorization server and therefore does not resolve CIMD URLs.
+- `Enterprise-Managed Authorization` (`io.modelcontextprotocol/enterprise-managed-authorization`,
+  stable extension) lets a client exchange an Identity Assertion JWT
+  Authorization Grant from an enterprise IdP at the MCP authorization server.
+  The token that reaches HELM is still validated by `JWKSValidator` on issuer,
+  audience, resource, scopes and expiry; HELM performs no ID-JAG exchange.
+- Protocol-version negotiation: `core/pkg/mcp/protocol.go` declares
+  `2025-11-25` as the latest supported revision. The final 2026-07-28 wire
+  contract (no `initialize`, `_meta`-carried version and capabilities,
+  `server/discover`, `resultType` on every result, `Mcp-Method`/`Mcp-Name`
+  headers) is not implemented by the gateway. This page maps only the
+  authorization model, which the gateway enforces regardless of revision.
+
 ## Out-of-scope notes
 
-- The RC also removes protocol-level sessions (SEP-2567) and the
+- The revision also removes protocol-level sessions (SEP-2567) and the
   `initialize` handshake (SEP-2575); HELM's session-scoped authorization is
   carried in validated token claims and per-call scope grants, so
   authorization does not depend on the removed `Mcp-Session-Id` header.
 - Gateway/proxy authorization propagation beyond trace context is not part
-  of this RC's six authorization SEPs; transitive delegation enforcement is
+  of the six authorization SEPs; transitive delegation enforcement is
   tracked separately (PCAS gap analysis, MIN-494).


### PR DESCRIPTION
## Summary

Three source-truth corrections found while mapping the current agent-ecosystem specifications (verified 2026-09-12) against what the kernel actually implements. No behavior, wire format, receipt field or telemetry key changes.

- `docs/MCP_2026_07_28_AUTHORIZATION_MAPPING.md`: the 2026-07-28 revision is final, not a release candidate ([spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization), [release post](https://blog.modelcontextprotocol.io/posts/2026-07-28/)). Adds the final-revision items outside the six SEPs: Dynamic Client Registration deprecated in favour of Client ID Metadata Documents, the stable Enterprise-Managed Authorization extension (ID-JAG exchange happens before HELM), and the explicit statement that `core/pkg/mcp/protocol.go` negotiates `2025-11-25`, not the final 2026-07-28 wire contract (no `initialize`, `_meta` version/capabilities, `server/discover`, `resultType`, `Mcp-Method`/`Mcp-Name`).
- `core/pkg/a2a/agent_card.go`: the package comment claimed alignment with the LF A2A v1.0 GA schema and a `/.well-known/agent.json` path; the handler serves `agent-card.json` and the card keys on `agent_id` with `supported_versions`/`auth_methods`/`features`, without A2A `url`/`version`/`protocolVersion`/`securitySchemes` ([A2A spec](https://a2a-protocol.org/latest/specification/)). It is now described as the HELM trust-protocol card that is not wire-compatible with an A2A peer.
- `core/pkg/observability/genai_attrs.go`: records that upstream moved GenAI conventions to `semantic-conventions-genai` (still Development), renamed `gen_ai.system` to `gen_ai.provider.name`, `azure.openai` to `azure.ai.openai`, and names the tool operation `execute_tool`. HELM keeps its keys by the file's own major-version contract; the note prevents anyone claiming current-semconv conformance.

## Validation

```bash
cd core && GOWORK=off go vet ./pkg/a2a ./pkg/observability          # ok
cd core && GOWORK=off go test ./pkg/a2a ./pkg/observability -count=1  # ok (0.551s, 6.523s)
make docs-truth   # 722 coverage rows resolve to live sources and docs
gofmt -l core/pkg/a2a core/pkg/observability   # clean
```

None of the three files is in `tools/boundary/protected.manifest`; no manifest regeneration needed.

## Checklist

- [x] The change stays within the kernel scope in `README.md` and `docs/KERNEL_SCOPE.md`.
- [x] Public docs, SDKs, schemas, or examples are updated when behavior changes. (No behavior change.)
- [x] Launchpad live local-container changes were reviewed against `docs/launchpad/launch-conformance.md`. (Not touched.)
- [x] Contributor-facing docs or issue links are updated when this improves a first-run or first-PR path. (N/A)
- [x] Release version surfaces are lockstep (`make version-drift`) when touching release surfaces. (Not touched.)
- [x] Security-sensitive material is not included in the PR.
- [x] Breaking public interface changes are called out in `CHANGELOG.md`. (None.)
- [x] Advisory quality warnings are acknowledged or tracked when relevant.

Part of the HELM-709 ecosystem review; the full adopt/adapt/defer/reject matrix lives with that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
